### PR TITLE
avoid returning DiffCache through BMI

### DIFF
--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -508,7 +508,7 @@ function BMI.get_value_ptr(model::Model, name::AbstractString)
     if name == "volume"
         model.integrator.u.storage
     elseif name == "level"
-        model.integrator.p.basin.current_level
+        get_tmp(model.integrator.p.basin.current_level, 0)
     elseif name == "infiltration"
         model.integrator.p.basin.infiltration
     elseif name == "drainage"


### PR DESCRIPTION
This should fix the TeamCity libribasim tests. `test_bmi.py` did not catch it since only getting volume is tested: `libribasim.get_value_ptr("volume")`.

I'll add those tests later, but first let's unbreak CI.
