### PR TITLE
bump versions before release v2023.09.0

### DIFF
--- a/core/Project.toml
+++ b/core/Project.toml
@@ -1,7 +1,7 @@
 name = "Ribasim"
 uuid = "aac5e3d9-0b8f-4d4f-8241-b1a7a9632635"
 authors = ["Deltares and contributors"]
-version = "0.2.0"
+version = "0.3.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Ribasim"
-version = "0.1.0"
+version = "0.2.0"
 channels = ["conda-forge"]
 platforms = ["win-64", "linux-64", "osx-64"]
 

--- a/python/ribasim/ribasim/__init__.py
+++ b/python/ribasim/ribasim/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 
 from ribasim import models, utils

--- a/python/ribasim_api/ribasim_api/__init__.py
+++ b/python/ribasim_api/ribasim_api/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 from ribasim_api.ribasim_api import RibasimApi
 

--- a/python/ribasim_testmodels/ribasim_testmodels/__init__.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 from ribasim_testmodels.allocation import user_model
 from ribasim_testmodels.backwater import backwater_model

--- a/qgis/metadata.txt
+++ b/qgis/metadata.txt
@@ -7,7 +7,7 @@
 name=Ribasim-QGIS
 qgisMinimumVersion=3.0
 description=QGIS plugin to setup Ribasim models
-version=0.1
+version=0.2
 author=Deltares
 email=huitebootsma@gmail.com
 


### PR DESCRIPTION
Ribasim v2023.09.0 consists of:

```
    core Ribasim.jl v0.3.0
    pixi Ribasim v0.2.0
    ribasim-python v0.4.0
    ribasim_api v0.2.0
    ribasim_testmodels v0.2.0
    Ribasim-QGIS v0.2
```