### PR TITLE
C4 diagrams

### DIFF
--- a/docs/assets/c4_component_ribasim.mmd
+++ b/docs/assets/c4_component_ribasim.mmd
@@ -1,0 +1,39 @@
+flowchart TB
+modeler([Modeler]):::user
+
+api["Ribasim Python\n[python]"]:::system
+modeler-->|prepare model|api
+
+subgraph ribasimBoundary[Ribasim]
+    ribasim["Ribasim.jl\n[julia]"]:::system
+    libribasim["libribasim\n[julia + python + BMI]"]:::system
+    cli["Ribasim CLI\n[julia]"]:::system
+    cli-->ribasim
+    libribasim-->ribasim
+end
+modeler-->|start|cli
+modeler-->|coupled simulation|libribasim
+
+subgraph qgisBoundary[QGIS]
+    QGIS[QGIS Application]:::system_ext
+    qgisPlugin["Ribasim QGIS plugin\n[python]"]:::system
+    QGIS-->qgisPlugin
+end
+modeler-->|prepare model|qgisBoundary
+
+model[("input model data\n[toml + geopackage + arrow]")]:::system
+qgisPlugin-->|read/write|model
+api-->|read/write|model
+ribasim-->|simulate|model
+
+output[("simulation output\n[arrow]")]:::system
+ribasim-->|write|output
+
+class qgisBoundary,ribasimBoundary boundary
+
+%% class definitions for C4 model
+classDef default stroke-width:1px,stroke:white,color:white
+classDef system fill:#1168bd
+classDef user fill:#08427b
+classDef system_ext fill:#999999
+classDef boundary fill:transparent,stroke-dasharray:5 5,stroke:black,color:black

--- a/docs/assets/c4_system.mmd
+++ b/docs/assets/c4_system.mmd
@@ -1,4 +1,3 @@
-```{mermaid}
 flowchart TB
 modeler([Modeler]):::user
 
@@ -31,4 +30,3 @@ classDef system fill:#1168bd;
 classDef user fill:#08427b;
 classDef system_ext fill:#999999;
 classDef boundary fill:transparent,stroke-dasharray:5 5,stroke:black,color:black;
-```

--- a/docs/assets/c4_system.mmd
+++ b/docs/assets/c4_system.mmd
@@ -19,7 +19,7 @@ qgisPlugin-->|read/write|model
 api-->|read/write|model
 ribasim-->|simulate|model
 
-output[("simulation output\n[arrow]")]:::system
+output[("simulation results\n[arrow]")]:::system
 ribasim-->|write|output
 
 class qgisBoundary boundary

--- a/docs/assets/c4_system.mmd
+++ b/docs/assets/c4_system.mmd
@@ -1,7 +1,7 @@
 flowchart TB
 modeler([Modeler]):::user
 
-api["Ribasim Python API\n[python]"]:::system
+api["Ribasim Python\n[python]"]:::system
 modeler-->|prepare model|api
 
 ribasim["Ribasim\n[julia]"]:::system
@@ -25,8 +25,8 @@ ribasim-->|write|output
 class qgisBoundary boundary
 
 %% class definitions for C4 model
-classDef default stroke-width:1px,stroke:white,color:white;
-classDef system fill:#1168bd;
-classDef user fill:#08427b;
-classDef system_ext fill:#999999;
-classDef boundary fill:transparent,stroke-dasharray:5 5,stroke:black,color:black;
+classDef default stroke-width:1px,stroke:white,color:white
+classDef system fill:#1168bd
+classDef user fill:#08427b
+classDef system_ext fill:#999999
+classDef boundary fill:transparent,stroke-dasharray:5 5,stroke:black,color:black

--- a/docs/assets/c4_system.qmd
+++ b/docs/assets/c4_system.qmd
@@ -1,0 +1,34 @@
+```{mermaid}
+flowchart TB
+modeler([Modeler]):::user
+
+api["Ribasim Python API\n[python]"]:::system
+modeler-->|prepare model|api
+
+ribasim["Ribasim\n[julia]"]:::system
+modeler-->|start|ribasim
+
+subgraph qgisBoundary[QGIS]
+    QGIS[QGIS Application]:::system_ext
+    qgisPlugin["Ribasim QGIS plugin\n[python]"]:::system
+    QGIS-->qgisPlugin
+end
+modeler-->|prepare model|qgisBoundary
+
+model[("input model data\n[toml + geopackage + arrow]")]:::system
+qgisPlugin-->|read/write|model
+api-->|read/write|model
+ribasim-->|simulate|model
+
+output[("simulation output\n[arrow]")]:::system
+ribasim-->|write|output
+
+class qgisBoundary boundary
+
+%% class definitions for C4 model
+classDef default stroke-width:1px,stroke:white,color:white;
+classDef system fill:#1168bd;
+classDef user fill:#08427b;
+classDef system_ext fill:#999999;
+classDef boundary fill:transparent,stroke-dasharray:5 5,stroke:black,color:black;
+```

--- a/docs/core/index.qmd
+++ b/docs/core/index.qmd
@@ -11,3 +11,8 @@ The core is implemented in the [Julia programming language](https://julialang.or
 can be found in the [Ribasim repository](https://github.com/Deltares/Ribasim) under the
 `core/` folder. For developers we also advise to read the
 [developer documentation](../contribute/core.qmd).
+
+```{mermaid}
+%%| file: ../assets/c4_component_ribasim.mmd
+%%| fig-cap: "Component overview of Ribasim"
+```

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -44,6 +44,8 @@ Currently only Windows builds for `ribasim_cli.zip` are available.
 
 See [Usage](core/usage.qmd) for more information.
 
+{{< include assets/c4_system.qmd >}}
+
 # Status
 
 The initial focus is on being able to

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -44,7 +44,10 @@ Currently only Windows builds for `ribasim_cli.zip` are available.
 
 See [Usage](core/usage.qmd) for more information.
 
-{{< include assets/c4_system.qmd >}}
+```{mermaid}
+%%| file: assets/c4_system.mmd
+%%| fig-cap: "System overview of Ribasim"
+```
 
 # Status
 


### PR DESCRIPTION
Add diagrams for C4 model showing the different components for ribasim, the preprocessing API, and the QGIS plugin.

We could go even further and make a detailed diagram of the different modules that are connected to each other. But these diagrams already give an overview of the components that are involved in the system.