### PR TITLE
migrate to python tools extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,8 @@
     "recommendations": [
         "julialang.language-julia",
         "ms-python.python",
+        "ms-python.black-formatter",
+        "ms-python.mypy-type-checker",
         "charliermarsh.ruff",
         "njpwerner.autodocstring"
     ]

--- a/.vscode/settings_template.json
+++ b/.vscode/settings_template.json
@@ -5,12 +5,10 @@
     "julia.environmentPath": "core",
     "notebook.formatOnSave.enabled": true,
     "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter",
         "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
             "source.fixAll": true
         }
-    },
-    "python.formatting.provider": "black",
-    "python.linting.mypyEnabled": true,
-    "python.linting.enabled": true
+    }
 }


### PR DESCRIPTION
When I opened my settings.json it warned me these settings will be deprecated soon, with this link for more info:

https://github.com/microsoft/vscode-python/wiki/Migration-to-Python-Tools-Extensions
