### PR TITLE
Allow setting edge_type for Edge in QGIS.

### DIFF
--- a/qgis/core/nodes.py
+++ b/qgis/core/nodes.py
@@ -224,6 +224,21 @@ class Edge(Input):
     def is_spatial(cls):
         return True
 
+    def set_editor_widget(self) -> None:
+        layer = self.layer
+        index = layer.fields().indexFromName("edge_type")
+        setup = QgsEditorWidgetSetup(
+            "ValueMap",
+            {"map": {node: node for node in EDGETYPES}},
+        )
+        layer.setEditorWidgetSetup(index, setup)
+
+        layer_form_config = layer.editFormConfig()
+        layer_form_config.setReuseLastValue(1, True)
+        layer.setEditFormConfig(layer_form_config)
+
+        return
+
     @property
     def renderer(self) -> QgsCategorizedSymbolRenderer:
         MARKERS = {
@@ -263,14 +278,6 @@ class Edge(Input):
             attrName="edge_type", categories=categories
         )
         return renderer
-
-    def set_read_only(self) -> None:
-        layer = self.layer
-        config = layer.editFormConfig()
-        for index in range(len(layer.fields())):
-            config.setReadOnly(index, True)
-        layer.setEditFormConfig(config)
-        return
 
 
 class BasinProfile(Input):
@@ -447,6 +454,7 @@ NODES = {cls.input_type: cls for cls in Input.__subclasses__()}
 NONSPATIALNODETYPES = {
     cls.nodetype() for cls in Input.__subclasses__() if not cls.is_spatial()
 }
+EDGETYPES = {"flow", "control"}
 
 
 def load_nodes_from_geopackage(path: str) -> Dict[str, Input]:

--- a/qgis/widgets/dataset_widget.py
+++ b/qgis/widgets/dataset_widget.py
@@ -191,7 +191,6 @@ class DatasetWidget(QWidget):
         fields = edge.fields()
         field1 = fields.indexFromName("from_node_id")
         field2 = fields.indexFromName("to_node_id")
-        field3 = fields.indexFromName("edge_type")
         try:
             # Avoid infinite recursion
             edge.blockSignals(True)
@@ -201,7 +200,7 @@ class DatasetWidget(QWidget):
                     # Nota bene: will fail with numpy integers, has to be Python type!
                     edge.changeAttributeValue(fid, field1, int(id1))
                     edge.changeAttributeValue(fid, field2, int(id2))
-                    edge.changeAttributeValue(fid, field3, "flow")
+
         finally:
             edge.blockSignals(False)
 
@@ -212,7 +211,7 @@ class DatasetWidget(QWidget):
         layer: Any,
         destination: Any,
         renderer: Any = None,
-        suppress: bool = None,
+        suppress: bool = False,
         on_top: bool = False,
         labels: Any = None,
     ) -> QgsMapLayer:
@@ -229,8 +228,6 @@ class DatasetWidget(QWidget):
         element = item.element
         layer, renderer, labels = element.from_geopackage()
         suppress = self.suppress_popup_checkbox.isChecked()
-        if element.input_type == "Edge":
-            suppress = True
         self.add_layer(layer, "Ribasim Input", renderer, suppress, labels=labels)
         element.set_editor_widget()
         element.set_read_only()
@@ -294,11 +291,7 @@ class DatasetWidget(QWidget):
             layer = item.element.layer
             if layer is not None:
                 config = layer.editFormConfig()
-                # Always suppress the attribute form pop-up for edges.
-                if item.element.input_type == "Edge":
-                    config.setSuppress(True)
-                else:
-                    config.setSuppress(suppress)
+                config.setSuppress(suppress)
                 layer.setEditFormConfig(config)
 
     def active_nodes(self):


### PR DESCRIPTION
Fixes the [discussion](https://github.com/Deltares/Ribasim/discussions/486) about the control node.

- Added the possible options for edge_type
- Removed the hardcoded read-only setting for Edge
- Removed the popup supression for Edge

Note that the fid could be set (like the Node) to anything, which will probably break things. The from_ and to_id in Edge can be set to anything, but are reset correctly on save.
