### PR TITLE
add ManningResistance to QGIS node type dropdown

### DIFF
--- a/qgis/core/nodes.py
+++ b/qgis/core/nodes.py
@@ -147,6 +147,7 @@ class Node(Input):
                     "LevelBoundary": "LevelBoundary",
                     "FlowBoundary": "FlowBoundary",
                     "LinearResistance": "LinearResistance",
+                    "ManningResistance": "ManningResistance",
                     "Pump": "Pump",
                     "Terminal": "Terminal",
                     "Control": "Control",


### PR DESCRIPTION
This one was missing:

![image](https://github.com/Deltares/Ribasim/assets/4471859/0a830796-eebb-4ff9-b039-0cb307e9ee99)

All others are there, and I verified that this step is listed in the dev docs on adding node types.