### PR TITLE
add navbar to Home

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -9,6 +9,8 @@ website:
   navbar:
     logo: https://user-images.githubusercontent.com/4471859/224825908-bee7e044-bc6b-4561-8b08-5d330cce3ed5.png
     left:
+      - text: "Home"
+        href: index.qmd
       - text: "Julia core"
         file: core/index.qmd
       - text: "Python tooling"


### PR DESCRIPTION
This goes from

![image](https://github.com/Deltares/Ribasim/assets/4471859/de4d0207-4c77-4c52-984e-bdfc67d759a4)

to

![image](https://github.com/Deltares/Ribasim/assets/4471859/0683eb2d-95dd-46b9-9cdf-812d812a2a47)

The Ribasim button to the left of "Home" also acts as a home button, but perhaps this is not obvious to users. The default template at least includes this "Home" button, so I think it is best to have it as well.