### PR TITLE
Validate nodetypes in graph.

### DIFF
--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -9,7 +9,7 @@ using DataInterpolations: LinearInterpolation
 using DataStructures: DefaultDict
 using Dates
 using DBInterface: execute, prepare
-using Dictionaries: Indices, Dictionary, gettoken, gettokenvalue
+using Dictionaries: Indices, Dictionary, gettoken, gettokenvalue, dictionary
 using DiffEqCallbacks
 using Graphs: DiGraph, add_edge!, adjacency_matrix, inneighbors, outneighbors
 using Legolas: Legolas, @schema, @version, validate, SchemaVersion, declared

--- a/core/src/create.jl
+++ b/core/src/create.jl
@@ -1,10 +1,10 @@
 function Connectivity(db::DB)::Connectivity
-    graph, edge_ids = create_graph(db)
+    graph, edge_ids, edge_types = create_graph(db)
 
     flow = adjacency_matrix(graph, Float64)
     nonzeros(flow) .= 0.0
 
-    return Connectivity(graph, flow, edge_ids)
+    return Connectivity(graph, flow, edge_ids, edge_types)
 end
 
 function LinearResistance(db::DB, config::Config)::LinearResistance

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -17,7 +17,7 @@ struct Connectivity
         if is_valid(graph, flow, edge_ids, edge_types)
             new(graph, flow, edge_ids, edge_types)
         else
