### PR TITLE
Ribasim python graph plot consistent with QGIS

### DIFF
--- a/docs/contribute/addnode.qmd
+++ b/docs/contribute/addnode.qmd
@@ -129,18 +129,18 @@ Now in `python/ribasim/ribasim/__init__.py` add
 In `python/ribasim/ribasim/model.py`, add
 
 - `from ribasim.new_node_type import NewNodeType`;
-- `(NewNodetype, "new_node_type")` in the `_NODES` list;
+- `(NewNodetype, "new_node_type")` in the `NODES` list;
 - new_node_type as a parameter and in the docstring of the `Model` class.
 
-In `python/ribasim/ribasim/node.py` add a shape specifier in the `_MARKERS` dictionary
-to specify the shape of a node when calling `ribasim.model.plot`.
+In `python/ribasim/ribasim/node.py` add a color and shape description in the `MARKERS` and `COLORS` dictionaries.
 
 # QGIS plugin
 
 The script `qgis/core/nodes.py` has to be updated to specify how the new node type is displayed by the QGIS plugin. Specifically:
 
 - Add `"NewNodeType: NewNodeType",` to the `"map"` dictionary in `Node.set_editor_widget`;
-- Add a color and shape description in the `markers` dictionary in `Node.renderer`;
+- Add a color and shape description in the `MARKERS` dictionary in `Node.renderer`,
+  consistent with the entries added above;
 - Add an input class per schema, e.g.
 
 ```python

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -201,7 +201,7 @@ class Model(BaseModel):
 
         return Model(**kwargs)
 
-    def plot(self, ax=None) -> Any:
+    def plot(self, ax=None, legend=False) -> Any:
         """
         Plot the nodes and edges of the model.
 
@@ -209,6 +209,9 @@ class Model(BaseModel):
         ----------
         ax : matplotlib.pyplot.Artist, optional
             Axes on which to draw the plot.
+
+        legend: bool, optional
+            Whether a node legend will be shown
 
         Returns
         -------
@@ -218,7 +221,7 @@ class Model(BaseModel):
             _, ax = plt.subplots()
             ax.axis("off")
         self.edge.plot(ax=ax, zorder=2)
-        self.node.plot(ax=ax, zorder=3)
+        self.node.plot(ax=ax, zorder=3, legend=legend)
         return ax
 
     def sort(self):

--- a/python/ribasim/ribasim/node.py
+++ b/python/ribasim/ribasim/node.py
@@ -106,7 +106,7 @@ class Node(InputMixin, BaseModel):
         handles = []
         legend_labels = []
 
-        markers = {
+        MARKERS = {
             "Basin": "o",
             "FractionalFlow": "^",
             "LevelControl": "*",
@@ -119,7 +119,7 @@ class Node(InputMixin, BaseModel):
             "": "o",
         }
 
-        colors = {
+        COLORS = {
             "Basin": "b",
             "FractionalFlow": "r",
             "LevelControl": "b",
@@ -133,8 +133,8 @@ class Node(InputMixin, BaseModel):
         }
 
         for nodetype, df in self.static.groupby("type"):
-            marker = markers[nodetype]
-            color = colors[nodetype]
+            marker = MARKERS[nodetype]
+            color = COLORS[nodetype]
             kwargs["marker"] = marker
             kwargs["color"] = color
             df.plot(**kwargs)

--- a/python/ribasim/ribasim/node.py
+++ b/python/ribasim/ribasim/node.py
@@ -29,7 +29,7 @@ _MARKERS = {
     "": "o",
 }
 
-_COlORS = {
+_COLORS = {
     "Basin": "b",
     "FractionalFlow": "r",
     "LevelControl": "b",
@@ -134,7 +134,7 @@ class Node(InputMixin, BaseModel):
 
         for nodetype, df in self.static.groupby("type"):
             marker = _MARKERS[nodetype]
-            color = _COlORS[nodetype]
+            color = _COLORS[nodetype]
             kwargs["marker"] = marker
             kwargs["color"] = color
             df.plot(**kwargs)

--- a/python/ribasim/ribasim/node.py
+++ b/python/ribasim/ribasim/node.py
@@ -16,32 +16,6 @@ T = TypeVar("T")
 
 __all__ = ("Node",)
 
-_MARKERS = {
-    "Basin": "o",
-    "FractionalFlow": "^",
-    "LevelControl": "*",
-    "LevelBoundary": "o",
-    "LinearResistance": "^",
-    "ManningResistance": "D",
-    "TabulatedRatingCurve": "D",
-    "Pump": "h",
-    "Terminal": "s",
-    "": "o",
-}
-
-_COLORS = {
-    "Basin": "b",
-    "FractionalFlow": "r",
-    "LevelControl": "b",
-    "LevelBoundary": "g",
-    "LinearResistance": "g",
-    "ManningResistance": "r",
-    "TabulatedRatingCurve": "g",
-    "Pump": "0.5",  # grayscale level
-    "Terminal": "m",
-    "": "k",
-}
-
 
 class StaticSchema(pa.SchemaModel):
     type: Series[str]
@@ -132,9 +106,35 @@ class Node(InputMixin, BaseModel):
         handles = []
         legend_labels = []
 
+        markers = {
+            "Basin": "o",
+            "FractionalFlow": "^",
+            "LevelControl": "*",
+            "LevelBoundary": "o",
+            "LinearResistance": "^",
+            "ManningResistance": "D",
+            "TabulatedRatingCurve": "D",
+            "Pump": "h",
+            "Terminal": "s",
+            "": "o",
+        }
+
+        colors = {
+            "Basin": "b",
+            "FractionalFlow": "r",
+            "LevelControl": "b",
+            "LevelBoundary": "g",
+            "LinearResistance": "g",
+            "ManningResistance": "r",
+            "TabulatedRatingCurve": "g",
+            "Pump": "0.5",  # grayscale level
+            "Terminal": "m",
+            "": "k",
+        }
+
         for nodetype, df in self.static.groupby("type"):
-            marker = _MARKERS[nodetype]
-            color = _COLORS[nodetype]
+            marker = markers[nodetype]
+            color = colors[nodetype]
             kwargs["marker"] = marker
             kwargs["color"] = color
             df.plot(**kwargs)

--- a/python/ribasim/ribasim/node.py
+++ b/python/ribasim/ribasim/node.py
@@ -25,7 +25,21 @@ _MARKERS = {
     "ManningResistance": "D",
     "TabulatedRatingCurve": "D",
     "Pump": "h",
+    "Terminal": "s",
     "": "o",
+}
+
+_COlORS = {
+    "Basin": "b",
+    "FractionalFlow": "r",
+    "LevelControl": "b",
+    "LevelBoundary": "g",
+    "LinearResistance": "g",
+    "ManningResistance": "r",
+    "TabulatedRatingCurve": "g",
+    "Pump": "0.5",  # grayscale level
+    "Terminal": "m",
+    "": "k",
 }
 
 
@@ -115,10 +129,24 @@ class Node(InputMixin, BaseModel):
             ax.axis("off")
             kwargs["ax"] = ax
 
+        handles = []
+        legend_labels = []
+
         for nodetype, df in self.static.groupby("type"):
             marker = _MARKERS[nodetype]
+            color = _COlORS[nodetype]
             kwargs["marker"] = marker
+            kwargs["color"] = color
             df.plot(**kwargs)
+
+            if kwargs["legend"]:
+                handles.append(
+                    ax.scatter([], [], label=nodetype, marker=marker, color=color)
+                )
+                legend_labels.append(nodetype)
+
+        if kwargs["legend"]:
+            ax.legend(handles, legend_labels, bbox_to_anchor=(1.2, 1))
 
         geometry = self.static["geometry"]
         for text, xy in zip(

--- a/qgis/core/nodes.py
+++ b/qgis/core/nodes.py
@@ -162,7 +162,7 @@ class Node(Input):
     @property
     def renderer(self) -> QgsCategorizedSymbolRenderer:
         shape = QgsSimpleMarkerSymbolLayerBase
-        markers = {
+        MARKERS = {
             "Basin": (QColor("blue"), "Basin", shape.Circle),
             "FractionalFlow": (QColor("red"), "FractionalFlow", shape.Triangle),
             "LinearResistance": (
@@ -187,7 +187,7 @@ class Node(Input):
         }
 
         categories = []
-        for value, (colour, label, shape) in markers.items():
+        for value, (colour, label, shape) in MARKERS.items():
             symbol = QgsMarkerSymbol()
             symbol.symbolLayer(0).setShape(shape)
             symbol.setColor(QColor(colour))

--- a/qgis/core/nodes.py
+++ b/qgis/core/nodes.py
@@ -178,6 +178,7 @@ class Node(Input):
             "LevelBoundary": (QColor("green"), "LevelBoundary", shape.Circle),
             "LevelControl": (QColor("blue"), "LevelControl", shape.Star),
             "Pump": (QColor("gray"), "Pump", shape.Hexagon),
+            "ManningResistance": (QColor("red"), "ManningResistance", shape.Diamond),
             "": (
                 QColor("white"),
                 "",


### PR DESCRIPTION
I made sure that the node representation in the ribasim python graph plot and the QGIS plugin are consistent (in terms of marker and color) and added an option for a legend in the ribasim python plot:

![ribasim_python_graph](https://github.com/Deltares/Ribasim/assets/74617371/a4f0c577-abac-4039-bc23-7206fc5b4d73)
