### PR TITLE
add QGIS how-to to docs

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -17,6 +17,8 @@ website:
         file: developer.qmd
       - text: "Python"
         file: python/index.qmd
+      - text: "QGIS plugin"
+        file: qgis/index.qmd
     right:
       - icon: github
         href: https://github.com/Deltares/Ribasim

--- a/docs/qgis/index.qmd
+++ b/docs/qgis/index.qmd
@@ -1,0 +1,160 @@
+---
+title: "QGIS plugin"
+---
+
+# How to
+
+## Start
+
+### Add Ribasim and iMOD plugins to QGIS version 3.28 or higher
+
+Plugins menu > Manage and Install Plugins...
+
+![](https://user-images.githubusercontent.com/4471859/224939069-9aae77ea-898f-442f-83b5-f2671c114956.png){fig-align="left"}
+
+Select "Install from ZIP":
+
+- Browse to the `ribasim_qgis.zip` file that contains the plugin
+- Click "Install Plugin"
+- Repeat for the iMOD plugin, `imodqgis.zip`
+
+![](https://user-images.githubusercontent.com/4471859/224939080-7fec5db2-4417-4f7b-8e45-034d4cf4fd75.png){fig-align="left"}
+
+Start the Ribasim plugin.
+
+![](https://user-images.githubusercontent.com/4471859/224939101-228e068a-875b-4df2-98bb-6ee6a3830ddd.png){fig-align="left"}
+
+### Prepare your model
+
+Open example model `basic.gpkg` or create a new model.
+
+![](https://user-images.githubusercontent.com/4471859/224939126-b38f0eed-2e89-4120-b541-5b8c31798c09.png){fig-align="left"}
+
+Check if your coordinate reference system (CRS) is set correctly.
+
+![](https://user-images.githubusercontent.com/4471859/224939143-19e9931e-da4b-4717-ba28-67a0f141dd40.png){fig-align="left"}
+
+If you are working with an unknown CRS, right click the model GeoPakcage group in Layers,
+and click "Set Group CRS...".
+
+![](https://user-images.githubusercontent.com/4471859/224939165-45807f16-2d3a-41b3-92a2-7fe0e86ae72b.png){fig-align="left"}
+
+If you are modeling the Netherlands, select "Amersfoort / RD New" (EPSG:28992).
+
+![](https://user-images.githubusercontent.com/4471859/224939182-3486ff0b-842b-4f98-a37e-ecd04f29aa7f.png){fig-align="left"}
+
+## Edit nodes
+
+### Add nodes on the map
+
+Select the Node layer.
+
+![](https://user-images.githubusercontent.com/4471859/224939204-2aa2ead2-a028-4673-b747-abeadd821ec8.png){fig-align="left"}
+
+Turn on the edit mode to be able to add nodes on the map.
+
+![](https://user-images.githubusercontent.com/4471859/224939223-66e232c0-748c-46f0-ba1b-8751a965f114.png){fig-align="left"}
+
+Add nodes to the map with a left click and select the node type.
+
+![](https://user-images.githubusercontent.com/4471859/224939237-67c1150b-15ec-4044-a02a-26a82f81da05.png){fig-align="left"}
+
+Turn the edit mode off and save the edits to the Nodes layer.
+
+![](https://user-images.githubusercontent.com/4471859/224946136-e37021d5-80c1-4d90-ac04-d0dbd96879f3.png){fig-align="left"}
+
+### Edit tables
+
+Right click a layer and select "Open Attribute Table".
+
+![](https://user-images.githubusercontent.com/4471859/224939276-ca8f856d-3325-49a7-b457-78b09b81ac5e.png){fig-align="left"}
+
+Click the yellow pencil icon on the top left to enable editing, and copy and paste a record.
+A record can be selected by clicking on the row number.
+
+![](https://user-images.githubusercontent.com/4471859/224939287-a8b9f351-9aea-4e3a-8417-3867cd40cda5.png){fig-align="left"}
+
+Adjust the content. If you prefer, it also works to copy data with the same columns from
+Excel. Turn off edit mode and save changes to the layer.
+
+![](https://user-images.githubusercontent.com/4471859/224939297-4b0ca812-9618-4d25-ab7a-518bf1ca63e1.png){fig-align="left"}
+
+## Connect nodes
+
+### Turn on snapping
+
+Make sure the Snapping Toolbar is visible, by going to the View > Toolbars menu. Turn on
+snapping mode by clicking the magnet and set the snapping distance to 25 pixels.
+
+![](https://user-images.githubusercontent.com/4471859/224939328-8359272a-30bb-4eb1-ab6c-968318ac3997.png){fig-align="left"}
+
+### Create connecting edges
+
+Select the Edge layer and turn on the edit mode.
+
+![](https://user-images.githubusercontent.com/4471859/224939342-c6939331-a60d-4526-a350-3cddb122c62d.png){fig-align="left"}
+
+Select "Add line feature".
+
+![](https://user-images.githubusercontent.com/4471859/224939354-523cac79-dcd5-4c43-ab5a-db7672fb743e.png){fig-align="left"}
+
+Create a connection by left clicking a source node and right clicking the destination node.
+
+![](https://user-images.githubusercontent.com/4471859/224939363-88716d43-0536-499d-adb8-2fb4223c0f87.png){fig-align="left"}
+
+Now leave the edit mode and save the results to the layer.
+
+## Run a model
+
+- Open a text editor and create an empty file next to your GeoPackage, with the `.toml`
+  extension.
+- Add the following content to the TOML file:
+```{.TOML filename="basic.toml"}
+starttime = 2020-01-01 00:00:00
+endtime = 2021-01-01 00:00:00
+geopackage = "basic.gpkg"
+```
+- Unzip the Ribasim command line interface, `ribasim_cli.zip`
+- Open your terminal and go to the directory where your TOML is stored. Now run
+  `path/to/ribasim_cli/ribasim basic.toml`. Adjust the path to the `ribasim_cli` folder to
+  where you placed it. This runs the model.
+- In your model directory there is now an `output/` folder with `basin.arrow` and
+  `flow.arrow` output files.
+
+## Inspect results
+
+### Associate output to iMOD time series window
+
+In QGIS select the model group.
+
+![](https://user-images.githubusercontent.com/4471859/224939378-a026aec7-419d-4e6e-8b20-df80aa415659.png){fig-align="left"}
+
+In the Ribasim plugin widget, select the Output tab and click "Associate Output".
+
+![](https://user-images.githubusercontent.com/4471859/224939389-17add58d-6701-49c5-a23a-ce367572d9cd.png){fig-align="left"}
+
+Select `output/basin.arrow`.
+
+![](https://user-images.githubusercontent.com/4471859/224939408-5c291840-90a4-4efa-a2f0-4fb5986b8779.png){fig-align="left"}
+
+This adds metadata to the model that the iMOD plugin can use to find the timeseries data
+that is associated to the model nodes.
+
+### Plot time series
+
+Click the "Time Series" button of the iMOD plugin.
+
+![](https://user-images.githubusercontent.com/4471859/224939424-ec4c77ff-3d6b-4635-b407-ef18376587e9.png){fig-align="left"}
+
+Select the variables that you want to plot.
+
+![](https://user-images.githubusercontent.com/4471859/224939436-a9643b68-dff0-49c3-899d-6ba13d9a6d52.png){fig-align="left"}
+
+Click "Select points" and select a node by left clicking it on the map. Hold the Ctrl key to
+select multiple nodes. Currently only the Basin nodes can be plotted.
+
+![](https://user-images.githubusercontent.com/4471859/224939450-e369791d-3229-4621-87b0-7e1d34d0514d.png){fig-align="left"}
+
+The associated time series are shown the the graph.
+
+![](https://user-images.githubusercontent.com/4471859/224939471-85a23936-6eb6-4a80-a5b7-8c9a55ddc7f7.png){fig-align="left"}


### PR DESCRIPTION
I imagine later on there will be multiple QGIS pages, so I created a separate folder just like for the Python package.

This is a translation of the how-to guide by @gijsber, with some small edits.

Images are stored in #1.
Fixes #96 

![image](https://user-images.githubusercontent.com/4471859/224959221-0e5f8a94-acee-41d2-9505-442ddca8b6b7.png)
