### PR TITLE
Pin pydantic to v1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - pip:
     - quartodoc
   - pyarrow
-  - pydantic
+  - pydantic~=1.0
   - pyogrio
   - pytest
   - pytest-cov

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - pip:
     - quartodoc
   - pyarrow
-  - pydantic~=1.0
+  - pydantic=1
   - pyogrio
   - pytest
   - pytest-cov

--- a/python/ribasim/pyproject.toml
+++ b/python/ribasim/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pandas",
     "pandera",
     "pyarrow",
-    "pydantic",
+    "pydantic = 1.0",
     "pyogrio",
     "shapely >= 2.0",
     "tomli",

--- a/python/ribasim/pyproject.toml
+++ b/python/ribasim/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pandas",
     "pandera",
     "pyarrow",
-    "pydantic = 1.0",
+    "pydantic ~= 1.0",
     "pyogrio",
     "shapely >= 2.0",
     "tomli",


### PR DESCRIPTION
Should fix the libribasim tests (and maybe others as well)

See https://dpcbuild.deltares.nl/buildConfiguration/Ribasim_Ribasim_TestLibribasimWindows/2527687?buildTab=log&focusLine=0&linesState=891&logView=flowAware