### PR TITLE
Ignore errors when cleaning generated testmodels

### DIFF
--- a/utils/generate-testmodels.py
+++ b/utils/generate-testmodels.py
@@ -6,9 +6,9 @@ import ribasim_testmodels
 if __name__ == "__main__":
     datadir = Path("generated_testmodels")
     if datadir.is_dir():
-        shutil.rmtree(datadir)
+        shutil.rmtree(datadir, ignore_errors=True)
 
-    datadir.mkdir()
+    datadir.mkdir(exist_ok=True)
     readme = datadir / "README.md"
     readme.write_text(
         """\


### PR DESCRIPTION
Otherwise it would give an error halfway if you still have a terminal open.