### PR TITLE
move config from qmd to separate toml

### DIFF
--- a/core/test/config.jl
+++ b/core/test/config.jl
@@ -5,12 +5,6 @@ using Configurations: UndefKeywordError
 using OrdinaryDiffEq: alg_autodiff, AutoFiniteDiff, AutoForwardDiff
 
 @testset "config" begin
-    config = Ribasim.parsefile(normpath(@__DIR__, "testrun.toml"))
-    @test config isa Ribasim.Config
-    @test config.update_timestep == 86400.0
-    @test config.endtime > config.starttime
-    @test config.solver == Ribasim.Solver(; saveat = 86400.0)
-
     @test_throws UndefKeywordError Ribasim.Config()
     @test_throws UndefKeywordError Ribasim.Config(
         startime = now(),
@@ -18,6 +12,18 @@ using OrdinaryDiffEq: alg_autodiff, AutoFiniteDiff, AutoForwardDiff
         geopackage = "",
         foo = "bar",
     )
+
+    @testset "testrun" begin
+        config = Ribasim.parsefile(normpath(@__DIR__, "testrun.toml"))
+        @test config isa Ribasim.Config
+        @test config.update_timestep == 86400.0
+        @test config.endtime > config.starttime
+        @test config.solver == Ribasim.Solver(; saveat = 86400.0)
+    end
+
+    @testset "docs" begin
+        Ribasim.parsefile(normpath(@__DIR__, "docs.toml"))
+    end
 end
 
 @testset "Solver" begin

--- a/core/test/docs.toml
+++ b/core/test/docs.toml
@@ -9,15 +9,16 @@ update_timestep = 86400.0  # optional, default 1 day
 # input files
 geopackage = "model.gpkg"  # required
 
+[output]
 # These output files are always written
-flow = "output/flow.arrow"    # optional, default "output/flow.arrow"
-basin = "output/basin.arrow"  # optional, default "output/basin.arrow"
-control = "output/control.arrow" # optional, default "output/control.arrow" 
+flow = "output/flow.arrow"        # optional, default "output/flow.arrow"
+basin = "output/basin.arrow"      # optional, default "output/basin.arrow"
+control = "output/control.arrow"  # optional, default "output/control.arrow"
 
 # Specific tables can also go into Arrow files rather than the GeoPackage.
 # For large tables this can benefit from better compressed file sizes.
 # This is optional, tables are retrieved from the GeoPackage if not specified in the TOML.
-[Basin]
+[basin]
 forcing = "forcing.arrow"
 
 

--- a/core/test/docs.toml
+++ b/core/test/docs.toml
@@ -1,0 +1,34 @@
+# start- and endtime of the simulation
+# can also be set to a date-time like 1979-05-27T07:32:00
+starttime = 2019-01-01  # required
+endtime = 2021-01-01    # required
+
+# all timesteps are in seconds
+update_timestep = 86400.0  # optional, default 1 day
+
+# input files
+geopackage = "model.gpkg"  # required
+
+# These output files are always written
+flow = "output/flow.arrow"    # optional, default "output/flow.arrow"
+basin = "output/basin.arrow"  # optional, default "output/basin.arrow"
+control = "output/control.arrow" # optional, default "output/control.arrow" 
+
+# Specific tables can also go into Arrow files rather than the GeoPackage.
+# For large tables this can benefit from better compressed file sizes.
+# This is optional, tables are retrieved from the GeoPackage if not specified in the TOML.
+[Basin]
+forcing = "forcing.arrow"
+
+
+[solver]
+algorithm = "QNDF"  # optional, default "QNDF"
+# autodiff can only be set to true for implicit solvers, but is not yet supported
+autodiff = false  # optional, default false
+# saveat can be a number, which is the saving interval in seconds, or
+# it can be a list of numbers, which are the times in seconds since start that are saved
+saveat = []  # optional, default [], which will save every timestep
+dt = 0.0  # optional, default 0.0
+abstol = 1e-6  # optional, default 1e-6
+reltol = 1e-3  # optional, default 1e-3
+maxiters = 1e9  # optional, default 1e9

--- a/docs/_extensions/quarto-ext/include-code-files/_extension.yml
+++ b/docs/_extensions/quarto-ext/include-code-files/_extension.yml
@@ -1,0 +1,7 @@
+title: Include Code Files
+author: Bruno Beaufils
+version: 1.0.0
+quarto-required: ">=1.2"
+contributes:
+  filters:
+    - include-code-files.lua

