### PR TITLE
bump versions before release v2023.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ libraries, notably [ModelingToolkit.jl](https://mtk.sciml.ai/stable/).
 For most users the [latest release](https://github.com/Deltares/Ribasim/releases/latest) is recommended, it can be downloaded here:
 
 - Ribasim executable: [ribasim_cli.zip](https://github.com/Deltares/Ribasim/releases/latest/download/ribasim_cli.zip).
-- Python package: [ribasim-0.4.0-py3-none-any.whl](https://github.com/Deltares/Ribasim/releases/latest/download/ribasim-0.4.0-py3-none-any.whl)
+- Python package: [ribasim-0.5.0-py3-none-any.whl](https://github.com/Deltares/Ribasim/releases/latest/download/ribasim-0.5.0-py3-none-any.whl)
 - QGIS plugin: [ribasim_qgis.zip](https://github.com/Deltares/Ribasim/releases/latest/download/ribasim_qgis.zip).
 - Generated testmodels: [generated_testmodels.zip](https://github.com/Deltares/Ribasim/releases/latest/download/generated_testmodels.zip)
 
 The nightly builds contain the latest developments and can be found below. It is important to either use the release or nightly for all components.
 
 - Ribasim executable: [ribasim_cli.zip](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim_cli.zip).
-- Python package: [ribasim-0.4.0-py3-none-any.whl](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim-0.4.0-py3-none-any.whl)
+- Python package: [ribasim-0.5.0-py3-none-any.whl](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim-0.5.0-py3-none-any.whl)
 - QGIS plugin: [ribasim_qgis.zip](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim_qgis.zip).
 
 Currently only Windows builds for `ribasim_cli.zip` are available.

--- a/core/Project.toml
+++ b/core/Project.toml
@@ -1,7 +1,7 @@
 name = "Ribasim"
 uuid = "aac5e3d9-0b8f-4d4f-8241-b1a7a9632635"
 authors = ["Deltares and contributors <ribasim.info@deltares.nl>"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/docs/contribute/release.qmd
+++ b/docs/contribute/release.qmd
@@ -64,7 +64,7 @@ If this succeeds, the release assets are uploaded to an S3 link with the version
 
 ```
 https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/v2023.07.0/ribasim_cli.zip
-https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/v2023.07.0/ribasim-0.4.0-py3-none-any.whl
+https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/v2023.07.0/ribasim-0.5.0-py3-none-any.whl
 https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/v2023.07.0/ribasim_qgis.zip
 ```
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -30,14 +30,14 @@ libraries, notably [DifferentialEquations.jl](https://docs.sciml.ai/DiffEqDocs/s
 For most users the [latest release](https://github.com/Deltares/Ribasim/releases/latest) is recommended, it can be downloaded here:
 
 - Ribasim executable: [ribasim_cli.zip](https://github.com/Deltares/Ribasim/releases/latest/download/ribasim_cli.zip).
-- Python package: [ribasim-0.4.0-py3-none-any.whl](https://github.com/Deltares/Ribasim/releases/latest/download/ribasim-0.4.0-py3-none-any.whl)
+- Python package: [ribasim-0.5.0-py3-none-any.whl](https://github.com/Deltares/Ribasim/releases/latest/download/ribasim-0.5.0-py3-none-any.whl)
 - QGIS plugin: [ribasim_qgis.zip](https://github.com/Deltares/Ribasim/releases/latest/download/ribasim_qgis.zip).
 - Generated testmodels: [generated_testmodels.zip](https://github.com/Deltares/Ribasim/releases/latest/download/generated_testmodels.zip)
 
 The nightly builds contain the latest developments and can be found below. It is important to either use the release or nightly for all components.
 
 - Ribasim executable: [ribasim_cli.zip](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim_cli.zip).
-- Python package: [ribasim-0.4.0-py3-none-any.whl](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim-0.4.0-py3-none-any.whl)
+- Python package: [ribasim-0.5.0-py3-none-any.whl](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim-0.5.0-py3-none-any.whl)
 - QGIS plugin: [ribasim_qgis.zip](https://ribasim.s3.eu-west-3.amazonaws.com/teamcity/Ribasim_Ribasim/BuildRibasimCliWindows/latest/ribasim_qgis.zip).
 
 Currently only Windows builds for `ribasim_cli.zip` are available.

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Ribasim"
-version = "0.2.0"
+version = "0.3.0"
 description = "Water resources modeling"
 authors = ["Deltares and contributors <ribasim.info@deltares.nl>"]
 channels = ["conda-forge"]

--- a/python/ribasim/ribasim/__init__.py
+++ b/python/ribasim/ribasim/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 
 from ribasim import models, utils

--- a/python/ribasim_api/ribasim_api/__init__.py
+++ b/python/ribasim_api/ribasim_api/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 from ribasim_api.ribasim_api import RibasimApi
 

--- a/python/ribasim_testmodels/ribasim_testmodels/__init__.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 from typing import Callable, Dict
 

--- a/qgis/metadata.txt
+++ b/qgis/metadata.txt
@@ -7,7 +7,7 @@
 name=Ribasim-QGIS
 qgisMinimumVersion=3.0
 description=QGIS plugin to setup Ribasim models
-version=0.2
+version=0.3
 author=Deltares and contributors
 email=ribasim.info@deltares.nl
 


### PR DESCRIPTION
Ribasim v2023.10.0 consists of:

```
    core Ribasim.jl v0.4.0
    ribasim-python v0.5.0
    ribasim_testmodels v0.3.0
    ribasim_api v0.2.0
    Ribasim-QGIS v0.2
    pixi Ribasim v0.2.0
```