### PR TITLE
add data tables to gpkg_contents

### DIFF
--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -101,6 +101,7 @@ class TableModel(BaseModel):
         """
         self.sort()
         directory = Path(directory)
+        sql = "INSERT INTO gpkg_contents (table_name, data_type, identifier) VALUES (?, ?, ?)"
         for field in self.fields():
             dataframe = getattr(self, field)
             if dataframe is None:
@@ -109,6 +110,7 @@ class TableModel(BaseModel):
 
             with connect(directory / f"{modelname}.gpkg") as connection:
                 dataframe.to_sql(name, connection, if_exists="replace")
+                connection.execute(sql, (name, "attributes", name))
 
         return
 

--- a/qgis/widgets/dataset_widget.py
+++ b/qgis/widgets/dataset_widget.py
@@ -191,6 +191,7 @@ class DatasetWidget(QWidget):
         fields = edge.fields()
         field1 = fields.indexFromName("from_node_id")
         field2 = fields.indexFromName("to_node_id")
+        field3 = fields.indexFromName("edge_type")
         try:
             # Avoid infinite recursion
             edge.blockSignals(True)
@@ -200,6 +201,7 @@ class DatasetWidget(QWidget):
                     # Nota bene: will fail with numpy integers, has to be Python type!
                     edge.changeAttributeValue(fid, field1, int(id1))
                     edge.changeAttributeValue(fid, field2, int(id2))
+                    edge.changeAttributeValue(fid, field3, "flow")
         finally:
             edge.blockSignals(False)
 
@@ -255,7 +257,7 @@ class DatasetWidget(QWidget):
         # Connect node and edge layer to derive connectivities.
         self.node_layer = nodes["Node"].layer
         self.edge_layer = nodes["Edge"].layer
-        self.edge_layer.afterCommitChanges.connect(self.explode_and_connect)
+        self.edge_layer.editingStopped.connect(self.explode_and_connect)
         return
 
     def new_geopackage(self) -> None:


### PR DESCRIPTION
Fixes #291

The QGIS plugin uses this metadata table to get the table names. Since switching from GDAL to SQLite for writing data tables, the data tables were not registered in gpkg_contents anymore. The GeoPackage [spec](http://www.geopackage.org/spec131/#attributes) says this needs to be done, but GDAL itself is more lenient, still showing the data tables without registering them.

So now the gpkg_contents of basic.gpkg looks like this:

<img width="734" alt="image" src="https://github.com/Deltares/Ribasim/assets/4471859/0e8bf370-4cad-4c0a-844e-3a3cb6b15ef4">

Fixes #288 

Meant to create a separate PR for this, but bd4aae4dfb9d213b38eceb333cc1fd2f7516ce51 fixes two more issues. One is that clicking save before stopping editing did not trigger the old `afterCommitChanges`, using `editingStopped` works in both cases. The other is that the new column edge_type is now also filled in automatically with "flow". There is #301 for control in QGIS. To fix that this function also needs to be updated.