### PR TITLE
fix output IDs

### DIFF
--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -6,7 +6,7 @@ import BasicModelInterface as BMI
 using Arrow: Arrow, Table
 using Configurations: Configurations, Maybe, @option, from_toml
 using DataInterpolations: LinearInterpolation
-using DataStructures: DefaultDict
+using DataStructures: DefaultDict, OrderedDict
 using Dates
 using DBInterface: execute, prepare
 using DiffEqCallbacks

--- a/core/src/create.jl
+++ b/core/src/create.jl
@@ -5,7 +5,7 @@ function Connectivity(db::DB)::Connectivity
     nonzeros(flow) .= 0.0
 
     basin_id = get_ids(db, "Basin")
-    u_index = Dict(id => i for (i, id) in enumerate(basin_id))
+    u_index = OrderedDict(id => i for (i, id) in enumerate(basin_id))
 
     return Connectivity(graph, flow, u_index, edge_ids)
 end

--- a/core/src/io.jl
+++ b/core/src/io.jl
@@ -116,7 +116,8 @@ function write_basin_output(model::Model)
     (; config, integrator) = model
     (; sol, p) = integrator
 
-    basin_id = sort(collect(keys(p.connectivity.u_index)))
+    # u_index is an OrderedDict, in the same order as u
+    basin_id = collect(keys(p.connectivity.u_index))
     nbasin = length(basin_id)
     tsteps = datetime_since.(timesteps(model), config.starttime)
     ntsteps = length(tsteps)

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -12,8 +12,8 @@ edge_ids: get the external edge id from (src, dst)
 struct Connectivity
     graph::DiGraph{Int}
     flow::SparseMatrixCSC{Float64, Int}
-    u_index::Dict{Int, Int}
-    edge_ids::Dict{Tuple{Int, Int}, Int}
+    u_index::OrderedDict{Int, Int}
+    edge_ids::OrderedDict{Tuple{Int, Int}, Int}
     Connectivity(graph, flow, u_index, edge_ids) =
         is_valid(graph, flow, u_index, edge_ids) ? new(graph, flow, u_index, edge_ids) :
         error("Invalid graph")
@@ -23,8 +23,8 @@ end
 function is_valid(
     graph::DiGraph{Int},
     flow::SparseMatrixCSC{Float64, Int},
-    u_index::Dict{Int, Int},
-    edge_ids::Dict{Tuple{Int, Int}, Int},
+    u_index::OrderedDict{Int, Int},
+    edge_ids::OrderedDict{Tuple{Int, Int}, Int},
 )
     return true
 end

--- a/core/src/utils.jl
+++ b/core/src/utils.jl
@@ -11,10 +11,10 @@ end
 Return a directed graph, and a mapping from source and target nodes to edge
 fid.
 "
-function create_graph(db::DB)::Tuple{DiGraph, Dict{Tuple{Int, Int}, Int}}
+function create_graph(db::DB)::Tuple{DiGraph, OrderedDict{Tuple{Int, Int}, Int}}
     n = length(get_ids(db))
     graph = DiGraph(n)
-    edge_ids = Dict{Tuple{Int, Int}, Int}()
+    edge_ids = OrderedDict{Tuple{Int, Int}, Int}()
     rows = execute(db, "select fid, from_node_id, to_node_id from Edge")
     for (; fid, from_node_id, to_node_id) in rows
         add_edge!(graph, from_node_id, to_node_id)


### PR DESCRIPTION
The `sort` is important here since we use a regular unordered Dict. This resulted in the wrong `node_id` in the header of the basin output.

Also adds `edge_id` to the flow output, as intended in #163.

No tests right now since we don't have any tests on the output tables yet. I createad #171 for that.