### PR TITLE
Retain the order of the schemas and generated Python code

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,6 +3,7 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 DocumenterMarkdown = "997ab1e6-3595-5248-9280-8efb232c3433"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 
 [compat]
 JSON3 = "1.12"

--- a/docs/schema/BasinProfile.schema.json
+++ b/docs/schema/BasinProfile.schema.json
@@ -1,32 +1,32 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/BasinProfile.schema.json",
+    "title": "BasinProfile",
+    "description": "A BasinProfile object based on Ribasim.BasinProfileV1",
+    "type": "object",
     "properties": {
-        "remarks": {
+        "node_id": {
             "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
+            "type": "integer"
         },
         "area": {
             "format": "double",
             "type": "number"
         },
-        "node_id": {
-            "format": "default",
-            "type": "integer"
-        },
         "level": {
             "format": "double",
             "type": "number"
+        },
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
+            "format": "default",
+            "default": ""
         }
     },
     "required": [
         "node_id",
         "area",
         "level"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/BasinProfile.schema.json",
-    "title": "BasinProfile",
-    "description": "A BasinProfile object based on Ribasim.BasinProfileV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/BasinState.schema.json
+++ b/docs/schema/BasinState.schema.json
@@ -1,12 +1,10 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/BasinState.schema.json",
+    "title": "BasinState",
+    "description": "A BasinState object based on Ribasim.BasinStateV1",
+    "type": "object",
     "properties": {
-        "remarks": {
-            "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
-        },
         "node_id": {
             "format": "default",
             "type": "integer"
@@ -14,14 +12,16 @@
         "level": {
             "format": "double",
             "type": "number"
+        },
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
+            "format": "default",
+            "default": ""
         }
     },
     "required": [
         "node_id",
         "level"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/BasinState.schema.json",
-    "title": "BasinState",
-    "description": "A BasinState object based on Ribasim.BasinStateV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/BasinStatic.schema.json
+++ b/docs/schema/BasinStatic.schema.json
@@ -1,13 +1,19 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/BasinStatic.schema.json",
+    "title": "BasinStatic",
+    "description": "A BasinStatic object based on Ribasim.BasinStaticV1",
+    "type": "object",
     "properties": {
-        "remarks": {
+        "node_id": {
             "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
+            "type": "integer"
         },
-        "precipitation": {
+        "drainage": {
+            "format": "double",
+            "type": "number"
+        },
+        "potential_evaporation": {
             "format": "double",
             "type": "number"
         },
@@ -15,21 +21,19 @@
             "format": "double",
             "type": "number"
         },
+        "precipitation": {
+            "format": "double",
+            "type": "number"
+        },
         "urban_runoff": {
             "format": "double",
             "type": "number"
         },
-        "node_id": {
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
             "format": "default",
-            "type": "integer"
-        },
-        "potential_evaporation": {
-            "format": "double",
-            "type": "number"
-        },
-        "drainage": {
-            "format": "double",
-            "type": "number"
+            "default": ""
         }
     },
     "required": [
@@ -39,9 +43,5 @@
         "infiltration",
         "precipitation",
         "urban_runoff"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/BasinStatic.schema.json",
-    "title": "BasinStatic",
-    "description": "A BasinStatic object based on Ribasim.BasinStaticV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/BasinTime.schema.json
+++ b/docs/schema/BasinTime.schema.json
@@ -1,17 +1,23 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/BasinTime.schema.json",
+    "title": "BasinTime",
+    "description": "A BasinTime object based on Ribasim.BasinTimeV1",
+    "type": "object",
     "properties": {
-        "remarks": {
+        "node_id": {
             "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
+            "type": "integer"
         },
         "time": {
             "format": "date-time",
             "type": "string"
         },
-        "precipitation": {
+        "drainage": {
+            "format": "double",
+            "type": "number"
+        },
+        "potential_evaporation": {
             "format": "double",
             "type": "number"
         },
@@ -19,21 +25,19 @@
             "format": "double",
             "type": "number"
         },
+        "precipitation": {
+            "format": "double",
+            "type": "number"
+        },
         "urban_runoff": {
             "format": "double",
             "type": "number"
         },
-        "node_id": {
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
             "format": "default",
-            "type": "integer"
-        },
-        "potential_evaporation": {
-            "format": "double",
-            "type": "number"
-        },
-        "drainage": {
-            "format": "double",
-            "type": "number"
+            "default": ""
         }
     },
     "required": [
@@ -44,9 +48,5 @@
         "infiltration",
         "precipitation",
         "urban_runoff"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/BasinTime.schema.json",
-    "title": "BasinTime",
-    "description": "A BasinTime object based on Ribasim.BasinTimeV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/Config.schema.json
+++ b/docs/schema/Config.schema.json
@@ -1,7 +1,44 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/Config.schema.json",
+    "title": "Config",
+    "description": "A Config object based on Ribasim.config.Config",
+    "type": "object",
     "properties": {
+        "starttime": {
+            "format": "date-time",
+            "type": "string"
+        },
+        "endtime": {
+            "format": "date-time",
+            "type": "string"
+        },
+        "update_timestep": {
+            "format": "double",
+            "type": "number",
+            "default": 86400
+        },
+        "relative_dir": {
+            "format": "default",
+            "type": "string",
+            "default": "."
+        },
+        "input_dir": {
+            "format": "default",
+            "type": "string",
+            "default": "."
+        },
+        "output_dir": {
+            "format": "default",
+            "type": "string",
+            "default": "."
+        },
+        "geopackage": {
+            "format": "default",
+            "type": "string"
+        },
         "output": {
+            "$ref": "https://deltares.github.io/Ribasim/schema/Output.schema.json",
             "default": {
                 "basin": "output/basin.arrow",
                 "flow": "output/flow.arrow",
@@ -9,56 +46,10 @@
                 "outstate": null,
                 "compression": "zstd",
                 "compression_level": 6
-            },
-            "$ref": "https://deltares.github.io/Ribasim/schema/Output.schema.json"
-        },
-        "starttime": {
-            "format": "date-time",
-            "type": "string"
-        },
-        "update_timestep": {
-            "format": "double",
-            "default": 86400,
-            "type": "number"
-        },
-        "input_dir": {
-            "format": "default",
-            "default": ".",
-            "type": "string"
-        },
-        "output_dir": {
-            "format": "default",
-            "default": ".",
-            "type": "string"
-        },
-        "level_boundary": {
-            "default": {
-                "static": null,
-                "time": null
-            },
-            "$ref": "https://deltares.github.io/Ribasim/schema/level_boundary.schema.json"
-        },
-        "user": {
-            "default": {
-                "static": null,
-                "time": null
-            },
-            "$ref": "https://deltares.github.io/Ribasim/schema/user.schema.json"
-        },
-        "pump": {
-            "default": {
-                "static": null
-            },
-            "$ref": "https://deltares.github.io/Ribasim/schema/pump.schema.json"
-        },
-        "discrete_control": {
-            "default": {
-                "condition": null,
-                "logic": null
-            },
-            "$ref": "https://deltares.github.io/Ribasim/schema/discrete_control.schema.json"
+            }
         },
         "solver": {
+            "$ref": "https://deltares.github.io/Ribasim/schema/Solver.schema.json",
             "default": {
                 "algorithm": "QNDF",
                 "saveat": [
@@ -73,90 +64,103 @@
                 "maxiters": 1000000000,
                 "sparse": true,
                 "autodiff": true
-            },
-            "$ref": "https://deltares.github.io/Ribasim/schema/Solver.schema.json"
-        },
-        "flow_boundary": {
-            "default": {
-                "static": null,
-                "time": null
-            },
-            "$ref": "https://deltares.github.io/Ribasim/schema/flow_boundary.schema.json"
-        },
-        "pid_control": {
-            "default": {
-                "static": null,
-                "time": null
-            },
-            "$ref": "https://deltares.github.io/Ribasim/schema/pid_control.schema.json"
-        },
-        "fractional_flow": {
-            "default": {
-                "static": null
-            },
-            "$ref": "https://deltares.github.io/Ribasim/schema/fractional_flow.schema.json"
-        },
-        "relative_dir": {
-            "format": "default",
-            "default": ".",
-            "type": "string"
-        },
-        "endtime": {
-            "format": "date-time",
-            "type": "string"
-        },
-        "manning_resistance": {
-            "default": {
-                "static": null
-            },
-            "$ref": "https://deltares.github.io/Ribasim/schema/manning_resistance.schema.json"
-        },
-        "tabulated_rating_curve": {
-            "default": {
-                "static": null,
-                "time": null
-            },
-            "$ref": "https://deltares.github.io/Ribasim/schema/tabulated_rating_curve.schema.json"
+            }
         },
         "logging": {
+            "$ref": "https://deltares.github.io/Ribasim/schema/Logging.schema.json",
             "default": {
                 "verbosity": {
                     "level": 0
                 },
                 "timing": false
-            },
-            "$ref": "https://deltares.github.io/Ribasim/schema/Logging.schema.json"
-        },
-        "outlet": {
-            "default": {
-                "static": null
-            },
-            "$ref": "https://deltares.github.io/Ribasim/schema/outlet.schema.json"
-        },
-        "geopackage": {
-            "format": "default",
-            "type": "string"
+            }
         },
         "terminal": {
+            "$ref": "https://deltares.github.io/Ribasim/schema/terminal.schema.json",
             "default": {
                 "static": null
-            },
-            "$ref": "https://deltares.github.io/Ribasim/schema/terminal.schema.json"
+            }
+        },
+        "pid_control": {
+            "$ref": "https://deltares.github.io/Ribasim/schema/pid_control.schema.json",
+            "default": {
+                "static": null,
+                "time": null
+            }
+        },
+        "level_boundary": {
+            "$ref": "https://deltares.github.io/Ribasim/schema/level_boundary.schema.json",
+            "default": {
+                "static": null,
+                "time": null
+            }
+        },
+        "pump": {
+            "$ref": "https://deltares.github.io/Ribasim/schema/pump.schema.json",
+            "default": {
+                "static": null
+            }
+        },
+        "tabulated_rating_curve": {
+            "$ref": "https://deltares.github.io/Ribasim/schema/tabulated_rating_curve.schema.json",
+            "default": {
+                "static": null,
+                "time": null
+            }
+        },
+        "user": {
+            "$ref": "https://deltares.github.io/Ribasim/schema/user.schema.json",
+            "default": {
+                "static": null,
+                "time": null
+            }
+        },
+        "flow_boundary": {
+            "$ref": "https://deltares.github.io/Ribasim/schema/flow_boundary.schema.json",
+            "default": {
+                "static": null,
+                "time": null
+            }
         },
         "basin": {
+            "$ref": "https://deltares.github.io/Ribasim/schema/basin.schema.json",
             "default": {
                 "profile": null,
                 "state": null,
                 "static": null,
                 "time": null
-            },
-            "$ref": "https://deltares.github.io/Ribasim/schema/basin.schema.json"
+            }
         },
-        "linear_resistance": {
+        "manning_resistance": {
+            "$ref": "https://deltares.github.io/Ribasim/schema/manning_resistance.schema.json",
             "default": {
                 "static": null
-            },
-            "$ref": "https://deltares.github.io/Ribasim/schema/linear_resistance.schema.json"
+            }
+        },
+        "discrete_control": {
+            "$ref": "https://deltares.github.io/Ribasim/schema/discrete_control.schema.json",
+            "default": {
+                "condition": null,
+                "logic": null
+            }
+        },
+        "outlet": {
+            "$ref": "https://deltares.github.io/Ribasim/schema/outlet.schema.json",
+            "default": {
+                "static": null
+            }
+        },
+        "linear_resistance": {
+            "$ref": "https://deltares.github.io/Ribasim/schema/linear_resistance.schema.json",
+            "default": {
+                "static": null
+            }
+        },
+        "fractional_flow": {
+            "$ref": "https://deltares.github.io/Ribasim/schema/fractional_flow.schema.json",
+            "default": {
+                "static": null
+            }
         }
     },
     "required": [
@@ -183,9 +187,5 @@
         "outlet",
         "linear_resistance",
         "fractional_flow"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/Config.schema.json",
-    "title": "Config",
-    "description": "A Config object based on Ribasim.config.Config",
-    "type": "object"
+    ]
 }

--- a/docs/schema/DiscreteControlCondition.schema.json
+++ b/docs/schema/DiscreteControlCondition.schema.json
@@ -1,27 +1,25 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/DiscreteControlCondition.schema.json",
+    "title": "DiscreteControlCondition",
+    "description": "A DiscreteControlCondition object based on Ribasim.DiscreteControlConditionV1",
+    "type": "object",
     "properties": {
-        "remarks": {
-            "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
-        },
-        "greater_than": {
-            "format": "double",
-            "type": "number"
-        },
-        "listen_feature_id": {
+        "node_id": {
             "format": "default",
             "type": "integer"
         },
-        "node_id": {
+        "listen_feature_id": {
             "format": "default",
             "type": "integer"
         },
         "variable": {
             "format": "default",
             "type": "string"
+        },
+        "greater_than": {
+            "format": "double",
+            "type": "number"
         },
         "look_ahead": {
             "format": "default",
@@ -33,6 +31,12 @@
                     "type": "number"
                 }
             ]
+        },
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
+            "format": "default",
+            "default": ""
         }
     },
     "required": [
@@ -40,9 +44,5 @@
         "listen_feature_id",
         "variable",
         "greater_than"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/DiscreteControlCondition.schema.json",
-    "title": "DiscreteControlCondition",
-    "description": "A DiscreteControlCondition object based on Ribasim.DiscreteControlConditionV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/DiscreteControlLogic.schema.json
+++ b/docs/schema/DiscreteControlLogic.schema.json
@@ -1,32 +1,32 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/DiscreteControlLogic.schema.json",
+    "title": "DiscreteControlLogic",
+    "description": "A DiscreteControlLogic object based on Ribasim.DiscreteControlLogicV1",
+    "type": "object",
     "properties": {
-        "remarks": {
+        "node_id": {
             "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
+            "type": "integer"
         },
         "truth_state": {
             "format": "default",
             "type": "string"
         },
-        "node_id": {
-            "format": "default",
-            "type": "integer"
-        },
         "control_state": {
             "format": "default",
             "type": "string"
+        },
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
+            "format": "default",
+            "default": ""
         }
     },
     "required": [
         "node_id",
         "truth_state",
         "control_state"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/DiscreteControlLogic.schema.json",
-    "title": "DiscreteControlLogic",
-    "description": "A DiscreteControlLogic object based on Ribasim.DiscreteControlLogicV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/Edge.schema.json
+++ b/docs/schema/Edge.schema.json
@@ -1,17 +1,15 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/Edge.schema.json",
+    "title": "Edge",
+    "description": "A Edge object based on Ribasim.EdgeV1",
+    "type": "object",
     "properties": {
-        "remarks": {
-            "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
-        },
-        "edge_type": {
-            "format": "default",
-            "type": "string"
-        },
         "fid": {
+            "format": "default",
+            "type": "integer"
+        },
+        "from_node_id": {
             "format": "default",
             "type": "integer"
         },
@@ -19,9 +17,15 @@
             "format": "default",
             "type": "integer"
         },
-        "from_node_id": {
+        "edge_type": {
             "format": "default",
-            "type": "integer"
+            "type": "string"
+        },
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
+            "format": "default",
+            "default": ""
         }
     },
     "required": [
@@ -29,9 +33,5 @@
         "from_node_id",
         "to_node_id",
         "edge_type"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/Edge.schema.json",
-    "title": "Edge",
-    "description": "A Edge object based on Ribasim.EdgeV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/FlowBoundaryStatic.schema.json
+++ b/docs/schema/FlowBoundaryStatic.schema.json
@@ -1,11 +1,13 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/FlowBoundaryStatic.schema.json",
+    "title": "FlowBoundaryStatic",
+    "description": "A FlowBoundaryStatic object based on Ribasim.FlowBoundaryStaticV1",
+    "type": "object",
     "properties": {
-        "remarks": {
+        "node_id": {
             "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
+            "type": "integer"
         },
         "active": {
             "format": "default",
@@ -22,17 +24,15 @@
             "format": "double",
             "type": "number"
         },
-        "node_id": {
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
             "format": "default",
-            "type": "integer"
+            "default": ""
         }
     },
     "required": [
         "node_id",
         "flow_rate"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/FlowBoundaryStatic.schema.json",
-    "title": "FlowBoundaryStatic",
-    "description": "A FlowBoundaryStatic object based on Ribasim.FlowBoundaryStaticV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/FlowBoundaryTime.schema.json
+++ b/docs/schema/FlowBoundaryTime.schema.json
@@ -1,11 +1,13 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/FlowBoundaryTime.schema.json",
+    "title": "FlowBoundaryTime",
+    "description": "A FlowBoundaryTime object based on Ribasim.FlowBoundaryTimeV1",
+    "type": "object",
     "properties": {
-        "remarks": {
+        "node_id": {
             "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
+            "type": "integer"
         },
         "time": {
             "format": "date-time",
@@ -15,18 +17,16 @@
             "format": "double",
             "type": "number"
         },
-        "node_id": {
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
             "format": "default",
-            "type": "integer"
+            "default": ""
         }
     },
     "required": [
         "node_id",
         "time",
         "flow_rate"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/FlowBoundaryTime.schema.json",
-    "title": "FlowBoundaryTime",
-    "description": "A FlowBoundaryTime object based on Ribasim.FlowBoundaryTimeV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/FractionalFlowStatic.schema.json
+++ b/docs/schema/FractionalFlowStatic.schema.json
@@ -1,12 +1,10 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/FractionalFlowStatic.schema.json",
+    "title": "FractionalFlowStatic",
+    "description": "A FractionalFlowStatic object based on Ribasim.FractionalFlowStaticV1",
+    "type": "object",
     "properties": {
-        "remarks": {
-            "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
-        },
         "node_id": {
             "format": "default",
             "type": "integer"
@@ -25,14 +23,16 @@
                     "type": "string"
                 }
             ]
+        },
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
+            "format": "default",
+            "default": ""
         }
     },
     "required": [
         "node_id",
         "fraction"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/FractionalFlowStatic.schema.json",
-    "title": "FractionalFlowStatic",
-    "description": "A FractionalFlowStatic object based on Ribasim.FractionalFlowStaticV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/LevelBoundaryStatic.schema.json
+++ b/docs/schema/LevelBoundaryStatic.schema.json
@@ -1,11 +1,13 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/LevelBoundaryStatic.schema.json",
+    "title": "LevelBoundaryStatic",
+    "description": "A LevelBoundaryStatic object based on Ribasim.LevelBoundaryStaticV1",
+    "type": "object",
     "properties": {
-        "remarks": {
+        "node_id": {
             "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
+            "type": "integer"
         },
         "active": {
             "format": "default",
@@ -18,21 +20,19 @@
                 }
             ]
         },
-        "node_id": {
-            "format": "default",
-            "type": "integer"
-        },
         "level": {
             "format": "double",
             "type": "number"
+        },
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
+            "format": "default",
+            "default": ""
         }
     },
     "required": [
         "node_id",
         "level"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/LevelBoundaryStatic.schema.json",
-    "title": "LevelBoundaryStatic",
-    "description": "A LevelBoundaryStatic object based on Ribasim.LevelBoundaryStaticV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/LevelBoundaryTime.schema.json
+++ b/docs/schema/LevelBoundaryTime.schema.json
@@ -1,32 +1,32 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/LevelBoundaryTime.schema.json",
+    "title": "LevelBoundaryTime",
+    "description": "A LevelBoundaryTime object based on Ribasim.LevelBoundaryTimeV1",
+    "type": "object",
     "properties": {
-        "remarks": {
+        "node_id": {
             "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
+            "type": "integer"
         },
         "time": {
             "format": "date-time",
             "type": "string"
         },
-        "node_id": {
-            "format": "default",
-            "type": "integer"
-        },
         "level": {
             "format": "double",
             "type": "number"
+        },
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
+            "format": "default",
+            "default": ""
         }
     },
     "required": [
         "node_id",
         "time",
         "level"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/LevelBoundaryTime.schema.json",
-    "title": "LevelBoundaryTime",
-    "description": "A LevelBoundaryTime object based on Ribasim.LevelBoundaryTimeV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/LinearResistanceStatic.schema.json
+++ b/docs/schema/LinearResistanceStatic.schema.json
@@ -1,11 +1,13 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/LinearResistanceStatic.schema.json",
+    "title": "LinearResistanceStatic",
+    "description": "A LinearResistanceStatic object based on Ribasim.LinearResistanceStaticV1",
+    "type": "object",
     "properties": {
-        "remarks": {
+        "node_id": {
             "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
+            "type": "integer"
         },
         "active": {
             "format": "default",
@@ -17,10 +19,6 @@
                     "type": "boolean"
                 }
             ]
-        },
-        "node_id": {
-            "format": "default",
-            "type": "integer"
         },
         "resistance": {
             "format": "double",
@@ -36,14 +34,16 @@
                     "type": "string"
                 }
             ]
+        },
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
+            "format": "default",
+            "default": ""
         }
     },
     "required": [
         "node_id",
         "resistance"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/LinearResistanceStatic.schema.json",
-    "title": "LinearResistanceStatic",
-    "description": "A LinearResistanceStatic object based on Ribasim.LinearResistanceStaticV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/Logging.schema.json
+++ b/docs/schema/Logging.schema.json
@@ -1,23 +1,23 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/Logging.schema.json",
+    "title": "Logging",
+    "description": "A Logging object based on Ribasim.config.Logging",
+    "type": "object",
     "properties": {
-        "timing": {
-            "format": "default",
-            "default": false,
-            "type": "boolean"
-        },
         "verbosity": {
             "format": "default",
-            "default": "info",
-            "type": "string"
+            "type": "string",
+            "default": "info"
+        },
+        "timing": {
+            "format": "default",
+            "type": "boolean",
+            "default": false
         }
     },
     "required": [
         "verbosity",
         "timing"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/Logging.schema.json",
-    "title": "Logging",
-    "description": "A Logging object based on Ribasim.config.Logging",
-    "type": "object"
+    ]
 }

