### PR TITLE
add solver setting "adaptive"

### DIFF
--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -67,6 +67,7 @@ function BMI.initialize(T::Type{Model}, config::Config)::Model
         progress_name = "Simulating",
         callback,
         config.solver.saveat,
+        config.solver.adaptive,
         config.solver.dt,
         config.solver.abstol,
         config.solver.reltol,

--- a/core/src/config.jl
+++ b/core/src/config.jl
@@ -65,6 +65,7 @@ const nodetypes = collect(keys(nodekinds))
     algorithm::String = "QNDF"
     autodiff::Bool = false
     saveat::Union{Float64, Vector{Float64}, Vector{Union{}}} = Float64[]
+    adaptive::Bool = true
     dt::Float64 = 0.0
     abstol::Float64 = 1e-6
     reltol::Float64 = 1e-3

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -346,7 +346,7 @@ function valid_profiles(
         if areas[1] != 0
             push!(
                 errors,
-                "Basins profiles must start with area 0 at the bottom (got area $(areas[1]) for node #$id).",
+                "Basin profiles must start with area 0 at the bottom (got area $(areas[1]) for node #$id).",
             )
         end
     end

--- a/core/test/bmi.jl
+++ b/core/test/bmi.jl
@@ -27,9 +27,10 @@ end
 @testset "fixed timestepping" begin
     dict = to_dict(config_template)
     dt = 3600
-    dict["solver"] = Ribasim.Solver(; algorithm = "Euler", dt)
+    dict["solver"] = Ribasim.Solver(; algorithm = "ImplicitEuler", adaptive = false, dt)
     config = from_dict(Ribasim.Config, dict)
-    @test config.solver.algorithm == "Euler"
+    @test config.solver.algorithm == "ImplicitEuler"
+    @test !config.solver.adaptive
     model = BMI.initialize(Ribasim.Model, config)
 
     @test BMI.get_time_step(model) == dt

--- a/core/test/config.jl
+++ b/core/test/config.jl
@@ -33,6 +33,7 @@ end
         algorithm = "Rosenbrock23",
         autodiff = true,
         saveat = 3600.0,
+        adaptive = true,
         dt = 0,
         abstol = 1e-5,
         reltol = 1e-4,

--- a/core/test/docs.toml
+++ b/core/test/docs.toml
@@ -29,6 +29,7 @@ autodiff = false  # optional, default false
 # saveat can be a number, which is the saving interval in seconds, or
 # it can be a list of numbers, which are the times in seconds since start that are saved
 saveat = []  # optional, default [], which will save every timestep
+adaptive = true  # optional, default true
 dt = 0.0  # optional, default 0.0
 abstol = 1e-6  # optional, default 1e-6
 reltol = 1e-3  # optional, default 1e-3

--- a/core/test/validation.jl
+++ b/core/test/validation.jl
@@ -11,7 +11,7 @@ using Logging
     area = [[100.0, 100.0]]
     errors = Ribasim.valid_profiles(node_id, level, area)
     @test "Basin #1 has repeated levels, this cannot be interpolated." in errors
-    @test "Basins profiles must start with area 0 at the bottom (got area 100.0 for node #1)." in
+    @test "Basin profiles must start with area 0 at the bottom (got area 100.0 for node #1)." in
           errors
     @test length(errors) == 2
 

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -35,6 +35,7 @@ class Solver(BaseModel):
     algorithm: Optional[str]
     autodiff: Optional[bool]
     saveat: Optional[Union[float, List[float]]]
+    adaptive: Optional[bool]
     dt: Optional[float]
     abstol: Optional[float]
     reltol: Optional[float]


### PR DESCRIPTION
If an algorithm supports adaptive timestepping, `dt` only means the initial timestep. We need to set adaptive to false to be able to run with fixed timesteps.

In the future we might want to consider setting this to false by default, but for not let's not flip that switch, and follow SciML default adaptive=true.