### PR TITLE
ManningResistance can't connect to LevelBoundary

### DIFF
--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -40,9 +40,9 @@ neighbortypes(::Val{:FractionalFlow}) =
     Set((:Basin, :FractionalFlow, :Terminal, :LevelBoundary))
 neighbortypes(::Val{:FlowBoundary}) =
     Set((:Basin, :FractionalFlow, :Terminal, :LevelBoundary))
-neighbortypes(::Val{:LevelBoundary}) = Set((:LinearResistance, :ManningResistance))
+neighbortypes(::Val{:LevelBoundary}) = Set((:LinearResistance,))
 neighbortypes(::Val{:LinearResistance}) = Set((:Basin, :LevelBoundary))
-neighbortypes(::Val{:ManningResistance}) = Set((:Basin, :LevelBoundary))
+neighbortypes(::Val{:ManningResistance}) = Set((:Basin,))
 neighbortypes(::Val{:TabulatedRatingCurve}) =
     Set((:Basin, :FractionalFlow, :Terminal, :LevelBoundary))
 neighbortypes(::Any) = Set{Symbol}()


### PR DESCRIPTION
ManningResistance doesn't just need the level on either side, but also the botton elevation, which LevelBoundary doesn't have.

@Huite do you think we can easily support LevelBoundary? Otherwise we should merge this PR.

Came up in https://github.com/d2hydro/lhm-ribasim/issues/5#issuecomment-1595142706