### PR TITLE
use LF for all text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,1 @@
-* text=auto
-
-**/Project.toml eol=lf
-**/Manifest.toml eol=lf
-**/*.json eol=lf
+* text=auto eol=lf


### PR DESCRIPTION
Julia writes newlines as LF. Before we had to specify files written by Julia in the .gitattributes. But it is easier to just set this as the default for all text files. There is no real advantage to using CRLF since the tools we use can handle both.

Another advantage is that this is independent of global settings that can be different for different users.

For reference, I now decided to go for these global settings, useful for (especially Julia) repos without .gitattributes.

```
[core]
eol = lf
autocrlf = input
```

The `autocrlf = input` converts CRLF to LF when committing, but not vice versa when checking out.

Also I set my VS Code settings to create new files with LF by default. To do that for Julia only, you can

```
    "[julia]": {
        "files.eol": "\n",
    },
```