--- a/docs/schema/ManningResistanceStatic.schema.json
+++ b/docs/schema/ManningResistanceStatic.schema.json
@@ -1,19 +1,13 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/ManningResistanceStatic.schema.json",
+    "title": "ManningResistanceStatic",
+    "description": "A ManningResistanceStatic object based on Ribasim.ManningResistanceStaticV1",
+    "type": "object",
     "properties": {
-        "length": {
-            "format": "double",
-            "type": "number"
-        },
-        "manning_n": {
-            "format": "double",
-            "type": "number"
-        },
-        "remarks": {
+        "node_id": {
             "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
+            "type": "integer"
         },
         "active": {
             "format": "default",
@@ -26,13 +20,17 @@
                 }
             ]
         },
-        "profile_width": {
+        "length": {
             "format": "double",
             "type": "number"
         },
-        "node_id": {
-            "format": "default",
-            "type": "integer"
+        "manning_n": {
+            "format": "double",
+            "type": "number"
+        },
+        "profile_width": {
+            "format": "double",
+            "type": "number"
         },
         "profile_slope": {
             "format": "double",
@@ -48,6 +46,12 @@
                     "type": "string"
                 }
             ]
+        },
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
+            "format": "default",
+            "default": ""
         }
     },
     "required": [
@@ -56,9 +60,5 @@
         "manning_n",
         "profile_width",
         "profile_slope"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/ManningResistanceStatic.schema.json",
-    "title": "ManningResistanceStatic",
-    "description": "A ManningResistanceStatic object based on Ribasim.ManningResistanceStaticV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/Node.schema.json
+++ b/docs/schema/Node.schema.json
@@ -1,12 +1,10 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/Node.schema.json",
+    "title": "Node",
+    "description": "A Node object based on Ribasim.NodeV1",
+    "type": "object",
     "properties": {
-        "remarks": {
-            "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
-        },
         "fid": {
             "format": "default",
             "type": "integer"
@@ -14,14 +12,16 @@
         "type": {
             "format": "default",
             "type": "string"
+        },
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
+            "format": "default",
+            "default": ""
         }
     },
     "required": [
         "fid",
         "type"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/Node.schema.json",
-    "title": "Node",
-    "description": "A Node object based on Ribasim.NodeV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/OutletStatic.schema.json
+++ b/docs/schema/OutletStatic.schema.json
@@ -1,7 +1,30 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/OutletStatic.schema.json",
+    "title": "OutletStatic",
+    "description": "A OutletStatic object based on Ribasim.OutletStaticV1",
+    "type": "object",
     "properties": {
-        "max_flow_rate": {
+        "node_id": {
+            "format": "default",
+            "type": "integer"
+        },
+        "active": {
+            "format": "default",
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "boolean"
+                }
+            ]
+        },
+        "flow_rate": {
+            "format": "double",
+            "type": "number"
+        },
+        "min_flow_rate": {
             "format": "default",
             "anyOf": [
                 {
@@ -12,20 +35,14 @@
                 }
             ]
         },
-        "remarks": {
-            "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
-        },
-        "active": {
+        "max_flow_rate": {
             "format": "default",
             "anyOf": [
                 {
                     "type": "null"
                 },
                 {
-                    "type": "boolean"
+                    "type": "number"
                 }
             ]
         },
@@ -40,14 +57,6 @@
                 }
             ]
         },
