### PR TITLE
Allow missing nodetypes in python model validation

### DIFF
--- a/python/ribasim/tests/test_model.py
+++ b/python/ribasim/tests/test_model.py
@@ -17,7 +17,10 @@ def test_invalid_node_type(basic):
         {"type": "InvalidNodeType", "geometry": Point(0, 0)}, ignore_index=True
     )
 
-    with pytest.raises(TypeError, match="InvalidNodeType is not a valid node type.+"):
+    with pytest.raises(
+        TypeError,
+        match=re.escape("Invalid node types detected: [InvalidNodeType].") + ".+",
+    ):
         model.validate_model_node_types()
 
 

--- a/python/ribasim_testmodels/ribasim_testmodels/basic.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/basic.py
@@ -346,7 +346,7 @@ def tabulated_rating_curve_model() -> ribasim.Model:
     rating_curve = ribasim.TabulatedRatingCurve(
         static=pd.DataFrame(
             data={
-                "node_id": [2, 2],
+                "node_id": [2, 3],
                 "level": [0.0, 1.0],
                 "discharge": [0.0, q1000],
             }


### PR DESCRIPTION
Also some better error messages in the model validation (i.e. identify all of the same problems in stead of raising an exception at the first).