### PR TITLE
remove outdated plots from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,9 @@ The latest builds can be downloaded here:
 - QGIS plugin: [ribasim_qgis.zip](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim_qgis.zip).
 
 Currently only Windows builds for `ribasim_cli.zip` are available.
+
+![Timeseries of
+results](https://user-images.githubusercontent.com/4471859/179259333-070dfe18-8f43-4ac4-bb38-013b252e2e4b.png)
+
+![Daily water
+balance](https://user-images.githubusercontent.com/4471859/179259174-0caccd4a-c51b-449e-873c-17d48cfc8870.png)

--- a/README.md
+++ b/README.md
@@ -20,9 +20,3 @@ The latest builds can be downloaded here:
 - QGIS plugin: [ribasim_qgis.zip](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim_qgis.zip).
 
 Currently only Windows builds for `ribasim_cli.zip` are available.
-
-![Timeseries of
-results](https://user-images.githubusercontent.com/4471859/179259333-070dfe18-8f43-4ac4-bb38-013b252e2e4b.png)
-
-![Daily water
-balance](https://user-images.githubusercontent.com/4471859/179259174-0caccd4a-c51b-449e-873c-17d48cfc8870.png)

--- a/python/ribasim/tests/test_io.py
+++ b/python/ribasim/tests/test_io.py
@@ -48,6 +48,7 @@ def test_basic_transient(basic_transient, tmp_path):
     assert_equal(model_orig.edge.static, model_loaded.edge.static)
 
     forcing = model_loaded.basin.forcing
+    assert model_orig.basin.forcing.time[0] == forcing.time[0]
     assert_equal(model_orig.basin.forcing, forcing)
     assert forcing.shape == (1468, 8)
 


### PR DESCRIPTION
Mainly want to see if CI is ok, seeing some GeoPackage time related issues locally.
