### PR TITLE
sort the tables

### DIFF
--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -21,8 +21,7 @@ function BMI.initialize(T::Type{Model}, config::Config)::Model
             # default to nearly empty basins, perhaps make required input
             fill(1.0, n)
         else
-            # get state in the right order
-            sort(state; by = row -> row.node_id).storage
+            state.storage
         end::Vector{Float64}
         @assert length(u0) == n "Basin / state length differs from number of Basins"
         t_end = seconds_since(config.endtime, config.starttime)

--- a/core/src/io.jl
+++ b/core/src/io.jl
@@ -1,9 +1,9 @@
 function get_ids(db::DB)::Vector{Int}
-    return only(execute(columntable, db, "select fid from Node"))
+    return only(execute(columntable, db, "SELECT fid FROM Node ORDER BY fid"))
 end
 
 function get_ids(db::DB, nodetype)::Vector{Int}
-    sql = "select fid from Node where type = $(esc_id(nodetype))"
+    sql = "SELECT fid FROM Node where type = $(esc_id(nodetype)) ORDER BY fid"
     return only(execute(columntable, db, sql))
 end
 
@@ -67,7 +67,7 @@ end
 
 Load data from Arrow files if available, otherwise the GeoPackage.
 Always returns a StructVector of the given struct type T, which is empty if the table is
-not found.
+not found. This function validates the schema, and enforces the required sort order.
 """
 function load_structvector(
     db::DB,
@@ -97,7 +97,7 @@ function load_structvector(
         @warn "No (validation) schema declared for $nodetype $kind"
     end
 
-    return table
+    return sorted_table!(table)
 end
 
 "Construct a path relative to both the TOML directory and the optional `input_dir`"

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -58,8 +58,8 @@ interpolation in between. Relation can be updated in time, which is done by movi
 the `time` field into the `tables`, which is done in the `update_tabulated_rating_curve`
 callback.
 
-Type parameter C indicates the content backing the StructVector,which can be a NamedTuple of
-vectors or Arrow Tables, and is added to avoid type instabilities.
+Type parameter C indicates the content backing the StructVector, which can be a NamedTuple
+of Vectors or Arrow Primitives, and is added to avoid type instabilities.
 """
 struct TabulatedRatingCurve{C}
     node_id::Vector{Int}
@@ -78,8 +78,6 @@ struct LinearLevelConnection
     conductance::Vector{Float64}
 end
 
-LinearLevelConnection() = LinearLevelConnection(Int[], Float64[])
-
 """
 Requirements:
 
@@ -92,8 +90,6 @@ struct FractionalFlow
     fraction::Vector{Float64}
 end
 
-FractionalFlow() = FractionalFlow(Int[], Float64[])
-
 """
 node_id: node ID of the LevelControl node
 target_level: target level for the connected Basin
@@ -105,8 +101,6 @@ struct LevelControl
     conductance::Vector{Float64}
 end
 
