### PR TITLE
always run tests

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -2,18 +2,9 @@ name: Julia Tests
 on:
   push:
     branches: [main]
+    paths-ignore: [".teamcity/**"]
     tags: ["*"]
-    paths:
-      - ".github/**"
-      - "build/**"
-      - "core/**"
-      - "python/**"
   pull_request:
-    paths:
-      - ".github/**"
-      - "build/**"
-      - "core/**"
-      - "python/**"
   merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -2,10 +2,9 @@ name: Python Lint
 on:
   push:
     branches: [main]
+    paths-ignore: [".teamcity/**"]
     tags: ["*"]
-    paths: [".github/**", "python/**"]
   pull_request:
-    paths: [".github/**", "python/**"]
   merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -2,10 +2,9 @@ name: Ribasim Python Tests
 on:
   push:
     branches: [main]
+    paths-ignore: [".teamcity/**"]
     tags: ["*"]
-    paths: [".github/**", "python/ribasim/**"]
   pull_request:
-    paths: [".github/**", "python/ribasim/**"]
   merge_group:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/qgis.yml
+++ b/.github/workflows/qgis.yml
@@ -3,16 +3,9 @@ name: QGIS
 on:
     push:
       branches: [main]
+      paths-ignore: [".teamcity/**"]
       tags: ["*"]
-      paths:
-        - ".github/qgis.yml"
-        - "python/ribasim/ribasim/models.py"
-        - "qgis/**"
     pull_request:
-      paths:
-        - ".github/qgis.yml"
-        - "python/ribasim/ribasim/models.py"
-        - "qgis/**"
     merge_group:
 jobs:
     test-qgis:


### PR DESCRIPTION
If we want to use the merge queue with required status checks, those status checks must always be available for every PR.

This adds paths-ignore for the teamcity pushes to main (synchronizing settings), to the other Actions as well.
