### PR TITLE
allow one-directional outflow to LevelBoundary

### DIFF
--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -36,12 +36,15 @@ neighbortypes(::Val{:Basin}) = Set((
     :FlowBoundary,
 ))
 neighbortypes(::Val{:Terminal}) = Set{Symbol}() # only endnode
-neighbortypes(::Val{:FractionalFlow}) = Set((:Basin, :FractionalFlow, :Terminal))
-neighbortypes(::Val{:FlowBoundary}) = Set((:Basin, :FractionalFlow, :Terminal))
+neighbortypes(::Val{:FractionalFlow}) =
+    Set((:Basin, :FractionalFlow, :Terminal, :LevelBoundary))
+neighbortypes(::Val{:FlowBoundary}) =
+    Set((:Basin, :FractionalFlow, :Terminal, :LevelBoundary))
 neighbortypes(::Val{:LevelBoundary}) = Set((:LinearResistance, :ManningResistance))
 neighbortypes(::Val{:LinearResistance}) = Set((:Basin, :LevelBoundary))
 neighbortypes(::Val{:ManningResistance}) = Set((:Basin, :LevelBoundary))
-neighbortypes(::Val{:TabulatedRatingCurve}) = Set((:Basin, :FractionalFlow, :Terminal))
+neighbortypes(::Val{:TabulatedRatingCurve}) =
+    Set((:Basin, :FractionalFlow, :Terminal, :LevelBoundary))
 neighbortypes(::Any) = Set{Symbol}()
 
 # TODO NodeV1 and EdgeV1 are not yet used


### PR DESCRIPTION
This came up in a model from @d2hydro (https://github.com/d2hydro/lhm-ribasim/issues/5#issuecomment-1593707186).

FractionalFlow, FlowBoundary and TabulatedRatingCurve should be able to flow out into a LevelBoundary. This is slightly odd since  in these cases the level of the level boundary does not matter, since the flow is always into the LevelBoundary as determined by the other side. So using a Terminal might make more sense there.

Still, validation shouldn't block this since you may want a single boundary node that connects to multiple node types, some directed like this, some with resistance for which you need a level.