### PR TITLE
CI: Fix setting of Python version

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -32,7 +32,6 @@ jobs:
       - name: Setup Micromamba
         uses: mamba-org/provision-with-micromamba@main
         with:
-          python_version: "3.11"
           cache-downloads: true
           cache-env: true
           environment-file: ./environment.yml

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Micromamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/provision-with-micromamba@v15
         with:
           cache-downloads: true
           cache-env: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   publish:
-    name: Docs Julia ${{ matrix.julia_version }} - Python ${{ matrix.python_version }}  - ${{ matrix.arch }}
+    name: Docs Julia ${{ matrix.julia_version }} - ${{ matrix.arch }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -20,8 +20,6 @@ jobs:
       matrix:
         julia_version:
           - "1.9"
-        python_version:
-          - "3.11"
         arch:
           - x64
     steps:
@@ -49,7 +47,6 @@ jobs:
       - name: Setup Micromamba
         uses: mamba-org/provision-with-micromamba@main
         with:
-          python_version: ${{ matrix.python_version }}
           cache-downloads: true
           cache-env: true
           environment-file: ./environment.yml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-test-
 
       - name: Setup Micromamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/provision-with-micromamba@v15
         with:
           cache-downloads: true
           cache-env: true

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -11,46 +11,30 @@ concurrency:
   cancel-in-progress: true
 jobs:
   black:
-    name: Black Python ${{ matrix.python_version }} - ${{ matrix.os }} - ${{ matrix.arch }}
-    runs-on: ${{ matrix.os }}
+    name: Black
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
-        python_version:
-          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Micromamba
         uses: mamba-org/provision-with-micromamba@main
         with:
-          python_version: ${{ matrix.python_version }}
           cache-downloads: true
           cache-env: true
           environment-file: ./environment.yml
+
       - name: Run black
         run: |
           black --check python
 
   ruff:
-    name: Ruff Python ${{ matrix.python_version }} - ${{ matrix.os }} - ${{ matrix.arch }}
-    runs-on: ${{ matrix.os }}
+    name: Ruff
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash -l {0}
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
-        python_version:
-          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Micromamba
@@ -66,20 +50,12 @@ jobs:
 
 
   mypy:
-    name: Mypy Python ${{ matrix.python_version }} - ${{ matrix.os }} - ${{ matrix.arch }}
-    runs-on: ${{ matrix.os }}
+    name: Mypy
+    runs-on: ubuntu-latest
+    continue-on-error: true
     defaults:
       run:
         shell: bash -l {0}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
-        python_version:
-          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - name: Setup Micromamba

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Micromamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/provision-with-micromamba@v15
         with:
           cache-downloads: true
           cache-env: true
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Micromamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/provision-with-micromamba@v15
         with:
           python_version: ${{ matrix.python_version }}
           cache-downloads: true
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Micromamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/provision-with-micromamba@v15
         with:
           python_version: ${{ matrix.python_version }}
           cache-downloads: true

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup Micromamba
-        uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/provision-with-micromamba@v15
         with:
           cache-downloads: true
           cache-env: true

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   test:
-    name: Ribasim Python ${{ matrix.python_version }} - ${{ matrix.os }}
+    name: Ribasim Python ${{ matrix.python_version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -27,6 +27,8 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+        arch:
+          - x86
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   test:
-    name: Ribasim Python ${{ matrix.python_version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: Ribasim Python ${{ matrix.python_version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -27,18 +27,17 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-        arch:
-          - x64
     steps:
       - uses: actions/checkout@v3
 
       - name: Setup Micromamba
         uses: mamba-org/provision-with-micromamba@main
         with:
-          python_version: ${{ matrix.python_version }}
           cache-downloads: true
           cache-env: true
           environment-file: ./environment.yml
+          extra-specs: |
+            python=${{ matrix.python_version }}
 
       - name: Install ribasim
         run: pip install --editable python/ribasim

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   test:
-    name: Ribasim Python ${{ matrix.python_version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    name: Python ${{ matrix.python_version }} - ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - pydantic
   - pyogrio
   - pytest
-  - python>3.9
+  - python>=3.9
   - ruff
   - shapely>=2.0
   - tomli

--- a/python/ribasim_testmodels/pyproject.toml
+++ b/python/ribasim_testmodels/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Hydrology",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 dependencies = ["ribasim", "geopandas", "numpy", "pandas"]
 dynamic = ["version"]
 


### PR DESCRIPTION
Unfortunately, the mamba action only reports a warning when using invalid parameters.
So setting the Python version never worked.