### PR TITLE
Pid equation test

### DIFF
--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -21,7 +21,7 @@ function BMI.initialize(T::Type{Model}, config::Config)::Model
             error("Invalid number of connections for certain node types.")
         end
 
-        (; pid_control, connectivity, basin) = parameters
+        (; pid_control, connectivity, basin, pump) = parameters
         if !valid_pid_connectivity(
             pid_control.node_id,
             pid_control.listen_node_id,
@@ -30,6 +30,12 @@ function BMI.initialize(T::Type{Model}, config::Config)::Model
             basin.node_id,
         )
             error("Invalid PidControl connectivity.")
+        end
+
+        for id in pid_control.node_id
+            id_pump = only(outneighbors(connectivity.graph_control, id))
+            pump_idx = findsorted(pump.node_id, id_pump)
+            pump.is_pid_controlled[pump_idx] = true
         end
 
         # use state

--- a/core/src/create.jl
+++ b/core/src/create.jl
@@ -252,7 +252,7 @@ function Pump(db::DB, config::Config)::Pump
     defaults = (; min_flow_rate = 0.0, max_flow_rate = NaN, active = true)
     static_parsed = parse_static(static, db, "Pump", defaults)
 
-    # TODO: use this in formulate! (and formulate_jac!) for pump
+    # TODO: use this in formulate_jac! for pump
     is_pid_controlled = falses(length(static_parsed.node_id))
 
     return Pump(

--- a/core/src/create.jl
+++ b/core/src/create.jl
@@ -252,6 +252,9 @@ function Pump(db::DB, config::Config)::Pump
     defaults = (; min_flow_rate = 0.0, max_flow_rate = NaN, active = true)
     static_parsed = parse_static(static, db, "Pump", defaults)
 
+    # TODO: use this in formulate! (and formulate_jac!) for pump
+    is_pid_controlled = falses(length(static_parsed.node_id))
+
     return Pump(
         static_parsed.node_id,
         static_parsed.active,
@@ -259,6 +262,7 @@ function Pump(db::DB, config::Config)::Pump
         static_parsed.min_flow_rate,
         static_parsed.max_flow_rate,
         static_parsed.control_mapping,
+        is_pid_controlled,
     )
 end
 
@@ -292,8 +296,6 @@ function Basin(db::DB, config::Config)::Basin
     # If not specified, target_level = NaN
     target_level = coalesce.(static.target_level, NaN)
 
-    dstorage = zero(target_level)
-
     return Basin(
         Indices(node_id),
         precipitation,
@@ -307,7 +309,6 @@ function Basin(db::DB, config::Config)::Basin
         storage,
         target_level,
         time,
-        dstorage,
     )
 end
 

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -433,7 +433,7 @@ function get_error!(pid_control::PidControl, p::Parameters)
     (; basin) = p
     (; listen_node_id) = pid_control
 
-    Error = pid_control.error
+    pid_error = pid_control.error
 
     for i in eachindex(listen_node_id)
         listened_node_id = listen_node_id[i]
@@ -443,7 +443,7 @@ function get_error!(pid_control::PidControl, p::Parameters)
         if isnan(target_level)
             error("No target level specified for listen basin #$listened_node_id.")
         end
-        Error[i] = target_level - basin.current_level[listened_node_idx]
+        pid_error[i] = target_level - basin.current_level[listened_node_idx]
     end
 end
 

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -490,37 +490,29 @@ function continuous_control!(
             flow_rate += proportional[i] * error[i]
         end
 
-        println(flow_rate)
-
         if !isnan(derivative[i])
             # dlevel/dstorage = 1/area
             area = basin.current_area[listened_node_idx]
+            level_derivative = dstorage[listened_node_idx] / area
+            target_level_derivative = 0.0
 
-            error_deriv = -dstorage[listened_node_idx] / area
+            error_deriv = target_level_derivative - level_derivative
             flow_rate += derivative[i] * error_deriv
         end
-
-        println(flow_rate)
 
         if !isnan(integral[i])
             # coefficient * current value of integral
             flow_rate += integral[i] * integral_value[i]
         end
 
-        println(flow_rate)
-
         # Clip values outside pump flow rate bounds
         flow_rate = max(flow_rate, min_flow_rate[i])
-
-        println(flow_rate)
 
         if !isnan(max_flow_rate[i])
             flow_rate = min(flow_rate, max_flow_rate[i])
         end
 
         println(flow_rate)
-        println("-------------------")
-
         pump.flow_rate[controlled_node_idx] = flow_rate
     end
     return nothing

--- a/core/src/utils.jl
+++ b/core/src/utils.jl
@@ -553,7 +553,7 @@ function update_jac_prototype!(
         has_index, idx_out_out = id_index(basin.node_id, id_pump_out)
 
         if has_index
-            # The basin downstream of the pu,p PID control integral state
+            # The basin downstream of the pump PID control integral state
             jac_prototype[pid_state_idx, idx_out_out] = 1.0
 
             # The basin downstream of the pump also depends on the controlled basin

--- a/core/test/equations.jl
+++ b/core/test/equations.jl
@@ -149,6 +149,51 @@ end
     @test all(isapprox.(LHS, RHS; rtol = 0.005)) # Fails with '≈'
 end
 
+# The second order linear inhomogeneous ODE for this model is derived by
+# differentiating the equation for the storage of the controlled basin
+# once to time to get rid of the integral term.
+@testset "PID control" begin
+    toml_path =
+        normpath(@__DIR__, "../../data/pid_control_equation/pid_control_equation.toml")
+    @test ispath(toml_path)
+    model = Ribasim.run(toml_path)
+    @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
+    p = model.integrator.p
+    (; basin, pid_control) = p
+
+    storage = Ribasim.get_storages_and_levels(model).storage[:]
+    t = Ribasim.timesteps(model)
+
+    K_p = pid_control.proportional[1]
+    K_i = pid_control.integral[1]
+    K_d = pid_control.derivative[1]
+    storage_min = 50
+    level_min = basin.level[1][2]
+    SP = basin.target_level[1]
+    storage0 = storage[1]
+    area = basin.area[1][2]
+    level0 = level_min + (storage0 - storage_min) / area
+
+    α = 1 - K_d / area
+    β = -K_p / area
+    γ = -K_i / area
+    δ = -K_i * (SP - level_min + storage_min / area)
+
+    λ_1 = (-β + sqrt(β^2 - 4 * α * γ)) / (2 * α)
+    λ_2 = (-β - sqrt(β^2 - 4 * α * γ)) / (2 * α)
+
+    c_1 = storage0 - δ / γ
+    c_2 = -K_p * (SP - level0) / (1 - K_d / area)
+
+    Δλ = λ_2 - λ_1
+    k_1 = (λ_2 * c_1 - c_2) / Δλ
+    k_2 = (-λ_1 * c_1 + c_2) / Δλ
+
+    storage_predicted = @. k_1 * exp(λ_1 * t) + k_2 * exp(λ_2 * t) + δ / γ
+
+    @test all(isapprox.(storage, storage_predicted; rtol = 0.001))
+end
+
 # Simple solutions:
 # storage1 = storage1(t0) + (t-t0)*(frac*q_boundary - q_pump)
 # storage2 = storage2(t0) + (t-t0)*q_pump

--- a/core/test/utils.jl
+++ b/core/test/utils.jl
@@ -24,7 +24,6 @@ end
     level = [[0.0, 1.0], [4.0, 5.0]]
     storage = Ribasim.profile_storage.(level, area)
     target_level = [0.0, 0.0]
-    dstorage = target_level
     basin = Ribasim.Basin(
         Indices([5, 7]),
         [2.0, 3.0],
@@ -38,7 +37,6 @@ end
         storage,
         target_level,
         StructVector{Ribasim.BasinForcingV1}(undef, 0),
-        dstorage,
     )
 
     @test basin.level[2][1] === 4.0

--- a/core/test/utils.jl
+++ b/core/test/utils.jl
@@ -126,7 +126,7 @@ end
 
     @test jac_prototype.m == 2
     @test jac_prototype.n == 2
-    @test jac_prototype.colptr == [1, 2, 3]
-    @test jac_prototype.rowval == [2, 1]
-    @test jac_prototype.nzval == ones(2)
+    @test jac_prototype.colptr == [1, 3, 4]
+    @test jac_prototype.rowval == [1, 2, 1]
+    @test jac_prototype.nzval == ones(3)
 end

--- a/core/test/validation.jl
+++ b/core/test/validation.jl
@@ -60,6 +60,7 @@ end
         [0.0, 0.0],
         [1.0, 1.0],
         Dict{Tuple{Int, String}, NamedTuple}(),
+        falses(2),
     )
 
     errors = Ribasim.valid_n_neighbors(graph_flow, pump)

--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -186,6 +186,7 @@ potential_evaporation | Float64 | $m s^{-1}$   | non-negative
 drainage              | Float64 | $m^3 s^{-1}$ | non-negative
 infiltration          | Float64 | $m^3 s^{-1}$ | non-negative
 urban_runoff          | Float64 | $m^3 s^{-1}$ | non-negative
+target_level          | Float64 | $m^3$        | (optional)
 
 Note that if variables are not set in the static table, default values are used when
 possible. These are generally zero, e.g. no precipitation, no inflow. If it is not possible

--- a/python/ribasim/tests/conftest.py
+++ b/python/ribasim/tests/conftest.py
@@ -13,6 +13,7 @@ from ribasim_testmodels import (
     linear_resistance_model,
     manning_resistance_model,
     misc_nodes_model,
+    pid_control_equation_model,
     pid_control_model,
     pump_discrete_control_model,
     rating_curve_model,
@@ -64,3 +65,4 @@ if __name__ == "__main__":
     misc_nodes_model().write(datadir / "misc_nodes")
     invalid_qh_model().write(datadir / "invalid_qh")
     flow_boundary_time_model().write(datadir / "flow_boundary_time")
+    pid_control_equation_model().write(datadir / "pid_control_equation")

--- a/python/ribasim_testmodels/ribasim_testmodels/__init__.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/__init__.py
@@ -16,6 +16,7 @@ from ribasim_testmodels.equations import (
     linear_resistance_model,
     manning_resistance_model,
     misc_nodes_model,
+    pid_control_equation_model,
     rating_curve_model,
 )
 from ribasim_testmodels.invalid import invalid_qh_model
@@ -40,4 +41,5 @@ __all__ = [
     "tabulated_rating_curve_control_model",
     "invalid_qh_model",
     "flow_boundary_time_model",
+    "pid_control_equation_model",
 ]

--- a/python/ribasim_testmodels/ribasim_testmodels/equations.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/equations.py
@@ -551,7 +551,7 @@ def pid_control_equation_model():
             data={
                 "node_id": [4],
                 "listen_node_id": [1],
-                "proportional": [-1.2],
+                "proportional": [-2.5],
                 "integral": [-3e-3],
                 "derivative": [10.0],
             }

--- a/python/ribasim_testmodels/ribasim_testmodels/equations.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/equations.py
@@ -453,3 +453,121 @@ def misc_nodes_model():
     )
 
     return model
+
+
+def pid_control_equation_model():
+    """Set up a model with pid control for an analytical solution test"""
+
+    xy = np.array(
+        [
+            (0.0, 0.0),  # 1: Basin
+            (1.0, 0.0),  # 2: Pump
+            (2.0, 0.0),  # 3: Terminal
+            (0.5, 1.0),  # 4: PidControl
+        ]
+    )
+    node_xy = gpd.points_from_xy(x=xy[:, 0], y=xy[:, 1])
+
+    node_type = ["Basin", "Pump", "Terminal", "PidControl"]
+
+    # Make sure the feature id starts at 1: explicitly give an index.
+    node = ribasim.Node(
+        static=gpd.GeoDataFrame(
+            data={"type": node_type},
+            index=pd.Index(np.arange(len(xy)) + 1, name="fid"),
+            geometry=node_xy,
+            crs="EPSG:28992",
+        )
+    )
+
+    # Setup the edges:
+    from_id = np.array([1, 2, 4], dtype=np.int64)
+    to_id = np.array([2, 3, 2], dtype=np.int64)
+    lines = ribasim.utils.geometry_from_connectivity(node, from_id, to_id)
+    edge = ribasim.Edge(
+        static=gpd.GeoDataFrame(
+            data={
+                "from_node_id": from_id,
+                "to_node_id": to_id,
+                "edge_type": ["flow", "flow", "control"],
+            },
+            geometry=lines,
+            crs="EPSG:28992",
+        )
+    )
+
+    # Setup the basins:
+    profile = pd.DataFrame(
+        data={
+            "node_id": [1, 1, 1],
+            "area": [0.0, 100.0, 100.0],
+            "level": [0.0, 1.0, 2.0],
+        }
+    )
+
+    static = pd.DataFrame(
+        data={
+            "node_id": [1],
+            "drainage": [0.0],
+            "potential_evaporation": [0.0],
+            "infiltration": [0.0],
+            "precipitation": [0.0],
+            "urban_runoff": [0.0],
+            "target_level": [10.0],
+        }
+    )
+
+    state = pd.DataFrame(
+        data={
+            "node_id": [1],
+            "storage": [1500.0],
+        }
+    )
+
+    basin = ribasim.Basin(profile=profile, static=static, state=state)
+
+    # Setup pump:
+    pump = ribasim.Pump(
+        static=pd.DataFrame(
+            data={
+                "node_id": [2],
+                "flow_rate": [0.0],  # irrelevant, will be overwritten
+            }
+        )
+    )
+
+    # Setup terminal:
+    terminal = ribasim.Terminal(
+        static=pd.DataFrame(
+            data={
+                "node_id": [3],
+            }
+        )
+    )
+
+    # Setup PID control
+    pid_control = ribasim.PidControl(
+        static=pd.DataFrame(
+            data={
+                "node_id": [4],
+                "listen_node_id": [1],
+                "proportional": [-1.2],
+                "integral": [-3e-3],
+                "derivative": [10.0],
+            }
+        )
+    )
+
+    model = ribasim.Model(
+        modelname="pid_control_equation",
+        node=node,
+        edge=edge,
+        basin=basin,
+        pump=pump,
+        terminal=terminal,
+        pid_control=pid_control,
+        starttime="2020-01-01 00:00:00",
+        endtime="2020-01-01 00:30:00",
+    )
+
+    return model

--- a/python/ribasim_testmodels/ribasim_testmodels/equations.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/equations.py
@@ -552,7 +552,7 @@ def pid_control_equation_model():
                 "node_id": [4],
                 "listen_node_id": [1],
                 "proportional": [-2.5],
-                "integral": [-3e-3],
+                "integral": [-0.001],
                 "derivative": [10.0],
             }
         )
