### PR TITLE
make `BMI.update_until(model, t)` stop on t

### DIFF
--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -3,7 +3,7 @@ module Ribasim
 import BasicModelInterface as BMI
 
 using Arrow: Arrow, Table
-using Configurations: Configurations, Maybe, @option, from_toml, from_dict
+using Configurations: Configurations, Maybe, @option, from_toml
 using DataFrames
 using DataInterpolations: LinearInterpolation
 using Dates

--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -70,7 +70,7 @@ function BMI.update_until(model::Model, time)::Model
     elseif dt == 0
         return model
     else
-        step!(integrator, dt)
+        step!(integrator, dt, true)
     end
     return model
 end

--- a/core/test/bmi.jl
+++ b/core/test/bmi.jl
@@ -1,10 +1,12 @@
+using Configurations: from_dict, to_dict
 using Ribasim
 import BasicModelInterface as BMI
 
 toml_path = normpath(@__DIR__, "../../data/basic/basic.toml")
+config_template = Ribasim.parsefile(toml_path)
 model = BMI.initialize(Ribasim.Model, toml_path)
 
-@testset "time" begin
+@testset "adaptive timestepping" begin
     @test BMI.get_time_units(model) == "s"
     @test BMI.get_time_step(model) ≈ 0.011461467f0
     @test BMI.get_start_time(model) === 0.0
@@ -15,7 +17,22 @@ model = BMI.initialize(Ribasim.Model, toml_path)
     @test_throws ErrorException BMI.update_until(model, 0.005)
     @test BMI.get_current_time(model) ≈ 0.011461467f0
     BMI.update_until(model, 86400.0)
-    # TODO it oversteps here to 103995.266f0
-    @test BMI.get_current_time(model) == 86400.0 broken = true
-    # TODO test fixed timestep, and determine correct update_until behavior for both cases
+    @test BMI.get_current_time(model) == 86400.0
+end
+
+@testset "fixed timestepping" begin
+    dict = to_dict(config_template)
+    dict["solver"] = Ribasim.Solver(; algorithm = "Euler", dt = 3600)
+    config = from_dict(Ribasim.Config, dict)
+    @test config.solver.algorithm == "Euler"
+    model = BMI.initialize(Ribasim.Model, config)
+
+    @test BMI.get_time_step(model) == 3600
+    BMI.update(model)
+    @test BMI.get_current_time(model) == 3600
+    @test_throws ErrorException BMI.update_until(model, 3000)
+    BMI.update_until(model, 3660)
+    @test BMI.get_current_time(model) == 3660
+    BMI.update(model)
+    @test BMI.get_current_time(model) == 3600 + 60 + 3600
 end

--- a/core/test/bmi.jl
+++ b/core/test/bmi.jl
@@ -8,31 +8,33 @@ model = BMI.initialize(Ribasim.Model, toml_path)
 
 @testset "adaptive timestepping" begin
     @test BMI.get_time_units(model) == "s"
-    @test BMI.get_time_step(model) ≈ 0.011461467f0
+    dt0 = 0.011461467f0
+    @test BMI.get_time_step(model) ≈ dt0
     @test BMI.get_start_time(model) === 0.0
     @test BMI.get_current_time(model) === 0.0
     @test BMI.get_end_time(model) ≈ 3.16224e7
     BMI.update(model)
-    @test BMI.get_current_time(model) ≈ 0.011461467f0
+    @test BMI.get_current_time(model) ≈ dt0
     @test_throws ErrorException BMI.update_until(model, 0.005)
-    @test BMI.get_current_time(model) ≈ 0.011461467f0
+    @test BMI.get_current_time(model) ≈ dt0
     BMI.update_until(model, 86400.0)
     @test BMI.get_current_time(model) == 86400.0
 end
 
 @testset "fixed timestepping" begin
     dict = to_dict(config_template)