-        "flow_rate": {
-            "format": "double",
-            "type": "number"
-        },
-        "node_id": {
-            "format": "default",
-            "type": "integer"
-        },
         "control_state": {
             "format": "default",
             "anyOf": [
@@ -59,24 +68,15 @@
                 }
             ]
         },
-        "min_flow_rate": {
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
             "format": "default",
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "number"
-                }
-            ]
+            "default": ""
         }
     },
     "required": [
         "node_id",
         "flow_rate"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/OutletStatic.schema.json",
-    "title": "OutletStatic",
-    "description": "A OutletStatic object based on Ribasim.OutletStaticV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/Output.schema.json
+++ b/docs/schema/Output.schema.json
@@ -1,25 +1,24 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/Output.schema.json",
+    "title": "Output",
+    "description": "A Output object based on Ribasim.config.Output",
+    "type": "object",
     "properties": {
-        "compression": {
-            "format": "default",
-            "default": "zstd",
-            "type": "string"
-        },
         "basin": {
             "format": "default",
-            "default": "output/basin.arrow",
-            "type": "string"
+            "type": "string",
+            "default": "output/basin.arrow"
         },
         "flow": {
             "format": "default",
-            "default": "output/flow.arrow",
-            "type": "string"
+            "type": "string",
+            "default": "output/flow.arrow"
         },
         "control": {
             "format": "default",
-            "default": "output/control.arrow",
-            "type": "string"
+            "type": "string",
+            "default": "output/control.arrow"
         },
         "outstate": {
             "format": "default",
@@ -33,10 +32,15 @@
             ],
             "default": null
         },
+        "compression": {
+            "format": "default",
+            "type": "string",
+            "default": "zstd"
+        },
         "compression_level": {
             "format": "default",
-            "default": 6,
-            "type": "integer"
+            "type": "integer",
+            "default": 6
         }
     },
     "required": [
@@ -45,9 +49,5 @@
         "control",
         "compression",
         "compression_level"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/Output.schema.json",
-    "title": "Output",
-    "description": "A Output object based on Ribasim.config.Output",
-    "type": "object"
+    ]
 }

