### PR TITLE
Write files during finalize

### DIFF
--- a/build/libribasim/src/libribasim.jl
+++ b/build/libribasim/src/libribasim.jl
@@ -81,6 +81,9 @@ end
 
 Base.@ccallable function finalize()::Cint
     @try_c_uninitialized begin
+        if !isnothing(model)
+            BMI.finalize(model)
+        end
         model = nothing
     end
 end

--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -59,10 +59,11 @@ function BMI.initialize(T::Type{Model}, config::Config)::Model
     return Model(integrator, config, saved_flow)
 end
 
-function BMI.finalize(model::Model)
+function BMI.finalize(model::Model)::Model
     write_basin_output(model)
     write_flow_output(model)
     write_control_output(model)
+    return model
 end
 
 function set_initial_controlled_parameters!(

--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -59,6 +59,12 @@ function BMI.initialize(T::Type{Model}, config::Config)::Model
     return Model(integrator, config, saved_flow)
 end
 
+function BMI.finalize(model::Model)
+    write_basin_output(model)
+    write_flow_output(model)
+    write_control_output(model)
+end
+
 function set_initial_controlled_parameters!(
     integrator,
     control::Control,
@@ -318,8 +324,6 @@ run(config_file::AbstractString)::Model = run(parsefile(config_file))
 function run(config::Config)::Model
     model = BMI.initialize(Model, config)
     solve!(model.integrator)
-    write_basin_output(model)
-    write_flow_output(model)
-    write_control_output(model)
+    BMI.finalize(model)
     return model
 end


### PR DESCRIPTION
Before, there was no way of writing output files when using the BMI. Now the files are written during finalize