-            error("Invalid graph")
+            error("Invalid network")
         end
     end
 end

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -35,7 +35,7 @@ function is_valid(
             a, b = rev_edge_ids[edge_id]
             push!(
                 errors,
-                "Edge #$edge_id from $from_type (#$a) to $to_type (#$b) is not allowed.",
+                "Cannot connect a $from_type to a $to_type (edge #$edge_id from node #$a to #$b).",
             )
         end
     end

--- a/core/src/utils.jl
+++ b/core/src/utils.jl
@@ -3,7 +3,7 @@ function create_graph(
     db::DB,
 )::Tuple{DiGraph, Dictionary{Tuple{Int, Int}, Int}, Dictionary{Int, Tuple{Symbol, Symbol}}}
     noderows = execute(db, "select fid, type from Node")
-    nodes = dictionary((fid => Symbol(lowercase(type)) for (; fid, type) in noderows))
+    nodes = dictionary((fid => Symbol(type) for (; fid, type) in noderows))
     graph = DiGraph(length(nodes))
     edgerows = execute(db, "select fid, from_node_id, to_node_id from Edge")
     edge_ids = Dictionary{Tuple{Int, Int}, Int}()

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -23,6 +23,28 @@ isnode(sv::Type{SchemaVersion{T, N}}) where {T, N} = length(split(string(T), "."
 nodetype(sv::Type{SchemaVersion{T, N}}) where {T, N} = Symbol.(split(string(T), ".")[2:3])
 nodetype(sv::SchemaVersion{T, N}) where {T, N} = Symbol.(split(string(T), ".")[2:3])
 
+# Allowed types for downstream (to_node_id) nodes given the type of the upstream (from_node_id) node
+neighbortypes(nodetype::Symbol) = neighbortypes(Val(nodetype))
+neighbortypes(::Val{:pump}) = Set((:basin,))
+neighbortypes(::Val{:basin}) = Set((
+    :linearresistance,
+    :tabulatedratingcurve,
+    :manningresistance,
+    :pump,
+    :terminal,
+    :levelboundary,
+    :linearlevelconnection,
+))
+neighbortypes(::Val{:terminal}) = Set{Symbol}() # only endnode
+neighbortypes(::Val{:fractionalflow}) = Set((:basin, :terminal))
+neighbortypes(::Val{:flowboundary}) = Set((:basin,))
+neighbortypes(::Val{:levelboundary}) = Set((:linearresistance,))
+neighbortypes(::Val{:linearresistance}) = Set((:basin, :levelboundary))
+neighbortypes(::Val{:manningresistance}) = Set((:basin,))
+neighbortypes(::Val{:tabulatedratingcurve}) = Set((:basin, :fractionalflow))
+neighbortypes(::Val{:linearlevelconnection}) = Set((:basin,))
+neighbortypes(::Any) = Set{Symbol}()
+
 # TODO NodeV1 and EdgeV1 are not yet used
 @version NodeV1 begin
     fid::Int

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -25,24 +25,22 @@ nodetype(sv::SchemaVersion{T, N}) where {T, N} = Symbol.(split(string(T), ".")[2
 
 # Allowed types for downstream (to_node_id) nodes given the type of the upstream (from_node_id) node
 neighbortypes(nodetype::Symbol) = neighbortypes(Val(nodetype))
-neighbortypes(::Val{:pump}) = Set((:basin,))
-neighbortypes(::Val{:basin}) = Set((
-    :linearresistance,
-    :tabulatedratingcurve,
-    :manningresistance,
-    :pump,
-    :terminal,
-    :levelboundary,
-    :linearlevelconnection,
+neighbortypes(::Val{:Pump}) = Set((:Basin,))
+neighbortypes(::Val{:Basin}) = Set((
+    :LinearResistance,
+    :TabulatedRatingCurve,
+    :ManningResistance,
+    :Pump,
+    :Terminal,
+    :LevelBoundary,
 ))
-neighbortypes(::Val{:terminal}) = Set{Symbol}() # only endnode
-neighbortypes(::Val{:fractionalflow}) = Set((:basin, :terminal))
-neighbortypes(::Val{:flowboundary}) = Set((:basin,))
-neighbortypes(::Val{:levelboundary}) = Set((:linearresistance,))
-neighbortypes(::Val{:linearresistance}) = Set((:basin, :levelboundary))
-neighbortypes(::Val{:manningresistance}) = Set((:basin,))
-neighbortypes(::Val{:tabulatedratingcurve}) = Set((:basin, :fractionalflow))
-neighbortypes(::Val{:linearlevelconnection}) = Set((:basin,))
+neighbortypes(::Val{:Terminal}) = Set{Symbol}() # only endnode
+neighbortypes(::Val{:FractionalFlow}) = Set((:Basin, :Terminal))
+neighbortypes(::Val{:FlowBoundary}) = Set((:Basin,))
+neighbortypes(::Val{:LevelBoundary}) = Set((:LinearResistance,))
+neighbortypes(::Val{:LinearResistance}) = Set((:Basin, :LevelBoundary))
+neighbortypes(::Val{:ManningResistance}) = Set((:Basin,))
+neighbortypes(::Val{:TabulatedRatingCurve}) = Set((:Basin, :FractionalFlow))
 neighbortypes(::Any) = Set{Symbol}()
 
 # TODO NodeV1 and EdgeV1 are not yet used

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -25,22 +25,21 @@ nodetype(sv::SchemaVersion{T, N}) where {T, N} = Symbol.(split(string(T), ".")[2
 
 # Allowed types for downstream (to_node_id) nodes given the type of the upstream (from_node_id) node
 neighbortypes(nodetype::Symbol) = neighbortypes(Val(nodetype))
-neighbortypes(::Val{:Pump}) = Set((:Basin,))
+neighbortypes(::Val{:Pump}) = Set((:Basin, :FractionalFlow, :Terminal))
 neighbortypes(::Val{:Basin}) = Set((
     :LinearResistance,
     :TabulatedRatingCurve,
     :ManningResistance,
     :Pump,
-    :Terminal,
-    :LevelBoundary,
+    :FlowBoundary,
 ))
 neighbortypes(::Val{:Terminal}) = Set{Symbol}() # only endnode
-neighbortypes(::Val{:FractionalFlow}) = Set((:Basin, :Terminal))
-neighbortypes(::Val{:FlowBoundary}) = Set((:Basin,))
-neighbortypes(::Val{:LevelBoundary}) = Set((:LinearResistance,))
+neighbortypes(::Val{:FractionalFlow}) = Set((:Basin, :FractionalFlow, :Terminal))
+neighbortypes(::Val{:FlowBoundary}) = Set((:Basin, :FractionalFlow, :Terminal))
+neighbortypes(::Val{:LevelBoundary}) = Set((:LinearResistance, :ManningResistance))
 neighbortypes(::Val{:LinearResistance}) = Set((:Basin, :LevelBoundary))
-neighbortypes(::Val{:ManningResistance}) = Set((:Basin,))
-neighbortypes(::Val{:TabulatedRatingCurve}) = Set((:Basin, :FractionalFlow))
+neighbortypes(::Val{:ManningResistance}) = Set((:Basin, :LevelBoundary))
+neighbortypes(::Val{:TabulatedRatingCurve}) = Set((:Basin, :FractionalFlow, :Terminal))
 neighbortypes(::Any) = Set{Symbol}()
 
 # TODO NodeV1 and EdgeV1 are not yet used

--- a/docs/contribute/addnode.qmd
+++ b/docs/contribute/addnode.qmd
@@ -39,6 +39,13 @@ Here `Static` refers to data that does not change over time. For naming conventi
 
 `validation.jl` also deals with checking and applying a specific sorting order for the tabular data (default is sorting by node ID only), see `sort_by_function` and `sorted_table!`.
 
+For validation it is also required to describe which are allowed downstream connections, for both your new newnodetype, as existing nodetypes:
+
+```julia
+neighbortypes(::Val{:NewNodeType}) = Set((:Basin,))  # set allowed downstream types
+neighbortypes(::Val{:Pump}) = Set((:Basin, :NewNodeType))  # add your newnodetype as acceptable downstream connection of other types
+```
+
 Now we define the function that is called in the second bullet above, in `create.jl`:
 
 ```julia

--- a/docs/core/equations.qmd
+++ b/docs/core/equations.qmd
@@ -146,7 +146,7 @@ basins (external nodes) in a network.
 
 The OutflowTable is a tabulation of a basin's discharge behavior. It describes
 a piecewise linear relationship between the basin's storage volume and its
-discharge. It can be understood as an emprical description of a basin's
+discharge. It can be understood as an empirical description of a basin's
 properties. This can include a weir, but also the lumped hydraulic behavior of the
 upstream channels.
 


### PR DESCRIPTION
Solves issue #200 

# Description
To determine valid connections between nodetypes on an edge in the graph, one defines:

```julia
# Allowed types for downstream (to_node_id) nodes given the type of the upstream (from_node_id) node
neighbortypes(::Val{:Pump}) = Set((:Basin,))
```