-LevelControl() = LevelControl(Int[], Float64[], Float64[])
-
 """
 node_id: node ID of the Pump node
 flow_rate: target flow rate
@@ -115,9 +109,6 @@ struct Pump
     node_id::Vector{Int}
     flow_rate::Vector{Float64}
 end
-
-# TODO Kwarg constructor
-Pump() = Pump(Int[], Float64[])
 
 # TODO Automatically add all nodetypes here
 struct Parameters

--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -120,7 +120,7 @@ between nodes, and never have storage of their own.
 
 column    | type     | restriction
 --------- | -------- | -----------
-fid       | Int      | unique
+fid       | Int      | unique, sorted
 type      | String   | known node type
 geometry  | geoarrow | (optional)
 
@@ -165,7 +165,7 @@ or removed.
 
 column         | type     | restriction
 -------------- | -------- | -----------
-fid            | Int      | unique
+fid            | Int      | unique, sorted
 from_node_id   | Int      | -
 to_node_id     | Int      | -
 geom           | geometry | (optional)
@@ -195,7 +195,7 @@ forcing table, it is empty, or all timestamps of that variable are missing.
 
 column                | type    | unit         | restriction
 ---------             | ------- | ------------ | -----------
-node_id               | Int     | -            | -
+node_id               | Int     | -            | sorted
 precipitation         | Float64 | $m s^{-1}$   | non-negative
 potential_evaporation | Float64 | $m s^{-1}$   | non-negative
 drainage              | Float64 | $m^3 s^{-1}$ | non-negative
@@ -209,8 +209,10 @@ example of this is the `target_volume` from the LevelLink node.
 
 ### Basin / forcing
 
-This table is the transient form of the `Basin` table. The only difference is that a time
-column is added. A linear interpolation between the given timesteps is currently done if the
+This table is the transient form of the `Basin` table.
+The only difference is that a time column is added.
+The table must by sorted by time, and per time it must be sorted by node_id.
+A linear interpolation between the given timesteps is currently done if the
 solver takes timesteps between the given data points. More options will be available later.
 
 ### Basin / profile
@@ -220,7 +222,7 @@ The profile table defines the physical dimensions of the storage reservoir of ea
 column    | type    | unit         | restriction
 --------- | ------- | ------------ | -----------
 node_id   | Int     | -            | sorted
-storage   | Float64 | $m^3$        | non-negative, start at 0
+storage   | Float64 | $m^3$        | non-negative, per node_id: start at 0 and increasing
 area      | Float64 | $m^2$        | non-negative
 level     | Float64 | $m$          | -
 
@@ -251,7 +253,8 @@ discharge | Float64 | $m^3 s^{-1}$ | non-negative
 ### TabulatedRatingCurve / time
 
 This table is the transient form of the `TabulatedRatingCurve` table.
-The only difference is that a time column is added, which must be sorted.
+The only difference is that a time column is added.
+The table must by sorted by time, and per time it must be sorted by node_id.
 With this the rating curves can be updated over time.
 Note that a `node_id` can be either in this table or in the static one, but not both.
 
@@ -265,7 +268,7 @@ Note that the intake must always be a Basin.
 
 column                | type    | unit         | restriction
 ---------             | ------- | ------------ | -----------
-node_id               | Int     | -            | -
+node_id               | Int     | -            | sorted
 flow_rate             | Float64 | $m^3 s^{-1}$ | -
 
 ### Basin output
@@ -280,6 +283,8 @@ node_id  | Int      | -
 storage  | Float64  | $m^3$
 level    | Float64  | $m$
 
+The table is sorted by time, and per time it is sorted by node_id.
+
 ### Flow output
 
 The flow tables contains outputs of the flow on every edge in the model, for each solver
@@ -292,6 +297,8 @@ edge_id       | Int      | -
 from_node_id  | Int      | -
 to_node_id    | Int      | -
 flow          | Float64  | $m^3 s^{-1}$
+
+The table is sorted by time, and per time the same edge_id order is used, though not sorted.
 
 ## Example input files
 

--- a/python/ribasim/ribasim/basin.py
+++ b/python/ribasim/ribasim/basin.py
@@ -108,3 +108,16 @@ class Basin(InputMixin, BaseModel):
         state: Optional[pd.DataFrame] = None,
     ):
         super().__init__(**locals())
+
+    def sort(self):
+        self.profile = self.profile.sort_values(
+            ["node_id", "storage"], ignore_index=True
+        )
+        if self.static is not None:
+            self.static = self.static.sort_values("node_id", ignore_index=True)
+        if self.forcing is not None:
+            self.forcing = self.forcing.sort_values(
+                ["time", "node_id"], ignore_index=True
+            )
+        if self.state is not None:
+            self.state = self.state.sort_values("node_id", ignore_index=True)

--- a/python/ribasim/ribasim/edge.py
+++ b/python/ribasim/ribasim/edge.py
@@ -66,6 +66,7 @@ class Edge(InputMixin, BaseModel):
         directory: FilePath
         modelname: str
         """