-    dict["solver"] = Ribasim.Solver(; algorithm = "Euler", dt = 3600)
+    dt = 3600
+    dict["solver"] = Ribasim.Solver(; algorithm = "Euler", dt)
     config = from_dict(Ribasim.Config, dict)
     @test config.solver.algorithm == "Euler"
     model = BMI.initialize(Ribasim.Model, config)
 
-    @test BMI.get_time_step(model) == 3600
+    @test BMI.get_time_step(model) == dt
     BMI.update(model)
-    @test BMI.get_current_time(model) == 3600
-    @test_throws ErrorException BMI.update_until(model, 3000)
-    BMI.update_until(model, 3660)
-    @test BMI.get_current_time(model) == 3660
+    @test BMI.get_current_time(model) == dt
+    @test_throws ErrorException BMI.update_until(model, dt - 60)
+    BMI.update_until(model, dt + 60)
+    @test BMI.get_current_time(model) == dt + 60
     BMI.update(model)
-    @test BMI.get_current_time(model) == 3600 + 60 + 3600
+    @test BMI.get_current_time(model) == 2dt + 60
 end

--- a/core/test/bmi.jl
+++ b/core/test/bmi.jl
@@ -8,15 +8,15 @@ model = BMI.initialize(Ribasim.Model, toml_path)
 
 @testset "adaptive timestepping" begin
     @test BMI.get_time_units(model) == "s"
-    dt0 = 0.011461467f0
-    @test BMI.get_time_step(model) ≈ dt0
+    dt0 = 0.011371289f0
+    @test BMI.get_time_step(model) ≈ dt0 atol = 5e-3
     @test BMI.get_start_time(model) === 0.0
     @test BMI.get_current_time(model) === 0.0
     @test BMI.get_end_time(model) ≈ 3.16224e7
     BMI.update(model)
-    @test BMI.get_current_time(model) ≈ dt0
+    @test BMI.get_current_time(model) ≈ dt0 atol = 5e-3
     @test_throws ErrorException BMI.update_until(model, 0.005)
-    @test BMI.get_current_time(model) ≈ dt0
+    @test BMI.get_current_time(model) ≈ dt0 atol = 5e-3
     BMI.update_until(model, 86400.0)
     @test BMI.get_current_time(model) == 86400.0
 end

--- a/core/test/config.jl
+++ b/core/test/config.jl
@@ -8,8 +8,7 @@ using OrdinaryDiffEq: alg_autodiff
     @test config isa Ribasim.Config
     @test config.update_timestep == 86400.0
     @test config.endtime > config.starttime
-    @test config.solver ==
-          Ribasim.Solver("QNDF", false, 86400.0, 0, 1.0e-6, 0.001, Int(1e9))
+    @test config.solver == Ribasim.Solver(; saveat = 86400.0)
 
     @test_throws UndefKeywordError Ribasim.Config()
     @test_throws UndefKeywordError Ribasim.Config(
@@ -21,9 +20,9 @@ using OrdinaryDiffEq: alg_autodiff
 end
 
 @testset "Solver" begin
-    @test Ribasim.Solver() ==
-          Ribasim.Solver("QNDF", false, Float64[], 0, 1.0e-6, 0.001, Int(1e9))
-    @test Ribasim.Solver(;
+    solver = Ribasim.Solver()
+    @test solver.algorithm == "QNDF"
+    Ribasim.Solver(;
         algorithm = "Rosenbrock23",
         autodiff = true,
         saveat = 3600.0,
@@ -31,7 +30,7 @@ end
         abstol = 1e-5,
         reltol = 1e-4,
         maxiters = 1e5,
-    ) == Ribasim.Solver("Rosenbrock23", true, 3600.0, 0, 1e-5, 1e-4, 1e5)
+    )
     Ribasim.Solver(; algorithm = "DoesntExist")
     @test_throws InexactError Ribasim.Solver(autodiff = 2)
     @test_throws "algorithm DoesntExist not supported" Ribasim.algorithm(


### PR DESCRIPTION
Also adds tests for fixed timestepping, which actually also allows different sized timesteps with `BMI.update_until`.