### PR TITLE
don't save flow for every solver timestep

### DIFF
--- a/core/src/io.jl
+++ b/core/src/io.jl
@@ -193,7 +193,7 @@ function write_flow_output(model::Model, compress)
     edge_id = repeat(unique_edge_ids; outer = ntsteps)
     from_node_id = repeat(I; outer = ntsteps)
     to_node_id = repeat(J; outer = ntsteps)
-    flow = collect(Iterators.flatten(saveval))
+    flow = FlatVector(saveval)
 
     table = (; time, edge_id, from_node_id, to_node_id, flow)
     path = output_path(config, config.output.flow)

--- a/core/src/utils.jl
+++ b/core/src/utils.jl
@@ -849,7 +849,14 @@ struct FlatVector{T} <: AbstractVector{T}
     v::Vector{Vector{T}}
 end
 
-Base.length(fv::FlatVector) = length(fv.v) * length(first(fv.v))
+function Base.length(fv::FlatVector)
+    return if isempty(fv.v)
+        0
+    else
+        length(fv.v) * length(first(fv.v))
+    end
+end
+
 Base.size(fv::FlatVector) = (length(fv),)
 
 function Base.getindex(fv::FlatVector, i::Int)

--- a/core/src/utils.jl
+++ b/core/src/utils.jl
@@ -834,3 +834,27 @@ function get_fractional_flow_connected_basins(
     end
     return fractional_flow_idxs, basin_idxs
 end
+
+"""
+    struct FlatVector{T} <: AbstractVector{T}
+
+A FlatVector is an AbstractVector that iterates the T of a `Vector{Vector{T}}`.
+
+Each inner vector is assumed to be of equal length.
+
+It is similar to `Iterators.flatten`, though that doesn't work with the `Tables.Column`
+interface, which needs `length` and `getindex` support.
+"""
+struct FlatVector{T} <: AbstractVector{T}
+    v::Vector{Vector{T}}
+end
+
+Base.length(fv::FlatVector) = length(fv.v) * length(first(fv.v))
+Base.size(fv::FlatVector) = (length(fv),)
+
+function Base.getindex(fv::FlatVector, i::Int)
+    veclen = length(first(fv.v))
+    d, r = divrem(i - 1, veclen)
+    v = fv.v[d + 1]
+    return v[r + 1]
+end

--- a/core/test/bmi.jl
+++ b/core/test/bmi.jl
@@ -3,8 +3,6 @@ using Configurations: from_toml
 using Ribasim
 import BasicModelInterface as BMI
 
-include("../../build/libribasim/src/libribasim.jl")
-
 toml_path = normpath(@__DIR__, "../../data/basic/basic.toml")
 
 @testset "adaptive timestepping" begin
@@ -65,44 +63,5 @@ end
         value_second = BMI.get_value_ptr(model, name)
         # get_value_ptr does not copy
         @test value_first === value_second
-    end
-end
-
-@testset "libribasim" begin
-    # data from which we create pointers for libribasim
-    time = [-1.0]
-    var_name = "volume"
-    type = ones(UInt8, 8)
-
-    GC.@preserve time var_name value type toml_path begin
-        var_name_ptr = Base.unsafe_convert(Cstring, var_name)
-        time_ptr = pointer(time)
-        type_ptr = Cstring(pointer(type))
-        toml_path_ptr = Base.unsafe_convert(Cstring, toml_path)
-
-        # safe to finalize uninitialized model
-        @test isnothing(libribasim.model)
-        @test libribasim.finalize() == 0
-        @test isnothing(libribasim.model)
-
-        # cannot get time of uninitialized model
-        @test libribasim.last_error_message == ""
-        retcode = libribasim.get_current_time(time_ptr)
-        @test retcode == 1
-        @test time[1] == -1
-        @test libribasim.last_error_message == "Model not initialized"
-
-        @test libribasim.initialize(toml_path_ptr) == 0
-        @test libribasim.model isa Ribasim.Model
-        @test libribasim.model.integrator.t == 0.0
-
-        @test libribasim.get_current_time(time_ptr) == 0
-        @test time[1] == 0.0
-
-        @test libribasim.get_var_type(var_name_ptr, type_ptr) == 0
-        @test unsafe_string(type_ptr) == "double"
-
-        @test libribasim.finalize() == 0
-        @test isnothing(libribasim.model)
     end
 end

--- a/core/test/libribasim.jl
+++ b/core/test/libribasim.jl
@@ -1,0 +1,46 @@
+using Test
+using Ribasim
+import BasicModelInterface as BMI
+
+include("../../build/libribasim/src/libribasim.jl")
+
+toml_path = normpath(@__DIR__, "../../data/basic/basic.toml")
+
+@testset "libribasim" begin
+    # data from which we create pointers for libribasim
+    time = [-1.0]
+    var_name = "volume"
+    type = ones(UInt8, 8)
+
+    GC.@preserve time var_name value type toml_path begin
+        var_name_ptr = Base.unsafe_convert(Cstring, var_name)
+        time_ptr = pointer(time)
+        type_ptr = Cstring(pointer(type))
+        toml_path_ptr = Base.unsafe_convert(Cstring, toml_path)
+
+        # safe to finalize uninitialized model
+        @test isnothing(libribasim.model)
+        @test libribasim.finalize() == 0
+        @test isnothing(libribasim.model)
+
+        # cannot get time of uninitialized model
+        @test libribasim.last_error_message == ""
+        retcode = libribasim.get_current_time(time_ptr)
+        @test retcode == 1
+        @test time[1] == -1
+        @test libribasim.last_error_message == "Model not initialized"
+
+        @test libribasim.initialize(toml_path_ptr) == 0
+        @test libribasim.model isa Ribasim.Model
+        @test libribasim.model.integrator.t == 0.0
+
+        @test libribasim.get_current_time(time_ptr) == 0
+        @test time[1] == 0.0
+
+        @test libribasim.get_var_type(var_name_ptr, type_ptr) == 0
+        @test unsafe_string(type_ptr) == "double"
+
+        @test libribasim.finalize() == 0
+        @test isnothing(libribasim.model)
+    end
+end

--- a/core/test/runtests.jl
+++ b/core/test/runtests.jl
@@ -10,10 +10,11 @@ using SafeTestsets: @safetestset
     @safetestset "Equations" include("equations.jl")
     @safetestset "Run Test Models" include("run_models.jl")
     @safetestset "Basic Model Interface" include("bmi.jl")
-    @safetestset "Command Line Interface" include("cli.jl")
     @safetestset "Utility functions" include("utils.jl")
     @safetestset "Control" include("control.jl")
     @safetestset "Time" include("time.jl")
     @safetestset "Docs" include("docs.jl")
+    @safetestset "Command Line Interface" include("cli.jl")
+    @safetestset "libribasim" include("libribasim.jl")
     Aqua.test_all(Ribasim; ambiguities = false)
 end

--- a/core/test/utils.jl
+++ b/core/test/utils.jl
@@ -192,3 +192,14 @@ end
     @test jac_prototype.rowval == [1, 2, 3, 1, 1]
     @test jac_prototype.nzval == ones(5)
 end
+
+@testset "FlatVector" begin
+    vv = [[2.2, 3.2], [4.3, 5.3], [6.4, 7.4]]
+    fv = Ribasim.FlatVector(vv)
+    @test length(fv) == 6
+    @test size(fv) == (6,)
+    @test collect(fv) == [2.2, 3.2, 4.3, 5.3, 6.4, 7.4]
+    @test fv[begin] == 2.2
+    @test fv[5] == 6.4
+    @test fv[end] == 7.4
+end

--- a/core/test/utils.jl
+++ b/core/test/utils.jl
@@ -202,4 +202,9 @@ end
     @test fv[begin] == 2.2
     @test fv[5] == 6.4
     @test fv[end] == 7.4
+
+    vv = Vector{Float64}[]
+    fv = Ribasim.FlatVector(vv)
+    @test isempty(fv)
+    @test length(fv) == 0
 end


### PR DESCRIPTION
This led to huge output files with larger test models.
We now also avoid making an extra copy of the data in memory, for which we use the FlatVector wrapper type, see individual commit messages.