### PR TITLE
don't use geopandas for nonspatial table IO

### DIFF
--- a/core/src/io.jl
+++ b/core/src/io.jl
@@ -81,8 +81,9 @@ function load_structvector(
 
     nt = Tables.columntable(table)
     if table isa Query && haskey(nt, :time)
-        # time is stored as a String in the GeoPackage
-        nt = merge(nt, (; time = DateTime.(nt.time)))
+        # time has type timestamp and is stored as a String in the GeoPackage
+        # currently SQLite.jl does not automatically convert it to DateTime
+        nt = merge(nt, (; time = DateTime.(nt.time, dateformat"yyyy-mm-dd HH:MM:SS.s")))
     end
 
     table = StructVector{T}(nt)

--- a/python/ribasim/ribasim/edge.py
+++ b/python/ribasim/ribasim/edge.py
@@ -1,5 +1,7 @@
-from typing import Any
+from pathlib import Path
+from typing import Any, Dict, Type, TypeVar
 
+import geopandas as gpd
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -10,6 +12,9 @@ from pandera.typing.geopandas import GeoSeries
 from pydantic import BaseModel
 
 from ribasim.input_base import InputMixin
+from ribasim.types import FilePath
+
+T = TypeVar("T")
 
 __all__ = ("Edge",)
 
@@ -48,6 +53,42 @@ class Edge(InputMixin, BaseModel):
     @classmethod
     def _layername(cls, field) -> str:
         return f"{cls._input_type}"
+
+    def write(self, directory: FilePath, modelname: str) -> None:
+        """
+        Write the contents of the input to a GeoPackage.
+
+        The Geopackage will be written in ``directory`` and will be be named
+        ``{modelname}.gpkg``.
+
+        Parameters
+        ----------
+        directory: FilePath
+        modelname: str
+        """
+        directory = Path(directory)
+        dataframe = self.static
+        name = self._layername(dataframe)
+
+        gdf = gpd.GeoDataFrame(data=dataframe)
+        if "geometry" in gdf.columns:
+            gdf = gdf.set_geometry("geometry")
+        else:
+            gdf["geometry"] = None
+        gdf.to_file(directory / f"{modelname}.gpkg", layer=name)
+
+        return
+
+    @classmethod
+    def _kwargs_from_geopackage(cls: Type[T], path: FilePath) -> Dict:
+        kwargs = {}
+
+        field = "static"
+        layername = cls._layername(field)
+        df = gpd.read_file(path, layer=layername, engine="pyogrio", fid_as_index=True)
+        kwargs[field] = df
+
+        return kwargs
 
     def plot(self, **kwargs) -> Any:
         ax = kwargs.get("ax", None)

--- a/python/ribasim/ribasim/node.py
+++ b/python/ribasim/ribasim/node.py
@@ -1,5 +1,7 @@
-from typing import Any
+from pathlib import Path
+from typing import Any, Dict, Type, TypeVar
 
+import geopandas as gpd
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -9,9 +11,11 @@ from pandera.typing.geopandas import GeoSeries
 from pydantic import BaseModel
 
 from ribasim.input_base import InputMixin
+from ribasim.types import FilePath
+
+T = TypeVar("T")
 
 __all__ = ("Node",)
-
 
 _MARKERS = {
     "Basin": "o",
@@ -56,6 +60,42 @@ class Node(InputMixin, BaseModel):
     @classmethod
     def _layername(cls, field) -> str:
         return f"{cls._input_type}"
+
+    def write(self, directory: FilePath, modelname: str) -> None:
+        """
+        Write the contents of the input to a GeoPackage.
+
+        The Geopackage will be written in ``directory`` and will be be named
+        ``{modelname}.gpkg``.
+
+        Parameters
+        ----------
+        directory: FilePath
+        modelname: str
+        """
+        directory = Path(directory)
+        dataframe = self.static
+        name = self._layername(dataframe)
+
+        gdf = gpd.GeoDataFrame(data=dataframe)
+        if "geometry" in gdf.columns:
+            gdf = gdf.set_geometry("geometry")
+        else:
+            gdf["geometry"] = None
+        gdf.to_file(directory / f"{modelname}.gpkg", layer=name)
+
+        return
+
+    @classmethod
+    def _kwargs_from_geopackage(cls: Type[T], path: FilePath) -> Dict:
+        kwargs = {}
+
+        field = "static"
+        layername = cls._layername(field)
+        df = gpd.read_file(path, layer=layername, engine="pyogrio", fid_as_index=True)
+        kwargs[field] = df
+
+        return kwargs
 
     def plot(self, **kwargs) -> Any:
         """

--- a/python/ribasim/tests/test_io.py
+++ b/python/ribasim/tests/test_io.py
@@ -3,18 +3,11 @@ from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal
 
 
-def assert_equal(a, b, geometry=True):
+def assert_equal(a, b):
     "pandas.testing.assert_frame_equal, but ignoring the index"
+    # TODO support assert basic == model, ignoring the index for all but node
     a = a.reset_index(drop=True)
     b = b.reset_index(drop=True)
-
-    # Currently nonspatial tables are read into GeoDataFrames with a geometry column
-    # filled with None, leading to inequalities. Allow ignoring these.
-    # TODO load only node and edge tables to a GeoDataFrame
-    # TODO support assert basic == model, ignoring the index for all but node
-    if not geometry:
-        a = a.drop(columns="geometry", errors="ignore")
-        b = b.drop(columns="geometry", errors="ignore")
 
     # avoid comparing datetime64[ns] with datetime64[ms]
     if "time" in a:
@@ -48,5 +41,5 @@ def test_basic_transient(basic_transient, tmp_path):
     assert_equal(basic_transient.edge.static, model.edge.static)
 
     forcing = model.basin.forcing
-    assert_equal(basic_transient.basin.forcing, forcing, geometry=False)
-    assert forcing.shape == (1468, 8)
+    assert_equal(basic_transient.basin.forcing, forcing)
+    assert forcing.shape == (1468, 7)


### PR DESCRIPTION
Only the node and edge table support geometries. This copies the input_base IO functions to the node and edge classes, to special case them. These functions are the same for node and edge, so there is a bit of duplication there.

In input_base we use the sqlite3 stdlib and pandas to read and write. I use `pd.read_sql_query` instead of `pd.read_sql_table` because that way it works with `sqlite3` stdlib instead of needing SQLAlchemy. Pandas refers to the sqlite3 functionality as legacy, but I thought it's not worth another dependency.

I noticed this does change the string representation from `yyyy-mm-ddTHH:MM:SS.s` to `yyyy-mm-dd HH:MM:SS.s`, (the T separator becomes a space). This seems to go against ISO conventions, although it's probably more familiar and common, so I just went with it.

Also fixes #173, by deleting old geopackage files if they exist.