--- a/docs/schema/PIDControlStatic.schema.json
+++ b/docs/schema/PIDControlStatic.schema.json
@@ -1,17 +1,11 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/PidControlStatic.schema.json",
+    "title": "PidControlStatic",
+    "description": "A PidControlStatic object based on Ribasim.PidControlStaticV1",
+    "type": "object",
     "properties": {
-        "integral": {
-            "format": "double",
-            "type": "number"
-        },
-        "remarks": {
-            "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
-        },
-        "listen_node_id": {
+        "node_id": {
             "format": "default",
             "type": "integer"
         },
@@ -26,15 +20,19 @@
                 }
             ]
         },
-        "proportional": {
-            "format": "double",
-            "type": "number"
-        },
-        "node_id": {
+        "listen_node_id": {
             "format": "default",
             "type": "integer"
         },
         "target": {
+            "format": "double",
+            "type": "number"
+        },
+        "proportional": {
+            "format": "double",
+            "type": "number"
+        },
+        "integral": {
             "format": "double",
             "type": "number"
         },
@@ -52,6 +50,12 @@
                     "type": "string"
                 }
             ]
+        },
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
+            "format": "default",
+            "default": ""
         }
     },
     "required": [
@@ -61,9 +65,5 @@
         "proportional",
         "integral",
         "derivative"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/PidControlStatic.schema.json",
-    "title": "PidControlStatic",
-    "description": "A PidControlStatic object based on Ribasim.PidControlStaticV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/PidControlTime.schema.json
+++ b/docs/schema/PidControlTime.schema.json
@@ -1,15 +1,13 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/PidControlTime.schema.json",
+    "title": "PidControlTime",
+    "description": "A PidControlTime object based on Ribasim.PidControlTimeV1",
+    "type": "object",
     "properties": {
-        "integral": {
-            "format": "double",
-            "type": "number"
-        },
-        "remarks": {
+        "node_id": {
             "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
+            "type": "integer"
         },
         "listen_node_id": {
             "format": "default",
@@ -19,15 +17,15 @@
             "format": "date-time",
             "type": "string"
         },
+        "target": {
+            "format": "double",
+            "type": "number"
+        },
         "proportional": {
             "format": "double",
             "type": "number"
         },
-        "node_id": {
-            "format": "default",
-            "type": "integer"
-        },
-        "target": {
+        "integral": {
             "format": "double",
             "type": "number"
         },
@@ -45,6 +43,12 @@
                     "type": "string"
                 }
             ]
+        },
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
+            "format": "default",
+            "default": ""
         }
     },
     "required": [
@@ -55,9 +59,5 @@
         "proportional",
         "integral",
         "derivative"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/PidControlTime.schema.json",
-    "title": "PidControlTime",
-    "description": "A PidControlTime object based on Ribasim.PidControlTimeV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/PumpStatic.schema.json
+++ b/docs/schema/PumpStatic.schema.json
@@ -1,22 +1,13 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/PumpStatic.schema.json",
+    "title": "PumpStatic",
+    "description": "A PumpStatic object based on Ribasim.PumpStaticV1",
+    "type": "object",
     "properties": {
-        "max_flow_rate": {
+        "node_id": {
             "format": "default",
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "number"
-                }
-            ]
-        },
-        "remarks": {
-            "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
+            "type": "integer"
         },
         "active": {
             "format": "default",
@@ -33,9 +24,27 @@
             "format": "double",
             "type": "number"
         },
-        "node_id": {
+        "min_flow_rate": {
             "format": "default",
-            "type": "integer"
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "max_flow_rate": {
+            "format": "default",
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "number"
+                }
+            ]
         },
         "control_state": {
             "format": "default",
@@ -48,24 +57,15 @@
                 }
             ]
         },
-        "min_flow_rate": {
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
             "format": "default",
-            "anyOf": [
-                {
-                    "type": "null"
-                },
-                {
-                    "type": "number"
-                }
-            ]
+            "default": ""
         }
     },
     "required": [
         "node_id",
         "flow_rate"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/PumpStatic.schema.json",
-    "title": "PumpStatic",
-    "description": "A PumpStatic object based on Ribasim.PumpStaticV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/Solver.schema.json
+++ b/docs/schema/Solver.schema.json
@@ -1,20 +1,35 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/Solver.schema.json",
+    "title": "Solver",
+    "description": "A Solver object based on Ribasim.config.Solver",
+    "type": "object",
     "properties": {
-        "autodiff": {
+        "algorithm": {
             "format": "default",
-            "default": true,
-            "type": "boolean"
+            "type": "string",
+            "default": "QNDF"
+        },
+        "saveat": {
+            "format": "default",
+            "anyOf": [
+                {
+                    "type": "number"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                }
+            ],
+            "default": [
+            ]
         },
         "adaptive": {
             "format": "default",
-            "default": true,
-            "type": "boolean"
-        },
-        "force_dtmin": {
-            "format": "default",
-            "default": false,
-            "type": "boolean"
+            "type": "boolean",
+            "default": true
         },
         "dt": {
             "format": "default",
@@ -28,27 +43,6 @@
             ],
             "default": null
         },
-        "saveat": {
-            "format": "default",
-            "anyOf": [
-                {
-                    "items": {
-                        "type": "number"
-                    },
-                    "type": "array"
-                },
-                {
-                    "type": "number"
-                }
-            ],
-            "default": [
-            ]
-        },
-        "maxiters": {
-            "format": "default",
-            "default": 1000000000,
-            "type": "integer"
-        },
         "dtmin": {
             "format": "default",
             "anyOf": [
@@ -61,26 +55,6 @@
             ],
             "default": null
         },
-        "sparse": {
-            "format": "default",
-            "default": true,
-            "type": "boolean"
-        },
-        "algorithm": {
-            "format": "default",
-            "default": "QNDF",
-            "type": "string"
-        },
-        "abstol": {
-            "format": "double",
-            "default": 1.0e-6,
-            "type": "number"
-        },
-        "reltol": {
-            "format": "double",
-            "default": 0.001,
-            "type": "number"
-        },
         "dtmax": {
             "format": "default",
             "anyOf": [
@@ -92,6 +66,36 @@
                 }
             ],
             "default": null
+        },
+        "force_dtmin": {
+            "format": "default",
+            "type": "boolean",
+            "default": false
+        },
+        "abstol": {
+            "format": "double",
+            "type": "number",
+            "default": 1.0e-6
+        },
+        "reltol": {
+            "format": "double",
+            "type": "number",
+            "default": 0.001
+        },
+        "maxiters": {
+            "format": "default",
+            "type": "integer",
+            "default": 1000000000
+        },
+        "sparse": {
+            "format": "default",
+            "type": "boolean",
+            "default": true
+        },
+        "autodiff": {
+            "format": "default",
+            "type": "boolean",
+            "default": true
         }
     },
     "required": [
@@ -104,9 +108,5 @@
         "maxiters",
         "sparse",
         "autodiff"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/Solver.schema.json",
-    "title": "Solver",
-    "description": "A Solver object based on Ribasim.config.Solver",
-    "type": "object"
+    ]
 }

--- a/docs/schema/TabulatedRatingCurveStatic.schema.json
+++ b/docs/schema/TabulatedRatingCurveStatic.schema.json
@@ -1,11 +1,13 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/TabulatedRatingCurveStatic.schema.json",
+    "title": "TabulatedRatingCurveStatic",
+    "description": "A TabulatedRatingCurveStatic object based on Ribasim.TabulatedRatingCurveStaticV1",
+    "type": "object",
     "properties": {
-        "remarks": {
+        "node_id": {
             "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
+            "type": "integer"
         },
         "active": {
             "format": "default",
@@ -18,15 +20,11 @@
                 }
             ]
         },
-        "node_id": {
-            "format": "default",
-            "type": "integer"
-        },
-        "discharge": {
+        "level": {
             "format": "double",
             "type": "number"
         },
-        "level": {
+        "discharge": {
             "format": "double",
             "type": "number"
         },
@@ -40,15 +38,17 @@
                     "type": "string"
                 }
             ]
