### PR TITLE
Make Config Nodetype groups CamelCased.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,5 @@ dmypy.json
 
 # vscode
 .vscode/settings.json
+
+/.luarc.json

--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -4,9 +4,8 @@ import IterTools
 import BasicModelInterface as BMI
 
 using Arrow: Arrow, Table
-using Configurations: Configurations, Maybe, @option, from_toml
+using Configurations: from_toml
 using DataInterpolations: LinearInterpolation
-using DataStructures: DefaultDict
 using Dates
 using DBInterface: execute, prepare
 using Dictionaries: Indices, Dictionary, gettoken, gettokenvalue, dictionary
@@ -28,6 +27,12 @@ TimerOutputs.complement!()
 include("validation.jl")
 include("solve.jl")
 include("config.jl")
+
+# namespaced config.jl to prevent clashes
+const Config = C.Config
+const Solver = C.Solver
+const algorithm = C.algorithm
+
 include("utils.jl")
 include("lib.jl")
 include("io.jl")

--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -27,12 +27,7 @@ TimerOutputs.complement!()
 include("validation.jl")
 include("solve.jl")
 include("config.jl")
-
-# namespaced config.jl to prevent clashes
-const Config = C.Config
-const Solver = C.Solver
-const algorithm = C.algorithm
-
+using .config: Config, Solver, algorithm
 include("utils.jl")
 include("lib.jl")
 include("io.jl")

--- a/core/src/config.jl
+++ b/core/src/config.jl
@@ -1,4 +1,4 @@
-module C
+module config
 
 using Configurations: Configurations, Maybe, @option, from_toml, @type_alias
 using DataStructures: DefaultDict

--- a/core/src/config.jl
+++ b/core/src/config.jl
@@ -1,3 +1,12 @@
+module C
+
+using Configurations: Configurations, Maybe, @option, from_toml, @type_alias
+using DataStructures: DefaultDict
+using Dates
+using Legolas: Legolas, record_type
+using ..Ribasim: Ribasim, isnode, nodetype
+using OrdinaryDiffEq
+
 const schemas =
     getfield.(
         Ref(Ribasim),
@@ -130,3 +139,5 @@ function algorithm(solver::Solver)::OrdinaryDiffEqAlgorithm
         algotype()
     end
 end
+
+end  # module

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -22,8 +22,16 @@ const delimiter = " / "
 tablename(sv::Type{SchemaVersion{T, N}}) where {T, N} = join(nodetype(sv), delimiter)
 tablename(sv::SchemaVersion{T, N}) where {T, N} = join(nodetype(sv), delimiter)
 isnode(sv::Type{SchemaVersion{T, N}}) where {T, N} = length(split(string(T), ".")) == 3
-nodetype(sv::Type{SchemaVersion{T, N}}) where {T, N} = Symbol.(split(string(T), ".")[2:3])
-nodetype(sv::SchemaVersion{T, N}) where {T, N} = Symbol.(split(string(T), ".")[2:3])
+nodetype(sv::Type{SchemaVersion{T, N}}) where {T, N} = nodetype(sv())
+function nodetype(sv::SchemaVersion{T, N}) where {T, N}
+    n, k = split(string(T), ".")[2:3]
+    # Names derived from a schema are in underscores (basinforcing), 
+    # so we parse the related record Ribasim.BasinForcingV1
+    # to derive BasinForcing from it. 
+    record = Legolas.record_type(sv)
+    node = last(split(string(Symbol(record)), "."))
+    Symbol(node[begin:length(n)]), Symbol(k)
+end
 
 # Allowed types for downstream (to_node_id) nodes given the type of the upstream (from_node_id) node
 neighbortypes(nodetype::Symbol) = neighbortypes(Val(nodetype))

--- a/core/test/docs.toml
+++ b/core/test/docs.toml
@@ -18,7 +18,7 @@ control = "output/control.arrow"  # optional, default "output/control.arrow"
 # Specific tables can also go into Arrow files rather than the GeoPackage.
 # For large tables this can benefit from better compressed file sizes.
 # This is optional, tables are retrieved from the GeoPackage if not specified in the TOML.
-[basin]
+[Basin]
 forcing = "forcing.arrow"
 
 

--- a/core/test/testrun.toml
+++ b/core/test/testrun.toml
@@ -13,7 +13,7 @@ geopackage = "model.gpkg"
 [output]
 waterbalance = "waterbalance.arrow"
 
-[basin]
+[Basin]
 forcing = "forcing.arrow"
 
 [solver]


### PR DESCRIPTION
Fixes #316 

### Description
So now you have to do this (note `Basin` in `core/test/docs.toml`), I'm not sure if I like it.

```toml
# can also be set to a date-time like 1979-05-27T07:32:00
starttime = 2019-01-01  # required
endtime = 2021-01-01    # required

# all timesteps are in seconds
update_timestep = 86400.0  # optional, default 1 day

# input files
geopackage = "model.gpkg"  # required


# Specific tables can also go into Arrow files rather than the GeoPackage.
# For large tables this can benefit from better compressed file sizes.
# This is optional, tables are retrieved from the GeoPackage if not specified in the TOML.
[Basin]
forcing = "forcing.arrow"


[solver]
algorithm = "QNDF"  # optional, default "QNDF"
# autodiff can only be set to true for implicit solvers, but is not yet supported
autodiff = false  # optional, default false
# saveat can be a number, which is the saving interval in seconds, or
# it can be a list of numbers, which are the times in seconds since start that are saved
saveat = []  # optional, default [], which will save every timestep
dt = 0.0  # optional, default 0.0
abstol = 1e-6  # optional, default 1e-6
reltol = 1e-3  # optional, default 1e-3
maxiters = 1e9  # optional, default 1e9
```