### PR TITLE
Fix progressbar.

### DIFF
--- a/build/ribasim_cli/src/ribasim_cli.jl
+++ b/build/ribasim_cli/src/ribasim_cli.jl
@@ -1,6 +1,6 @@
 module ribasim_cli
 
-using Logging: global_logger
+using Logging: global_logger, with_logger
 using TerminalLoggers: TerminalLogger
 using SciMLBase: successful_retcode
 using Ribasim
@@ -30,8 +30,8 @@ function julia_main()::Cint
 
     try
         # show progress bar in terminal
-        with_logger(TerminalLogger()) do
-            model = Ribasim.run(arg)
+        model = with_logger(TerminalLogger()) do
+            Ribasim.run(arg)
         end
         println(model.integrator.sol.retcode)
         return if successful_retcode(model)

--- a/build/ribasim_cli/src/ribasim_cli.jl
+++ b/build/ribasim_cli/src/ribasim_cli.jl
@@ -30,8 +30,9 @@ function julia_main()::Cint
 
     try
         # show progress bar in terminal
-        global_logger(TerminalLogger())
-        model = Ribasim.run(arg)
+        with_logger(TerminalLogger()) do
+            model = Ribasim.run(arg)
+        end
         println(model.integrator.sol.retcode)
         return if successful_retcode(model)
             0

--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -526,7 +526,9 @@ BMI.get_time_step(model::Model) = get_proposed_dt(model.integrator)
 run(config_file::AbstractString)::Model = run(Config(config_file))
 
 function is_current_module(log)
-    (log._module == @__MODULE__) || (parentmodule(log._module) == @__MODULE__)
+    (log._module == @__MODULE__) ||
+        (parentmodule(log._module) == @__MODULE__) ||
+        log._module == OrdinaryDiffEq  # for the progress bar
 end
 
 function run(config::Config)::Model
@@ -534,7 +536,7 @@ function run(config::Config)::Model
 
     # Reconfigure the logger if necessary with the correct loglevel
     # but make sure to only log from Ribasim
-    if min_enabled_level(logger) != config.logging.verbosity
+    if min_enabled_level(logger) + 1 != config.logging.verbosity
         logger = EarlyFilteredLogger(
             is_current_module,
             LevelOverrideLogger(config.logging.verbosity, logger),

--- a/core/test/run_models.jl
+++ b/core/test/run_models.jl
@@ -35,7 +35,7 @@ end
     @test model.integrator.sol.u[end] ≈ Float32[519.8817, 519.8798, 339.3959, 1418.4331] skip =
         Sys.isapple() atol = 1.5
 
-    @test length(logger.logs) == 5
+    @test length(logger.logs) == 7
     @test logger.logs[1].level == Debug
     @test logger.logs[1].message == "Read database into memory."
 end


### PR DESCRIPTION
Fixes #542 
Note that in a interactive VS Code environment, you need to run

```julia
with_logger(TerminalLogger()) do 
    Ribasim.run(toml_path)
end
```

As VS Code attaches a task logger, overriding any global logger set.