### PR TITLE
mypy: Ignore missing imports

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 plugins = pydantic.mypy, numpy.typing.mypy_plugin, pandera.mypy
+ignore_missing_imports = True
 
 warn_unused_configs = True
 warn_redundant_casts = True

--- a/pixi.toml
+++ b/pixi.toml
@@ -42,9 +42,9 @@ quarto-render = { cmd = "export QUARTO_PYTHON=python && quarto render docs --to 
 ] }
 docs = { depends_on = ["build-julia-docs", "quarto-preview"] }
 # Lint
-mypy-ribasim-python = "mypy --ignore-missing-imports python/ribasim/ribasim"
-mypy-ribasim-testmodels = "mypy --ignore-missing-imports python/ribasim_testmodels/ribasim_testmodels"
-mypy-ribasim-api = "mypy --ignore-missing-imports python/ribasim_api/ribasim_api"
+mypy-ribasim-python = "mypy python/ribasim/ribasim"
+mypy-ribasim-testmodels = "mypy python/ribasim_testmodels/ribasim_testmodels"
+mypy-ribasim-api = "mypy python/ribasim_api/ribasim_api"
 pre-commit = "pre-commit run --all-files"
 lint = { depends_on = [
     "pre-commit",


### PR DESCRIPTION
That should stop mypy from complaining about untyped libraries, including when used via vscode