### PR TITLE
minor formatting + cleanup

### DIFF
--- a/core/src/io.jl
+++ b/core/src/io.jl
@@ -110,8 +110,10 @@ function output_path(config::Config, path::String)
     return normpath(config.relative_dir, config.output_dir, path)
 end
 
-parsefile(config_path::AbstractString) =
-    from_toml(Config, config_path; relative_dir = dirname(normpath(config_path)))
+"Parse a TOML file to a Config"
+function parsefile(config_path::AbstractString)::Config
+    return from_toml(Config, config_path; relative_dir = dirname(normpath(config_path)))
+end
 
 function write_basin_output(model::Model)
     (; config, integrator) = model

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -12,9 +12,13 @@ struct Connectivity
     graph::DiGraph{Int}
     flow::SparseMatrixCSC{Float64, Int}
     edge_ids::Dictionary{Tuple{Int, Int}, Int}
-    Connectivity(graph, flow, edge_ids) =
-        is_valid(graph, flow, edge_ids) ? new(graph, flow, edge_ids) :
-        error("Invalid graph")
+    function Connectivity(graph, flow, edge_ids)
+        if is_valid(graph, flow, edge_ids)
+            new(graph, flow, edge_ids)
+        else
+            error("Invalid graph")
+        end
+    end
 end
 
 # TODO Add actual validation

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -17,8 +17,6 @@
 @schema "ribasim.tabulatedratingcurve.time" TabulatedRatingCurveTime
 
 const delimiter = " / "
-schemaversion(node::Symbol, kind::Symbol, v = 1) =
-    SchemaVersion{Symbol(join((:ribasim, node, kind), ".")), v}
 tablename(sv::Type{SchemaVersion{T, N}}) where {T, N} = join(nodetype(sv), delimiter)
 tablename(sv::SchemaVersion{T, N}) where {T, N} = join(nodetype(sv), delimiter)
 isnode(sv::Type{SchemaVersion{T, N}}) where {T, N} = length(split(string(T), ".")) == 3
@@ -152,10 +150,14 @@ sort_by_id_storage(row) = (row.node_id, row.storage)
 
 # get the right sort by function given the Schema, with sort_by_id as the default
 sort_by_function(table::StructVector{<:Legolas.AbstractRecord}) = sort_by_id
-sort_by_function(table::StructVector{<:Union{TabulatedRatingCurveTimeV1, BasinForcingV1}}) =
-    sort_by_time_id
 sort_by_function(table::StructVector{TabulatedRatingCurveStaticV1}) = sort_by_id_level
 sort_by_function(table::StructVector{BasinProfileV1}) = sort_by_id_storage
+
+const TimeSchemas = Union{TabulatedRatingCurveTimeV1, BasinForcingV1}
+
+function sort_by_function(table::StructVector{<:TimeSchemas})
+    return sort_by_time_id
+end
 
 """
 Depending on if a table can be sorted, either sort it or assert that it is sorted.

--- a/core/test/runtests.jl
+++ b/core/test/runtests.jl
@@ -4,32 +4,12 @@ using Test: @testset
 using SafeTestsets: @safetestset
 
 @testset "Ribasim" begin
-    @safetestset "Input/Output" begin
-        include("io.jl")
-    end
-    @safetestset "Configuration" begin
-        include("config.jl")
-    end
-
-    @safetestset "Equations" begin
-        include("equations.jl")
-    end
-
-    @safetestset "Basin" begin
-        include("basin.jl")
-    end
-
-    @safetestset "Basic Model Interface" begin
-        include("bmi.jl")
-    end
-
-    @safetestset "Command Line Interface" begin
-        include("cli.jl")
-    end
-
-    @safetestset "Utility functions" begin
-        include("utils.jl")
-    end
-
+    @safetestset "Input/Output" include("io.jl")
+    @safetestset "Configuration" include("config.jl")
+    @safetestset "Equations" include("equations.jl")
+    @safetestset "Basin" include("basin.jl")
+    @safetestset "Basic Model Interface" include("bmi.jl")
+    @safetestset "Command Line Interface" include("cli.jl")
+    @safetestset "Utility functions" include("utils.jl")
     Aqua.test_all(Ribasim; ambiguities = false)
 end


### PR DESCRIPTION
- `schemaversion` was not used anywhere
- `safetestset` now supports brief syntax
- some formatting, moving function definitions to long form if they don't fit on a line