@@ -567,7 +567,7 @@ def pid_control_equation_model():
         terminal=terminal,
         pid_control=pid_control,
         starttime="2020-01-01 00:00:00",
-        endtime="2020-01-01 00:30:00",
+        endtime="2020-01-01 00:05:00",
     )
 
     return model


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/473.

There are some complications with the PID derivative term that make it rather complex to implement. The core of the problem is that the derivative term makes the storage change of the listened to basin dependent on itself:

$$
\frac{\text{d}u}{\text{d}t} = \sum F + \sum Q - \phi(u)\left[ K_pe + K_iI + K_d\left(\dot{\text{SP}} - \frac{\text{d}u}{\text{d}t}\right) \right]
$$

where $\phi(u)$ is defined the same as here: https://github.com/Deltares/Ribasim/pull/465.

This computation is further complicated by the clipping of the pump flow value to its minimum or maximum. I don't think it is possible to create an analytical solution of the above equation that converges to the setpoint with only positive flow without using the derivative term (of course that shouldn't be the main argument to keep the derivative term). Here is what the solution looks like (assuming this is correct): https://www.desmos.com/calculator/jqbpnlv8pi.

There is already a `PidControl` test that converges to the setpoint without the derivative term with the pump turning of when the PID control dictates negative flow. I could attempt to formulate an analytical solution of that one.

The reason I started reformulating the derivative term of PID control is that currently the right hand side $\frac{\text{d}u}{\text{d}t}$ of the above equation was taken from not the current but the previous call to `water_balance!`, which I thought could lead to problems (since I got ill behaved solutions).