### PR TITLE
allow overwriting open GeoPackage

### DIFF
--- a/python/ribasim/ribasim/geometry/edge.py
+++ b/python/ribasim/ribasim/geometry/edge.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Any, Dict, Union
 
 import geopandas as gpd
@@ -43,20 +42,15 @@ class Edge(TableModel):
     def _layername(cls, field) -> str:
         return cls.get_input_type()
 
-    def write(self, directory: FilePath, modelname: str) -> None:
+    def write_layer(self, path: FilePath) -> None:
         """
         Write the contents of the input to a GeoPackage.
 
-        The Geopackage will be written in ``directory`` and will be be named
-        ``{modelname}.gpkg``.
-
         Parameters
         ----------
-        directory : FilePath
-        modelname : str
+        path : FilePath
         """
         self.sort()
-        directory = Path(directory)
         dataframe = self.static
         name = self._layername(dataframe)
 
@@ -65,7 +59,7 @@ class Edge(TableModel):
             gdf = gdf.set_geometry("geometry")
         else:
             gdf["geometry"] = None
-        gdf.to_file(directory / f"{modelname}.gpkg", layer=name, driver="GPKG")
+        gdf.to_file(path, layer=name, driver="GPKG")
 
         return
 

--- a/python/ribasim/ribasim/geometry/node.py
+++ b/python/ribasim/ribasim/geometry/node.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Any, Dict, Union
 
 import geopandas as gpd
@@ -75,31 +74,22 @@ class Node(TableModel):
 
         return node_id, node_type
 
-    def write(self, directory: FilePath, modelname: str) -> None:
+    def write_layer(self, path: FilePath) -> None:
         """
         Write the contents of the input to a GeoPackage.
 
-        The Geopackage will be written in ``directory`` and will be be named
-        ``{modelname}.gpkg``.
-
         Parameters
         ----------
-        directory : FilePath
-        modelname : str
+        path : FilePath
         """
         self.sort()
-        directory = Path(directory)
         dataframe = self.static
         name = self._layername(dataframe)
 
         gdf = gpd.GeoDataFrame(data=dataframe)
         gdf = gdf.set_geometry("geometry")
 
-        gdf.to_file(
-            directory / f"{modelname}.gpkg",
-            layer=name,
-            driver="GPKG",
-        )
+        gdf.to_file(path, layer=name, driver="GPKG")
 
         return
 


### PR DESCRIPTION
This works fine having the file open in QGIS on Windows. We write to another file, and at the end move this file over the destination file.

Fixes #563
