### PR TITLE
render every node type in QGIS

### DIFF
--- a/qgis/core/nodes.py
+++ b/qgis/core/nodes.py
@@ -198,6 +198,7 @@ class Node(Input):
             symbol.setColor(QColor(colour))
             symbol.setSize(4)
             category = QgsRendererCategory(value, symbol, label, shape)
+            category.setRenderState(True)
             categories.append(category)
 
         renderer = QgsCategorizedSymbolRenderer(attrName="type", categories=categories)


### PR DESCRIPTION
Fixes #308

Looking into this I saw that only the square symbols don't render by default.

I guess you have to be there or be square.