--- a/docs/_extensions/quarto-ext/include-code-files/include-code-files.lua
+++ b/docs/_extensions/quarto-ext/include-code-files/include-code-files.lua
@@ -1,0 +1,62 @@
+--- include-code-files.lua – filter to include code from source files
+---
+--- Copyright: © 2020 Bruno BEAUFILS
+--- License:   MIT – see LICENSE file for details
+
+--- Dedent a line
+local function dedent (line, n)
+  return line:sub(1,n):gsub(" ","") .. line:sub(n+1)
+end
+
+--- Filter function for code blocks
+local function transclude (cb)
+  if cb.attributes.include then
+    local content = ""
+    local fh = io.open(cb.attributes.include)
+    if not fh then
+      io.stderr:write("Cannot open file " .. cb.attributes.include .. " | Skipping includes\n")
+    else
+      local number = 1
+      local start = 1
+
+      -- change hyphenated attributes to PascalCase
+      for i,pascal in pairs({"startLine", "endLine"})
+      do
+         local hyphen = pascal:gsub("%u", "-%0"):lower()
+         if cb.attributes[hyphen] then
+            cb.attributes[pascal] = cb.attributes[hyphen]
+            cb.attributes[hyphen] = nil
+         end
+      end
+
+      if cb.attributes.startLine then
+        cb.attributes.startFrom = cb.attributes.startLine
+        start = tonumber(cb.attributes.startLine)
+      end
+      for line in fh:lines ("L")
+      do
+        if cb.attributes.dedent then
+          line = dedent(line, cb.attributes.dedent)
+        end
+        if number >= start then
+          if not cb.attributes.endLine or number <= tonumber(cb.attributes.endLine) then
+            content = content .. line
+          end
+        end
+        number = number + 1
+      end
+      fh:close()
+    end
+    -- remove key-value pair for used keys
+    cb.attributes.include = nil
+    cb.attributes.startLine = nil
+    cb.attributes.endLine = nil
+    cb.attributes.dedent = nil
+    -- return final code block
+    return pandoc.CodeBlock(content, cb.attr)
+  end
+end
+
+return {
+  { CodeBlock = transclude }
+}

--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -1,5 +1,7 @@
 ---
 title: "Usage"
+filters:
+  - include-code-files
 ---
 
 Ribasim is typically used as a command-line interface (CLI). It is distributed as a `.zip`
@@ -26,41 +28,7 @@ Usage: ribasim 'path/to/config.toml'
 Ribasim has a single configuration file, which is written in the [TOML](https://toml.io/)
 format. It contains settings, as well as paths to other input and output files.
 
-```toml
-# start- and endtime of the simulation
-# can also be set to a date-time like 1979-05-27T07:32:00
-starttime = 2019-01-01  # required
-endtime = 2021-01-01    # required
-
-# all timesteps are in seconds
-update_timestep = 86400.0  # optional, default 1 day
-
-# input files
-geopackage = "model.gpkg"  # required
-
-# These output files are always written
-flow = "output/flow.arrow"    # optional, default "output/flow.arrow"
-basin = "output/basin.arrow"  # optional, default "output/basin.arrow"
-control = "output/control.arrow" # optional, default "output/control.arrow" 
-
-# Specific tables can also go into Arrow files rather than the GeoPackage.
-# For large tables this can benefit from better compressed file sizes.
-# This is optional, tables are retrieved from the GeoPackage if not specified in the TOML.
-[Basin]
-forcing = "forcing.arrow"
-
-
-[solver]
-algorithm = "QNDF"  # optional, default "QNDF"
-# autodiff can only be set to true for implicit solvers, but is not yet supported
-autodiff = false  # optional, default false
-# saveat can be a number, which is the saving interval in seconds, or
-# it can be a list of numbers, which are the times in seconds since start that are saved
-saveat = []  # optional, default [], which will save every timestep
-dt = 0.0  # optional, default 0.0
-abstol = 1e-6  # optional, default 1e-6
-reltol = 1e-3  # optional, default 1e-3
-maxiters = 1e9  # optional, default 1e9
+```{.toml include="../../core/test/docs.toml"}
 ```
 
 For more information on the solver options, see the [DifferentialEquations.jl docs](https://docs.sciml.ai/DiffEqDocs/latest/basics/common_solver_opts/#solver_options).


### PR DESCRIPTION
Fixes #304

The separate toml is included into the docs, so it looks the same as before. This way we can test this configuration to make sure it doesn't go out of date.

This checks in https://github.com/quarto-ext/include-code-files as suggested there.