### PR TITLE
don't add data tables index to GeoPackage

### DIFF
--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -109,7 +109,7 @@ class TableModel(BaseModel):
             name = self._layername(field)
 
             with connect(directory / f"{modelname}.gpkg") as connection:
-                dataframe.to_sql(name, connection, if_exists="replace")
+                dataframe.to_sql(name, connection, index=False, if_exists="replace")
                 connection.execute(sql, (name, "attributes", name))
 
         return

--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -123,9 +123,7 @@ class TableModel(BaseModel):
 
                 if exists(connection, layername):
                     query = f"select * from {esc_id(layername)}"
-                    df = pd.read_sql_query(
-                        query, connection, index_col="index", parse_dates=["time"]
-                    )
+                    df = pd.read_sql_query(query, connection, parse_dates=["time"])
                 else:
                     df = None
 


### PR DESCRIPTION
Fixes #344

Passing required columns as an index always led to validation errors, so this should be safe.