### PR TITLE
Run core tests when libribasim module changes

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -3,9 +3,9 @@ on:
   push:
     branches: [main]
     tags: ["*"]
-    paths: [".github/**", "core/**"]
+    paths: [".github/**", "build/libribasim/src/**", "core/**"]
   pull_request:
-    paths: [".github/**", "core/**"]
+    paths: [".github/**", "build/libribasim/src/**", "core/**"]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
I saw #162 broke the core tests, since CI was not triggered. In the core tests we test the libribasim module as well (without first compiling it into a shared library).