### PR TITLE
quartodoc now can be called directly

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,7 +67,7 @@ jobs:
         working-directory: docs
         # objects.json: https://github.com/machow/quartodoc/issues/63
         run: |
-          python -m quartodoc build
+          quartodoc build
           rm objects.json
 
       - name: Render Quarto Project

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -5,3 +5,4 @@ python/reference/
 python/data/
 *.html
 /Manifest.toml
+objects.json

--- a/docs/contribute/core.qmd
+++ b/docs/contribute/core.qmd
@@ -103,7 +103,7 @@ The Python API reference is created using quartodoc by running this command from
 folder:
 
 ```bash
-python -m quartodoc build
+quartodoc build
 ```
 
 You typically only have to run this once, or if you want to check out how it looks after

--- a/docs/contribute/python.qmd
+++ b/docs/contribute/python.qmd
@@ -63,7 +63,7 @@ pytest tests
 Run in the docs folder:
 
 ```
-python -m quartodoc build
+quartodoc build
 ```
 
 This will generate the `.qmd` files in `docs/python/reference` for inspection.


### PR DESCRIPTION
https://github.com/machow/quartodoc/releases/tag/v0.3.0
