### PR TITLE
draw edges without edge_type

### DIFF
--- a/qgis/core/nodes.py
+++ b/qgis/core/nodes.py
@@ -231,6 +231,7 @@ class Edge(Input):
         MARKERS = {
             "flow": (QColor("#3690c0"), "flow"),  # lightblue
             "control": (QColor("gray"), "control"),
+            "": (QColor("black"), ""),  # All other edges, or incomplete input
         }
 
         categories = []


### PR DESCRIPTION
I noticed there was one small regression in #335. When drawing new edges, they were invisible, until you stopped editing. At that point the plugin would fill in the current default edge_type = "flow" and it would show up in blue.

With this PR the newly created edges are visible in black, until they are turned into flow edges and become blue again.
The node markers already have a similar "other / unknown / new" marker for this purpose, it makes sense to have that for edges as well.
![image](https://github.com/Deltares/Ribasim/assets/4471859/f39aa012-dba4-4cf0-8ca1-2be9e3a7a5d4)
