### PR TITLE
update wheel links, which include the version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ libraries, notably [ModelingToolkit.jl](https://mtk.sciml.ai/stable/).
 The latest builds can be downloaded here:
 
 - Ribasim executable: [ribasim_cli.zip](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim_cli.zip).
-- Python package: [ribasim-0.2.0-py3-none-any.whl](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim-0.2.0-py3-none-any.whl)
+- Python package: [ribasim-0.4.0-py3-none-any.whl](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim-0.4.0-py3-none-any.whl)
 - QGIS plugin: [ribasim_qgis.zip](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim_qgis.zip).
 
 Currently only Windows builds for `ribasim_cli.zip` are available.

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -14,7 +14,7 @@ libraries, notably [DifferentialEquations.jl](https://docs.sciml.ai/DiffEqDocs/s
 The latest builds can be downloaded here:
 
 - Ribasim executable: [ribasim_cli.zip](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim_cli.zip).
-- Python package: [ribasim-0.2.0-py3-none-any.whl](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim-0.2.0-py3-none-any.whl)
+- Python package: [ribasim-0.4.0-py3-none-any.whl](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim-0.4.0-py3-none-any.whl)
 - QGIS plugin: [ribasim_qgis.zip](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim_qgis.zip).
 
 Currently only Windows builds for `ribasim_cli.zip` are available. See [Usage](core/usage.qmd) for more information.

--- a/docs/python/index.qmd
+++ b/docs/python/index.qmd
@@ -13,6 +13,6 @@ One can also use Ribasim Python to build entire models from base data, such that
 setup is fully reproducible.
 
 The package is [registered in PyPI](https://pypi.org/project/ribasim/) and can therefore
-be installed with `pip install ribasim`. The most recent (nightly) version can be downloaded here: [ribasim-0.2.0-py3-none-any.whl](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim-0.2.0-py3-none-any.whl). It can be installed with `pip install ribasim-0.2.0-py3-none-any.whl`.
+be installed with `pip install ribasim`. The most recent (nightly) version can be downloaded here: [ribasim-0.4.0-py3-none-any.whl](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim-0.4.0-py3-none-any.whl). It can be installed with `pip install ribasim-0.4.0-py3-none-any.whl`.
 
 For documentation please see the [examples](examples.ipynb) and [API reference](reference/).


### PR DESCRIPTION
Looks like we forgot about 0.3.0...
Adding a bullet to the list of #499.
