### PR TITLE
run ruff hook with autofix before black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,16 +11,16 @@ repos:
       - id: check-vcs-permalinks
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/psf/black
-    rev: 22.10.0
-    hooks:
-      - id: black
-      - id: black-jupyter
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.277
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+      - id: black
+      - id: black-jupyter
   - repo: https://github.com/kynan/nbstripout
     rev: 0.6.1
     hooks:


### PR DESCRIPTION
Follow up on #406.

On https://github.com/astral-sh/ruff-pre-commit it states:

> Ruff's pre-commit hook should be placed after other formatting tools, such as Black and isort, unless you enable autofix, in which case, Ruff's pre-commit hook should run before Black, isort, and other formatting tools, as Ruff's autofix behavior can output code changes that require reformatting.
