### PR TITLE
More accurate interpolation

### DIFF
--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -144,7 +144,8 @@ function get_value(p::Parameters, node_id::Int, variable::String, u)
         # NOTE: Getting the level with get_level does NOT work since water_balance!
         # is not called during rootfinding for callback
         hasindex, basin_idx = id_index(basin.node_id, node_id)
-        value = basin.level[basin_idx](u[basin_idx])
+        _, level = get_area_and_level(basin, basin_idx, u[basin_idx])
+        value = level
     else
         throw(ValueError("Unsupported condition variable $variable."))
     end

--- a/core/src/create.jl
+++ b/core/src/create.jl
@@ -110,7 +110,7 @@ function Basin(db::DB, config::Config)::Basin
     infiltration = fill(NaN, length(node_id))
     table = (; precipitation, potential_evaporation, drainage, infiltration)
 
-    area, level = create_storage_tables(db, config)
+    area, level, storage = create_storage_tables(db, config)
 
     # both static and forcing are optional, but we need fallback defaults
     static = load_structvector(db, config, BasinStaticV1)
@@ -129,6 +129,7 @@ function Basin(db::DB, config::Config)::Basin
         current_level,
         area,
         level,
+        storage,
         time,
     )
 end

--- a/core/src/io.jl
+++ b/core/src/io.jl
@@ -131,7 +131,8 @@ function write_basin_output(model::Model)
     storage = reshape(vec(sol), nbasin, ntsteps)
     level = zero(storage)
     for (i, basin_storage) in enumerate(eachrow(storage))
-        level[i, :] = p.basin.level[i].(basin_storage)
+        level[i, :] =
+            [get_area_and_level(p.basin, i, storage)[2] for storage in basin_storage]
     end
 
     basin = (; time, node_id, storage = vec(storage), level = vec(level))

