### PR TITLE
Add fixed setuptools.packages.find

### DIFF
--- a/python/ribasim/pyproject.toml
+++ b/python/ribasim/pyproject.toml
@@ -41,6 +41,9 @@ zip-safe = true
 [tool.setuptools.dynamic]
 version = { attr = "ribasim.__version__" }
 
+[tool.setuptools.packages.find]
+include = ["ribasim", "ribasim.*"]
+
 [tool.setuptools.package-data]
 "ribasim" = ["py.typed"]
 

--- a/python/ribasim_api/pyproject.toml
+++ b/python/ribasim_api/pyproject.toml
@@ -29,6 +29,9 @@ zip-safe = true
 [tool.setuptools.dynamic]
 version = { attr = "ribasim_api.__version__" }
 
+[tool.setuptools.packages.find]
+include = ["ribasim_api", "ribasim_api.*"]
+
 [tool.setuptools.package-data]
 "ribasim_api" = ["py.typed"]
 

--- a/python/ribasim_testmodels/pyproject.toml
+++ b/python/ribasim_testmodels/pyproject.toml
@@ -25,6 +25,9 @@ zip-safe = true
 [tool.setuptools.dynamic]
 version = { attr = "ribasim_testmodels.__version__" }
 
+[tool.setuptools.packages.find]
+include = ["ribasim_testmodels", "ribasim_testmodels.*"]
+
 [tool.setuptools.package-data]
 "ribasim_testmodels" = ["py.typed"]
 

--- a/python/ribasim_testmodels/pyproject.toml
+++ b/python/ribasim_testmodels/pyproject.toml
@@ -23,7 +23,7 @@ tests = ["pytest"]
 zip-safe = true
 
 [tool.setuptools.dynamic]
-version = { attr = "ribasim_testmodels.__version__" }
+version.attr = "ribasim_testmodels.__version__"
 
 [tool.setuptools.packages.find]
 include = ["ribasim_testmodels", "ribasim_testmodels.*"]


### PR DESCRIPTION
It has been brought to my attention that simply removing this section could lead to unwanted data (e.g. tests) being included when deploying. Adding the asterisk fixes the earlier bug where submodules weren't included