### PR TITLE
add solver docs and sparse and jac options

### DIFF
--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -96,8 +96,9 @@ function BMI.initialize(T::Type{Model}, config::Config)::Model
     @assert eps(t_end) < 3600 "Simulation time too long"
     timespan = (zero(t_end), t_end)
 
-    jac_prototype = get_jac_prototype(parameters)
-    RHS = ODEFunction(water_balance!; jac_prototype, jac = water_balance_jac!)
+    jac_prototype = config.jac_prototype ? get_jac_prototype(parameters) : nothing
+    jac = config.jac ? water_balance_jac! : nothing
+    RHS = ODEFunction(water_balance!; jac_prototype, jac)
 
     @timeit_debug to "Setup ODEProblem" begin
         prob = ODEProblem(RHS, u0, timespan, parameters)

--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -1,5 +1,5 @@
 function BMI.initialize(T::Type{Model}, config_path::AbstractString)::Model
-    config = parsefile(config_path)
+    config = Config(config_path)
     BMI.initialize(T, config)
 end
 
@@ -507,7 +507,7 @@ BMI.get_end_time(model::Model) = seconds_since(model.config.endtime, model.confi
 BMI.get_time_units(model::Model) = "s"
 BMI.get_time_step(model::Model) = get_proposed_dt(model.integrator)
 
-run(config_file::AbstractString)::Model = run(parsefile(config_file))
+run(config_file::AbstractString)::Model = run(Config(config_file))
 
 function is_current_module(log)
     (log._module == @__MODULE__) || (parentmodule(log._module) == @__MODULE__)

--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -96,8 +96,8 @@ function BMI.initialize(T::Type{Model}, config::Config)::Model
     @assert eps(t_end) < 3600 "Simulation time too long"
     timespan = (zero(t_end), t_end)
 
-    jac_prototype = config.jac_prototype ? get_jac_prototype(parameters) : nothing
-    jac = config.jac ? water_balance_jac! : nothing
+    jac_prototype = config.solver.sparse ? get_jac_prototype(parameters) : nothing
+    jac = config.solver.jac ? water_balance_jac! : nothing
     RHS = ODEFunction(water_balance!; jac_prototype, jac)
 
     @timeit_debug to "Setup ODEProblem" begin

--- a/core/src/config.jl
+++ b/core/src/config.jl
@@ -64,13 +64,15 @@ const nodetypes = collect(keys(nodekinds))
 
 @option struct Solver <: TableOption
     algorithm::String = "QNDF"
-    autodiff::Bool = false
     saveat::Union{Float64, Vector{Float64}, Vector{Union{}}} = Float64[]
     adaptive::Bool = true
     dt::Float64 = 0.0
     abstol::Float64 = 1e-6
     reltol::Float64 = 1e-3
     maxiters::Int = 1e9
+    sparse::Bool = true
+    jac::Bool = true
+    autodiff::Bool = false
 end
 
 @enum Compression begin

--- a/core/src/io.jl
+++ b/core/src/io.jl
@@ -119,9 +119,19 @@ function output_path(config::Config, path::String)
     return normpath(config.relative_dir, config.output_dir, path)
 end
 
-"Parse a TOML file to a Config"
-function parsefile(config_path::AbstractString)::Config
-    return from_toml(Config, config_path; relative_dir = dirname(normpath(config_path)))
+"""
+    Config(config_path::AbstractString; kwargs...)
+
+Parse a TOML file to a Config. Keys can be overruled using keyword arguments. To overrule
+keys from a subsection, e.g. `dt` from the `solver` section, use underscores: `solver_dt`.
+"""
+function Config(config_path::AbstractString; kwargs...)::Config
+    return from_toml(
+        Config,
+        config_path;
+        relative_dir = dirname(normpath(config_path)),
+        kwargs...,
+    )
 end
 
 "Get the storage and level of all basins as matrices of nbasin × ntime"

--- a/core/src/jac.jl
+++ b/core/src/jac.jl
@@ -1,14 +1,13 @@
 """
-The Jacobian is a n x n sparse matrix where n is the number of basins plus the number of
+The Jacobian is a n x n matrix where n is the number of basins plus the number of
 PidControl nodes. Each basin has a storage state, and each PidControl node has an error integral
-state. If we write water_balance! as f(u, p(t), t) where u is the vector of all states, then
-J[i,j] = ∂f_j/∂u_i. f_j dictates the time derivative of state j.
+state. If we write `water_balance!` as `f(u, p(t), t)` where u is the vector of all states, then
+`J[i,j] = ∂f_j/∂u_i`. f_j dictates the time derivative of state j.
 
-J is very sparse because each state only depends on a small number of other states.
-For more on the sparsity see get_jac_prototype.
+For more on the sparsity see [`get_jac_prototype`](@ref).
 """
 function water_balance_jac!(
-    J::SparseMatrixCSC{Float64, Int64},
+    J::AbstractMatrix,
     u::ComponentVector{Float64},
     p::Parameters,
     t,

--- a/core/src/jac.jl
+++ b/core/src/jac.jl
@@ -37,7 +37,7 @@ The contributions of LinearResistance nodes to the Jacobian.
 """
 function formulate_jac!(
     linear_resistance::LinearResistance,
-    J::SparseMatrixCSC{Float64, Int64},
+    J::AbstractMatrix,
     u::ComponentVector{Float64},
     p::Parameters,
     t::Float64,
@@ -84,7 +84,7 @@ The contributions of ManningResistance nodes to the Jacobian.
 """
 function formulate_jac!(
     manning_resistance::ManningResistance,
-    J::SparseMatrixCSC{Float64, Int64},
+    J::AbstractMatrix,
     u::ComponentVector{Float64},
     p::Parameters,
     t::Float64,
@@ -215,7 +215,7 @@ The contributions of Pump and Outlet nodes to the Jacobian.
 """
 function formulate_jac!(
     node::Union{Pump, Outlet},
-    J::SparseMatrixCSC{Float64, Int64},
+    J::AbstractMatrix,
     u::ComponentVector{Float64},
     p::Parameters,
     t::Float64,
@@ -288,7 +288,7 @@ The contributions of TabulatedRatingCurve nodes to the Jacobian.
 """
 function formulate_jac!(
     tabulated_rating_curve::TabulatedRatingCurve,
-    J::SparseMatrixCSC{Float64, Int64},
+    J::AbstractMatrix,
     u::ComponentVector{Float64},
     p::Parameters,
     t::Float64,
@@ -360,7 +360,7 @@ The contributions of PidControl nodes to the Jacobian.
 """
 function formulate_jac!(
     pid_control::PidControl,
-    J::SparseMatrixCSC{Float64, Int64},
+    J::AbstractMatrix,
     u::ComponentVector{Float64},
     p::Parameters,
     t::Float64,
@@ -572,7 +572,7 @@ Method for nodes that do not contribute to the Jacobian
 """
 function formulate_jac!(
     node::AbstractParameterNode,
-    J::SparseMatrixCSC{Float64, Int64},
+    J::AbstractMatrix,
     u::ComponentVector{Float64},
     p::Parameters,
     t::Float64,

--- a/core/src/lib.jl
+++ b/core/src/lib.jl
@@ -30,3 +30,7 @@ function Base.show(io::IO, model::Model)
     nsaved = length(timesteps(model))
     println(io, "Model(ts: $nsaved, t: $t)")
 end
+
+function SciMLBase.successful_retcode(model::Model)::Bool
+    return SciMLBase.successful_retcode(model.integrator.sol)
+end

--- a/core/src/utils.jl
+++ b/core/src/utils.jl
@@ -573,6 +573,9 @@ Get a sparse matrix whose sparsity matches the sparsity of the Jacobian
 of the ODE problem. All nodes are taken into consideration, also the ones
 that are inactive.
 
+In Ribasim the Jacobian is typically sparse because each state only depends on a small
+number of other states.
+
 Note: the name 'prototype' does not mean this code is a prototype, it comes
 from the naming convention of this sparsity structure in the
 differentialequations.jl docs.

--- a/core/test/bmi.jl
+++ b/core/test/bmi.jl
@@ -1,12 +1,11 @@
 using Test
-using Configurations: from_dict, to_dict
+using Configurations: from_toml
 using Ribasim
 import BasicModelInterface as BMI
 
 include("../../build/libribasim/src/libribasim.jl")
 
 toml_path = normpath(@__DIR__, "../../data/basic/basic.toml")
-config_template = Ribasim.parsefile(toml_path)
 
 @testset "adaptive timestepping" begin
     model = BMI.initialize(Ribasim.Model, toml_path)
@@ -25,10 +24,12 @@ config_template = Ribasim.parsefile(toml_path)
 end
 
 @testset "fixed timestepping" begin
-    dict = to_dict(config_template)
-    dt = 10
-    dict["solver"] = Ribasim.Solver(; algorithm = "ImplicitEuler", adaptive = false, dt)
-    config = from_dict(Ribasim.Config, dict)
+    config = Ribasim.Config(
+        toml_path;
+        solver_algorithm = "ImplicitEuler",
+        solver_adaptive = false,
+        solver_dt = 10,
+    )
     @test config.solver.algorithm == "ImplicitEuler"
     @test !config.solver.adaptive
     model = BMI.initialize(Ribasim.Model, config)

--- a/core/test/bmi.jl
+++ b/core/test/bmi.jl
@@ -24,11 +24,12 @@ toml_path = normpath(@__DIR__, "../../data/basic/basic.toml")
 end
 
 @testset "fixed timestepping" begin
+    dt = 10.0
     config = Ribasim.Config(
         toml_path;
         solver_algorithm = "ImplicitEuler",
         solver_adaptive = false,
-        solver_dt = 10,
+        solver_dt = dt,
     )
     @test config.solver.algorithm == "ImplicitEuler"
     @test !config.solver.adaptive

--- a/core/test/config.jl
+++ b/core/test/config.jl
@@ -14,7 +14,7 @@ using OrdinaryDiffEq: alg_autodiff, AutoFiniteDiff, AutoForwardDiff
     )
 
     @testset "testrun" begin
-        config = Ribasim.parsefile(normpath(@__DIR__, "testrun.toml"))
+        config = Ribasim.Config(normpath(@__DIR__, "testrun.toml"))
         @test config isa Ribasim.Config
         @test config.update_timestep == 86400.0
         @test config.endtime > config.starttime
@@ -30,7 +30,7 @@ using OrdinaryDiffEq: alg_autodiff, AutoFiniteDiff, AutoForwardDiff
     end
 
     @testset "docs" begin
-        Ribasim.parsefile(normpath(@__DIR__, "docs.toml"))
+        Ribasim.Config(normpath(@__DIR__, "docs.toml"))
     end
 end
 

--- a/core/test/docs.toml
+++ b/core/test/docs.toml
@@ -23,19 +23,17 @@ compression_level = 6            # optional, default 6
 [basin]
 forcing = "forcing.arrow"
 
-
 [solver]
 algorithm = "QNDF" # optional, default "QNDF"
-# autodiff can only be set to true for implicit solvers, but is not yet supported
-autodiff = false # optional, default false
-# saveat can be a number, which is the saving interval in seconds, or
-# it can be a list of numbers, which are the times in seconds since start that are saved
-saveat = []     # optional, default [], which will save every timestep
-adaptive = true # optional, default true
-dt = 0.0        # optional, default 0.0
-abstol = 1e-6   # optional, default 1e-6
-reltol = 1e-3   # optional, default 1e-3
-maxiters = 1e9  # optional, default 1e9
+saveat = []        # optional, default [], which saves every timestep
+adaptive = true    # optional, default true
+dt = 0.0           # optional, default 0.0
+abstol = 1e-6      # optional, default 1e-6
+reltol = 1e-3      # optional, default 1e-3
+maxiters = 1e9     # optional, default 1e9
+sparse = true      # optional, default true
+jac = true         # optional, default true
+autodiff = false   # optional, default false
 
 [logging]
 # defines the logging level of Ribasim

--- a/core/test/equations.jl
+++ b/core/test/equations.jl
@@ -3,7 +3,7 @@ using Dates
 using Ribasim
 using Arrow
 import BasicModelInterface as BMI
-using SciMLBase
+using SciMLBase: successful_retcode
 using TimerOutputs
 
 include("../../utils/testdata.jl")
@@ -66,7 +66,7 @@ TimerOutputs.disable_debug_timings(Ribasim)  # causes recompilation (!)
     toml_path = normpath(@__DIR__, "../../data/linear_resistance/linear_resistance.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
-    @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
+    @test successful_retcode(model)
     p = model.integrator.p
 
     t = Ribasim.timesteps(model)
@@ -90,7 +90,7 @@ end
     toml_path = normpath(@__DIR__, "../../data/rating_curve/rating_curve.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
-    @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
+    @test successful_retcode(model)
     p = model.integrator.p
 
     t = Ribasim.timesteps(model)
@@ -122,7 +122,7 @@ end
     toml_path = normpath(@__DIR__, "../../data/manning_resistance/manning_resistance.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
-    @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
+    @test successful_retcode(model)
     p = model.integrator.p
     (; manning_resistance) = p
 
@@ -157,7 +157,7 @@ end
         normpath(@__DIR__, "../../data/pid_control_equation/pid_control_equation.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
-    @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
+    @test successful_retcode(model)
     p = model.integrator.p
     (; basin, pid_control) = p
 
@@ -202,7 +202,7 @@ end
     toml_path = normpath(@__DIR__, "../../data/misc_nodes/misc_nodes.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
-    @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
+    @test successful_retcode(model)
     p = model.integrator.p
     (; flow_boundary, fractional_flow, pump) = p
 

--- a/core/test/io.jl
+++ b/core/test/io.jl
@@ -70,7 +70,7 @@ end
 
 @testset "table sort" begin
     toml_path = normpath(@__DIR__, "../../data/basic_transient/basic_transient.toml")
-    config = Ribasim.parsefile(toml_path)
+    config = Ribasim.Config(toml_path)
     gpkg_path = Ribasim.input_path(config, config.geopackage)
     db = SQLite.DB(gpkg_path)
 

--- a/core/test/run_models.jl
+++ b/core/test/run_models.jl
@@ -51,6 +51,28 @@ end
         Sys.isapple()
 end
 
+@testset "sparse and jac solver options" begin
+    toml_path = normpath(@__DIR__, "../../data/basic_transient/basic_transient.toml")
+
+    config = Ribasim.Config(toml_path; solver_sparse = true, solver_jac = true)
+    sparse_jac = Ribasim.run(config)
+    config = Ribasim.Config(toml_path; solver_sparse = false, solver_jac = true)
+    dense_jac = Ribasim.run(config)
+    config = Ribasim.Config(toml_path; solver_sparse = true, solver_jac = false)
+    sparse_fdm = Ribasim.run(config)
+    config = Ribasim.Config(toml_path; solver_sparse = false, solver_jac = false)
+    dense_fdm = Ribasim.run(config)
+
+    @test successful_retcode(sparse_jac)
+    @test successful_retcode(dense_jac)
+    @test successful_retcode(sparse_fdm)
+    @test successful_retcode(dense_fdm)
+
+    @test dense_jac.integrator.sol.u[end] ≈ sparse_jac.integrator.sol.u[end]
+    @test sparse_fdm.integrator.sol.u[end] ≈ sparse_jac.integrator.sol.u[end] atol = 1e-3
+    @test dense_fdm.integrator.sol.u[end] ≈ sparse_jac.integrator.sol.u[end] atol = 1e-3
+end
+
 @testset "TabulatedRatingCurve model" begin
     toml_path =
         normpath(@__DIR__, "../../data/tabulated_rating_curve/tabulated_rating_curve.toml")

--- a/core/test/run_models.jl
+++ b/core/test/run_models.jl
@@ -2,7 +2,7 @@ using Logging: Debug, with_logger
 using Test
 using Ribasim
 import BasicModelInterface as BMI
-using SciMLBase
+using SciMLBase: successful_retcode
 import Tables
 
 @testset "trivial model" begin
@@ -10,7 +10,7 @@ import Tables
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
     @test model isa Ribasim.Model
-    @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
+    @test successful_retcode(model)
 end
 
 @testset "bucket model" begin
@@ -18,7 +18,7 @@ end
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
     @test model isa Ribasim.Model
-    @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
+    @test successful_retcode(model)
 end
 
 @testset "basic model" begin
@@ -31,7 +31,7 @@ end
     end
 
     @test model isa Ribasim.Model
-    @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
+    @test successful_retcode(model)
     @test model.integrator.sol.u[end] ≈ Float32[519.8817, 519.8798, 339.3959, 1418.4331] skip =
         Sys.isapple() atol = 1.5
 
@@ -45,7 +45,7 @@ end
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
     @test model isa Ribasim.Model
-    @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
+    @test successful_retcode(model)
     @test length(model.integrator.p.basin.precipitation) == 4
     @test model.integrator.sol.u[end] ≈ Float32[469.8923, 469.89038, 410.71472, 1427.4194] skip =
         Sys.isapple()
@@ -57,7 +57,7 @@ end
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
     @test model isa Ribasim.Model
-    @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
+    @test successful_retcode(model)
     @test model.integrator.sol.u[end] ≈ Float32[5.949285, 725.9446] skip = Sys.isapple()
     # the highest level in the dynamic table is updated to 1.2 from the callback
     @test model.integrator.p.tabulated_rating_curve.tables[end].t[end] == 1.2
@@ -168,7 +168,7 @@ end
     toml_path = normpath(@__DIR__, "../../data/backwater/backwater.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
-    @test model.integrator.sol.retcode == Ribasim.ReturnCode.Success
+    @test successful_retcode(model)
 
     u = model.integrator.sol.u[end]
     p = model.integrator.p

--- a/core/test/utils.jl
+++ b/core/test/utils.jl
@@ -164,7 +164,7 @@ end
 @testset "Jacobian sparsity" begin
     toml_path = normpath(@__DIR__, "../../data/basic/basic.toml")
 
-    cfg = Ribasim.parsefile(toml_path)
+    cfg = Ribasim.Config(toml_path)
     gpkg_path = Ribasim.input_path(cfg, cfg.geopackage)
     db = SQLite.DB(gpkg_path)
 
@@ -179,7 +179,7 @@ end
 
     toml_path = normpath(@__DIR__, "../../data/pid_control/pid_control.toml")
 
-    cfg = Ribasim.parsefile(toml_path)
+    cfg = Ribasim.Config(toml_path)
     gpkg_path = Ribasim.input_path(cfg, cfg.geopackage)
     db = SQLite.DB(gpkg_path)
 

--- a/core/test/validation.jl
+++ b/core/test/validation.jl
@@ -29,7 +29,7 @@ end
     toml_path = normpath(@__DIR__, "../../data/invalid_qh/invalid_qh.toml")
     @test ispath(toml_path)
 
-    config = Ribasim.parsefile(toml_path)
+    config = Ribasim.Config(toml_path)
     gpkg_path = Ribasim.input_path(config, config.geopackage)
     db = SQLite.DB(gpkg_path)
 
@@ -132,7 +132,7 @@ if !Sys.islinux()
         )
         @test ispath(toml_path)
 
-        config = Ribasim.parsefile(toml_path)
+        config = Ribasim.Config(toml_path)
         gpkg_path = Ribasim.input_path(config, config.geopackage)
         db = SQLite.DB(gpkg_path)
         p = Ribasim.Parameters(db, config)
@@ -167,7 +167,7 @@ end
     )
     @test ispath(toml_path)
 
-    cfg = Ribasim.parsefile(toml_path)
+    cfg = Ribasim.Config(toml_path)
     gpkg_path = Ribasim.input_path(cfg, cfg.geopackage)
     db = SQLite.DB(gpkg_path)
     p = Ribasim.Parameters(db, cfg)
@@ -231,7 +231,7 @@ end
     toml_path = normpath(@__DIR__, "../../data/invalid_edge_types/invalid_edge_types.toml")
     @test ispath(toml_path)
 
-    cfg = Ribasim.parsefile(toml_path)
+    cfg = Ribasim.Config(toml_path)
     gpkg_path = Ribasim.input_path(cfg, cfg.geopackage)
     db = SQLite.DB(gpkg_path)
     logger = TestLogger()

--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -31,8 +31,42 @@ format. It contains settings, as well as paths to other input and output files.
 ```{.toml include="../../core/test/docs.toml"}
 ```
 
-For more information on the solver options, see the [DifferentialEquations.jl docs](https://docs.sciml.ai/DiffEqDocs/latest/basics/common_solver_opts/#solver_options).
+#### Solver settings
+
+The solver section in the configuration file is entirely optional, since we aim to use defaults that will generally work well.
+Common reasons to modify the solver settings are to adjust the calculation or output stepsizes: `adaptive`, `dt`, and `saveat`.
+If your model does not converge, or your performance is lower than expected, it can help to adjust other solver settings as well.
+
+The default solver `algorithm = "QNDF"`, which is a multistep method similar to Matlab's `ode15s` [@shampine1997matlab].
+It is an implicit method that supports the default `adaptive = true` timestepping.
+The full list of available solvers is: `QNDF`, `Rosenbrock23`, `TRBDF2`, `Rodas5`, `KenCarp4`, `Tsit5`, `RK4`, `ImplicitEuler`, `Euler`.
 Information on the solver algorithms can be found on the [ODE solvers page](https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve/).
+
+The `dt` controls the stepsize.
+When `adaptive = true` this only applies to the initial stepsize, and the default of 0.0 means that it is automatically determined.
+When `adaptive = false` a suitable `dt` must always be provided.
+The value is in seconds, so `dt = 3600.0` corresponds to an hourly timestep.
+
+By default the calculation and output stepsize are the same, with `saveat = []`, which will save every timestep.
+`saveat` can be a number, which is the saving interval in seconds, or it can be a list of numbers, which are the times in seconds since start that are saved.
+For instance, `saveat = 86400.0` will save output after every day that passed.
+
+The Jacobian matrix provides information about the local sensitivity of the model with respect to changes in the states.
+For implicit solvers it must be calculated often, which can be expensive to do.
+There are several methods to do this.
+By default Ribasim uses an analytical Jacobian function written by the Ribasim developers.
+This is enabled by default, with the solver setting `jac = true`.
+If this is not used, the Jacobian is calculated with a finite difference method, which can be less accurate and more expensive.
+In the future we want to additionally support `autodiff = true` to calculate the Jacobian with automatic differentiation.
+
+By default the Jacobian matrix is a sparse matrix (`sparse = true`).
+Since each state typically only depends on a small number of other states, this is generally more efficient, especially for larger models.
+The sparsity structure is calculated from the network and provided as a Jacobian prototype to the solver.
+For small or highly connected models it could be faster to use a dense Jacobian matrix instead by setting `sparse = false`.
+
+The total maximum number of iterations `maxiters = 1e9`, can normally stay as-is unless doing extremely long simulations.
+
+The absolute and relative tolerance for adaptive timestepping can be set with `abstol` and `reltol`. For more information on these and other solver options, see the [DifferentialEquations.jl docs](https://docs.sciml.ai/DiffEqDocs/latest/basics/common_solver_opts/#solver_options).
 
 ### GeoPackage and Arrow tables
 

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -87,3 +87,14 @@
   url =  "https://www.pdok.nl/downloads/-/article/basisregistratie-topografie-brt-topnl",
   note = "[Online; accessed 31-August-2022]"
 }
+
+@article{shampine1997matlab,
+  title={The matlab ode suite},
+  author={Shampine, Lawrence F and Reichelt, Mark W},
+  journal={SIAM journal on scientific computing},
+  volume={18},
+  number={1},
+  pages={1--22},
+  year={1997},
+  publisher={SIAM}
+}

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -35,13 +35,15 @@ from ribasim.types import FilePath
 
 class Solver(BaseModel):
     algorithm: Optional[str]
-    autodiff: Optional[bool]
     saveat: Optional[Union[float, List[float]]]
     adaptive: Optional[bool]
     dt: Optional[float]
     abstol: Optional[float]
     reltol: Optional[float]
     maxiters: Optional[int]
+    sparse: Optional[bool]
+    jac: Optional[bool]
+    autodiff: Optional[bool]
 
 
 class Verbosity(str, Enum):

--- a/python/ribasim_testmodels/ribasim_testmodels/basic.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/basic.py
@@ -265,6 +265,7 @@ def basic_transient_model(model) -> ribasim.Model:
 
     model.basin.forcing = forcing
     model.basin.state = state
+    model.logging = None
 
     model.modelname = "basic_transient"
     return model


### PR DESCRIPTION
Fixes #476

This adds the boolean solver options `sparse` and `jac`, which both default to true. Also elaborated the solver documentation.
~~Still needs tests.~~

This includes some convenience functions that make testing a bit easier, like extending the `SciMLBase.successful_retcode` method on Model, and renaming `Ribasim.parsefile` to a new `Ribasim.Config(::AbstractString; kwargs)` method, which allows specifying keywords to overrule the TOML.