### PR TITLE
Avoid pandera 16.0

### DIFF
--- a/python/ribasim/pyproject.toml
+++ b/python/ribasim/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "geopandas",
     "matplotlib",
     "pandas",
-    "pandera",
+    "pandera != 16.0",
     "pyarrow",
     "pydantic ~= 1.0",
     "pyogrio",


### PR DESCRIPTION
See https://github.com/unionai-oss/pandera/issues/1267


That bug made the iMOD Coupler testbench fail: 
https://dpcbuild.deltares.nl/buildConfiguration/iMOD6_Coupler_TestbenchCouplerWin64_2/2568077?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildProblemsSection=true