### PR TITLE
Test for success

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -56,6 +56,7 @@ jobs:
       - uses: julia-actions/cache@v1
         with:
           cache-compiled: "true"
+          cache-registries: "true"
       - uses: julia-actions/julia-buildpkg@v1
         with:
           project: core

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: julia-actions/cache@v1
         with:
           cache-compiled: "true"
+          cache-registries: "true"
 
       - name: Setup Micromamba
         uses: mamba-org/setup-micromamba@v1

--- a/core/test/equations.jl
+++ b/core/test/equations.jl
@@ -66,6 +66,7 @@ TimerOutputs.disable_debug_timings(Ribasim)  # causes recompilation (!)
     toml_path = normpath(@__DIR__, "../../data/linear_resistance/linear_resistance.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
+    @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
     p = model.integrator.p
 
     t = Ribasim.timesteps(model)
@@ -89,6 +90,7 @@ end
     toml_path = normpath(@__DIR__, "../../data/rating_curve/rating_curve.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
+    @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
     p = model.integrator.p
 
     t = Ribasim.timesteps(model)
@@ -120,6 +122,7 @@ end
     toml_path = normpath(@__DIR__, "../../data/manning_resistance/manning_resistance.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
+    @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
     p = model.integrator.p
     (; manning_resistance) = p
 
@@ -154,6 +157,7 @@ end
     toml_path = normpath(@__DIR__, "../../data/misc_nodes/misc_nodes.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
+    @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
     p = model.integrator.p
     (; flow_boundary, fractional_flow, pump) = p
 

--- a/core/test/run_models.jl
+++ b/core/test/run_models.jl
@@ -158,6 +158,7 @@ end
     toml_path = normpath(@__DIR__, "../../data/backwater/backwater.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
+    @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
 
     u = model.integrator.sol.u[end]
     p = model.integrator.p

--- a/python/ribasim_testmodels/ribasim_testmodels/equations.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/equations.py
@@ -432,6 +432,7 @@ def miscellaneous_nodes_model():
 
     # Setup solver:
     solver = ribasim.Solver(
+        adaptive=False,
         dt=24 * 24 * 60,
         algorithm="Euler",
     )


### PR DESCRIPTION
https://github.com/Deltares/Ribasim/pull/450 broke the misc_nodes tests since now `adaptive=false` has to be expilictly set.

This only showed up as a warning:

```
┌ Warning: dt(3.725290298461914e-9) <= dtmin(3.725290298461914e-9) at t=34560.0, and step error estimate = 1.0. Aborting. There is either an error in your model specification or the true solution is unstable.
└ @ SciMLBase C:\Users\visser_mn\.julia\packages\SciMLBase\kTUaf\src\integrator_interface.jl:599
```

To avoid missing issues like that we should check if the model returns with a `ReturnCode.Success`.