### PR TITLE
update forcings in callback

### DIFF
--- a/core/src/utils.jl
+++ b/core/src/utils.jl
@@ -80,3 +80,95 @@ function qh_interpolation(node_id::Int, table::StructVector)::LinearInterpolatio
     @assert !isempty(rowrange) "timeseries starts after model start time"
     return LinearInterpolation(table.discharge[rowrange], table.level[rowrange])
 end
+
+"""
+Find the index of element x in a sorted collection a.
+Returns the index of x if it exists, or nothing if it doesn't.
+If x occurs more than once, throw an error.
+"""
+function findsorted(a, x)::Union{Int, Nothing}
+    r = searchsorted(a, x)
+    return if isempty(r)
+        nothing
+    elseif length(r) == 1
+        only(r)
+    else
+        error("Multiple occurances of $x found.")
+    end
+end
+
+"""
+Update `table` at row index `i`, with the values of a given row.
+`table` must be a NamedTuple of vectors with all variables that must be loaded.
+The row must contain all the column names that are present in the table.
+If a value is NaN, it is not set.
+"""
+function set_table_row!(table::NamedTuple, row, i::Int)::NamedTuple
+    for (symbol, vector) in pairs(table)
+        val = getproperty(row, symbol)
+        if !isnan(val)
+            vector[i] = val
+        end
+    end
+    return table
+end
+
+"""
+Load data from a source table `static` into a destination `table`.
+Data is matched based on the node_id, which is sorted.
+"""
+function set_static_value!(
+    table::NamedTuple,
+    node_id::Vector{Int},
+    static::StructVector,
+)::NamedTuple
+    for (i, id) in enumerate(node_id)
+        idx = findsorted(static.node_id, id)
+        isnothing(idx) && continue
+        row = static[idx]
+        set_table_row!(table, row, i)
+    end
+    return table
+end
+
+"""
+From a timeseries table `time`, load the most recent applicable data into `table`.
+`table` must be a NamedTuple of vectors with all variables that must be loaded.
+The most recent applicable data is non-NaN data for a given ID that is on or before `t`.
+"""
+function set_current_value!(
+    table::NamedTuple,
+    node_id::Vector{Int},
+    time::StructVector,
+    t::DateTime,
+)::NamedTuple
+    idx_starttime = searchsortedlast(time.time, t)
+    pre_table = view(time, 1:idx_starttime)
+
+    for (i, id) in enumerate(node_id)
+        for (symbol, vector) in pairs(table)
+            idx = findlast(
+                row -> row.node_id == id && !isnan(getproperty(row, symbol)),
+                pre_table,
+            )
+            if !isnothing(idx)
+                vector[i] = getproperty(pre_table, symbol)[idx]
+            end
+        end
+    end
+    return table
+end
+
+function check_no_nans(table::NamedTuple, nodetype::String)
+    for (symbol, vector) in pairs(table)
+        any(isnan, vector) &&
+            error("Missing initial data for the $nodetype variable $symbol")
+    end
+    return nothing
+end
+
+"From an iterable of DateTimes, find the times the solver needs to stop"
+function get_tstops(time, starttime::DateTime)::Vector{Float64}
+    unique_times = unique(time)
+    return seconds_since.(unique_times, starttime)
+end

--- a/core/test/basin.jl
+++ b/core/test/basin.jl
@@ -18,9 +18,9 @@ end
     model = Ribasim.run(toml_path)
     @test model isa Ribasim.Model
     @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
-    @test length(model.integrator.p.basin.precipitation) == 8
+    @test length(model.integrator.p.basin.precipitation) == 4
     # TODO on MacOS CI this deviates ~0.5m3, not on local MacOS
-    @test model.integrator.sol.u[end] ≈ Float32[229.4959, 164.44641, 0.5336011, 1533.0612] broken =
+    @test model.integrator.sol.u[end] ≈ Float32[235.80775, 168.88895, 0.4997849, 1534.171] broken =
         (Sys.isapple() && get(ENV, "CI", "false") == "true")
 end
 
@@ -31,7 +31,7 @@ end
     model = Ribasim.run(toml_path)
     @test model isa Ribasim.Model
     @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
-    @test model.integrator.sol.u[end] ≈ Float32[54.455338, 679.4662]
+    @test model.integrator.sol.u[end] ≈ Float32[54.459435, 313.50992]
     # the highest level in the dynamic table is updated to 1.2 from the callback
     @test model.integrator.p.tabulated_rating_curve.tables[end].t[end] == 1.2
 end

--- a/python/ribasim/tests/conftest.py
+++ b/python/ribasim/tests/conftest.py
@@ -276,7 +276,7 @@ def tabulated_rating_curve_model() -> ribasim.Model:
     profile["node_id"] = [1, 1, 4, 4]
 
     # Convert steady forcing to m/s
-    # 2 mm/d precipitation, 1 mm/d evaporation
+    # 2 mm/d precipitation
     seconds_in_day = 24 * 3600
     precipitation = 0.002 / seconds_in_day
     # only the upstream basin gets precipitation


### PR DESCRIPTION
Before we loaded the whole timeseries for Basin into memory and put a LinearInterpolation onto it. Then during each solver iteration the interpolation object was queried with the current time t.

A downside of this approach was that there are no guarantees that your forcing ends up in your model. The solver could possibly take a large timestep and completely miss a rainfall peak. To avoid this we need to stop the solver every time there is new forcing data available, and then load it into the model.

With this we can currently only do forward fill interpolation. This might be a bit harder on the solver since a precipitation peak will come as a shock. We could consider building something on top of this that provides some smoothing, though fundamentally I think this is the correct and conservative thing to do.

Some extra utility functions were added to load the initial forcing parameters. These are generic and will be used for time tables of other nodes as well.

The transient model state deviation is small and expected as explained above. The TabulatedRatingCurve change is large. I recalculated the water balance there, and the new one is correct. It looks like rain fall on the downstream basin before, but that was not intended.