### PR TITLE
use julia-actions/cache and cache more

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -53,16 +53,9 @@ jobs:
         with:
           version: ${{ matrix.julia_version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v3
-        env:
-          cache-name: cache-artifacts
+      - uses: julia-actions/cache@v1
         with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+          cache-compiled: "true"
       - uses: julia-actions/julia-buildpkg@v1
         with:
           project: core

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,15 +34,9 @@ jobs:
         with:
           project: core
 
-      - uses: actions/cache@v3
-        env:
-          cache-name: cache-artifacts
+      - uses: julia-actions/cache@v1
         with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
+          cache-compiled: "true"
 
       - name: Setup Micromamba
         uses: mamba-org/setup-micromamba@v1


### PR DESCRIPTION
This will hopefully help to speed up CI. [julia-actions/cache](https://github.com/julia-actions/cache) is a wrapper around actions/cache.

I added `cache-compiled: "true"`, and I know what I'm doing (or rather trust people on Slack).
