### PR TITLE
Escape SQL parameters.

### DIFF
--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -14,7 +14,7 @@ using Legolas: Legolas, @schema, @version, validate
 using OrdinaryDiffEq
 using SciMLBase
 using SparseArrays
-using SQLite: SQLite, DB, Query
+using SQLite: SQLite, DB, Query, esc_id
 using Statistics: median
 using Tables: columntable
 using TimerOutputs

--- a/core/src/io.jl
+++ b/core/src/io.jl
@@ -3,14 +3,14 @@ function get_ids(db::DB)::Vector{Int}
 end
 
 function get_ids(db::DB, nodetype)::Vector{Int}
-    sql = "select fid from Node where type = '$nodetype'"
+    sql = "select fid from Node where type = $(esc_id(nodetype))"
     return only(execute(columntable, db, sql))
 end
 
 function exists(db::DB, tablename::String)
     query = execute(
         db,
-        "SELECT name FROM sqlite_master WHERE type='table' AND name='$tablename'",
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=$(esc_id(tablename))",
     )
     return !isempty(query)
 end
@@ -61,7 +61,7 @@ function load_data(db::DB, config::Config, tablename::String)::Union{Table, Quer
     end
 
     if exists(db, tablename)
-        return execute(db, string("select * from '$tablename'"))
+        return execute(db, "select * from $(esc_id(tablename))")
     end
 
     return nothing


### PR DESCRIPTION
To prevent injections or other oddly formatted strings.