+        },
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
+            "format": "default",
+            "default": ""
         }
     },
     "required": [
         "node_id",
         "level",
         "discharge"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/TabulatedRatingCurveStatic.schema.json",
-    "title": "TabulatedRatingCurveStatic",
-    "description": "A TabulatedRatingCurveStatic object based on Ribasim.TabulatedRatingCurveStaticV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/TabulatedRatingCurveTime.schema.json
+++ b/docs/schema/TabulatedRatingCurveTime.schema.json
@@ -1,27 +1,31 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/TabulatedRatingCurveTime.schema.json",
+    "title": "TabulatedRatingCurveTime",
+    "description": "A TabulatedRatingCurveTime object based on Ribasim.TabulatedRatingCurveTimeV1",
+    "type": "object",
     "properties": {
-        "remarks": {
+        "node_id": {
             "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
+            "type": "integer"
         },
         "time": {
             "format": "date-time",
             "type": "string"
         },
-        "node_id": {
-            "format": "default",
-            "type": "integer"
+        "level": {
+            "format": "double",
+            "type": "number"
         },
         "discharge": {
             "format": "double",
             "type": "number"
         },
-        "level": {
-            "format": "double",
-            "type": "number"
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
+            "format": "default",
+            "default": ""
         }
     },
     "required": [
@@ -29,9 +33,5 @@
         "time",
         "level",
         "discharge"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/TabulatedRatingCurveTime.schema.json",
-    "title": "TabulatedRatingCurveTime",
-    "description": "A TabulatedRatingCurveTime object based on Ribasim.TabulatedRatingCurveTimeV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/TerminalStatic.schema.json
+++ b/docs/schema/TerminalStatic.schema.json
@@ -1,22 +1,22 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/TerminalStatic.schema.json",
+    "title": "TerminalStatic",
+    "description": "A TerminalStatic object based on Ribasim.TerminalStaticV1",
+    "type": "object",
     "properties": {
-        "remarks": {
-            "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
-        },
         "node_id": {
             "format": "default",
             "type": "integer"
+        },
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
+            "format": "default",
+            "default": ""
         }
     },
     "required": [
         "node_id"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/TerminalStatic.schema.json",
-    "title": "TerminalStatic",
-    "description": "A TerminalStatic object based on Ribasim.TerminalStaticV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/UserStatic.schema.json
+++ b/docs/schema/UserStatic.schema.json
@@ -1,13 +1,11 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/UserStatic.schema.json",
+    "title": "UserStatic",
+    "description": "A UserStatic object based on Ribasim.UserStaticV1",
+    "type": "object",
     "properties": {
-        "remarks": {
-            "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
-        },
-        "priority": {
+        "node_id": {
             "format": "default",
             "type": "integer"
         },
@@ -34,9 +32,15 @@
             "format": "double",
             "type": "number"
         },
-        "node_id": {
+        "priority": {
             "format": "default",
             "type": "integer"
+        },
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
+            "format": "default",
+            "default": ""
         }
     },
     "required": [
@@ -45,9 +49,5 @@
         "return_factor",
         "min_level",
         "priority"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/UserStatic.schema.json",
-    "title": "UserStatic",
-    "description": "A UserStatic object based on Ribasim.UserStaticV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/UserTime.schema.json
+++ b/docs/schema/UserTime.schema.json
@@ -1,13 +1,11 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/UserTime.schema.json",
+    "title": "UserTime",
+    "description": "A UserTime object based on Ribasim.UserTimeV1",
+    "type": "object",
     "properties": {
-        "remarks": {
-            "format": "default",
-            "default": "",
-            "description": "a hack for pandera",
-            "type": "string"
-        },
-        "priority": {
+        "node_id": {
             "format": "default",
             "type": "integer"
         },
@@ -27,9 +25,15 @@
             "format": "double",
             "type": "number"
         },
-        "node_id": {
+        "priority": {
             "format": "default",
             "type": "integer"
+        },
+        "remarks": {
+            "description": "a hack for pandera",
+            "type": "string",
+            "format": "default",
+            "default": ""
         }
     },
     "required": [
@@ -39,9 +43,5 @@
         "return_factor",
         "min_level",
         "priority"
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/UserTime.schema.json",
-    "title": "UserTime",
-    "description": "A UserTime object based on Ribasim.UserTimeV1",
-    "type": "object"
+    ]
 }

--- a/docs/schema/basin.schema.json
+++ b/docs/schema/basin.schema.json
@@ -1,5 +1,9 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/basin.schema.json",
+    "title": "basin",
+    "description": "A basin object based on Ribasim.config.basin",
+    "type": "object",
     "properties": {
         "profile": {
             "format": "default",
@@ -13,7 +17,7 @@
             ],
             "default": null
         },
-        "time": {
+        "state": {
             "format": "default",
             "anyOf": [
                 {
@@ -37,7 +41,7 @@
             ],
             "default": null
         },
-        "state": {
+        "time": {
             "format": "default",
             "anyOf": [
                 {
@@ -51,9 +55,5 @@
         }
     },
     "required": [
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/basin.schema.json",
-    "title": "basin",
-    "description": "A basin object based on Ribasim.config.basin",
-    "type": "object"
+    ]
 }

--- a/docs/schema/discrete_control.schema.json
+++ b/docs/schema/discrete_control.schema.json
@@ -1,7 +1,11 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/discrete_control.schema.json",
+    "title": "discrete_control",
+    "description": "A discrete_control object based on Ribasim.config.discrete_control",
+    "type": "object",
     "properties": {
-        "logic": {
+        "condition": {
             "format": "default",
             "anyOf": [
                 {
@@ -13,7 +17,7 @@
             ],
             "default": null
         },
-        "condition": {
+        "logic": {
             "format": "default",
             "anyOf": [
                 {
@@ -27,9 +31,5 @@
         }
     },
     "required": [
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/discrete_control.schema.json",
-    "title": "discrete_control",
-    "description": "A discrete_control object based on Ribasim.config.discrete_control",
-    "type": "object"
+    ]
 }

--- a/docs/schema/flow_boundary.schema.json
+++ b/docs/schema/flow_boundary.schema.json
@@ -1,7 +1,11 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/flow_boundary.schema.json",
+    "title": "flow_boundary",
+    "description": "A flow_boundary object based on Ribasim.config.flow_boundary",
+    "type": "object",
     "properties": {
-        "time": {
+        "static": {
             "format": "default",
             "anyOf": [
                 {
@@ -13,7 +17,7 @@
             ],
             "default": null
         },
-        "static": {
+        "time": {
             "format": "default",
             "anyOf": [
                 {
@@ -27,9 +31,5 @@
         }
     },
     "required": [
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/flow_boundary.schema.json",
-    "title": "flow_boundary",
-    "description": "A flow_boundary object based on Ribasim.config.flow_boundary",
-    "type": "object"
+    ]
 }

--- a/docs/schema/fractional_flow.schema.json
+++ b/docs/schema/fractional_flow.schema.json
@@ -1,5 +1,9 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/fractional_flow.schema.json",
+    "title": "fractional_flow",
+    "description": "A fractional_flow object based on Ribasim.config.fractional_flow",
+    "type": "object",
     "properties": {
         "static": {
             "format": "default",
@@ -15,9 +19,5 @@
         }
     },
     "required": [
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/fractional_flow.schema.json",
-    "title": "fractional_flow",
-    "description": "A fractional_flow object based on Ribasim.config.fractional_flow",
-    "type": "object"
+    ]
 }

--- a/docs/schema/level_boundary.schema.json
+++ b/docs/schema/level_boundary.schema.json
@@ -1,7 +1,11 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/level_boundary.schema.json",
+    "title": "level_boundary",
+    "description": "A level_boundary object based on Ribasim.config.level_boundary",
+    "type": "object",
     "properties": {
-        "time": {
+        "static": {
             "format": "default",
             "anyOf": [
                 {
@@ -13,7 +17,7 @@
             ],
             "default": null
         },
-        "static": {
+        "time": {
             "format": "default",
             "anyOf": [
                 {
@@ -27,9 +31,5 @@
         }
     },
     "required": [
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/level_boundary.schema.json",
-    "title": "level_boundary",
-    "description": "A level_boundary object based on Ribasim.config.level_boundary",
-    "type": "object"
+    ]
 }

--- a/docs/schema/linear_resistance.schema.json
+++ b/docs/schema/linear_resistance.schema.json
@@ -1,5 +1,9 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/linear_resistance.schema.json",
+    "title": "linear_resistance",
+    "description": "A linear_resistance object based on Ribasim.config.linear_resistance",
+    "type": "object",
     "properties": {
         "static": {
             "format": "default",
@@ -15,9 +19,5 @@
         }
     },
     "required": [
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/linear_resistance.schema.json",
-    "title": "linear_resistance",
-    "description": "A linear_resistance object based on Ribasim.config.linear_resistance",
-    "type": "object"
+    ]
 }

--- a/docs/schema/manning_resistance.schema.json
+++ b/docs/schema/manning_resistance.schema.json
@@ -1,5 +1,9 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/manning_resistance.schema.json",
+    "title": "manning_resistance",
+    "description": "A manning_resistance object based on Ribasim.config.manning_resistance",
+    "type": "object",
     "properties": {
         "static": {
             "format": "default",
@@ -15,9 +19,5 @@
         }
     },
     "required": [
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/manning_resistance.schema.json",
-    "title": "manning_resistance",
-    "description": "A manning_resistance object based on Ribasim.config.manning_resistance",
-    "type": "object"
+    ]
 }

--- a/docs/schema/outlet.schema.json
+++ b/docs/schema/outlet.schema.json
@@ -1,5 +1,9 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/outlet.schema.json",
+    "title": "outlet",
+    "description": "A outlet object based on Ribasim.config.outlet",
+    "type": "object",
     "properties": {
         "static": {
             "format": "default",
@@ -15,9 +19,5 @@
         }
     },
     "required": [
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/outlet.schema.json",
-    "title": "outlet",
-    "description": "A outlet object based on Ribasim.config.outlet",
-    "type": "object"
+    ]
 }

--- a/docs/schema/pid_control.schema.json
+++ b/docs/schema/pid_control.schema.json
@@ -1,7 +1,11 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/pid_control.schema.json",
+    "title": "pid_control",
+    "description": "A pid_control object based on Ribasim.config.pid_control",
+    "type": "object",
     "properties": {
-        "time": {
+        "static": {
             "format": "default",
             "anyOf": [
                 {
@@ -13,7 +17,7 @@
             ],
             "default": null
         },
-        "static": {
+        "time": {
             "format": "default",
             "anyOf": [
                 {
@@ -27,9 +31,5 @@
         }
     },
     "required": [
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/pid_control.schema.json",
-    "title": "pid_control",
-    "description": "A pid_control object based on Ribasim.config.pid_control",
-    "type": "object"
+    ]
 }

--- a/docs/schema/pump.schema.json
+++ b/docs/schema/pump.schema.json
@@ -1,5 +1,9 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/pump.schema.json",
+    "title": "pump",
+    "description": "A pump object based on Ribasim.config.pump",
+    "type": "object",
     "properties": {
         "static": {
             "format": "default",
@@ -15,9 +19,5 @@
         }
     },
     "required": [
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/pump.schema.json",
-    "title": "pump",
-    "description": "A pump object based on Ribasim.config.pump",
-    "type": "object"
+    ]
 }

--- a/docs/schema/root.schema.json
+++ b/docs/schema/root.schema.json
@@ -1,8 +1,20 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
+        "BasinProfile": {
+            "$ref": "BasinProfile.schema.json"
+        },
+        "BasinState": {
+            "$ref": "BasinState.schema.json"
+        },
+        "BasinStatic": {
+            "$ref": "BasinStatic.schema.json"
+        },
         "BasinTime": {
             "$ref": "BasinTime.schema.json"
+        },
+        "DiscreteControlCondition": {
+            "$ref": "DiscreteControlCondition.schema.json"
         },
         "DiscreteControlLogic": {
             "$ref": "DiscreteControlLogic.schema.json"
@@ -10,29 +22,32 @@
         "Edge": {
             "$ref": "Edge.schema.json"
         },
+        "FlowBoundaryStatic": {
+            "$ref": "FlowBoundaryStatic.schema.json"
+        },
         "FlowBoundaryTime": {
             "$ref": "FlowBoundaryTime.schema.json"
         },
-        "UserStatic": {
-            "$ref": "UserStatic.schema.json"
-        },
-        "PumpStatic": {
-            "$ref": "PumpStatic.schema.json"
+        "FractionalFlowStatic": {
+            "$ref": "FractionalFlowStatic.schema.json"
         },
         "LevelBoundaryStatic": {
             "$ref": "LevelBoundaryStatic.schema.json"
         },
-        "UserTime": {
-            "$ref": "UserTime.schema.json"
-        },
-        "DiscreteControlCondition": {
-            "$ref": "DiscreteControlCondition.schema.json"
+        "LevelBoundaryTime": {
+            "$ref": "LevelBoundaryTime.schema.json"
         },
         "LinearResistanceStatic": {
             "$ref": "LinearResistanceStatic.schema.json"
         },
-        "FractionalFlowStatic": {
-            "$ref": "FractionalFlowStatic.schema.json"
+        "ManningResistanceStatic": {
+            "$ref": "ManningResistanceStatic.schema.json"
+        },
+        "Node": {
+            "$ref": "Node.schema.json"
+        },
+        "OutletStatic": {
+            "$ref": "OutletStatic.schema.json"
         },
         "PidControlStatic": {
             "$ref": "PidControlStatic.schema.json"
@@ -40,38 +55,23 @@
         "PidControlTime": {
             "$ref": "PidControlTime.schema.json"
         },
-        "ManningResistanceStatic": {
-            "$ref": "ManningResistanceStatic.schema.json"
-        },
-        "FlowBoundaryStatic": {
-            "$ref": "FlowBoundaryStatic.schema.json"
-        },
-        "OutletStatic": {
-            "$ref": "OutletStatic.schema.json"
-        },
-        "Node": {
-            "$ref": "Node.schema.json"
-        },
-        "TabulatedRatingCurveTime": {
-            "$ref": "TabulatedRatingCurveTime.schema.json"
+        "PumpStatic": {
+            "$ref": "PumpStatic.schema.json"
         },
         "TabulatedRatingCurveStatic": {
             "$ref": "TabulatedRatingCurveStatic.schema.json"
         },
-        "LevelBoundaryTime": {
-            "$ref": "LevelBoundaryTime.schema.json"
-        },
-        "BasinState": {
-            "$ref": "BasinState.schema.json"
-        },
-        "BasinProfile": {
-            "$ref": "BasinProfile.schema.json"
+        "TabulatedRatingCurveTime": {
+            "$ref": "TabulatedRatingCurveTime.schema.json"
         },
         "TerminalStatic": {
             "$ref": "TerminalStatic.schema.json"
         },
-        "BasinStatic": {
-            "$ref": "BasinStatic.schema.json"
+        "UserStatic": {
+            "$ref": "UserStatic.schema.json"
+        },
+        "UserTime": {
+            "$ref": "UserTime.schema.json"
         }
     },
     "$id": "https://deltares.github.io/Ribasim/schema/root.schema.json",

--- a/docs/schema/tabulated_rating_curve.schema.json
+++ b/docs/schema/tabulated_rating_curve.schema.json
@@ -1,7 +1,11 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/tabulated_rating_curve.schema.json",
+    "title": "tabulated_rating_curve",
+    "description": "A tabulated_rating_curve object based on Ribasim.config.tabulated_rating_curve",
+    "type": "object",
     "properties": {
-        "time": {
+        "static": {
             "format": "default",
             "anyOf": [
                 {
@@ -13,7 +17,7 @@
             ],
             "default": null
         },
-        "static": {
+        "time": {
             "format": "default",
             "anyOf": [
                 {
@@ -27,9 +31,5 @@
         }
     },
     "required": [
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/tabulated_rating_curve.schema.json",
-    "title": "tabulated_rating_curve",
-    "description": "A tabulated_rating_curve object based on Ribasim.config.tabulated_rating_curve",
-    "type": "object"
+    ]
 }

--- a/docs/schema/terminal.schema.json
+++ b/docs/schema/terminal.schema.json
@@ -1,5 +1,9 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/terminal.schema.json",
+    "title": "terminal",
+    "description": "A terminal object based on Ribasim.config.terminal",
+    "type": "object",
     "properties": {
         "static": {
             "format": "default",
@@ -15,9 +19,5 @@
         }
     },
     "required": [
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/terminal.schema.json",
-    "title": "terminal",
-    "description": "A terminal object based on Ribasim.config.terminal",
-    "type": "object"
+    ]
 }

--- a/docs/schema/user.schema.json
+++ b/docs/schema/user.schema.json
@@ -1,7 +1,11 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://deltares.github.io/Ribasim/schema/user.schema.json",
+    "title": "user",
+    "description": "A user object based on Ribasim.config.user",
+    "type": "object",
     "properties": {
-        "time": {
+        "static": {
             "format": "default",
             "anyOf": [
                 {
@@ -13,7 +17,7 @@
             ],
             "default": null
         },
-        "static": {
+        "time": {
             "format": "default",
             "anyOf": [
                 {
@@ -27,9 +31,5 @@
         }
     },
     "required": [
-    ],
-    "$id": "https://deltares.github.io/Ribasim/schema/user.schema.json",
-    "title": "user",
-    "description": "A user object based on Ribasim.config.user",
-    "type": "object"
+    ]
 }

--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -10,55 +10,88 @@ from pydantic import BaseModel, Field
 
 
 class Output(BaseModel):
-    compression: str = "zstd"
     basin: str = "output/basin.arrow"
     flow: str = "output/flow.arrow"
     control: str = "output/control.arrow"
     outstate: Optional[str] = None
+    compression: str = "zstd"
     compression_level: int = 6
 
 
+class Solver(BaseModel):
+    algorithm: str = "QNDF"
+    saveat: Union[float, List[float]] = []
+    adaptive: bool = True
+    dt: Optional[float] = None
+    dtmin: Optional[float] = None
+    dtmax: Optional[float] = None
+    force_dtmin: bool = False
+    abstol: float = 1e-06
+    reltol: float = 0.001
+    maxiters: int = 1000000000
+    sparse: bool = True
+    autodiff: bool = True
+
+
+class Logging(BaseModel):
+    verbosity: str = "info"
+    timing: bool = False
+
+
+class Terminal(BaseModel):
+    static: Optional[str] = None
+
+
+class PidControl(BaseModel):
+    static: Optional[str] = None
+    time: Optional[str] = None
+
+
 class LevelBoundary(BaseModel):
-    time: Optional[str] = None
     static: Optional[str] = None
-
-
-class User(BaseModel):
     time: Optional[str] = None
-    static: Optional[str] = None
 
 
 class Pump(BaseModel):
     static: Optional[str] = None
 
 
-class DiscreteControl(BaseModel):
-    logic: Optional[str] = None
-    condition: Optional[str] = None
+class TabulatedRatingCurve(BaseModel):
+    static: Optional[str] = None
+    time: Optional[str] = None
 
 
-class Solver(BaseModel):
-    autodiff: bool = True
-    adaptive: bool = True
-    force_dtmin: bool = False
-    dt: Optional[float] = None
-    saveat: Union[List[float], float] = []
-    maxiters: int = 1000000000
-    dtmin: Optional[float] = None
-    sparse: bool = True
-    algorithm: str = "QNDF"
-    abstol: float = 1e-06
-    reltol: float = 0.001
-    dtmax: Optional[float] = None
+class User(BaseModel):
+    static: Optional[str] = None
+    time: Optional[str] = None
 
 
 class FlowBoundary(BaseModel):
+    static: Optional[str] = None
     time: Optional[str] = None
+
+
+class Basin(BaseModel):
+    profile: Optional[str] = None
+    state: Optional[str] = None
+    static: Optional[str] = None
+    time: Optional[str] = None
+
+
+class ManningResistance(BaseModel):
     static: Optional[str] = None
 
 
-class PidControl(BaseModel):
-    time: Optional[str] = None
+class DiscreteControl(BaseModel):
+    condition: Optional[str] = None
+    logic: Optional[str] = None
+
+
+class Outlet(BaseModel):
+    static: Optional[str] = None
+
+
+class LinearResistance(BaseModel):
     static: Optional[str] = None
 
 
@@ -66,40 +99,14 @@ class FractionalFlow(BaseModel):
     static: Optional[str] = None
 
 
-class ManningResistance(BaseModel):
-    static: Optional[str] = None
-
-
-class TabulatedRatingCurve(BaseModel):
-    time: Optional[str] = None
-    static: Optional[str] = None
-
-
-class Logging(BaseModel):
-    timing: bool = False
-    verbosity: str = "info"
-
-
-class Outlet(BaseModel):
-    static: Optional[str] = None
-
-
-class Terminal(BaseModel):
-    static: Optional[str] = None
-
-
-class Basin(BaseModel):
-    profile: Optional[str] = None
-    time: Optional[str] = None
-    static: Optional[str] = None
-    state: Optional[str] = None
-
-
-class LinearResistance(BaseModel):
-    static: Optional[str] = None
-
-
 class Config(BaseModel):
+    starttime: datetime
+    endtime: datetime
+    update_timestep: float = 86400
+    relative_dir: str = "."
+    input_dir: str = "."
+    output_dir: str = "."
+    geopackage: str
     output: Output = Field(
         default_factory=lambda: Output.parse_obj(
             {
@@ -110,22 +117,6 @@ class Config(BaseModel):
                 "compression": "zstd",
                 "compression_level": 6,
             }
-        )
-    )
-    starttime: datetime
-    update_timestep: float = 86400
-    input_dir: str = "."
-    output_dir: str = "."
-    level_boundary: LevelBoundary = Field(
-        default_factory=lambda: LevelBoundary.parse_obj({"static": None, "time": None})
-    )
-    user: User = Field(
-        default_factory=lambda: User.parse_obj({"static": None, "time": None})
-    )
-    pump: Pump = Field(default_factory=lambda: Pump.parse_obj({"static": None}))
-    discrete_control: DiscreteControl = Field(
-        default_factory=lambda: DiscreteControl.parse_obj(
-            {"condition": None, "logic": None}
         )
     )
     solver: Solver = Field(
@@ -146,40 +137,49 @@ class Config(BaseModel):
             }
         )
     )
-    flow_boundary: FlowBoundary = Field(
-        default_factory=lambda: FlowBoundary.parse_obj({"static": None, "time": None})
-    )
-    pid_control: PidControl = Field(
-        default_factory=lambda: PidControl.parse_obj({"static": None, "time": None})
-    )
-    fractional_flow: FractionalFlow = Field(
-        default_factory=lambda: FractionalFlow.parse_obj({"static": None})
-    )
-    relative_dir: str = "."
-    endtime: datetime
-    manning_resistance: ManningResistance = Field(
-        default_factory=lambda: ManningResistance.parse_obj({"static": None})
-    )
-    tabulated_rating_curve: TabulatedRatingCurve = Field(
-        default_factory=lambda: TabulatedRatingCurve.parse_obj(
-            {"static": None, "time": None}
-        )
-    )
     logging: Logging = Field(
         default_factory=lambda: Logging.parse_obj(
             {"verbosity": {"level": 0}, "timing": False}
         )
     )
-    outlet: Outlet = Field(default_factory=lambda: Outlet.parse_obj({"static": None}))
-    geopackage: str
     terminal: Terminal = Field(
         default_factory=lambda: Terminal.parse_obj({"static": None})
+    )
+    pid_control: PidControl = Field(
+        default_factory=lambda: PidControl.parse_obj({"static": None, "time": None})
+    )
+    level_boundary: LevelBoundary = Field(
+        default_factory=lambda: LevelBoundary.parse_obj({"static": None, "time": None})
+    )
+    pump: Pump = Field(default_factory=lambda: Pump.parse_obj({"static": None}))
+    tabulated_rating_curve: TabulatedRatingCurve = Field(
+        default_factory=lambda: TabulatedRatingCurve.parse_obj(
+            {"static": None, "time": None}
+        )
+    )
+    user: User = Field(
+        default_factory=lambda: User.parse_obj({"static": None, "time": None})
+    )
+    flow_boundary: FlowBoundary = Field(
+        default_factory=lambda: FlowBoundary.parse_obj({"static": None, "time": None})
     )
     basin: Basin = Field(
         default_factory=lambda: Basin.parse_obj(
             {"profile": None, "state": None, "static": None, "time": None}
         )
     )
+    manning_resistance: ManningResistance = Field(
+        default_factory=lambda: ManningResistance.parse_obj({"static": None})
+    )
+    discrete_control: DiscreteControl = Field(
+        default_factory=lambda: DiscreteControl.parse_obj(
+            {"condition": None, "logic": None}
+        )
+    )
+    outlet: Outlet = Field(default_factory=lambda: Outlet.parse_obj({"static": None}))
     linear_resistance: LinearResistance = Field(
         default_factory=lambda: LinearResistance.parse_obj({"static": None})
+    )
+    fractional_flow: FractionalFlow = Field(
+        default_factory=lambda: FractionalFlow.parse_obj({"static": None})
     )

--- a/python/ribasim/ribasim/models.py
+++ b/python/ribasim/ribasim/models.py
@@ -9,233 +9,233 @@ from typing import Optional
 from pydantic import BaseModel, Field
 
 
-class BasinTime(BaseModel):
-    remarks: str = Field("", description="a hack for pandera")
-    time: datetime
-    precipitation: float
-    infiltration: float
-    urban_runoff: float
+class BasinProfile(BaseModel):
     node_id: int
-    potential_evaporation: float
-    drainage: float
-
-
-class DiscreteControlLogic(BaseModel):
-    remarks: str = Field("", description="a hack for pandera")
-    truth_state: str
-    node_id: int
-    control_state: str
-
-
-class Edge(BaseModel):
-    remarks: str = Field("", description="a hack for pandera")
-    edge_type: str
-    fid: int
-    to_node_id: int
-    from_node_id: int
-
-
-class FlowBoundaryTime(BaseModel):
-    remarks: str = Field("", description="a hack for pandera")
-    time: datetime
-    flow_rate: float
-    node_id: int
-
-
-class UserStatic(BaseModel):
-    remarks: str = Field("", description="a hack for pandera")
-    priority: int
-    active: Optional[bool] = None
-    demand: float
-    return_factor: float
-    min_level: float
-    node_id: int
-
-
-class PumpStatic(BaseModel):
-    max_flow_rate: Optional[float] = None
-    remarks: str = Field("", description="a hack for pandera")
-    active: Optional[bool] = None
-    flow_rate: float
-    node_id: int
-    control_state: Optional[str] = None
-    min_flow_rate: Optional[float] = None
-
-
-class LevelBoundaryStatic(BaseModel):
-    remarks: str = Field("", description="a hack for pandera")
-    active: Optional[bool] = None
-    node_id: int
+    area: float
     level: float
-
-
-class UserTime(BaseModel):
     remarks: str = Field("", description="a hack for pandera")
-    priority: int
-    time: datetime
-    demand: float
-    return_factor: float
-    min_level: float
-    node_id: int
-
-
-class DiscreteControlCondition(BaseModel):
-    remarks: str = Field("", description="a hack for pandera")
-    greater_than: float
-    listen_feature_id: int
-    node_id: int
-    variable: str
-    look_ahead: Optional[float] = None
-
-
-class LinearResistanceStatic(BaseModel):
-    remarks: str = Field("", description="a hack for pandera")
-    active: Optional[bool] = None
-    node_id: int
-    resistance: float
-    control_state: Optional[str] = None
-
-
-class FractionalFlowStatic(BaseModel):
-    remarks: str = Field("", description="a hack for pandera")
-    node_id: int
-    fraction: float
-    control_state: Optional[str] = None
-
-
-class PidControlStatic(BaseModel):
-    integral: float
-    remarks: str = Field("", description="a hack for pandera")
-    listen_node_id: int
-    active: Optional[bool] = None
-    proportional: float
-    node_id: int
-    target: float
-    derivative: float
-    control_state: Optional[str] = None
-
-
-class PidControlTime(BaseModel):
-    integral: float
-    remarks: str = Field("", description="a hack for pandera")
-    listen_node_id: int
-    time: datetime
-    proportional: float
-    node_id: int
-    target: float
-    derivative: float
-    control_state: Optional[str] = None
-
-
-class ManningResistanceStatic(BaseModel):
-    length: float
-    manning_n: float
-    remarks: str = Field("", description="a hack for pandera")
-    active: Optional[bool] = None
-    profile_width: float
-    node_id: int
-    profile_slope: float
-    control_state: Optional[str] = None
-
-
-class FlowBoundaryStatic(BaseModel):
-    remarks: str = Field("", description="a hack for pandera")
-    active: Optional[bool] = None
-    flow_rate: float
-    node_id: int
-
-
-class OutletStatic(BaseModel):
-    max_flow_rate: Optional[float] = None
-    remarks: str = Field("", description="a hack for pandera")
-    active: Optional[bool] = None
-    min_crest_level: Optional[float] = None
-    flow_rate: float
-    node_id: int
-    control_state: Optional[str] = None
-    min_flow_rate: Optional[float] = None
-
-
-class Node(BaseModel):
-    remarks: str = Field("", description="a hack for pandera")
-    fid: int
-    type: str
-
-
-class TabulatedRatingCurveTime(BaseModel):
-    remarks: str = Field("", description="a hack for pandera")
-    time: datetime
-    node_id: int
-    discharge: float
-    level: float
-
-
-class TabulatedRatingCurveStatic(BaseModel):
-    remarks: str = Field("", description="a hack for pandera")
-    active: Optional[bool] = None
-    node_id: int
-    discharge: float
-    level: float
-    control_state: Optional[str] = None
-
-
-class LevelBoundaryTime(BaseModel):
-    remarks: str = Field("", description="a hack for pandera")
-    time: datetime
-    node_id: int
-    level: float
 
 
 class BasinState(BaseModel):
-    remarks: str = Field("", description="a hack for pandera")
     node_id: int
     level: float
-
-
-class BasinProfile(BaseModel):
     remarks: str = Field("", description="a hack for pandera")
-    area: float
-    node_id: int
-    level: float
-
-
-class TerminalStatic(BaseModel):
-    remarks: str = Field("", description="a hack for pandera")
-    node_id: int
 
 
 class BasinStatic(BaseModel):
-    remarks: str = Field("", description="a hack for pandera")
-    precipitation: float
-    infiltration: float
-    urban_runoff: float
     node_id: int
-    potential_evaporation: float
     drainage: float
+    potential_evaporation: float
+    infiltration: float
+    precipitation: float
+    urban_runoff: float
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class BasinTime(BaseModel):
+    node_id: int
+    time: datetime
+    drainage: float
+    potential_evaporation: float
+    infiltration: float
+    precipitation: float
+    urban_runoff: float
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class DiscreteControlCondition(BaseModel):
+    node_id: int
+    listen_feature_id: int
+    variable: str
+    greater_than: float
+    look_ahead: Optional[float] = None
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class DiscreteControlLogic(BaseModel):
+    node_id: int
+    truth_state: str
+    control_state: str
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class Edge(BaseModel):
+    fid: int
+    from_node_id: int
+    to_node_id: int
+    edge_type: str
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class FlowBoundaryStatic(BaseModel):
+    node_id: int
+    active: Optional[bool] = None
+    flow_rate: float
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class FlowBoundaryTime(BaseModel):
+    node_id: int
+    time: datetime
+    flow_rate: float
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class FractionalFlowStatic(BaseModel):
+    node_id: int
+    fraction: float
+    control_state: Optional[str] = None
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class LevelBoundaryStatic(BaseModel):
+    node_id: int
+    active: Optional[bool] = None
+    level: float
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class LevelBoundaryTime(BaseModel):
+    node_id: int
+    time: datetime
+    level: float
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class LinearResistanceStatic(BaseModel):
+    node_id: int
+    active: Optional[bool] = None
+    resistance: float
+    control_state: Optional[str] = None
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class ManningResistanceStatic(BaseModel):
+    node_id: int
+    active: Optional[bool] = None
+    length: float
+    manning_n: float
+    profile_width: float
+    profile_slope: float
+    control_state: Optional[str] = None
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class Node(BaseModel):
+    fid: int
+    type: str
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class OutletStatic(BaseModel):
+    node_id: int
+    active: Optional[bool] = None
+    flow_rate: float
+    min_flow_rate: Optional[float] = None
+    max_flow_rate: Optional[float] = None
+    min_crest_level: Optional[float] = None
+    control_state: Optional[str] = None
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class PidControlStatic(BaseModel):
+    node_id: int
+    active: Optional[bool] = None
+    listen_node_id: int
+    target: float
+    proportional: float
+    integral: float
+    derivative: float
+    control_state: Optional[str] = None
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class PidControlTime(BaseModel):
+    node_id: int
+    listen_node_id: int
+    time: datetime
+    target: float
+    proportional: float
+    integral: float
+    derivative: float
+    control_state: Optional[str] = None
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class PumpStatic(BaseModel):
+    node_id: int
+    active: Optional[bool] = None
+    flow_rate: float
+    min_flow_rate: Optional[float] = None
+    max_flow_rate: Optional[float] = None
+    control_state: Optional[str] = None
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class TabulatedRatingCurveStatic(BaseModel):
+    node_id: int
+    active: Optional[bool] = None
+    level: float
+    discharge: float
+    control_state: Optional[str] = None
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class TabulatedRatingCurveTime(BaseModel):
+    node_id: int
+    time: datetime
+    level: float
+    discharge: float
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class TerminalStatic(BaseModel):
+    node_id: int
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class UserStatic(BaseModel):
+    node_id: int
+    active: Optional[bool] = None
+    demand: float
+    return_factor: float
+    min_level: float
+    priority: int
+    remarks: str = Field("", description="a hack for pandera")
+
+
+class UserTime(BaseModel):
+    node_id: int
+    time: datetime
+    demand: float
+    return_factor: float
+    min_level: float
+    priority: int
+    remarks: str = Field("", description="a hack for pandera")
 
 
 class Root(BaseModel):
+    BasinProfile: Optional[BasinProfile] = None
+    BasinState: Optional[BasinState] = None
+    BasinStatic: Optional[BasinStatic] = None
     BasinTime: Optional[BasinTime] = None
+    DiscreteControlCondition: Optional[DiscreteControlCondition] = None
     DiscreteControlLogic: Optional[DiscreteControlLogic] = None
     Edge: Optional[Edge] = None
+    FlowBoundaryStatic: Optional[FlowBoundaryStatic] = None
     FlowBoundaryTime: Optional[FlowBoundaryTime] = None
-    UserStatic: Optional[UserStatic] = None
-    PumpStatic: Optional[PumpStatic] = None
-    LevelBoundaryStatic: Optional[LevelBoundaryStatic] = None
-    UserTime: Optional[UserTime] = None
-    DiscreteControlCondition: Optional[DiscreteControlCondition] = None
-    LinearResistanceStatic: Optional[LinearResistanceStatic] = None
     FractionalFlowStatic: Optional[FractionalFlowStatic] = None
+    LevelBoundaryStatic: Optional[LevelBoundaryStatic] = None
+    LevelBoundaryTime: Optional[LevelBoundaryTime] = None
+    LinearResistanceStatic: Optional[LinearResistanceStatic] = None
+    ManningResistanceStatic: Optional[ManningResistanceStatic] = None
+    Node: Optional[Node] = None
+    OutletStatic: Optional[OutletStatic] = None
     PidControlStatic: Optional[PidControlStatic] = None
     PidControlTime: Optional[PidControlTime] = None
-    ManningResistanceStatic: Optional[ManningResistanceStatic] = None
-    FlowBoundaryStatic: Optional[FlowBoundaryStatic] = None
-    OutletStatic: Optional[OutletStatic] = None
-    Node: Optional[Node] = None
-    TabulatedRatingCurveTime: Optional[TabulatedRatingCurveTime] = None
+    PumpStatic: Optional[PumpStatic] = None
     TabulatedRatingCurveStatic: Optional[TabulatedRatingCurveStatic] = None
-    LevelBoundaryTime: Optional[LevelBoundaryTime] = None
-    BasinState: Optional[BasinState] = None
-    BasinProfile: Optional[BasinProfile] = None
+    TabulatedRatingCurveTime: Optional[TabulatedRatingCurveTime] = None
     TerminalStatic: Optional[TerminalStatic] = None
-    BasinStatic: Optional[BasinStatic] = None
+    UserStatic: Optional[UserStatic] = None
+    UserTime: Optional[UserTime] = None

--- a/python/ribasim/tests/test_io.py
+++ b/python/ribasim/tests/test_io.py
@@ -69,5 +69,5 @@ def test_repr():
 
     assert (
         repr(pump_1)
-        == "<ribasim.Pump>\n   static: DataFrame(rows=3)\n       (max_flow_rate, remarks, active, flow_rate,\n       node_id, control_state, min_flow_rate)"
+        == "<ribasim.Pump>\n   static: DataFrame(rows=3)\n       (node_id, active, flow_rate, min_flow_rate,\n       max_flow_rate, control_state, remarks)"
     )


### PR DESCRIPTION
Fixes #640, by using `OrderedDict` instead of `Dict` in `gen_schema.jl`.
