### PR TITLE
TeamCity: allow no newline at end of file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,9 @@ repos:
       - id: check-toml
       - id: check-merge-conflict
       - id: check-vcs-permalinks
-      - id: end-of-file-fixer
+      -
+        id: end-of-file-fixer
+        exclude: '.teamcity'
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.0.280


### PR DESCRIPTION
TeamCity defaults to no newlines for new files, which the bot then pushes to .teamcity, leading to a failing pre-commit.
