### PR TITLE
start using isoutofdomain

### DIFF
--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -126,6 +126,7 @@ function BMI.initialize(T::Type{Model}, config::Config)::Model
         progress_steps = 100,
         callback,
         tstops,
+        isoutofdomain = (u, p, t) -> any(<(0), u.storage),
         config.solver.saveat,
         config.solver.adaptive,
         config.solver.dt,

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -1154,14 +1154,6 @@ function water_balance!(
     # PID control (changes the du of PID controlled basins)
     continuous_control!(u, du, pid_control, p, integral, t)
 
-    # Negative storage must not decrease, based on Shampine's et. al. advice
-    # https://docs.sciml.ai/DiffEqCallbacks/stable/step_control/#DiffEqCallbacks.PositiveDomain
-    for i in eachindex(u.storage)
-        if u.storage[i] < 0
-            du.storage[i] = max(du.storage[i], 0.0)
-        end
-    end
-
     return nothing
 end
 

--- a/core/test/run_models.jl
+++ b/core/test/run_models.jl
@@ -38,6 +38,7 @@ end
     @test all(isconcretetype, fieldtypes(typeof(p)))
 
     @test successful_retcode(model)
+    @test allunique(model.integrator.sol.t)
     @test model.integrator.sol.u[end] ≈ Float32[519.8817, 519.8798, 339.3959, 1418.4331] skip =
         Sys.isapple() atol = 1.5
 


### PR DESCRIPTION
This rejects any steps that lead to a negative storage. See also:

https://docs.sciml.ai/DiffEqDocs/stable/basics/faq/#My-ODE-goes-negative-but-should-stay-positive,-what-tools-can-help?

When using adaptive solvers this will cause the dt to go down. If it is not adaptive and implicit, it will fail:

```
Warning: Newton steps could not converge and algorithm is not adaptive. Use a lower dt.
```

Both options seem desired behavior.

I managed to still get negative storages with an explicit solver with a large fixed dt, and a flux that empties a basin in well under a timestep. But adaptive is the default and should generally be used.

The `du` correction in `water_balance!` is also removed as it should normally not be needed anymore. And if it does, I'd prefer to not distort the water balance.

One alternative is to use the [`PositiveDomain`](https://docs.sciml.ai/DiffEqCallbacks/stable/step_control/#DiffEqCallbacks.PositiveDomain) callback, but this only works for `adaptive=false`, and is not easily adapted to enforce only the storage part of the state to be positive.



Also adds an unrelated test to avoid saving a t more than once when not needed.