### PR TITLE
Make project coverage informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,4 +6,4 @@ coverage:
 
     project:
       default:
-        threshold: 2%
+        informational: true


### PR DESCRIPTION
Something seems to be wrong with the codecov calculation. Let's make it informational for now