### PR TITLE
pandas exclude version 2.1.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - jupyterlab
   - matplotlib
   - mypy
-  - pandas
+  - pandas!=2.1.0
   - pandas-stubs
   - pandera
   - pip

--- a/python/ribasim/pyproject.toml
+++ b/python/ribasim/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.9"
 dependencies = [
     "geopandas",
     "matplotlib",
-    "pandas",
+    "pandas != 2.1.0",
     "pandera != 0.16.0",
     "pyarrow",
     "pydantic ~= 1.0",


### PR DESCRIPTION
A regression breaks writing timestamps to GeoPackage for us: https://github.com/pandas-dev/pandas/issues/54877

Found in https://github.com/Deltares/Ribasim/pull/586#issuecomment-1714490399