### PR TITLE
Add installation instructions for `ribasim_api`

### DIFF
--- a/python/ribasim_api/README.md
+++ b/python/ribasim_api/README.md
@@ -1,0 +1,23 @@
+# Ribasim API
+
+`ribasim_api` is an extension to [xmipy](https://pypi.org/project/xmipy/) for the Ribasim API.
+
+The `ribasim_api` can be used to access functionality in the eXtended Model Interface (XMI) wrapper (XmiWrapper)
+and additional functionality specific to the Ribasim API.
+
+
+`ribasim_api` can be installed by running
+
+```
+pip install ribasim-api
+```
+
+or
+
+```
+conda install -c conda-forge ribasim-api
+```
+
+# Contributing
+
+For the developer docs please have a look at https://deltares.github.io/Ribasim/python/developer.html

--- a/python/ribasim_api/ribasim_api/__init__.py
+++ b/python/ribasim_api/ribasim_api/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 from ribasim_api.ribasim_api import RibasimApi
 


### PR DESCRIPTION
Seems like PyPI changes `_` to `-` :(

