### PR TITLE
saveat is allowed to be a scalar float as well

### DIFF
--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -1,7 +1,7 @@
 import datetime
 import inspect
 from pathlib import Path
-from typing import Any, List, Optional, Type, cast
+from typing import Any, List, Optional, Type, Union, cast
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -33,7 +33,7 @@ from ribasim.types import FilePath
 class Solver(BaseModel):
     algorithm: Optional[str]
     autodiff: Optional[bool]
-    saveat: Optional[List[float]]
+    saveat: Optional[Union[float, List[float]]]
     dt: Optional[float]
     abstol: Optional[float]
     reltol: Optional[float]

--- a/python/ribasim/tests/test_model.py
+++ b/python/ribasim/tests/test_model.py
@@ -1,13 +1,29 @@
 import re
 
 import pytest
-from ribasim import Model
+from pydantic import ValidationError
+from ribasim import Model, Solver
 from shapely import Point
 
 
 def test_repr(basic):
     representation = repr(basic).split("\n")
     assert representation[0] == "<ribasim.Model>"
+
+
+def test_solver():
+    solver = Solver()
+    assert solver.algorithm is None
+    assert solver.saveat is None
+
+    solver = Solver(saveat=3600.0)
+    assert solver.saveat == 3600.0
+
+    solver = Solver(saveat=[3600.0, 7200.0])
+    assert solver.saveat == [3600.0, 7200.0]
+
+    with pytest.raises(ValidationError):
+        Solver(saveat="a")
 
 
 def test_invalid_node_type(basic):


### PR DESCRIPTION
Meaning an interval at which to save.

We support this option from [DifferentialEquations](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/#CommonSolve.solve-Tuple{SciMLBase.AbstractDEProblem,%20Vararg{Any}}):
> If saveat is given a number, then it will automatically expand to `tspan[1]:saveat:tspan[2]`.

This is already tested in Julia, but pydantic didn;t allow this yet. Also added tests.