### PR TITLE
add Pump

### DIFF
--- a/core/src/config.jl
+++ b/core/src/config.jl
@@ -4,7 +4,7 @@ nodetypes::Vector{Symbol} = [
     :LevelControl,
     :LinearLevelConnection,
     :TabulatedRatingCurve,
-    :WaterUser,
+    :Pump,
 ]
 
 """

--- a/core/src/create.jl
+++ b/core/src/create.jl
@@ -65,6 +65,13 @@ function LevelControl(db::DB, config::Config)::LevelControl
     return LevelControl(tbl.node_id, tbl.target_level, conductance)
 end
 
+function Pump(db::DB, config::Config)::Pump
+    data = load_data(db, config, "Pump")
+    data === nothing && return Pump()
+    tbl = columntable(data)
+    return Pump(tbl.node_id, tbl.flow_rate)
+end
+
 function push_time_interpolation!(
     interpolations::Vector{Interpolation},
     col::Symbol,
@@ -196,6 +203,7 @@ function Parameters(db::DB, config::Config)::Parameters
     tabulated_rating_curve = TabulatedRatingCurve(db, config)
     fractional_flow = FractionalFlow(db, config)
     level_control = LevelControl(db, config)
+    pump = Pump(db, config)
 
     basin = Basin(db, config)
 
@@ -206,5 +214,6 @@ function Parameters(db::DB, config::Config)::Parameters
         tabulated_rating_curve,
         fractional_flow,
         level_control,
+        pump,
     )
 end

--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -248,7 +248,7 @@ discharge | Float64 | $m^3 s^{-1}$ | non-negative
 
 Pump water from a source node to a destination node.
 The set flow rate will be pumped unless the intake storage is less than 10m3,
-in which case the flow rate will be linearly reduced to 0 m3/s.
+in which case the flow rate will be linearly reduced to $0~m^3/s$.
 A negative flow rate means pumping against the edge direction.
 Note that the intake must always be a Basin.
 

--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -247,7 +247,7 @@ discharge | Float64 | $m^3 s^{-1}$ | non-negative
 ### Pump
 
 Pump water from a source node to a destination node.
-The set flow rate will be pumped unless the intake storage is less than 10m3,
+The set flow rate will be pumped unless the intake storage is less than $10~m^3$,
 in which case the flow rate will be linearly reduced to $0~m^3/s$.
 A negative flow rate means pumping against the edge direction.
 Note that the intake must always be a Basin.

--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -244,6 +244,19 @@ node_id   | Int     | -            | sorted
 storage   | Float64 | $m^3$        | non-negative, start at 0
 discharge | Float64 | $m^3 s^{-1}$ | non-negative
 
+### Pump
+
+Pump water from a source node to a destination node.
+The set flow rate will be pumped unless the intake storage is less than 10m3,
+in which case the flow rate will be linearly reduced to 0 m3/s.
+A negative flow rate means pumping against the edge direction.
+Note that the intake must always be a Basin.
+
+column                | type    | unit         | restriction
+---------             | ------- | ------------ | -----------
+node_id               | Int     | -            | -
+flow_rate             | Float64 | $m^3 s^{-1}$ | -
+
 ### Basin output
 
 The basin table contains outputs of the storage and level of each basin at every solver

--- a/docs/python/examples.ipynb
+++ b/docs/python/examples.ipynb
@@ -63,7 +63,7 @@
         "        (3.0, 0.0),  # 4: TabulatedRatingCurve\n",
         "        (3.0, 1.0),  # 5: FractionalFlow\n",
         "        (3.0, 2.0),  # 6: Basin\n",
-        "        (3.0, 3.0),  # 7: TabulatedRatingCurve\n",
+        "        (4.0, 1.0),  # 7: Pump\n",
         "        (4.0, 0.0),  # 8: FractionalFlow\n",
         "        (5.0, 0.0),  # 9: Basin\n",
         "        (6.0, 0.0),  # 10: LevelControl\n",
@@ -78,7 +78,7 @@
         "    \"TabulatedRatingCurve\",\n",
         "    \"FractionalFlow\",\n",
         "    \"Basin\",\n",
-        "    \"TabulatedRatingCurve\",\n",
+        "    \"Pump\",\n",
         "    \"FractionalFlow\",\n",
         "    \"Basin\",\n",
         "    \"LevelControl\",\n",
@@ -108,8 +108,8 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "from_id = np.array([1, 2, 3, 4, 4, 5, 6, 8, 9], dtype=np.int64)\n",
-        "to_id = np.array([2, 3, 4, 5, 8, 6, 7, 9, 10], dtype=np.int64)\n",
+        "from_id = np.array([1, 2, 3, 4, 4, 5, 6, 8, 7, 9], dtype=np.int64)\n",
+        "to_id = np.array([2, 3, 4, 5, 8, 6, 7, 9, 9, 10], dtype=np.int64)\n",
         "lines = ribasim.utils.geometry_from_connectivity(node, from_id, to_id)\n",
         "edge = ribasim.Edge(\n",
         "    static=gpd.GeoDataFrame(\n",
@@ -206,9 +206,9 @@
         "rating_curve = ribasim.TabulatedRatingCurve(\n",
         "    static=pd.DataFrame(\n",
         "        data={\n",
-        "            \"node_id\": [4, 4, 7, 7],\n",
-        "            \"storage\": [0.0, 1000.0, 0.0, 1000.0],\n",
-        "            \"discharge\": [0.0, q1000, 0.0, q1000],\n",
+        "            \"node_id\": [4, 4],\n",
+        "            \"storage\": [0.0, 1000.0],\n",
+        "            \"discharge\": [0.0, q1000],\n",
         "        }\n",
         "    )\n",
         ")"
@@ -261,6 +261,30 @@
       ]
     },
     {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Setup pump:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "pump = ribasim.Pump(\n",
+        "    static=pd.DataFrame(\n",
+        "        data={\n",
+        "            \"node_id\": [7],\n",
+        "            \"flow_rate\": [0.5/3600],\n",
+        "        }\n",
+        "    )\n",
+        ")"
+      ]
+    },
+    {
       "cell_type": "markdown",
       "metadata": {},
       "source": [
@@ -279,6 +303,7 @@
         "    edge=edge,\n",
         "    basin=basin,\n",
         "    level_control=level_control,\n",
+        "    pump=pump,\n",
         "    linear_level_connection=linear_connection,\n",
         "    tabulated_rating_curve=rating_curve,\n",
         "    fractional_flow=fractional_flow,\n",
@@ -436,11 +461,12 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
         "Now run the model with `ribasim basic-transient/basic.toml`.\n",
-        "After running the model, read back the input:"
+        "After running the model, read back the output:"
       ]
     },
     {
@@ -449,9 +475,21 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "df = pd.read_feather(tempdir / \"basic-transient/output/basin.arrow\")\n",
-        "output = df.set_index([\"time\", \"node_id\"]).to_xarray()\n",
-        "output[\"level\"].plot(hue=\"node_id\")"
+        "df_basin = pd.read_feather(tempdir / \"basic-transient/output/basin.arrow\")\n",
+        "ds_basin = df_basin.set_index([\"time\", \"node_id\"]).to_xarray()\n",
+        "ds_basin[\"level\"].plot(hue=\"node_id\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "df_flow = pd.read_feather(tempdir / \"basic-transient/output/flow.arrow\")\n",
+        "df_flow[\"edge\"] = list(zip(df_flow.from_node_id, df_flow.to_node_id))\n",
+        "df_flow[\"flow_m3d\"] = df_flow.flow * 86400\n",
+        "df_flow.pivot_table(index='time',columns='edge',values='flow_m3d').plot()"
       ]
     },
     {
@@ -473,7 +511,15 @@
       "name": "python3"
     },
     "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
       "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
       "version": "3.10.9"
     }
   },

--- a/python/ribasim/__init__.py
+++ b/python/ribasim/__init__.py
@@ -12,4 +12,5 @@ from ribasim.linear_level_connection import (
 from ribasim.model import Model as Model
 from ribasim.model import Solver as Solver
 from ribasim.node import Node as Node
+from ribasim.pump import Pump as Pump
 from ribasim.tabulated_rating_curve import TabulatedRatingCurve as TabulatedRatingCurve

--- a/python/ribasim/model.py
+++ b/python/ribasim/model.py
@@ -17,6 +17,7 @@ from ribasim.input_base import InputMixin
 from ribasim.level_control import LevelControl
 from ribasim.linear_level_connection import LinearLevelConnection
 from ribasim.node import Node
+from ribasim.pump import Pump
 from ribasim.tabulated_rating_curve import TabulatedRatingCurve
 from ribasim.types import FilePath
 
@@ -28,6 +29,7 @@ _NODES = (
     (LevelControl, "level_control"),
     (LinearLevelConnection, "linear_level_connection"),
     (TabulatedRatingCurve, "tabulated_rating_curve"),
+    (Pump, "pump"),
 )
 
 
@@ -69,6 +71,7 @@ class Model(BaseModel):
     level_control: Optional[LevelControl]
     linear_level_connection: Optional[LinearLevelConnection]
     tabulated_rating_curve: Optional[TabulatedRatingCurve]
+    pump: Optional[Pump]
     starttime: datetime.datetime
     endtime: datetime.datetime
     solver: Optional[Solver]
@@ -88,6 +91,7 @@ class Model(BaseModel):
         level_control: Optional[LevelControl] = None,
         linear_level_connection: Optional[LinearLevelConnection] = None,
         tabulated_rating_curve: Optional[TabulatedRatingCurve] = None,
+        pump: Optional[Pump] = None,
         solver: Optional[Solver] = None,
     ):
         super().__init__(**locals())

--- a/python/ribasim/pump.py
+++ b/python/ribasim/pump.py
@@ -1,0 +1,42 @@
+import pandas as pd
+import pandera as pa
+from pandera.typing import DataFrame, Series
+from pydantic import BaseModel
+
+from ribasim.input_base import InputMixin
+
+__all__ = ("Pump",)
+
+
+class StaticSchema(pa.SchemaModel):
+    node_id: Series[int] = pa.Field(coerce=True)
+    flow_rate: Series[float]
+
+
+class Pump(InputMixin, BaseModel):
+    """
+    Pump water from a source node to a destination node.
+    The set flow rate will be pumped unless the intake storage is less than 10m3,
+    in which case the flow rate will be linearly reduced to 0 m3/s.
+    A negative flow rate means pumping against the edge direction.
+    Note that the intake must always be a Basin.
+
+    Parameters
+    ----------
+    static: pd.DataFrame
+
+        With columns:
+
+        * node_id
+        * flow_rate
+
+    """
+
+    _input_type = "Pump"
+    static: DataFrame[StaticSchema]
+
+    class Config:
+        validate_assignment = True
+
+    def __init__(self, static: pd.DataFrame):
+        super().__init__(**locals())

--- a/qgis/core/nodes.py
+++ b/qgis/core/nodes.py
@@ -25,6 +25,8 @@ from typing import Any, Dict, List, Tuple
 
 from PyQt5.QtCore import QVariant
 from PyQt5.QtGui import QColor
+from ribasim_qgis.core import geopackage
+
 from qgis.core import (
     QgsCategorizedSymbolRenderer,
     QgsEditorWidgetSetup,
@@ -38,7 +40,6 @@ from qgis.core import (
     QgsVectorLayer,
     QgsVectorLayerSimpleLabeling,
 )
-from ribasim_qgis.core import geopackage
 
 
 class Input(abc.ABC):
@@ -143,6 +144,7 @@ class Node(Input):
                     "TabulatedRatingCurve": "TabulatedRatingCurve",
                     "LevelControl": "LevelControl",
                     "LinearLevelConnection": "LinearLevelConnection",
+                    "Pump": "Pump",
                 },
             },
         )
@@ -171,6 +173,7 @@ class Node(Input):
                 shape.Diamond,
             ),
             "LevelControl": (QColor("blue"), "LevelControl", shape.Star),
+            "Pump": (QColor("gray"), "Pump", shape.Hexagon),
             "": (
                 QColor("white"),
                 "",
@@ -312,6 +315,15 @@ class LevelControl(Input):
     ]
 
 
+class Pump(Input):
+    input_type = "Pump"
+    geometry_type = "No Geometry"
+    attributes = [
+        QgsField("node_id", QVariant.Int),
+        QgsField("flow_rate", QVariant.Double),
+    ]
+
+
 NODES = {
     "Node": Node,
     "Edge": Edge,
@@ -323,6 +335,7 @@ NODES = {
     "FractionalFlow": FractionalFlow,
     "LinearLevelConnection": LinearLevelConnection,
     "LevelControl": LevelControl,
+    "Pump": Pump,
 }
 
 


### PR DESCRIPTION
Fixes #21. Except for the devdocs (#126) and unit tests. Since there are no proper unit tests for node types yet, I prefer to fix #116 first before addressing that.

A pump is added to the basic model which runs in the docs, and based on the output from there it seems to work ok, stopping to pump when the upstream basin is empty.