### PR TITLE
Add Control tables to QGIS plugin and visualize control edge.

### DIFF
--- a/docs/contribute/addnode.qmd
+++ b/docs/contribute/addnode.qmd
@@ -148,7 +148,6 @@ In `python/ribasim/ribasim/node.py` add a color and shape description in the `MA
 
 The script `qgis/core/nodes.py` has to be updated to specify how the new node type is displayed by the QGIS plugin. Specifically:
 
-- Add `"NewNodeType: NewNodeType",` to the `"map"` dictionary in `Node.set_editor_widget`;
 - Add a color and shape description in the `MARKERS` dictionary in `Node.renderer`,
   consistent with the entries added above;
 - Add an input class per schema, e.g.
@@ -162,8 +161,6 @@ class NewNodeTypeStatic:
         # Other fields for properties of this node
     ]
 ```
-
-and add these to the NODES dictionary.
 
 
 # Tests


### PR DESCRIPTION
Fixes #301
Fixes #313 

We can't show the listen edges yet, but I would propose to fix that in a seperate issue, by changing the control topology to make use of the edge table.

Visualization of `data/pump_control/control.gpkg`
<img width="819" alt="Screenshot 2023-06-19 at 11 44 57" src="https://github.com/Deltares/Ribasim/assets/8655030/55ecf215-9ac2-4e4d-bcdb-4dcad0594d63">

