### PR TITLE
Rename pixi task from `post-install` to `install`

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -31,7 +31,7 @@ jobs:
           pixi-version: "v0.3.0"
           cache: true
       - name: Prepare pixi
-        run: pixi run post-install-without-pre-commit
+        run: pixi run install-without-pre-commit
       - name: Prepare model input
         run: |
           pixi run generate-testmodels

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
           pixi-version: "v0.3.0"
           cache: true
       - name: Prepare pixi
-        run: pixi run post-install-without-pre-commit
+        run: pixi run install-without-pre-commit
 
       - name: Check Quarto installation and all engines
         run: pixi run quarto-check

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -21,7 +21,7 @@ jobs:
           pixi-version: "latest"
           cache: true
       - name: Prepare pixi
-        run: pixi run post-install-without-pre-commit
+        run: pixi run install-without-pre-commit
       - name: Run mypy on python/ribasim
         run: |
           pixi run mypy-ribasim-python

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -34,7 +34,7 @@ jobs:
           pixi-version: "v0.3.0"
           cache: true
       - name: Prepare pixi
-        run: pixi run post-install-without-pre-commit
+        run: pixi run install-without-pre-commit
 
       - name: Run tests
         run: pixi run test-ribasim-python-cov

--- a/.teamcity/Ribasim_Ribasim/buildTypes/Ribasim_Ribasim_TestRibasimCliWindows.xml
+++ b/.teamcity/Ribasim_Ribasim/buildTypes/Ribasim_Ribasim_TestRibasimCliWindows.xml
@@ -15,8 +15,7 @@
     <build-runners>
       <runner id="RUNNER_1501" name="Set up pixi" type="simpleRunner">
         <parameters>
-          <param name="script.content"><![CDATA[pixi install
-pixi run post-install]]></param>
+          <param name="script.content"><![CDATA[pixi run install]]></param>
           <param name="teamcity.build.workingDir" value="ribasim" />
           <param name="teamcity.step.mode" value="default" />
           <param name="use.custom.script" value="true" />
@@ -84,4 +83,3 @@ pip install --no-deps "python/ribasim_testmodels"]]></param>
     <cleanup />
   </settings>
 </build-type>
-

--- a/docs/contribute/python.qmd
+++ b/docs/contribute/python.qmd
@@ -11,8 +11,7 @@ First, set up pixi as described on their getting started [page](https://prefix.d
 Then set up the environment by running the following commands:
 
 ```
-pixi install
-pixi run post-install
+pixi run install
 ```
 
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -11,14 +11,14 @@ install-ribasim-api = "pip install --no-deps --editable python/ribasim_api"
 install-ribasim-testmodels = "pip install --no-deps --editable python/ribasim_testmodels"
 install-quartodoc = "pip install quartodoc"
 pre-commit-install = "pre-commit install"
-post-install-without-pre-commit = { depends_on = [
+install-without-pre-commit = { depends_on = [
     "install-ribasim-python",
     "install-ribasim-api",
     "install-ribasim-testmodels",
     "install-quartodoc",
 ] }
-post-install = { depends_on = [
-    "post-install-without-pre-commit",
+install = { depends_on = [
+    "install-without-pre-commit",
     "pre-commit-install",
 ] }
 # Docs

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,7 +10,7 @@ install-ribasim-python = "pip install --no-deps --editable python/ribasim"
 install-ribasim-api = "pip install --no-deps --editable python/ribasim_api"
 install-ribasim-testmodels = "pip install --no-deps --editable python/ribasim_testmodels"
 install-quartodoc = "pip install quartodoc"
-pre-commit-install = "pre-commit install"
+install-pre-commit = "pre-commit install"
 install-without-pre-commit = { depends_on = [
     "install-ribasim-python",
     "install-ribasim-api",
@@ -19,7 +19,7 @@ install-without-pre-commit = { depends_on = [
 ] }
 install = { depends_on = [
     "install-without-pre-commit",
-    "pre-commit-install",
+    "install-pre-commit",
 ] }
 # Docs
 instantiate-julia-docs = "julia --project=docs -e \"using Pkg; Pkg.instantiate()\""


### PR DESCRIPTION
Post-install is arguably correct, but an implementation detail. I also removed `pixi install` since I was wrong that this was needed.