--- a/core/src/utils.jl
+++ b/core/src/utils.jl
@@ -76,12 +76,14 @@ function get_area_and_level(
     # storage_idx: smallest index such that storage_discrete[storage_idx] >= storage
     storage_idx = searchsortedfirst(storage_discrete, storage)
 
-    if storage_idx == 1 # If the lowest discrete_storage level 0, this can only happen if the storage is 0 since storage is never negative
+    if storage_idx == 1
+        # This can only happen if the storage is 0
         level = level_discrete[1]
         area = area_discrete[1]
 
     elseif storage_idx == length(storage_discrete) + 1
-        # These values yield linear extrapolation of area(level) based on the last 2 values
+        # With a storage above the profile, use a linear extrapolation of area(level)
+        # based on the last 2 values.
         area_lower = area_discrete[end - 1]
         area_higher = area_discrete[end]
         level_lower = level_discrete[end - 1]
@@ -95,9 +97,8 @@ function get_area_and_level(
         if area_diff ≈ 0
             # Constant area means linear interpolation of level
             area = area_lower
-
             level =
-                area_higher +
+                level_higher +
                 level_diff * (storage - storage_higher) / (storage_higher - storage_lower)
         else
             area = sqrt(

--- a/core/test/basin.jl
+++ b/core/test/basin.jl
@@ -17,7 +17,7 @@ end
     model = Ribasim.run(toml_path)
     @test model isa Ribasim.Model
     @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
-    @test model.integrator.sol.u[end] ≈ Float32[476.8749, 476.85898, 1.8706497, 786.96686] skip =
+    @test model.integrator.sol.u[end] ≈ Float32[452.9688, 453.0431, 1.8501105, 1238.0144] skip =
         Sys.isapple()
 end
 
@@ -28,7 +28,7 @@ end
     @test model isa Ribasim.Model
     @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
     @test length(model.integrator.p.basin.precipitation) == 4
-    @test model.integrator.sol.u[end] ≈ Float32[480.5936, 480.58762, 1.4178488, 793.6097] skip =
+    @test model.integrator.sol.u[end] ≈ Float32[428.06897, 428.07315, 1.3662858, 1249.2343] skip =
         Sys.isapple()
 end
 
@@ -39,7 +39,46 @@ end
     model = Ribasim.run(toml_path)
     @test model isa Ribasim.Model
     @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
-    @test model.integrator.sol.u[end] ≈ Float32[27.273159, 340.68964] skip = Sys.isapple()
+    @test model.integrator.sol.u[end] ≈ Float32[1.4875988, 366.4851] skip = Sys.isapple()
     # the highest level in the dynamic table is updated to 1.2 from the callback
     @test model.integrator.p.tabulated_rating_curve.tables[end].t[end] == 1.2
+end
+
+@testset "Profile" begin
+    n_interpolations = 100
+    storage = range(0.0, 1000.0, n_interpolations)
+
+    # Covers interpolation for constant and non-constant area, extrapolation for constant area
+    area_discrete = [0.0, 100.0, 100.0]
+    level_discrete = [0.0, 10.0, 15.0]
+    storage_discrete = Ribasim.profile_storage(level_discrete, area_discrete)
+
+    area, level = zip(
+        [
+            Ribasim.get_area_and_level(storage_discrete, area_discrete, level_discrete, s) for s in storage
+        ]...,
+    )
+
+    level_expected =
+        ifelse.(storage .< 500.0, sqrt.(storage ./ 5), 10.0 .+ (storage .- 500.0) ./ 100.0)
+
+    @test all(level .≈ level_expected)
+    area_expected = min.(10.0 * level_expected, 100.0)
+    @test all(area .≈ area_expected)
+
+    # Covers extrapolation for non-constant area
+    area_discrete = [0.0, 100.0]
+    level_discrete = [0.0, 10.0]
+    storage_discrete = Ribasim.profile_storage(level_discrete, area_discrete)
+
+    area, level = zip(
+        [
+            Ribasim.get_area_and_level(storage_discrete, area_discrete, level_discrete, s) for s in storage
+        ]...,
+    )
+
+    level_expected = sqrt.(storage ./ 5)
+    @test all(level .≈ level_expected)
+    area_expected = 10.0 * level_expected
+    @test all(area .≈ area_expected)
 end

--- a/core/test/control.jl
+++ b/core/test/control.jl
@@ -1,6 +1,6 @@
 import Ribasim
 
-toml_path = normpath(@__DIR__, "../../data/pump_control/control.toml")
+toml_path = normpath(@__DIR__, "../../data/pump_control/pump_control.toml")
 
 @testset "pump control" begin
     @test ispath(toml_path)

--- a/core/test/utils.jl
+++ b/core/test/utils.jl
@@ -18,6 +18,10 @@ end
 end
 
 @testset "bottom" begin
+    # create two basins with different bottoms/levels
+    area = [[0.0, 1.0], [0.0, 1.0]]
+    level = [[0.0, 1.0], [4.0, 5.0]]
+    storage = Ribasim.profile_storage.(level, area)
     basin = Ribasim.Basin(
         Indices([5, 7]),
         [2.0, 3.0],
@@ -25,18 +29,13 @@ end
         [2.0, 3.0],
         [2.0, 3.0],
         [2.0, 3.0],
-        [   # area
-            LinearInterpolation([1.0, 1.0], [0.0, 1.0]),
-            LinearInterpolation([1.0, 1.0], [0.0, 1.0]),
-        ],
-        [   # level
-            LinearInterpolation([0.0, 1.0], [0.0, 1.0]),
-            LinearInterpolation([4.0, 3.0], [0.0, 1.0]),
-        ],
+        area,
+        level,
+        storage,
         StructVector{Ribasim.BasinForcingV1}(undef, 0),
     )
 
-    @test Ribasim.basin_bottom_index(basin, 2) === 4.0
+    @test basin.level[2][1] === 4.0
     @test Ribasim.basin_bottom(basin, 5) === 0.0
     @test Ribasim.basin_bottom(basin, 7) === 4.0
     @test Ribasim.basin_bottom(basin, 6) === nothing

--- a/python/ribasim_testmodels/ribasim_testmodels/control.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/control.py
@@ -129,7 +129,7 @@ def pump_control_model() -> ribasim.Model:
 
     # Setup a model:
     model = ribasim.Model(
-        modelname="control",
+        modelname="pump_control",
         node=node,
         edge=edge,
         basin=basin,


### PR DESCRIPTION
I have implemented the physical interpolation (as proposed in https://github.com/Deltares/Ribasim/issues/225). I have not checked whether this implementation is exactly what we want for extrapolation (https://github.com/Deltares/Ribasim/issues/279), but this implementation assumes that the storage is 0 at the lowest level and does linear extrapolation of the area as a function of the level based on the last 2 values.

This does not solve the problem of high oscillating flows produced by the ManningResistance node as hoped (https://github.com/Deltares/Ribasim/issues/80). I think the problem there is that the calculated flows are way to large, and therefore the equilibrium is overshooted at every time step.

I cannot wrap my head around the current ManningResistance implementation. I understand that flow occurs due to a difference in level, but I do not understand why that means that all the water comes in motion, not just the bit at the top (which is why I find LinearResistance more intuitive). Is anyone familiar with a ManningResistance being used for flow that can go both directions, or is it only used for flow that goes one direction due to gravity? In that last case I understand better why all water is in motion.

Also, the current implementation assumes the presence of a lot of water in the channel itself, which fluctuates with the level in the upstream basin with no regard for (local) water preservation (by which I do not mean that the ManningResistance node is not preserving but it is less physical).