+        self.sort()
         directory = Path(directory)
         dataframe = self.static
         name = self._layername(dataframe)
@@ -122,3 +123,6 @@ class Edge(InputMixin, BaseModel):
             )
 
         return ax
+
+    def sort(self):
+        self.static = self.static.sort_index()

--- a/python/ribasim/ribasim/fractional_flow.py
+++ b/python/ribasim/ribasim/fractional_flow.py
@@ -54,3 +54,10 @@ class FractionalFlow(InputMixin, BaseModel):
 
     def __init__(self, static: pd.DataFrame, forcing: Optional[pd.DataFrame] = None):
         super().__init__(**locals())
+
+    def sort(self):
+        self.static = self.static.sort_values("node_id", ignore_index=True)
+        if self.forcing is not None:
+            self.forcing = self.forcing.sort_values(
+                ["time", "node_id"], ignore_index=True
+            )

--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -81,6 +81,7 @@ class InputMixin(abc.ABC):
         directory: FilePath
         modelname: str
         """
+        self.sort()
         directory = Path(directory)
         for field in self.fields():
             dataframe = getattr(self, field)
@@ -165,3 +166,17 @@ class InputMixin(abc.ABC):
             return None
         else:
             return cls(**kwargs)
+
+    def sort(self):
+        """
+        Sort all input tables as required.
+        Tables are sorted by "node_id", unless otherwise specified.
+        Sorting is done automatically before writing the table.
+        """
+        for field in self.fields():
+            dataframe = getattr(self, field)
+            if dataframe is None:
+                continue
+            else:
+                dataframe = dataframe.sort_values("node_id", ignore_index=True)
+        return

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -212,3 +212,14 @@ class Model(BaseModel):
         self.edge.plot(ax=ax, zorder=2)
         self.node.plot(ax=ax, zorder=3)
         return ax
+
+    def sort(self):
+        """
+        Sort all input tables as required.
+        Tables are sorted by "node_id", unless otherwise specified.
+        Sorting is done automatically before writing the table.
+        """
+        for name in self.fields():
+            input_entry = getattr(self, name)
+            if isinstance(input_entry, InputMixin):
+                input_entry.sort()

--- a/python/ribasim/ribasim/node.py
+++ b/python/ribasim/ribasim/node.py
@@ -73,6 +73,7 @@ class Node(InputMixin, BaseModel):
         directory: FilePath
         modelname: str
         """
+        self.sort()
         directory = Path(directory)
         dataframe = self.static
         name = self._layername(dataframe)
@@ -129,3 +130,6 @@ class Node(InputMixin, BaseModel):
             ax.annotate(text=text, xy=xy, xytext=(2.0, 2.0), textcoords="offset points")
 
         return ax
+
+    def sort(self):
+        self.static = self.static.sort_index()

--- a/python/ribasim/ribasim/tabulated_rating_curve.py
+++ b/python/ribasim/ribasim/tabulated_rating_curve.py
@@ -56,3 +56,10 @@ class TabulatedRatingCurve(InputMixin, BaseModel):
 
     def __init__(self, static: pd.DataFrame, time: Optional[pd.DataFrame] = None):
         super().__init__(**locals())
+
+    def sort(self):
+        self.static = self.static.sort_values(["node_id", "level"], ignore_index=True)
+        if self.time is not None:
+            self.time = self.time.sort_values(
+                ["time", "node_id", "level"], ignore_index=True
+            )


### PR DESCRIPTION
Tables require a particular sorting order. Sometime the core assumed it was sorted, and sometimes it sorted it itself.

This PR sorts things out. The required sorting order is documented for all tables. Before writing tables, ribasim-python sorts them in the needed order.

The core now sorts it when it can, and asserts it is sorted if it can't. It can sort when the StructVector is in memory (comes from GeoPackage). It cannot sort memory mapped Arrow tables. At least not without loading them in memory, which is what we generally want to avoid when using Arrow tables.