### PR TITLE
update lockfile with pixi 0.7

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -1,3 +1,4 @@
+version: 2
 metadata:
   content_hash:
     linux-64: e90c2ee71ad70fc0a1c8302029533a7d1498f2bffcd0eaa8d2934700e775dc1d
@@ -302,15 +303,15 @@ package:
   timestamp: 1649077760928
 - platform: linux-64
   name: argcomplete
-  version: 3.1.4
+  version: 3.1.6
   category: main
   manager: conda
   dependencies:
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.1.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.1.6-pyhd8ed1ab_0.conda
   hash:
-    md5: 1be9feadb435ef26456efaf70852ce93
-    sha256: e0abc3e71e9f0af65afb9dc3f3d4991c117508023ebcef223b2394a43313ccc9
+    md5: c629a13439d80b37c6a946b098c4ac2b
+    sha256: 62c3486961e43fb9b495b7854f48fea9b486b2176a9629c6faf80c445543b1aa
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -318,19 +319,19 @@ package:
   license: Apache-2.0
   license_family: Apache
   noarch: python
-  size: 39566
-  timestamp: 1698912237718
+  size: 39628
+  timestamp: 1699843246341
 - platform: osx-64
   name: argcomplete
-  version: 3.1.4
+  version: 3.1.6
   category: main
   manager: conda
   dependencies:
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.1.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.1.6-pyhd8ed1ab_0.conda
   hash:
-    md5: 1be9feadb435ef26456efaf70852ce93
-    sha256: e0abc3e71e9f0af65afb9dc3f3d4991c117508023ebcef223b2394a43313ccc9
+    md5: c629a13439d80b37c6a946b098c4ac2b
+    sha256: 62c3486961e43fb9b495b7854f48fea9b486b2176a9629c6faf80c445543b1aa
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -338,19 +339,19 @@ package:
   license: Apache-2.0
   license_family: Apache
   noarch: python
-  size: 39566
-  timestamp: 1698912237718
+  size: 39628
+  timestamp: 1699843246341
 - platform: osx-arm64
   name: argcomplete
-  version: 3.1.4
+  version: 3.1.6
   category: main
   manager: conda
   dependencies:
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.1.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.1.6-pyhd8ed1ab_0.conda
   hash:
-    md5: 1be9feadb435ef26456efaf70852ce93
-    sha256: e0abc3e71e9f0af65afb9dc3f3d4991c117508023ebcef223b2394a43313ccc9
+    md5: c629a13439d80b37c6a946b098c4ac2b
+    sha256: 62c3486961e43fb9b495b7854f48fea9b486b2176a9629c6faf80c445543b1aa
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -358,19 +359,19 @@ package:
   license: Apache-2.0
   license_family: Apache
   noarch: python
-  size: 39566
-  timestamp: 1698912237718
+  size: 39628
+  timestamp: 1699843246341
 - platform: win-64
   name: argcomplete
-  version: 3.1.4
+  version: 3.1.6
   category: main
   manager: conda
   dependencies:
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.1.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/argcomplete-3.1.6-pyhd8ed1ab_0.conda
   hash:
-    md5: 1be9feadb435ef26456efaf70852ce93
-    sha256: e0abc3e71e9f0af65afb9dc3f3d4991c117508023ebcef223b2394a43313ccc9
+    md5: c629a13439d80b37c6a946b098c4ac2b
+    sha256: 62c3486961e43fb9b495b7854f48fea9b486b2176a9629c6faf80c445543b1aa
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -378,8 +379,8 @@ package:
   license: Apache-2.0
   license_family: Apache
   noarch: python
-  size: 39566
-  timestamp: 1698912237718
+  size: 39628
+  timestamp: 1699843246341
 - platform: linux-64
   name: argon2-cffi
   version: 23.1.0
@@ -484,20 +485,20 @@ package:
   dependencies:
   - cffi >=1.0.1
   - libgcc-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h459d7ec_4.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py312h98912ed_4.conda
   hash:
-    md5: de5b16869a430949b02161b04b844a30
-    sha256: 104194af519b4e667aa5341068b94b521a791aaaa05ec0091f8f0bdba43a60ac
-  build: py311h459d7ec_4
+    md5: 00536e0a1734dcde9815fe227f32fc5a
+    sha256: 8ddb4a586bc128f1b9484f82c5cb0226340527fbfe093adf3b76b7e755e11477
+  build: py312h98912ed_4
   arch: x86_64
   subdir: linux-64
   build_number: 4
   license: MIT
   license_family: MIT
-  size: 34955
-  timestamp: 1695386703660
+  size: 35142
+  timestamp: 1695386704886
 - platform: osx-64
   name: argon2-cffi-bindings
   version: 21.2.0
@@ -505,20 +506,20 @@ package:
   manager: conda
   dependencies:
   - cffi >=1.0.1
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h2725bcf_4.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py312h104f124_4.conda
   hash:
-    md5: e2aba0ad0f533ee73f9d4330d2e32549
-    sha256: be27659496bcb660fc9c3f5f74128a7bb090336897e9c7cfbcc55ae66f13b8d8
-  build: py311h2725bcf_4
+    md5: dddfb6125aed1fb84eb13319007c08fd
+    sha256: aa321e91f0ff365b5261fa1dcffa2d32aa957561bdbb38988e52e28e25a762a8
+  build: py312h104f124_4
   arch: x86_64
   subdir: osx-64
   build_number: 4
   license: MIT
   license_family: MIT
-  size: 32542
-  timestamp: 1695386887016
+  size: 32556
+  timestamp: 1695387174872
 - platform: osx-arm64
   name: argon2-cffi-bindings
   version: 21.2.0
@@ -526,21 +527,21 @@ package:
   manager: conda
   dependencies:
   - cffi >=1.0.1
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311heffc1b2_4.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py312h02f2b3b_4.conda
   hash:
-    md5: e9a56c22ca1215ed3a7b6a9e8c4e6f07
-    sha256: b9ab23e4f0d615432949d4b93723bd04b3c4aef725aa03b1e993903265c1b975
-  build: py311heffc1b2_4
+    md5: 015edbb6fae68ab35881f55f149d4725
+    sha256: 1cfcf4b2d36a3b183a5cb1c69f85768166e50af6ced5ae381c440666a6da12c6
+  build: py312h02f2b3b_4
   arch: aarch64
   subdir: osx-arm64
   build_number: 4
   license: MIT
   license_family: MIT
-  size: 34126
-  timestamp: 1695386994453
+  size: 33607
+  timestamp: 1695387216062
 - platform: win-64
   name: argon2-cffi-bindings
   version: 21.2.0
@@ -548,23 +549,23 @@ package:
   manager: conda
   dependencies:
   - cffi >=1.0.1
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311ha68e1ae_4.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py312he70551f_4.conda
   hash:
-    md5: e95c947541bf1cb821ea4a6bf7d5794c
-    sha256: 0b8eb99e7ac6b409abbb5f3b9733f883865ff4314e85146380f072f6f6234929
-  build: py311ha68e1ae_4
+    md5: 69b7a1d899d46b91f8eecab9abf9728c
+    sha256: 4c3c428b994400ca753d9d0adbb11ce2d2a87f4dacd86c91d6cf985c5d89a3e1
+  build: py312he70551f_4
   arch: x86_64
   subdir: win-64
   build_number: 4
   license: MIT
   license_family: MIT
-  size: 34687
-  timestamp: 1695387285415
+  size: 34750
+  timestamp: 1695387347676
 - platform: linux-64
   name: arrow
   version: 1.3.0
@@ -922,360 +923,360 @@ package:
   timestamp: 1683424195402
 - platform: linux-64
   name: aws-c-auth
-  version: 0.7.5
+  version: 0.7.6
   category: main
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-http >=0.7.14,<0.7.15.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
   - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.5-ha588130_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.6-h37ad1db_0.conda
   hash:
-    md5: 9e2e559c6f65c773428638d28992a020
-    sha256: 32cfb7d61aa11ffb449c54a57e8a91bed087dff57caf3d5a1cd5e483471549d3
-  build: ha588130_3
+    md5: 31836ccf72bc70ce2ec38a2ec2c8b504
+    sha256: 6f44ef79e2ab5005961847cdefd2a71aa3a33c741adc77e774ac9dbedd9a2f81
+  build: h37ad1db_0
   arch: x86_64
   subdir: linux-64
-  build_number: 3
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 101868
-  timestamp: 1699547683051
+  size: 102400
+  timestamp: 1699658580768
 - platform: osx-64
   name: aws-c-auth
-  version: 0.7.5
+  version: 0.7.6
   category: main
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-http >=0.7.14,<0.7.15.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
   - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.5-h3724742_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.6-hc3630cc_0.conda
   hash:
-    md5: 03074c51bcadc34cc887356164ce8daa
-    sha256: 4b7cb9bc0b3ef3a2593582c678293517a17a265eaead4d57bde291989838cbe0
-  build: h3724742_3
+    md5: 1d23f626932e996892200295251d3f21
+    sha256: c377f6d42e895409fef51d868f0061b4a99cbf728030abcde318a37a12c0518a
+  build: hc3630cc_0
   arch: x86_64
   subdir: osx-64
-  build_number: 3
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 89202
-  timestamp: 1699547932681
+  size: 89695
+  timestamp: 1699658862651
 - platform: osx-arm64
   name: aws-c-auth
-  version: 0.7.5
+  version: 0.7.6
   category: main
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-http >=0.7.14,<0.7.15.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
   - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.5-h9df502d_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.6-h30f9597_0.conda
   hash:
-    md5: dc72d81f6cec64e7e4e11b588abf504b
-    sha256: 4098cd8b6ca9250837bfefcb0caf086e853b1d45a11249d78b6134bc5f9fe801
-  build: h9df502d_3
+    md5: 91a5e2b3608eaa0760c0921e00cad72c
+    sha256: 349efb5d66e108cfe21df0cf62209f5175b7a59b99ef7bf96f841274ccb2cc56
+  build: h30f9597_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 3
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 87718
-  timestamp: 1699548019361
+  size: 88633
+  timestamp: 1699658886332
 - platform: win-64
   name: aws-c-auth
-  version: 0.7.5
+  version: 0.7.6
   category: main
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-http >=0.7.14,<0.7.15.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
   - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.5-h17e7c68_3.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.6-h2364229_0.conda
   hash:
-    md5: eae689f306df4f7c8a6a8675d31ef4e1
-    sha256: b3efc2fdd04f43ca611bdda5b0521f32d80c43d05eb1587267ef7c6383e30c94
-  build: h17e7c68_3
+    md5: ebe85caf614226fafe575ac4d77d5367
+    sha256: 78bc556723a85ab029bfc3405ae8127b07ca1c8c42fe003dd67d817f79fa5afe
+  build: h2364229_0
   arch: x86_64
   subdir: win-64
-  build_number: 3
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 97189
-  timestamp: 1699548292846
+  size: 98768
+  timestamp: 1699659225642
 - platform: linux-64
   name: aws-c-cal
   version: 0.6.9
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - libgcc-ng >=12
   - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.9-h0fad3b2_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.9-h3b91eb8_1.conda
   hash:
-    md5: fb2e57e277d6f22fd3ad63aaa4353f1f
-    sha256: 88bd3173d7079f86973d9fdc46e42850746004b92b62348dc40f957eeab18aee
-  build: h0fad3b2_0
+    md5: ab28ae62aa4738f7ca0622554aadc31b
+    sha256: 8bca41960971a2f6eea0d61a30e6d8b1bf80f520b5959aba92b87d1385d3d0cd
+  build: h3b91eb8_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 55576
-  timestamp: 1698723210863
+  size: 55385
+  timestamp: 1699535368278
 - platform: osx-64
   name: aws-c-cal
   version: 0.6.9
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.9-h01c20f0_0.conda
+  - aws-c-common >=0.9.8,<0.9.9.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.9-h49e9720_1.conda
   hash:
-    md5: f2e9b329a90095a855e3ad14b63d5ffe
-    sha256: f430e96964bba6108dfc3bbd177932d6691a822518cc29b037ba6cfbfe74b79d
-  build: h01c20f0_0
+    md5: a1fc363f4bcbc029a096df632e1b06ab
+    sha256: 4f7f92067ecf18696a40fedacdc189ffa045020ebd0948ad094624d7c5a8e5a2
+  build: h49e9720_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 45656
-  timestamp: 1698723511528
+  size: 45609
+  timestamp: 1699535536649
 - platform: osx-arm64
   name: aws-c-cal
   version: 0.6.9
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.9-he63e28a_0.conda
+  - aws-c-common >=0.9.8,<0.9.9.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.9-hea61927_1.conda
   hash:
-    md5: ee1d0219702c1b9fef1fe726d8c42607
-    sha256: 365948c17452e3974cccb8d9debca4fce768ba7793420b5766b1b7de6526ce41
-  build: he63e28a_0
+    md5: 844a59d5740f086963219373174de1d3
+    sha256: ebd4b794986b745fb9a9931162e7ca6a4a759625203d995749e5dfc0e23d0e6e
+  build: hea61927_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 39565
-  timestamp: 1698723617668
+  size: 39478
+  timestamp: 1699535745689
 - platform: win-64
   name: aws-c-cal
   version: 0.6.9
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.9-h6f45060_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.9-hde771f8_1.conda
   hash:
-    md5: 4eedbc42e1b7538ff814795fb6f108ed
-    sha256: d0b60235841a8e5ec387d6f50534ba7613139d9dacafdfa294a41980780318e0
-  build: h6f45060_0
+    md5: f7ff23ec97013e737bc7c864c3a17cc6
+    sha256: fea5e075ea232c0d5fe447aeb18a3c63fd7d412d8ab1d54b63426b4e11b20952
+  build: hde771f8_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 55274
-  timestamp: 1698723449078
+  size: 55317
+  timestamp: 1699535911970
 - platform: linux-64
   name: aws-c-common
-  version: 0.9.5
+  version: 0.9.8
   category: main
   manager: conda
   dependencies:
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.5-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.8-hd590300_0.conda
   hash:
-    md5: 122ea634665516ff5af2f21c816fbe33
-    sha256: be392c2287ff96b47425b6e27e06305360f2eefc850b443db4e91313963c6e57
+    md5: 1fd5f2ae093f2dbf28dc4f18fca57309
+    sha256: 09075cb426a0b903b7ca86e4f399eb0be02b6d24e403792a5f378064fcb7a08b
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 222208
-  timestamp: 1698608142340
+  size: 225053
+  timestamp: 1699511171901
 - platform: osx-64
   name: aws-c-common
-  version: 0.9.5
+  version: 0.9.8
   category: main
   manager: conda
   dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.5-h10d778d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.8-h10d778d_0.conda
   hash:
-    md5: 86cd033730d619e4c1a4d02c0f362055
-    sha256: a3081b4dd057046f89001a6b70a190abd8ea396f46b6224b1dc88727d76c7737
+    md5: 1835ae87bcb96111220344774a930f02
+    sha256: 4aac7a22b208c13707297d8e08c62569186f4dcc2ed3cd01ffa79af4576e3dcc
   build: h10d778d_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 206303
-  timestamp: 1698608208428
+  size: 207496
+  timestamp: 1699511311716
 - platform: osx-arm64
   name: aws-c-common
-  version: 0.9.5
+  version: 0.9.8
   category: main
   manager: conda
   dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.5-h93a5062_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.8-h93a5062_0.conda
   hash:
-    md5: 670b887541c5cee02511e39e29e509ae
-    sha256: 5c46363060b9cd15a1e45f9c03a7252f8e40c66e594d6696f7f2a1c37c14af54
+    md5: cde0cd0c85e62c192da64c49130a7ccd
+    sha256: 811730643b941f7b3419fdba4824aaac745944e4bcc462c5737ba4025213158e
   build: h93a5062_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 201197
-  timestamp: 1698608212743
+  size: 202672
+  timestamp: 1699511361474
 - platform: win-64
   name: aws-c-common
-  version: 0.9.5
+  version: 0.9.8
   category: main
   manager: conda
   dependencies:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.5-hcfcfb64_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.8-hcfcfb64_0.conda
   hash:
-    md5: 292211bae5e16575ed3a0daa96bd4506
-    sha256: fdb9cebe93ca2c2c4eb2fa3c3fb350a33628f70b11ba7adb9bb9e0283ac3bf85
+    md5: 35d4a1cd187c1902eb6d344686e66106
+    sha256: c0c093f2858eafa77520d83d5bbf94fde277da85c07d3da7fd91df7b1a7fbf87
   build: hcfcfb64_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 218817
-  timestamp: 1698608623257
+  size: 221926
+  timestamp: 1699511682549
 - platform: linux-64
   name: aws-c-compression
   version: 0.2.17
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.17-h3e65c2a_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.17-hfd9eb17_6.conda
   hash:
-    md5: e80b852f5333dd56353beb73f0fecd43
-    sha256: d791fe3a0ce361b37e00b7e796a4db13408cddaa31c7991617ca5f5dca213895
-  build: h3e65c2a_5
+    md5: aee687dcfcc2a75d77b6e6024273978a
+    sha256: d67e50aff37474eee393346d71c9e4bbb6d190f86722ac932b2837acfea33f76
+  build: hfd9eb17_6
   arch: x86_64
   subdir: linux-64
-  build_number: 5
+  build_number: 6
   license: Apache-2.0
   license_family: Apache
-  size: 19086
-  timestamp: 1698701411987
+  size: 19054
+  timestamp: 1699535389860
 - platform: osx-64
   name: aws-c-compression
   version: 0.2.17
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.17-ha78fcfa_5.conda
+  - aws-c-common >=0.9.8,<0.9.9.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.17-hff1f2c8_6.conda
   hash:
-    md5: 074f9f22878842c644cd1c7ea57cc6fa
-    sha256: 7de1d89825d5ddc9143f1d7b6a44e8bf978ce5556f27c48a092b31071ef2495d
-  build: ha78fcfa_5
+    md5: d44348239e6be8e1a418cfeda24bc1b5
+    sha256: b82eae800be7a26fb0a8d39c009c39f3b8f474d05dcb636b7b8e225ca7c7da2b
+  build: hff1f2c8_6
   arch: x86_64
   subdir: osx-64
-  build_number: 5
+  build_number: 6
   license: Apache-2.0
   license_family: Apache
-  size: 18097
-  timestamp: 1698701646677
+  size: 18031
+  timestamp: 1699535575204
 - platform: osx-arm64
   name: aws-c-compression
   version: 0.2.17
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.17-he63e28a_5.conda
+  - aws-c-common >=0.9.8,<0.9.9.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.17-hea61927_6.conda
   hash:
-    md5: 7e6495024259d31bd33a0f43620f238a
-    sha256: 06f77f7b9a176c7a57683e11b47c022a14bee574b09259675427d0b65c3be604
-  build: he63e28a_5
+    md5: 61e64f2091370b64430faf5fe021bc54
+    sha256: 01f5d5397def8f38263cc8bf3a31d2063602238073847a2941fd7f28f01da617
+  build: hea61927_6
   arch: aarch64
   subdir: osx-arm64
-  build_number: 5
+  build_number: 6
   license: Apache-2.0
   license_family: Apache
-  size: 18149
-  timestamp: 1698701642078
+  size: 17917
+  timestamp: 1699535888429
 - platform: win-64
   name: aws-c-compression
   version: 0.2.17
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.17-h6f45060_5.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.17-hde771f8_6.conda
   hash:
-    md5: 733834c9c9d08bdc86d0b64df82dc68b
-    sha256: 4d65b1ed46e8b4a219e2dfabc002577505d4ce803178e66971cc8d468fe3dca5
-  build: h6f45060_5
+    md5: 0e05aa2ca94405102e81d9afc0b89567
+    sha256: a3fe5734b11a77c5c51b7274f59fa09af33671692aad569c2f23452550536984
+  build: hde771f8_6
   arch: x86_64
   subdir: win-64
-  build_number: 5
+  build_number: 6
   license: Apache-2.0
   license_family: Apache
-  size: 22636
-  timestamp: 1698702029337
+  size: 22535
+  timestamp: 1699535932006
 - platform: linux-64
   name: aws-c-event-stream
   version: 0.3.2
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.3.2-hc1d3383_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.3.2-hae413d4_6.conda
   hash:
-    md5: 9064e3f924fe776f23197ac09e178915
-    sha256: 754ce138ad461df1ec81cfce817479af10cc3e2514eb265d16b277091fae8af4
-  build: hc1d3383_5
+    md5: b4e69f0e7f832dc901bd585f353487f0
+    sha256: b7b00593f4cd835780d3a4f61f6f77181b33b8e85cc0f78d9cb48dc1d84e8443
+  build: hae413d4_6
   arch: x86_64
   subdir: linux-64
-  build_number: 5
+  build_number: 6
   license: Apache-2.0
   license_family: Apache
-  size: 53918
-  timestamp: 1698738745123
+  size: 53880
+  timestamp: 1699561310776
 - platform: osx-64
   name: aws-c-event-stream
   version: 0.3.2
@@ -1283,22 +1284,22 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.9
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
   - libcxx >=16.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.3.2-h1738cac_5.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.3.2-hb6e475e_6.conda
   hash:
-    md5: ce2268bc63d3936eb7520b6b12997ee2
-    sha256: 15d0b1bf644a89461efa2f6a206f7c31caa3c605920da1645798379b06b36cfa
-  build: h1738cac_5
+    md5: 19b99f3797acdd59e95a8c1e9cc648df
+    sha256: 24f9fe6ad0f22c36d1dc49280fcbe90a157c3ba65664f27746aa6e67d6cbbb63
+  build: hb6e475e_6
   arch: x86_64
   subdir: osx-64
-  build_number: 5
+  build_number: 6
   license: Apache-2.0
   license_family: Apache
-  size: 47220
-  timestamp: 1698738960192
+  size: 46798
+  timestamp: 1699561524075
 - platform: osx-arm64
   name: aws-c-event-stream
   version: 0.3.2
@@ -1306,46 +1307,46 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.9
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
   - libcxx >=16.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.3.2-h1dc1696_5.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.3.2-h32206d9_6.conda
   hash:
-    md5: 4455748c072e91880008764d2bc7d5ae
-    sha256: d72e8eec3dba375236245a05dec61d6424fc891cd166eec04300d4d443157ee2
-  build: h1dc1696_5
+    md5: 498485eaae26d9241fa08641e461ec41
+    sha256: 2dbeab2e4211ff27ffcc8e4770df4e3083d8d9bb524154ff4ce8d42c3a35a54a
+  build: h32206d9_6
   arch: aarch64
   subdir: osx-arm64
-  build_number: 5
+  build_number: 6
   license: Apache-2.0
   license_family: Apache
-  size: 47449
-  timestamp: 1698739002903
+  size: 47000
+  timestamp: 1699561582569
 - platform: win-64
   name: aws-c-event-stream
   version: 0.3.2
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.3.2-h65f5141_5.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.3.2-he53de8f_6.conda
   hash:
-    md5: 235e8c9fa5aa698a6003357a55d0e711
-    sha256: 15bf9ba1bbc4f8b5e5e1edca49b9a6cd44bb5794536353080f1eadfc3b5991a5
-  build: h65f5141_5
+    md5: a8817c4fd9bd978fff70bc9feddb011f
+    sha256: fb7706d1da989da614349fd181b7c9b6159bd65ea4626705b99ad4b1e5f583ce
+  build: he53de8f_6
   arch: x86_64
   subdir: win-64
-  build_number: 5
+  build_number: 6
   license: Apache-2.0
   license_family: Apache
-  size: 54785
-  timestamp: 1698739263144
+  size: 54505
+  timestamp: 1699561879986
 - platform: linux-64
   name: aws-c-http
   version: 0.7.14
@@ -1353,22 +1354,22 @@ package:
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-compression >=0.2.17,<0.2.18.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.7.14-h858fa18_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.7.14-h162056d_1.conda
   hash:
-    md5: 02ca6e2c98d6d2512993eca3c634a7dc
-    sha256: 4a1d5979d5c0fc2d12d3a1983d4704d21f498c841525644871ff8c07613e8786
-  build: h858fa18_0
+    md5: e1b49ef8ddc4faca06a63a7e25da644f
+    sha256: dc4cda9ffef3b5859c5943f010e947e082315e7d84eb1f5e0b3cd58565eaf405
+  build: h162056d_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 194582
-  timestamp: 1699469226201
+  size: 194479
+  timestamp: 1699561380461
 - platform: osx-64
   name: aws-c-http
   version: 0.7.14
@@ -1376,21 +1377,21 @@ package:
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-compression >=0.2.17,<0.2.18.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.7.14-hbc44fbd_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.7.14-h950a07a_1.conda
   hash:
-    md5: f0c8129cb242c2a0f888525980605646
-    sha256: d0b7a2312d1139501a3c9fc6dcd34eb447cb9cda66b7ba09fd2a78d46455f593
-  build: hbc44fbd_0
+    md5: 0827fb5a8c4a4d209fa44088f3046b40
+    sha256: 9fe20e7a79f7a66dec9b4c4eccc56db3e820b7cc380689fff53f19e0b1c05b72
+  build: h950a07a_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 162623
-  timestamp: 1699469645007
+  size: 162494
+  timestamp: 1699561754961
 - platform: osx-arm64
   name: aws-c-http
   version: 0.7.14
@@ -1398,21 +1399,21 @@ package:
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-compression >=0.2.17,<0.2.18.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.7.14-h883952f_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.7.14-h673bc1b_1.conda
   hash:
-    md5: cbeb1609f324dd4a737238450e2fc703
-    sha256: 78afb1cdc94d2cdafea2f42c3813896417fd85a72c52db6e1b90659c48ea0a50
-  build: h883952f_0
+    md5: 8cb609edc86062a2f7a1482678c65e56
+    sha256: 320b1d8faa845b25a1e58371def7694fc7561d46cf7a38d8384997ac7cab8616
+  build: h673bc1b_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 151117
-  timestamp: 1699469666079
+  size: 151027
+  timestamp: 1699561878171
 - platform: win-64
   name: aws-c-http
   version: 0.7.14
@@ -1420,24 +1421,24 @@ package:
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-compression >=0.2.17,<0.2.18.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.7.14-h4076b5e_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.7.14-h0e17c8e_1.conda
   hash:
-    md5: 5b529ce58ccf7fde3e87eab0e7a76f68
-    sha256: 08d0319fad24822a33f30ef907e0761f5dd5c0ae0d579b5222c0ac028c1c0603
-  build: h4076b5e_0
+    md5: 043cbf65f2b35beeb830ef2b81928d55
+    sha256: 37263225a1405fc855bfd2f9b096afd34ea8b80fb12a87c238517a8be1fe127f
+  build: h0e17c8e_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 179958
-  timestamp: 1699469850661
+  size: 179364
+  timestamp: 1699561967054
 - platform: linux-64
   name: aws-c-io
   version: 0.13.35
@@ -1445,21 +1446,21 @@ package:
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - libgcc-ng >=12
   - s2n >=1.3.56,<1.3.57.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.35-hf90439a_7.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.35-hc23c90e_8.conda
   hash:
-    md5: 53c7db6199c129a61dfb3b8cb32bdc34
-    sha256: 2eecf18936cdfe470236d7b1ecd904017336a540f9705c3493e8462e88d51028
-  build: hf90439a_7
+    md5: 4cabe68190c1ff4c72154c0a7d2e980c
+    sha256: 89103265c27cb5ad67a0f6b67149532e7addae4b6ddfb704e77f0369f5520591
+  build: hc23c90e_8
   arch: x86_64
   subdir: linux-64
-  build_number: 7
+  build_number: 8
   license: Apache-2.0
   license_family: Apache
-  size: 156440
-  timestamp: 1699362826884
+  size: 156721
+  timestamp: 1699547987524
 - platform: osx-64
   name: aws-c-io
   version: 0.13.35
@@ -1467,19 +1468,19 @@ package:
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.13.35-ha5bf2a1_7.conda
+  - aws-c-common >=0.9.8,<0.9.9.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.13.35-hb98174f_8.conda
   hash:
-    md5: 6136be3da640eb5236c87c7c81d190b3
-    sha256: 0966a4263cf8b30cee9265c60b49a59d17f5723b385ae92a7953c24892e5dc9f
-  build: ha5bf2a1_7
+    md5: c7b0ed5a258d3a8bb991bdc935b3703a
+    sha256: f44243ab77bef1475565cfd2c432608d530d70f3b7d690effa8e1c47b3bb2d90
+  build: hb98174f_8
   arch: x86_64
   subdir: osx-64
-  build_number: 7
+  build_number: 8
   license: Apache-2.0
   license_family: Apache
-  size: 137623
-  timestamp: 1699362970908
+  size: 137165
+  timestamp: 1699548283457
 - platform: osx-arm64
   name: aws-c-io
   version: 0.13.35
@@ -1487,19 +1488,19 @@ package:
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.13.35-hc042dea_7.conda
+  - aws-c-common >=0.9.8,<0.9.9.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.13.35-he1b4ce3_8.conda
   hash:
-    md5: 77ba8c6681ba3cbe58d95053bed475ba
-    sha256: f00571ed7d9ec2592ff8349f2decb54e52b3937a1e27ea4395f8f937ca740e8c
-  build: hc042dea_7
+    md5: 2b17730ac8242c1ba995baa5cfb1641e
+    sha256: c0112899e785d550ed0c16e930ab52119c312098a24eebc5d808c53d0f36effb
+  build: he1b4ce3_8
   arch: aarch64
   subdir: osx-arm64
-  build_number: 7
+  build_number: 8
   license: Apache-2.0
   license_family: Apache
-  size: 136004
-  timestamp: 1699363132815
+  size: 137327
+  timestamp: 1699548210602
 - platform: win-64
   name: aws-c-io
   version: 0.13.35
@@ -1507,515 +1508,515 @@ package:
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.13.35-he032580_7.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.13.35-h56d495d_8.conda
   hash:
-    md5: e5b72b99c896b3b2c92520726a13ad37
-    sha256: 5faa13f659a3be86dde3bda43de2beee8d588f96011694d3d390c1e7e53e7c9d
-  build: he032580_7
+    md5: 56881dea8f76b30caa3f2afd9783a229
+    sha256: 176dd33dbcb4a3a4ed375cdf654598e77f9034ea3a323e6745ec1d87901e66f6
+  build: h56d495d_8
   arch: x86_64
   subdir: win-64
-  build_number: 7
+  build_number: 8
   license: Apache-2.0
   license_family: Apache
-  size: 158540
-  timestamp: 1699363418327
+  size: 159731
+  timestamp: 1699548539297
 - platform: linux-64
   name: aws-c-mqtt
-  version: 0.9.8
+  version: 0.9.9
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-http >=0.7.14,<0.7.15.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.9.8-ha08d473_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.9.9-h1387108_0.conda
   hash:
-    md5: 46b993e00e67389a5dec3e17f994553f
-    sha256: 01f6065480966df906d07be6842cfd9d11860623f47ade7d0f7c1ef58b5bc64c
-  build: ha08d473_2
+    md5: d03181571be036cfbe7accf52256efe7
+    sha256: 1df6ad0f5db319090718f5d4575b8829ff5aa5b663c8580e191fa9005e71072d
+  build: h1387108_0
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 162491
-  timestamp: 1699548592400
+  size: 163679
+  timestamp: 1699585384425
 - platform: osx-64
   name: aws-c-mqtt
-  version: 0.9.8
+  version: 0.9.9
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-http >=0.7.14,<0.7.15.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.9.8-h5727053_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.9.9-h5e4a26e_0.conda
   hash:
-    md5: 5ae5d4aaf1c82ea82fd9c70bbc68f543
-    sha256: a6cc94e058539c53c6b83a911461320f71c3db2c31a72aaa6e4a8ac8539f4e0e
-  build: h5727053_2
+    md5: 61eba6810125f2214ad6863bf8941c4e
+    sha256: e1812608ca7587561a7c8584c9c202404bfdf2d6f2e8f135fda92f5abf1556a4
+  build: h5e4a26e_0
   arch: x86_64
   subdir: osx-64
-  build_number: 2
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 138464
-  timestamp: 1699548792108
+  size: 139093
+  timestamp: 1699585537317
 - platform: osx-arm64
   name: aws-c-mqtt
-  version: 0.9.8
+  version: 0.9.9
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-http >=0.7.14,<0.7.15.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.9.8-h31ffd85_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.9.9-h2364c62_0.conda
   hash:
-    md5: d1065557cd6ae8b94bd258b6424a145d
-    sha256: d2165731873130ab8468b78de6ff79c87986794bd5cf989bb054e0b5d0756479
-  build: h31ffd85_2
+    md5: f6fa220e8b10a832127be45ddb7f6f04
+    sha256: f82dd9660edecf32482004d98a09ed6b2929cb3787be43e54f5db71be1d08b62
+  build: h2364c62_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 2
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 117623
-  timestamp: 1699548697243
+  size: 117617
+  timestamp: 1699585248460
 - platform: win-64
   name: aws-c-mqtt
-  version: 0.9.8
+  version: 0.9.9
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-http >=0.7.14,<0.7.15.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.9.8-h488a239_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.9.9-hd1ff352_0.conda
   hash:
-    md5: 6a4f0be04a20c987b5cc80d546b3e8e7
-    sha256: ae8a6bd2115401b8bcf8dbab084442480e87fd5a9fa4dbdee1c27dd8bc04d7c2
-  build: h488a239_2
+    md5: 654d96c26cf802b5140edf39b8c59965
+    sha256: 29c5dcd039ef6c18da4cccf219dd6ec19bf4f8496f935212efacc4cadf23e197
+  build: hd1ff352_0
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 157480
-  timestamp: 1699549135684
+  size: 157890
+  timestamp: 1699585731776
 - platform: linux-64
   name: aws-c-s3
-  version: 0.3.22
+  version: 0.3.23
   category: main
   manager: conda
   dependencies:
-  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-auth >=0.7.6,<0.7.7.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-http >=0.7.14,<0.7.15.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
   - libgcc-ng >=12
   - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.3.22-h74ef7d6_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.3.23-h7630044_1.conda
   hash:
-    md5: db8455c67955447be03d75aca4c67c29
-    sha256: 52cbb45d2e435f09214b4c9dde81cd5d863ff7b282aa29c7ab7458da27b02ab7
-  build: h74ef7d6_2
+    md5: 76eebe9871477c883d04042758493b98
+    sha256: a145f456f0a47f8f7482ce6c23f4bfc3b71cb013598d4e1294930dcc8db56c65
+  build: h7630044_1
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 88140
-  timestamp: 1699561386406
+  size: 90213
+  timestamp: 1699715186317
 - platform: osx-64
   name: aws-c-s3
-  version: 0.3.22
+  version: 0.3.23
   category: main
   manager: conda
   dependencies:
-  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-auth >=0.7.6,<0.7.7.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-http >=0.7.14,<0.7.15.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.3.22-hf862c59_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.3.23-hb1cbb54_1.conda
   hash:
-    md5: e1ca14384968cee866d7302682438db5
-    sha256: 78d97571ef3162f7d8ef7034c7972bbe70f52fbe67ec195074c2ca7f0cff6f2e
-  build: hf862c59_2
+    md5: dfea24cf0289adc80d7aa3bb562a58af
+    sha256: 2fba093610426d453350e335a69c33edb48ab30efcdb5a6191d583b5e36b5014
+  build: hb1cbb54_1
   arch: x86_64
   subdir: osx-64
-  build_number: 2
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 76506
-  timestamp: 1699561709060
+  size: 77961
+  timestamp: 1699715318050
 - platform: osx-arm64
   name: aws-c-s3
-  version: 0.3.22
+  version: 0.3.23
   category: main
   manager: conda
   dependencies:
-  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-auth >=0.7.6,<0.7.7.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-http >=0.7.14,<0.7.15.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.3.22-h0be9375_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.3.23-h3940a1a_1.conda
   hash:
-    md5: 7abf8ef7a90ff9168ba2abb7871a9ba9
-    sha256: c22fc3b6c15ba0598aec6880b79b29c91404b5b67ee3a203246bc1bfce6e8edf
-  build: h0be9375_2
+    md5: aebb27ad20745412030f68c42f9eb20d
+    sha256: 9faee6856651595fbd1408e73534109c723a154a03c6d21a34f2e1b59c7d11a1
+  build: h3940a1a_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 2
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 76028
-  timestamp: 1699561750338
+  size: 77576
+  timestamp: 1699715380097
 - platform: win-64
   name: aws-c-s3
-  version: 0.3.22
+  version: 0.3.23
   category: main
   manager: conda
   dependencies:
-  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-auth >=0.7.6,<0.7.7.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-http >=0.7.14,<0.7.15.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.3.22-h5a4ae1a_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.3.23-hec067e0_1.conda
   hash:
-    md5: ba86e203a57ddd7e5b8df24cd07e6529
-    sha256: 052b62f919449e7419bfac8aca672386dfb17ab373ed92fed41152d624712828
-  build: h5a4ae1a_2
+    md5: 75e8b0fa90aeed6e17f7a9ff1d2e3572
+    sha256: aef36f85d447ab66d2077a4cbb9fa559ddc5f2435763555057ec02a3896a3c50
+  build: hec067e0_1
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 85140
-  timestamp: 1699561967299
+  size: 87706
+  timestamp: 1699715424818
 - platform: linux-64
   name: aws-c-sdkutils
   version: 0.1.12
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.12-h3e65c2a_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.12-hfd9eb17_5.conda
   hash:
-    md5: 5fcc2df6693583ee38eb075555956392
-    sha256: 2041b37443b686aa60ca6b34ae86e54af6458c23e0bbc32de1ea0665eb191789
-  build: h3e65c2a_4
+    md5: af2bccdb4cf6e9254969426fd53c7c65
+    sha256: d109677012abbf7e062d2a64c0df55523b056e74e5895650841b49f7f94a48a1
+  build: hfd9eb17_5
   arch: x86_64
   subdir: linux-64
-  build_number: 4
+  build_number: 5
   license: Apache-2.0
   license_family: Apache
-  size: 53076
-  timestamp: 1698710311053
+  size: 53050
+  timestamp: 1699540560421
 - platform: osx-64
   name: aws-c-sdkutils
   version: 0.1.12
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.12-ha78fcfa_4.conda
+  - aws-c-common >=0.9.8,<0.9.9.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.12-hff1f2c8_5.conda
   hash:
-    md5: e309c5244f3912ac92a0b2313b2d5876
-    sha256: 0e417e207f96f3d588c0be748bfaf42ab0d94636cbf17a2fd5051ea7a41cdbf1
-  build: ha78fcfa_4
+    md5: 12164ac8e33917c5d6aeb25ab82c2771
+    sha256: 6953db4c9d56a367f921efaac18cf310985bc57ebd7ed50757c916912a99eeed
+  build: hff1f2c8_5
   arch: x86_64
   subdir: osx-64
-  build_number: 4
+  build_number: 5
   license: Apache-2.0
   license_family: Apache
-  size: 47404
-  timestamp: 1698710545856
+  size: 47222
+  timestamp: 1699540725086
 - platform: osx-arm64
   name: aws-c-sdkutils
   version: 0.1.12
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.12-he63e28a_4.conda
+  - aws-c-common >=0.9.8,<0.9.9.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.12-hea61927_5.conda
   hash:
-    md5: b7fad8d42a716920a4c6cee7d97a6be3
-    sha256: 584db23dd2d577445929572c4330863735fb4d27523abd1bc697379bf00fdce5
-  build: he63e28a_4
+    md5: 905d930730d618d5632011cb68d6744d
+    sha256: a1c60064bf93b4ddbc223bf494acb3e295b0846eb887017d435816e1bcfc51e5
+  build: hea61927_5
   arch: aarch64
   subdir: osx-arm64
-  build_number: 4
+  build_number: 5
   license: Apache-2.0
   license_family: Apache
-  size: 46919
-  timestamp: 1698710580834
+  size: 46881
+  timestamp: 1699541048893
 - platform: win-64
   name: aws-c-sdkutils
   version: 0.1.12
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.12-h6f45060_4.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.12-hde771f8_5.conda
   hash:
-    md5: 2ed18bb39f2e35b0de017637b4e267f3
-    sha256: 976e697ca7d9e85fd6291f4d047a353fc750bc1f10331134d72ca1cef186fc75
-  build: h6f45060_4
+    md5: 63d2fb4a9fbff5b3fd1bcf958d616533
+    sha256: 7c059bfaf81900c86d7e9033efe1d45486db3bbd095729fd431d4a805994bc49
+  build: hde771f8_5
   arch: x86_64
   subdir: win-64
-  build_number: 4
+  build_number: 5
   license: Apache-2.0
   license_family: Apache
-  size: 51749
-  timestamp: 1698710874007
+  size: 51783
+  timestamp: 1699540935579
 - platform: linux-64
   name: aws-checksums
   version: 0.1.17
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.17-h3e65c2a_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.17-hfd9eb17_5.conda
   hash:
-    md5: c01f89cb1a7ed2e1f37a72ffede9b870
-    sha256: fa7b6bd4557d117c3d8667166c7011e8df8423602eeeb734ec096897b77ec50b
-  build: h3e65c2a_4
+    md5: 92077b8c5f72e9b81f069b1eb492ab80
+    sha256: fa197cea5d34038066ac743ffa3ae688c057152fff55226ec740c5f68a136282
+  build: hfd9eb17_5
   arch: x86_64
   subdir: linux-64
-  build_number: 4
+  build_number: 5
   license: Apache-2.0
   license_family: Apache
-  size: 50231
-  timestamp: 1698710226989
+  size: 49997
+  timestamp: 1699540353416
 - platform: osx-64
   name: aws-checksums
   version: 0.1.17
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.17-ha78fcfa_4.conda
+  - aws-c-common >=0.9.8,<0.9.9.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.17-hff1f2c8_5.conda
   hash:
-    md5: 6e6254ef456413dfee737de75fd419bb
-    sha256: 6c34fe8de60d70ad5cdf19e3a90a68e61f4007b68e6c66eea2ee73dfb7bdce84
-  build: ha78fcfa_4
+    md5: 8b47ddfddaf30b4de34ea9d660c919c7
+    sha256: 8ebb4ac6617f87405b6966a23dc4a37bdc96d4627f990e72abf1dff136179579
+  build: hff1f2c8_5
   arch: x86_64
   subdir: osx-64
-  build_number: 4
+  build_number: 5
   license: Apache-2.0
   license_family: Apache
-  size: 48771
-  timestamp: 1698710387219
+  size: 48734
+  timestamp: 1699540654287
 - platform: osx-arm64
   name: aws-checksums
   version: 0.1.17
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.17-he63e28a_4.conda
+  - aws-c-common >=0.9.8,<0.9.9.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.17-hea61927_5.conda
   hash:
-    md5: 137e2a6fbd1a9af10327431a058995ea
-    sha256: 01a7df193c9f5ed33094d228cb58af8bf5975d369c8da2271756fad0914eef7c
-  build: he63e28a_4
+    md5: 4fcd94ba7456d0d162d3d84e5ef4db54
+    sha256: 72af0036cdb7492826fafe1513cc5f0aa0280ad5d5af4a9ebbca50b81920cbe6
+  build: hea61927_5
   arch: aarch64
   subdir: osx-arm64
-  build_number: 4
+  build_number: 5
   license: Apache-2.0
   license_family: Apache
-  size: 49162
-  timestamp: 1698710623741
+  size: 49092
+  timestamp: 1699540725982
 - platform: win-64
   name: aws-checksums
   version: 0.1.17
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.17-h6f45060_4.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.17-hde771f8_5.conda
   hash:
-    md5: 586ec2148c315b5cb6833999a894dae8
-    sha256: ada1fa9736841e568f15ba015d200deaaa4a7f33acbaa36309d490037aee6970
-  build: h6f45060_4
+    md5: 0085fd1d337cc977c15c4305164e6301
+    sha256: 874eab0a384b371f327a55638260023cdad23857ca736c7f28dd6dcaa173209c
+  build: hde771f8_5
   arch: x86_64
   subdir: win-64
-  build_number: 4
+  build_number: 5
   license: Apache-2.0
   license_family: Apache
-  size: 52227
-  timestamp: 1698710697630
+  size: 52206
+  timestamp: 1699540872454
 - platform: linux-64
   name: aws-crt-cpp
-  version: 0.24.5
+  version: 0.24.6
   category: main
   manager: conda
   dependencies:
-  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-auth >=0.7.6,<0.7.7.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-event-stream >=0.3.2,<0.3.3.0a0
   - aws-c-http >=0.7.14,<0.7.15.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
-  - aws-c-mqtt >=0.9.8,<0.9.9.0a0
-  - aws-c-s3 >=0.3.22,<0.3.23.0a0
+  - aws-c-mqtt >=0.9.9,<0.9.10.0a0
+  - aws-c-s3 >=0.3.23,<0.3.24.0a0
   - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.24.5-h48a4155_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.24.6-h270613d_0.conda
   hash:
-    md5: e5e36577dce77a90cefe999136833e18
-    sha256: ce4ddf0ca2d42c8919504c190848ae579b949d0c1f15790948a18a53afcb1f07
-  build: h48a4155_1
+    md5: 6c72523113e6bdb0b70e521f8e21f122
+    sha256: 850b00b1b7de5cce9e6e2af9fa8f69ae804e8778a3bc7b3b3eed0a194b1e206e
+  build: h270613d_0
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 327298
-  timestamp: 1699576000021
+  size: 325484
+  timestamp: 1699827131561
 - platform: osx-64
   name: aws-crt-cpp
-  version: 0.24.5
+  version: 0.24.6
   category: main
   manager: conda
   dependencies:
   - __osx >=10.9
-  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-auth >=0.7.6,<0.7.7.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-event-stream >=0.3.2,<0.3.3.0a0
   - aws-c-http >=0.7.14,<0.7.15.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
-  - aws-c-mqtt >=0.9.8,<0.9.9.0a0
-  - aws-c-s3 >=0.3.22,<0.3.23.0a0
+  - aws-c-mqtt >=0.9.9,<0.9.10.0a0
+  - aws-c-s3 >=0.3.23,<0.3.24.0a0
   - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
   - libcxx >=16.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.24.5-h4eb6da0_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.24.6-h7eda119_0.conda
   hash:
-    md5: 2981fb88e349aa0140e4fca3929a78ab
-    sha256: d1503553ac58e73d34880dfa4a98906bf9ff47e6cf2b3ff7177e1f5bb5512196
-  build: h4eb6da0_1
+    md5: f1e9885e6e8c37329493456d3f3741e3
+    sha256: 8c6a4987c2db07fff1b519ea7b98224a511894ef8abee464e6428b8405e23bf2
+  build: h7eda119_0
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 274767
-  timestamp: 1699576356780
+  size: 274300
+  timestamp: 1699827382342
 - platform: osx-arm64
   name: aws-crt-cpp
-  version: 0.24.5
+  version: 0.24.6
   category: main
   manager: conda
   dependencies:
   - __osx >=10.9
-  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-auth >=0.7.6,<0.7.7.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-event-stream >=0.3.2,<0.3.3.0a0
   - aws-c-http >=0.7.14,<0.7.15.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
-  - aws-c-mqtt >=0.9.8,<0.9.9.0a0
-  - aws-c-s3 >=0.3.22,<0.3.23.0a0
+  - aws-c-mqtt >=0.9.9,<0.9.10.0a0
+  - aws-c-s3 >=0.3.23,<0.3.24.0a0
   - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
   - libcxx >=16.0.6
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.24.5-h142c802_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.24.6-h8bfa36e_0.conda
   hash:
-    md5: 0805dfc4f9746831943e05a60da82b85
-    sha256: 6c85761c2c5d08bff18440401fa135bd9243336f1e0b1a181f90e5db4eb3d02d
-  build: h142c802_1
+    md5: 1308c70773a563087be5e8a70990692e
+    sha256: 7dc05da7d817dcfe25e0cf5053e99b6cecf449bd4941e0a78611c172595aafb2
+  build: h8bfa36e_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 213030
-  timestamp: 1699576289227
+  size: 212956
+  timestamp: 1699827346801
 - platform: win-64
   name: aws-crt-cpp
-  version: 0.24.5
+  version: 0.24.6
   category: main
   manager: conda
   dependencies:
-  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-auth >=0.7.6,<0.7.7.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-event-stream >=0.3.2,<0.3.3.0a0
   - aws-c-http >=0.7.14,<0.7.15.0a0
   - aws-c-io >=0.13.35,<0.13.36.0a0
-  - aws-c-mqtt >=0.9.8,<0.9.9.0a0
-  - aws-c-s3 >=0.3.22,<0.3.23.0a0
+  - aws-c-mqtt >=0.9.9,<0.9.10.0a0
+  - aws-c-s3 >=0.3.23,<0.3.24.0a0
   - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.24.5-he0af546_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.24.6-hb03f413_0.conda
   hash:
-    md5: 031bcdcd1b218031f289ffa053560dd8
-    sha256: 6946957ca5255d536d20bc26b74df6a8c51b11e711ab7ab9d916626b490936d6
-  build: he0af546_1
+    md5: 804fbdc65423422f9d7866e3a2a32cf6
+    sha256: c293d2d50ec79bcd9601d2db4567ffc2e95bd28c9c5b1ab4ffa88b5295a0b264
+  build: hb03f413_0
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 237104
-  timestamp: 1699576259324
+  size: 237639
+  timestamp: 1699827375830
 - platform: linux-64
   name: aws-sdk-cpp
   version: 1.11.182
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-event-stream >=0.3.2,<0.3.3.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
-  - aws-crt-cpp >=0.24.5,<0.24.6.0a0
+  - aws-crt-cpp >=0.24.6,<0.24.7.0a0
   - libcurl >=8.4.0,<9.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.182-h2b8e6fb_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.182-h771f7cb_6.conda
   hash:
-    md5: 804fb841eea68c47961461df8797c197
-    sha256: abb165dd2fd1f461cd83f6ef5e1632b0b4feb7fc912c7d67baafe3a36cf49f37
-  build: h2b8e6fb_4
+    md5: d7bdd7c6458cbfdbca8246d6687c9e87
+    sha256: 5a44a81fd9a1091edcee9dac57f2df34d213a0318ad71bfb838b17480baa627e
+  build: h771f7cb_6
   arch: x86_64
   subdir: linux-64
-  build_number: 4
+  build_number: 6
   license: Apache-2.0
   license_family: Apache
-  size: 3444820
-  timestamp: 1699443413009
+  size: 3439081
+  timestamp: 1699910664991
 - platform: osx-64
   name: aws-sdk-cpp
   version: 1.11.182
@@ -2023,26 +2024,26 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.9
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-event-stream >=0.3.2,<0.3.3.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
-  - aws-crt-cpp >=0.24.5,<0.24.6.0a0
+  - aws-crt-cpp >=0.24.6,<0.24.7.0a0
   - libcurl >=8.4.0,<9.0a0
   - libcxx >=16.0.6
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.182-h8a7c8da_4.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.182-h06c5342_6.conda
   hash:
-    md5: 702f9438f2b9e754a0657a3024bd05a2
-    sha256: 307a84c04bcec2b0ea9b70a2466c9a6f3a28d4e9aea686db5d1fca84464248b3
-  build: h8a7c8da_4
+    md5: 57a340066ffd1526abc6a946d7faf8ef
+    sha256: 308e26554c9deeb0b11e54f013d6e05c5ebd0aca283f86f94fd0771871bf6af7
+  build: h06c5342_6
   arch: x86_64
   subdir: osx-64
-  build_number: 4
+  build_number: 6
   license: Apache-2.0
   license_family: Apache
-  size: 3164674
-  timestamp: 1699443981539
+  size: 3170501
+  timestamp: 1699911606669
 - platform: osx-arm64
   name: aws-sdk-cpp
   version: 1.11.182
@@ -2050,52 +2051,52 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.9
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-event-stream >=0.3.2,<0.3.3.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
-  - aws-crt-cpp >=0.24.5,<0.24.6.0a0
+  - aws-crt-cpp >=0.24.6,<0.24.7.0a0
   - libcurl >=8.4.0,<9.0a0
   - libcxx >=16.0.6
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.182-h0c1a885_4.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.182-hb9aa301_6.conda
   hash:
-    md5: 4a69ed767d116ecf65943436ed6a8623
-    sha256: fd13b7aa184d8bb3135c70a53c5e076d7b38461d737f49ca198e3b835af71469
-  build: h0c1a885_4
+    md5: d59256fce1d063750aa34b535ca08bd2
+    sha256: 2d447acabb91224811de2967797ed5eb3239f6034a977fbd1823da3cf05aa8bb
+  build: hb9aa301_6
   arch: aarch64
   subdir: osx-arm64
-  build_number: 4
+  build_number: 6
   license: Apache-2.0
   license_family: Apache
-  size: 3182890
-  timestamp: 1699444269012
+  size: 3219725
+  timestamp: 1699911471167
 - platform: win-64
   name: aws-sdk-cpp
   version: 1.11.182
   category: main
   manager: conda
   dependencies:
-  - aws-c-common >=0.9.5,<0.9.6.0a0
+  - aws-c-common >=0.9.8,<0.9.9.0a0
   - aws-c-event-stream >=0.3.2,<0.3.3.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
-  - aws-crt-cpp >=0.24.5,<0.24.6.0a0
+  - aws-crt-cpp >=0.24.6,<0.24.7.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.182-hf4894ff_4.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.182-h0652cf5_6.conda
   hash:
-    md5: 27b9c5f743fd82c166445d1c02c3cebc
-    sha256: 794bf88e22b1b617340b3f993d30739cc5a3e4402f446aaa2f107b094641e4d6
-  build: hf4894ff_4
+    md5: 7e7e5f9119bca8bdd0b10a1d07ba8e3c
+    sha256: 508d8905b2c5a6be71c04c1047396449fc60f611cb6b2cdab0ba7e59251c0f50
+  build: h0652cf5_6
   arch: x86_64
   subdir: win-64
-  build_number: 4
+  build_number: 6
   license: Apache-2.0
   license_family: Apache
-  size: 3237710
-  timestamp: 1699444829349
+  size: 3244055
+  timestamp: 1699911997206
 - platform: linux-64
   name: babel
   version: 2.13.1
@@ -2527,20 +2528,20 @@ package:
   - packaging >=22.0
   - pathspec >=0.9
   - platformdirs >=2
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/black-23.10.1-py311h38be061_0.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/black-23.10.1-py312h7900ff3_0.conda
   hash:
-    md5: 17874858641cb402ad73b9adb0e11a27
-    sha256: f2114740c055ca5d250e363eec69d0181c2ae5b6ead7597762cf766eaa40fe1d
-  build: py311h38be061_0
+    md5: 8cd2baa0b2fd3d1257d4201143c8cbfb
+    sha256: 03fe0472e42d20480374f73f871cc098b4600cb60c6cb81b0931e43ea49d0664
+  build: py312h7900ff3_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 359696
-  timestamp: 1698342847430
+  size: 354998
+  timestamp: 1698342900815
 - platform: osx-64
   name: black
   version: 23.10.1
@@ -2552,20 +2553,20 @@ package:
   - packaging >=22.0
   - pathspec >=0.9
   - platformdirs >=2
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/black-23.10.1-py311h6eed73b_0.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/black-23.10.1-py312hb401068_0.conda
   hash:
-    md5: c802bfc16625b15e57e4d2d05bee622a
-    sha256: e6c81cc86c288f2d15852dc0068caa5acae3700eff57eeeeb5742844b1048b2b
-  build: py311h6eed73b_0
+    md5: ba9e12d82bd9d0643c854dfb5ed2641b
+    sha256: 62a8c5890d0337ce34ec2126b267a6697d300600be8fd497402c877a165e42b4
+  build: py312hb401068_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 360890
-  timestamp: 1698342991427
+  size: 355843
+  timestamp: 1698343050915
 - platform: osx-arm64
   name: black
   version: 23.10.1
@@ -2577,21 +2578,21 @@ package:
   - packaging >=22.0
   - pathspec >=0.9
   - platformdirs >=2
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/black-23.10.1-py311h267d04e_0.conda
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/black-23.10.1-py312h81bd7bf_0.conda
   hash:
-    md5: 12b064976b0152cb193120c645f6c3a0
-    sha256: ec50f430559024cc7c8ef8733457bab49a6c88ef1ae857b4f7f2b44fe32b388e
-  build: py311h267d04e_0
+    md5: f8d5916124223db87a88e18b24ad7c96
+    sha256: e0903af26367f3b8af9a14607029ccf50d4f6f7bd958a922f0ec7115d2950c1b
+  build: py312h81bd7bf_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 361600
-  timestamp: 1698343111708
+  size: 357193
+  timestamp: 1698343108277
 - platform: win-64
   name: black
   version: 23.10.1
@@ -2603,20 +2604,20 @@ package:
   - packaging >=22.0
   - pathspec >=0.9
   - platformdirs >=2
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/win-64/black-23.10.1-py311h1ea47a8_0.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/win-64/black-23.10.1-py312h2e8e312_0.conda
   hash:
-    md5: 2ffbba0bb141e3d4e0ba3a0344fd82a4
-    sha256: a87085a9d9bdfc5a6f7841a218105c9b162ab7a17c34fa3b49bdbb1339c669b4
-  build: py311h1ea47a8_0
+    md5: 75b975d3da95b635c8e99f0c165ac37f
+    sha256: 168347b4bc34ae43414be424fc15fcdc858bd322fd9a848dc2fa1a525cb925ab
+  build: py312h2e8e312_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 377595
-  timestamp: 1698343648045
+  size: 370899
+  timestamp: 1698343688120
 - platform: linux-64
   name: bleach
   version: 6.1.0
@@ -3168,13 +3169,13 @@ package:
   dependencies:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hb755f60_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h30efb56_1.conda
   hash:
-    md5: cce9e7c3f1c307f2a5fb08a2922d6164
-    sha256: 559093679e9fdb6061b7b80ca0f9a31fe6ffc213f1dae65bc5c82e2cd1a94107
-  build: py311hb755f60_1
+    md5: 45801a89533d3336a365284d93298e36
+    sha256: b68706698b6ac0d31196a8bcb061f0d1f35264bcd967ea45e03e108149a74c6f
+  build: py312h30efb56_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
@@ -3182,8 +3183,8 @@ package:
   - libbrotlicommon 1.1.0 hd590300_1
   license: MIT
   license_family: MIT
-  size: 351340
-  timestamp: 1695990160360
+  size: 350604
+  timestamp: 1695990206327
 - platform: osx-64
   name: brotli-python
   version: 1.1.0
@@ -3191,13 +3192,13 @@ package:
   manager: conda
   dependencies:
   - libcxx >=15.0.7
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hdf8f085_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py312heafc425_1.conda
   hash:
-    md5: 546fdccabb90492fbaf2da4ffb78f352
-    sha256: 0f5e0a7de58006f349220365e32db521a1fe494c37ee455e5ecf05b8fe567dcc
-  build: py311hdf8f085_1
+    md5: a288b88f06b8bfe0dedaf5c4b6ac6b7a
+    sha256: fc55988f9bc05a938ea4b8c20d6545bed6e9c6c10aa5147695f981136ca894c1
+  build: py312heafc425_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
@@ -3205,8 +3206,8 @@ package:
   - libbrotlicommon 1.1.0 h0dc2134_1
   license: MIT
   license_family: MIT
-  size: 366864
-  timestamp: 1695990449997
+  size: 366883
+  timestamp: 1695990710194
 - platform: osx-arm64
   name: brotli-python
   version: 1.1.0
@@ -3214,14 +3215,14 @@ package:
   manager: conda
   dependencies:
   - libcxx >=15.0.7
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311ha891d26_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py312h9f69965_1.conda
   hash:
-    md5: 5e802b015e33447d1283d599d21f052b
-    sha256: 2d78c79ccf2c17236c52ef217a4c34b762eb7908a6903d94439f787aac1c8f4b
-  build: py311ha891d26_1
+    md5: 1bc01b9ffdf42beb1a9fe4e9222e0567
+    sha256: 3418b1738243abba99e931c017b952771eeaa1f353c07f7d45b55e83bb74fcb3
+  build: py312h9f69965_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
@@ -3229,24 +3230,24 @@ package:
   - libbrotlicommon 1.1.0 hb547adb_1
   license: MIT
   license_family: MIT
-  size: 343332
-  timestamp: 1695991223439
+  size: 343435
+  timestamp: 1695990731924
 - platform: win-64
   name: brotli-python
   version: 1.1.0
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311h12c1d0e_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py312h53d5487_1.conda
   hash:
-    md5: 42fbf4e947c17ea605e6a4d7f526669a
-    sha256: 5390e1e5e8e159d4893ecbfd2c08ca75ef51bdce1a4a44ff4ee9e2d596004aac
-  build: py311h12c1d0e_1
+    md5: d01a6667b99f0e8ad4097af66c938e62
+    sha256: 769e276ecdebf86f097786cbde1ebd11e018cd6cd838800995954fe6360e0797
+  build: py312h53d5487_1
   arch: x86_64
   subdir: win-64
   build_number: 1
@@ -3254,8 +3255,8 @@ package:
   - libbrotlicommon 1.1.0 hcfcfb64_1
   license: MIT
   license_family: MIT
-  size: 322086
-  timestamp: 1695990976742
+  size: 322514
+  timestamp: 1695991054894
 - platform: linux-64
   name: build
   version: 0.7.0
@@ -3936,20 +3937,20 @@ package:
   - libffi >=3.4,<4.0a0
   - libgcc-ng >=12
   - pycparser
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py311hb3a22ac_0.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py312hf06ca03_0.conda
   hash:
-    md5: b3469563ac5e808b0cd92810d0697043
-    sha256: b71c94528ca0c35133da4b7ef69b51a0b55eeee570376057f3d2ad60c3ab1444
-  build: py311hb3a22ac_0
+    md5: 56b0ca764ce23cc54f3f7e2a7b970f6d
+    sha256: 5a36e2c254603c367d26378fa3a205bd92263e30acf195f488749562b4c44251
+  build: py312hf06ca03_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 300207
-  timestamp: 1696001873452
+  size: 294523
+  timestamp: 1696001868949
 - platform: osx-64
   name: cffi
   version: 1.16.0
@@ -3958,20 +3959,20 @@ package:
   dependencies:
   - libffi >=3.4,<4.0a0
   - pycparser
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py311hc0b63fd_0.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py312h38bf5a0_0.conda
   hash:
-    md5: 15d07b82223cac96af629e5e747ba27a
-    sha256: 1f13a5fa7f310fdbd27f5eddceb9e62cfb10012c58a58c923dd6f51fa979748a
-  build: py311hc0b63fd_0
+    md5: a45759c013ab20b9017ef9539d234dd7
+    sha256: 8b856583b56fc30f064a7cb286f85e4b5725f2bd4fda8ba0c4e94bffe258741e
+  build: py312h38bf5a0_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 289932
-  timestamp: 1696002096156
+  size: 282370
+  timestamp: 1696002004433
 - platform: osx-arm64
   name: cffi
   version: 1.16.0
@@ -3980,21 +3981,21 @@ package:
   dependencies:
   - libffi >=3.4,<4.0a0
   - pycparser
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py311h4a08483_0.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.16.0-py312h8e38eb3_0.conda
   hash:
-    md5: cbdde0484a47b40e6ce2a4e5aaeb48d7
-    sha256: 9430416328fe2a28e206e703de771817064c8613a79a6a21fe7107f6a783104c
-  build: py311h4a08483_0
+    md5: 960ecbd65860d3b1de5e30373e1bffb1
+    sha256: 1544403cb1a5ca2aeabf0dac86d9ce6066d6fb4363493643b33ffd1b78038d18
+  build: py312h8e38eb3_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 292511
-  timestamp: 1696002194472
+  size: 284245
+  timestamp: 1696002181644
 - platform: win-64
   name: cffi
   version: 1.16.0
@@ -4002,23 +4003,23 @@ package:
   manager: conda
   dependencies:
   - pycparser
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py311ha68e1ae_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py312he70551f_0.conda
   hash:
-    md5: d109d6e767c4890ea32880b8bfa4a3b6
-    sha256: eb7463fe3785dd9ac0b3b1e5fea3b721d20eb082e194cab0af8d9ff28c28934f
-  build: py311ha68e1ae_0
+    md5: 5a51096925d52332c62bfd8904899055
+    sha256: dd39e594f5c6bca52dfed343de2af9326a99700ce2ba3404bd89706926fc0137
+  build: py312he70551f_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 297043
-  timestamp: 1696002186279
+  size: 287805
+  timestamp: 1696002408940
 - platform: linux-64
   name: cfgv
   version: 3.3.1
@@ -4195,81 +4196,81 @@ package:
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/chardet-5.2.0-py311h38be061_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/chardet-5.2.0-py312h7900ff3_1.conda
   hash:
-    md5: b8cfb13de4dbe349a41800644391de6a
-    sha256: 80b547150fc6d125fe034bcc3e820222faa0136463b32b82d7cbe965cc5dec77
-  build: py311h38be061_1
+    md5: af3980cc4690716a5510c8a08cb06238
+    sha256: 584804790b465c8e28b3c3fcea8e774cb659fe479afd8adc0d39406e8c220194
+  build: py312h7900ff3_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   license: LGPL-2.1-only
   license_family: GPL
-  size: 264886
-  timestamp: 1695468797136
+  size: 260197
+  timestamp: 1695468803539
 - platform: osx-64
   name: chardet
   version: 5.2.0
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/chardet-5.2.0-py311h6eed73b_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/chardet-5.2.0-py312hb401068_1.conda
   hash:
-    md5: dd58f7f16513cea1fea710651e4df728
-    sha256: 5826e13627594bafa2f0b4074d9233b0de74227835d249641f216423b3dc8dfc
-  build: py311h6eed73b_1
+    md5: 488080e6ee9bc087762669d1f6d2dc8a
+    sha256: ba2ebeb6d05a3cdd94dbd7a52dabc0686192e4337774c4f7c32da7ef0e04dd10
+  build: py312hb401068_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   license: LGPL-2.1-only
   license_family: GPL
-  size: 267330
-  timestamp: 1695468986364
+  size: 259854
+  timestamp: 1695468947554
 - platform: osx-arm64
   name: chardet
   version: 5.2.0
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/chardet-5.2.0-py311h267d04e_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/chardet-5.2.0-py312h81bd7bf_1.conda
   hash:
-    md5: 2aa7eb0b906818f900e2075fc244976f
-    sha256: 69541a0c834baa0b404cb55f8389bb53f8e9d6962055d68285635d6fbc04334c
-  build: py311h267d04e_1
+    md5: ea728c39b7453cb5f7177bc44ee22c73
+    sha256: 2451501ec933017ff77c18436884baa90b289420c43ad4bdb4fe60d55e5dcdfd
+  build: py312h81bd7bf_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   license: LGPL-2.1-only
   license_family: GPL
-  size: 269754
-  timestamp: 1695469210623
+  size: 263585
+  timestamp: 1695469015195
 - platform: win-64
   name: chardet
   version: 5.2.0
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/win-64/chardet-5.2.0-py311h1ea47a8_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/win-64/chardet-5.2.0-py312h2e8e312_1.conda
   hash:
-    md5: 5c7813415d332343dfe550685954d1b5
-    sha256: 1972d150055784f8b10a0277f75176aed3164483cb529b027bff45ae4f32925f
-  build: py311h1ea47a8_1
+    md5: fcc4fea02fa461bc3ad2a5d6de0c43a8
+    sha256: 105e8f3c7a4510d8b8e3f164970c898e2b7ea02417b99369c7f58a0bb95af34d
+  build: py312h2e8e312_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   license: LGPL-2.1-only
   license_family: GPL
-  size: 284249
-  timestamp: 1695469001100
+  size: 277773
+  timestamp: 1695468989681
 - platform: linux-64
   name: charset-normalizer
   version: 3.3.2
@@ -4611,20 +4612,20 @@ package:
   dependencies:
   - cffi >=1.0.0
   - libgcc-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/cmarkgfm-0.8.0-py311h459d7ec_3.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/cmarkgfm-0.8.0-py312h98912ed_3.conda
   hash:
-    md5: 5090d5a3ab2580cabb17a3ae965e257f
-    sha256: 01316757b817f21ec8c901ecdd1cf60141a80ea5bfddf352846ba85f4c7a3e9d
-  build: py311h459d7ec_3
+    md5: 0c9c09134b2fb151c2bd8181b2c56080
+    sha256: 1a9e60b18664c22f872435a1d2b1d727e37ea4159736b116afff364b9577dc02
+  build: py312h98912ed_3
   arch: x86_64
   subdir: linux-64
   build_number: 3
   license: MIT
   license_family: MIT
-  size: 136524
-  timestamp: 1695669889658
+  size: 135963
+  timestamp: 1695669875921
 - platform: osx-64
   name: cmarkgfm
   version: 0.8.0
@@ -4632,20 +4633,20 @@ package:
   manager: conda
   dependencies:
   - cffi >=1.0.0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/cmarkgfm-0.8.0-py311h2725bcf_3.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/cmarkgfm-0.8.0-py312h104f124_3.conda
   hash:
-    md5: 3a4ef0858a3fae7e61ae9cdf72adefd1
-    sha256: a8036546261cc57f5383f9fcacaedd3c8aed76ca03c05fa5955fcd0a0707ff45
-  build: py311h2725bcf_3
+    md5: 75b0ed827a414319d0c6fa63b92341b6
+    sha256: d478a91584a96c5fcb372cde110cb37605b0821b2b8ec6e519d419b4851e9e4e
+  build: py312h104f124_3
   arch: x86_64
   subdir: osx-64
   build_number: 3
   license: MIT
   license_family: MIT
-  size: 113116
-  timestamp: 1695670250339
+  size: 112756
+  timestamp: 1695670021195
 - platform: osx-arm64
   name: cmarkgfm
   version: 0.8.0
@@ -4653,21 +4654,21 @@ package:
   manager: conda
   dependencies:
   - cffi >=1.0.0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cmarkgfm-0.8.0-py311heffc1b2_3.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cmarkgfm-0.8.0-py312h02f2b3b_3.conda
   hash:
-    md5: 5cb88950ae060fe9220ed27c2d06987d
-    sha256: d27c4d0cf73cd86551a403fa8363f61bdd270418a348aebbd51f5ca26be0661e
-  build: py311heffc1b2_3
+    md5: ffedee35be7a5015d09e2660a66b89c9
+    sha256: 2e95c3797cd2796f32de8408626d63cb1283f2b7b0826021d2e26cc58d9231a0
+  build: py312h02f2b3b_3
   arch: aarch64
   subdir: osx-arm64
   build_number: 3
   license: MIT
   license_family: MIT
-  size: 114180
-  timestamp: 1695670152127
+  size: 113474
+  timestamp: 1695670347968
 - platform: win-64
   name: cmarkgfm
   version: 0.8.0
@@ -4675,23 +4676,23 @@ package:
   manager: conda
   dependencies:
   - cffi >=1.0.0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/cmarkgfm-0.8.0-py311ha68e1ae_3.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/cmarkgfm-0.8.0-py312he70551f_3.conda
   hash:
-    md5: 489e7c645da48b8c19f8232d70b45ec8
-    sha256: 8fe56f677ec4b47043170d2437ce020c204c88a56895c58490e89277af93a2ca
-  build: py311ha68e1ae_3
+    md5: c02f42cc7c74c6dcac910f3aec3d3e6b
+    sha256: 9f5bdfbd843e58bfc727ae5a8b07079c2700d5579f0eef1e8c85aa4fa0ac5fa3
+  build: py312he70551f_3
   arch: x86_64
   subdir: win-64
   build_number: 3
   license: MIT
   license_family: MIT
-  size: 120405
-  timestamp: 1695670523318
+  size: 119774
+  timestamp: 1695670282391
 - platform: linux-64
   name: colorama
   version: 0.4.6
@@ -4865,20 +4866,20 @@ package:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - numpy >=1.20,<2
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.2.0-py311h9547e67_0.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.2.0-py312h8572e83_0.conda
   hash:
-    md5: 40828c5b36ef52433e21f89943e09f33
-    sha256: 2c76e2a970b74eef92ef9460aa705dbdc506dd59b7382bfbedce39d9c189d7f4
-  build: py311h9547e67_0
+    md5: b6249daaaf4577e6f72d95fc4ab767c6
+    sha256: 80fa469e2f027eb8ae95965d796ffa5457a5a1f7063e99d6aa54b19a21227b4e
+  build: py312h8572e83_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 255843
-  timestamp: 1699041590533
+  size: 253156
+  timestamp: 1699041681603
 - platform: osx-64
   name: contourpy
   version: 1.2.0
@@ -4888,20 +4889,20 @@ package:
   - __osx >=10.9
   - libcxx >=16.0.6
   - numpy >=1.20,<2
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.2.0-py311h7bea37d_0.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/contourpy-1.2.0-py312hbf0bb39_0.conda
   hash:
-    md5: 6711c052d956af4973a16749236a0387
-    sha256: 40bca4a644e0c0b0e6d58cef849ba02d4f218af715f7a5787d41845797f3b8a9
-  build: py311h7bea37d_0
+    md5: 74190e06053cda7139a0cb71f3e618fd
+    sha256: eddf6ba417fb23a3b44313528d561bb0ef9008af2644b888a1b8b028a2ef5e2e
+  build: py312hbf0bb39_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 248078
-  timestamp: 1699042040747
+  size: 246660
+  timestamp: 1699041735604
 - platform: osx-arm64
   name: contourpy
   version: 1.2.0
@@ -4911,21 +4912,21 @@ package:
   - __osx >=10.9
   - libcxx >=16.0.6
   - numpy >=1.20,<2
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.2.0-py311hd03642b_0.conda
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.2.0-py312h76e736e_0.conda
   hash:
-    md5: c0fa0bea0af7ecdea23bf983655fa2d0
-    sha256: 3ec341c3a33bbb7f60e9a96214e0e08c4ba9e4a553b18104194e7843abbb4ef4
-  build: py311hd03642b_0
+    md5: 1dadb551925202b61d137da997f99e08
+    sha256: 9651380de808917b67ca6d93d1ffa9db5ef0889c6e0ed87379ef0696517b47e3
+  build: py312h76e736e_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 240223
-  timestamp: 1699041881051
+  size: 237646
+  timestamp: 1699041880921
 - platform: win-64
   name: contourpy
   version: 1.2.0
@@ -4933,23 +4934,23 @@ package:
   manager: conda
   dependencies:
   - numpy >=1.20,<2
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.2.0-py311h005e61a_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.2.0-py312h0d7def4_0.conda
   hash:
-    md5: 6e36537c6d0c16d2ee8ba8c3dd847662
-    sha256: d043a1cc9157ee25319fa85271cba38fc4c51caf4d38354176659d95629d04ab
-  build: py311h005e61a_0
+    md5: 2f4496ef2b9e7a5ab9c866df31931028
+    sha256: 75a9369a76ab7af83bc17583f8fd5f2db2b33a1d937e3802aac4229c19956822
+  build: py312h0d7def4_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 206078
-  timestamp: 1699042419820
+  size: 205030
+  timestamp: 1699042174459
 - platform: linux-64
   name: coverage
   version: 7.3.2
@@ -4957,88 +4958,88 @@ package:
   manager: conda
   dependencies:
   - libgcc-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - tomli
-  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.3.2-py311h459d7ec_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.3.2-py312h98912ed_0.conda
   hash:
-    md5: 7b3145fed7adc7c63a0e08f6f29f5480
-    sha256: 8b56edd4336e7fc6ff9b73436a3a270cf835f57cf4d0565c6e240c40f1981085
-  build: py311h459d7ec_0
+    md5: b248b512221477e79e600c3b9368c7d0
+    sha256: 08c8f270851ce244e6e416d15022463076e94bdaf25002e85bc87e2a7ae7b00c
+  build: py312h98912ed_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  size: 355132
-  timestamp: 1696281925482
+  size: 346876
+  timestamp: 1696281826215
 - platform: osx-64
   name: coverage
   version: 7.3.2
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - tomli
-  url: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.3.2-py311h2725bcf_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.3.2-py312h104f124_0.conda
   hash:
-    md5: 0ce651c68a0322a6eacef726025b938a
-    sha256: ada34f95907fe0cd98d4d12e439bd1508363738f8b0fbe88d14cb398f4235af6
-  build: py311h2725bcf_0
+    md5: 1e98139a6dc6e29569dff47a1895a40c
+    sha256: 14adc346b2c1437543669ddf2bd163f2595fbac63a02bb689136c92e43896759
+  build: py312h104f124_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  size: 352862
-  timestamp: 1696282084699
+  size: 345557
+  timestamp: 1696282123278
 - platform: osx-arm64
   name: coverage
   version: 7.3.2
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
   - tomli
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.3.2-py311heffc1b2_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.3.2-py312h02f2b3b_0.conda
   hash:
-    md5: 75928ad6625a73ff93f08be98014248c
-    sha256: 88d116c4c51a106c43937b950d3fd14007800fb7b3945573a5a117533c450e6b
-  build: py311heffc1b2_0
+    md5: e24bb86144df711266255703328ce03d
+    sha256: 44c9e3bd2f2e137bc9a7fb6a5b34b21dfe89b4f17edec21944d0b95cbfbe9bc5
+  build: py312h02f2b3b_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  size: 353390
-  timestamp: 1696282185517
+  size: 345467
+  timestamp: 1696282123227
 - platform: win-64
   name: coverage
   version: 7.3.2
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - tomli
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/coverage-7.3.2-py311ha68e1ae_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/coverage-7.3.2-py312he70551f_0.conda
   hash:
-    md5: 6d0d75c92bdf393a2dd818b7fe6615a0
-    sha256: 1025c5a4da262a05563b7067101dd2fa9ef36b6f9c31e6c1df05db800375e18d
-  build: py311ha68e1ae_0
+    md5: 216219cb1e405a04ab52e27efa8eb94b
+    sha256: 190b65fa88ceee5838f3dc13a670f94e40b1d232e375a524ccafd22c1dd775d9
+  build: py312he70551f_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  size: 372107
-  timestamp: 1696282186892
+  size: 362433
+  timestamp: 1696282251916
 - platform: linux-64
   name: cryptography
   version: 41.0.5
@@ -5048,20 +5049,20 @@ package:
   - cffi >=1.12
   - libgcc-ng >=12
   - openssl >=3.1.4,<4.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-41.0.5-py311h63ff55d_0.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-41.0.5-py312h241aef2_0.conda
   hash:
-    md5: 22584e5c97ed8f1a6b63a0ff43dba827
-    sha256: 236ed2218fb857fecaa11fc7fee23574f683b3d03576f8f26f628b7fd2ced5fa
-  build: py311h63ff55d_0
+    md5: 123356abefc00c74a9f241382a37930c
+    sha256: c0567f165aeb95dfc9462394ddc266d5c62cb676c6a3db47c603d34b24a4843f
+  build: py312h241aef2_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
   license_family: BSD
-  size: 2036192
-  timestamp: 1698192294727
+  size: 2038475
+  timestamp: 1698192317014
 - platform: linux-64
   name: cycler
   version: 0.12.1
@@ -5224,6 +5225,7 @@ package:
   subdir: linux-64
   build_number: 0
   license: MIT
+  license_family: MIT
   noarch: python
   size: 68788
   timestamp: 1699472354004
@@ -5255,6 +5257,7 @@ package:
   subdir: osx-64
   build_number: 0
   license: MIT
+  license_family: MIT
   noarch: python
   size: 68788
   timestamp: 1699472354004
@@ -5286,6 +5289,7 @@ package:
   subdir: osx-arm64
   build_number: 0
   license: MIT
+  license_family: MIT
   noarch: python
   size: 68788
   timestamp: 1699472354004
@@ -5317,6 +5321,7 @@ package:
   subdir: win-64
   build_number: 0
   license: MIT
+  license_family: MIT
   noarch: python
   size: 68788
   timestamp: 1699472354004
@@ -5349,20 +5354,20 @@ package:
   dependencies:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.0-py311hb755f60_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.0-py312h30efb56_1.conda
   hash:
-    md5: 2c241533b8eafe8028442d46ef41eb13
-    sha256: f18492ebfaea54bbbeaec0ae207851f711ff589f60f2cc9b8a689f88b2442171
-  build: py311hb755f60_1
+    md5: 9a737622d319c22a3393d0cd5bec171e
+    sha256: 8169ebedbd0a1f769446eed6ed165da9aa643f2acc408f452a3121c57f889851
+  build: py312h30efb56_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   license: MIT
   license_family: MIT
-  size: 3001696
-  timestamp: 1695534493087
+  size: 2709821
+  timestamp: 1695534492281
 - platform: osx-64
   name: debugpy
   version: 1.8.0
@@ -5370,20 +5375,20 @@ package:
   manager: conda
   dependencies:
   - libcxx >=15.0.7
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.0-py311hdf8f085_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.0-py312heafc425_1.conda
   hash:
-    md5: 7f20ef8a63be62d1bcdaa8136ec09647
-    sha256: 93e94c9077b13f3dde47794bb6ca02f9c3174c794edf889158306a54764a075c
-  build: py311hdf8f085_1
+    md5: 695ceaf17c0c51890a759299081e0167
+    sha256: 1f03a0cd7a2408169b0659e2427f4a953608a7c21ff4432ff033a71ecc6baaeb
+  build: py312heafc425_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   license: MIT
   license_family: MIT
-  size: 2939392
-  timestamp: 1695534639423
+  size: 2752757
+  timestamp: 1695535219749
 - platform: osx-arm64
   name: debugpy
   version: 1.8.0
@@ -5391,44 +5396,44 @@ package:
   manager: conda
   dependencies:
   - libcxx >=15.0.7
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.0-py311ha891d26_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.0-py312h9f69965_1.conda
   hash:
-    md5: 575b875f1e7901213e9a0f44db9deccc
-    sha256: a7c3b4abf2d3d5256be7e891e76c86dd52e3893e9495d468e3c95e82932b9d7b
-  build: py311ha891d26_1
+    md5: 86aa5172acd2140b7a5134397938dd5a
+    sha256: d626f7e616ad7082e828fd4991a919d1f26925b5586fbd28baece8a3aa95ae52
+  build: py312h9f69965_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   license: MIT
   license_family: MIT
-  size: 2957693
-  timestamp: 1695534717336
+  size: 2764216
+  timestamp: 1695534715799
 - platform: win-64
   name: debugpy
   version: 1.8.0
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.0-py311h12c1d0e_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.0-py312h53d5487_1.conda
   hash:
-    md5: 8f521f35a7544cbf058b24e11561d53a
-    sha256: df14ab3bfa7864fedda2d45b16057792ad29dd607f0ff9a86b3e9cfbd0c41332
-  build: py311h12c1d0e_1
+    md5: d2b4266ebf19123f42420a91ba29f041
+    sha256: d57b150a127f575b8b48cf828c319eb3216c8fc6a15d39da41fab05564c70a9f
+  build: py312h53d5487_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   license: MIT
   license_family: MIT
-  size: 3870801
-  timestamp: 1695534773660
+  size: 3747099
+  timestamp: 1695534777959
 - platform: linux-64
   name: decorator
   version: 5.1.1
@@ -5791,77 +5796,77 @@ package:
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.20.1-py311h38be061_2.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.20.1-py312h7900ff3_2.conda
   hash:
-    md5: 33f8066e53679dd4be2355fec849bf01
-    sha256: 4e90bbc89f9ab192cb247d8b8ebe54c33e57652f8a057f9f176d9d9dd32993b9
-  build: py311h38be061_2
+    md5: 5e9bf8f7126528bea5c31f42ceebc06c
+    sha256: bade342768729e2e1f014d62f7c6c17db012ffe718e341274ce9f232d34383d4
+  build: py312h7900ff3_2
   arch: x86_64
   subdir: linux-64
   build_number: 2
   license: LicenseRef-Public-Domain-Dedictation AND BSD-3-Clause AND BSD-2-Clause AND LicenseRef-PSF-2.1.1
-  size: 915810
-  timestamp: 1695300614781
+  size: 897287
+  timestamp: 1695300608494
 - platform: osx-64
   name: docutils
   version: 0.20.1
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/docutils-0.20.1-py311h6eed73b_2.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/docutils-0.20.1-py312hb401068_2.conda
   hash:
-    md5: d56b49f1a2c908d05d1ca6b3f85d0fd5
-    sha256: 869e919066b308794e399bc551fc508c175da5f9324b7a324eb259cef8adabf2
-  build: py311h6eed73b_2
+    md5: 826e4b9430ddbcd481388ce0b5a997ee
+    sha256: 3f4bc9e3bf1f71e375cb5942150625650b6fa70406cd3caf64f4198d809459c3
+  build: py312hb401068_2
   arch: x86_64
   subdir: osx-64
   build_number: 2
   license: LicenseRef-Public-Domain-Dedictation AND BSD-3-Clause AND BSD-2-Clause AND LicenseRef-PSF-2.1.1
-  size: 921558
-  timestamp: 1695300850498
+  size: 901742
+  timestamp: 1695300800891
 - platform: osx-arm64
   name: docutils
   version: 0.20.1
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/docutils-0.20.1-py311h267d04e_2.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/docutils-0.20.1-py312h81bd7bf_2.conda
   hash:
-    md5: e82ee6e9db96d5f7ddf289399744240d
-    sha256: 3bc810b946ef8f87681ea4bee2610e8c418f9f61772f5d1ff3ffa803ae7cfbb6
-  build: py311h267d04e_2
+    md5: 1aaf14b460547f6d09329ecaa5043b59
+    sha256: 53bf9b9ddaa3c5523e9fe30cd456996fcac54524e36b1b75b74f24db02a36626
+  build: py312h81bd7bf_2
   arch: aarch64
   subdir: osx-arm64
   build_number: 2
   license: LicenseRef-Public-Domain-Dedictation AND BSD-3-Clause AND BSD-2-Clause AND LicenseRef-PSF-2.1.1
-  size: 921098
-  timestamp: 1695300974246
+  size: 902817
+  timestamp: 1695300988923
 - platform: win-64
   name: docutils
   version: 0.20.1
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/win-64/docutils-0.20.1-py311h1ea47a8_2.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/win-64/docutils-0.20.1-py312h2e8e312_2.conda
   hash:
-    md5: 6b90695c3fc8616b09e3fabc77f816df
-    sha256: 56c6737d61281897eee17947361704eed48b1cddaf2a9df4e0e10757852622c6
-  build: py311h1ea47a8_2
+    md5: f8e0b1c2a2f0d3bfe45a6e7674576632
+    sha256: 7a802cd0a2535a021e6653b2bc16f0c046cc1adfdd3f40d4ceb0e8511cd6e69e
+  build: py312h2e8e312_2
   arch: x86_64
   subdir: win-64
   build_number: 2
   license: LicenseRef-Public-Domain-Dedictation AND BSD-3-Clause AND BSD-2-Clause AND LicenseRef-PSF-2.1.1
-  size: 972760
-  timestamp: 1695301035902
+  size: 950891
+  timestamp: 1695300854692
 - platform: linux-64
   name: entrypoints
   version: '0.4'
@@ -6407,24 +6412,24 @@ package:
   - libgdal >=3.7.2,<3.8.0a0
   - libstdcxx-ng >=12
   - munch
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - setuptools
   - shapely
   - six >=1.7
-  url: https://conda.anaconda.org/conda-forge/linux-64/fiona-1.9.5-py311hbac4ec9_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/fiona-1.9.5-py312hc770a3a_0.conda
   hash:
-    md5: 786d3808394b1bdfd3f41f2e2c67279e
-    sha256: 529600df1964a94c7745b87e31f432ddc03c7b5fd652c193c594c995e1964c6b
-  build: py311hbac4ec9_0
+    md5: 95fe9ec01c226595e96885a7fb59f694
+    sha256: a5cdbeb5ab0f255e1985d0e3fb9131fbd389c09feb7537cff86196079cc035cc
+  build: py312hc770a3a_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 988348
-  timestamp: 1697078517209
+  size: 976572
+  timestamp: 1697078632323
 - platform: osx-64
   name: fiona
   version: 1.9.5
@@ -6441,24 +6446,24 @@ package:
   - libcxx >=16.0.6
   - libgdal >=3.7.2,<3.8.0a0
   - munch
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - setuptools
   - shapely
   - six >=1.7
-  url: https://conda.anaconda.org/conda-forge/osx-64/fiona-1.9.5-py311hf14a637_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/fiona-1.9.5-py312h8683509_0.conda
   hash:
-    md5: b0a818c3ad6768567ea7e72ca7a777f7
-    sha256: ce1888df0112ab2405e6f30f04a208fab379a9598e7b7c89289fb3bbc5b4950c
-  build: py311hf14a637_0
+    md5: 92d5ac0a5db5712cc2d4011a6ffa221e
+    sha256: d0b11dbbe52a6257d87b0d98eb3a320e564f95900fe3c6615aec9dfa36d77217
+  build: py312h8683509_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 871895
-  timestamp: 1697078935194
+  size: 857190
+  timestamp: 1697078764202
 - platform: osx-arm64
   name: fiona
   version: 1.9.5
@@ -6475,25 +6480,25 @@ package:
   - libcxx >=16.0.6
   - libgdal >=3.7.2,<3.8.0a0
   - munch
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
   - setuptools
   - shapely
   - six >=1.7
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fiona-1.9.5-py311h45231e3_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fiona-1.9.5-py312h0aea21f_0.conda
   hash:
-    md5: 50d570663d8aca587902d0f3642f17ac
-    sha256: 008993778253638c048f61ed90fded9f3090dd2fbeb5b9c48f5a6a8ac382e4cf
-  build: py311h45231e3_0
+    md5: 52cb2f8cf1cf1204a49f49343537053f
+    sha256: e3aaa6f6efb7d765f851586a168022d50298b01748bf61400843d014ffc4d859
+  build: py312h0aea21f_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 873617
-  timestamp: 1697078901418
+  size: 850710
+  timestamp: 1697078992674
 - platform: win-64
   name: fiona
   version: 1.9.5
@@ -6508,27 +6513,27 @@ package:
   - importlib-metadata
   - libgdal >=3.7.2,<3.8.0a0
   - munch
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - setuptools
   - shapely
   - six >=1.7
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/fiona-1.9.5-py311h4e4dc46_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/fiona-1.9.5-py312he9aeaab_0.conda
   hash:
-    md5: aaed872a9994c6c92cc9c5ffacbf6dc0
-    sha256: ef190c4e1db9ecdcff2af1dbfa86ae445a26e5fc2c55e377b80232db4d8b2730
-  build: py311h4e4dc46_0
+    md5: 022a306700c15f1e4b950b2ded4239e3
+    sha256: c2d21dbb64c0f1cb28a216792646e724093318e6ca6b5992b8e65e5beba16050
+  build: py312he9aeaab_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 837890
-  timestamp: 1697079199653
+  size: 816028
+  timestamp: 1697079297524
 - platform: linux-64
   name: folium
   version: 0.15.0
@@ -7200,20 +7205,20 @@ package:
   - brotli
   - libgcc-ng >=12
   - munkres
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.44.0-py311h459d7ec_0.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.44.0-py312h98912ed_0.conda
   hash:
-    md5: f12f4d7361178f94df1052d6b63fd868
-    sha256: d1a0023bc0a35b9e3f9be10b6fe5f305a0e14fe4e956d688304413f4234ae286
-  build: py311h459d7ec_0
+    md5: 285a46f34e2b5b357e5999b1e699714f
+    sha256: 121a315901b8a37ba46d8729b4268e172f920964a8e5de7daa89ae8d5218696f
+  build: py312h98912ed_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 2750270
-  timestamp: 1699023759636
+  size: 2678140
+  timestamp: 1699023712164
 - platform: osx-64
   name: fonttools
   version: 4.44.0
@@ -7222,20 +7227,20 @@ package:
   dependencies:
   - brotli
   - munkres
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.44.0-py311he705e18_0.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.44.0-py312h41838bb_0.conda
   hash:
-    md5: 548f6770647b112d218577be7c10f644
-    sha256: 30a7405f8689032835c34efae453af26ae5fb8750a90fe4eb907686bc2468902
-  build: py311he705e18_0
+    md5: 1e62e0d32f5e39d36d328f28738905e9
+    sha256: 091ea39260d44f0435ae5d54996fc80c019001a22acc1ca70e3aef3cceb63242
+  build: py312h41838bb_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 2652986
-  timestamp: 1699023878757
+  size: 2596829
+  timestamp: 1699024045442
 - platform: osx-arm64
   name: fonttools
   version: 4.44.0
@@ -7244,21 +7249,21 @@ package:
   dependencies:
   - brotli
   - munkres
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.44.0-py311h05b510d_0.conda
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.44.0-py312he37b823_0.conda
   hash:
-    md5: b39a3eefda8e93bbdf5be812e17bf521
-    sha256: eefa9107f6b33d65b951aec2f3022da94c146656d55e66fbdceb6e36f2a9cde4
-  build: py311h05b510d_0
+    md5: de39ff465966dcb19782684d2231a945
+    sha256: 0f213fcb2b237b0a5c1ea4a9e4c4f0013f6150e26356a98300087ffd034eea51
+  build: py312he37b823_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 2673474
-  timestamp: 1699024060218
+  size: 2615904
+  timestamp: 1699024213648
 - platform: win-64
   name: fonttools
   version: 4.44.0
@@ -7267,23 +7272,23 @@ package:
   dependencies:
   - brotli
   - munkres
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.44.0-py311ha68e1ae_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.44.0-py312he70551f_0.conda
   hash:
-    md5: 38ee0d81d9573521c9ce09c70a3f92fd
-    sha256: 477acc5cf0cd3503b457d893998aea30d59d8a46ee92015987ed0bb7ffe984af
-  build: py311ha68e1ae_0
+    md5: 0541c8350f1c1374c1c5a30adcc4a147
+    sha256: 2cbbf5c046accc93ef5c05e10f0e7aae20f1f346150e0498475ed048c406070c
+  build: py312he70551f_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 2341510
-  timestamp: 1699024310629
+  size: 2292522
+  timestamp: 1699024326888
 - platform: linux-64
   name: fqdn
   version: 1.5.1
@@ -7544,25 +7549,25 @@ package:
   dependencies:
   - hdf5 >=1.14.2,<1.14.3.0a0
   - libgcc-ng >=12
-  - libgdal 3.7.3 h6f3d308_2
+  - libgdal 3.7.3 h6f3d308_3
   - libstdcxx-ng >=12
   - libxml2 >=2.11.5,<2.12.0a0
-  - numpy >=1.23.5,<2.0a0
+  - numpy >=1.26.0,<2.0a0
   - openssl >=3.1.4,<4.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.7.3-py311h815a124_2.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.7.3-py312ha5e4baf_3.conda
   hash:
-    md5: 4811114768487ae6118e8068d0247ecb
-    sha256: 86a29ae673bb2fa82f28bca77f9c9be47f284728c7584bdf3a189e124c82c897
-  build: py311h815a124_2
+    md5: 9c16f71a28dfe77b52d703071ad40793
+    sha256: 4d706ff072e6de8fa267339f2f2bce75aff95dfb619003ef4515255a410da36b
+  build: py312ha5e4baf_3
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 3
   license: MIT
   license_family: MIT
-  size: 1625735
-  timestamp: 1699112276489
+  size: 1610301
+  timestamp: 1699853974958
 - platform: osx-64
   name: gdal
   version: 3.7.3
@@ -7572,24 +7577,24 @@ package:
   - __osx >=10.9
   - hdf5 >=1.14.2,<1.14.3.0a0
   - libcxx >=16.0.6
-  - libgdal 3.7.3 h926149b_2
+  - libgdal 3.7.3 h926149b_3
   - libxml2 >=2.11.5,<2.12.0a0
-  - numpy >=1.23.5,<2.0a0
+  - numpy >=1.26.0,<2.0a0
   - openssl >=3.1.4,<4.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.7.3-py311h5646c56_2.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.7.3-py312hffe8f62_3.conda
   hash:
-    md5: 6742cacdaf346b849be88a87aac67f73
-    sha256: 24d2d2567afc3be05a1fca9a8a55a6f4a24680fd1af77c4dd448794847d75deb
-  build: py311h5646c56_2
+    md5: de4aec4a0833a2cae892ae9fda75db1a
+    sha256: 4f86ded3d40e2efa5fdc227408b15eba1681609c58c188778a5f0b305d3ef05e
+  build: py312hffe8f62_3
   arch: x86_64
   subdir: osx-64
-  build_number: 2
+  build_number: 3
   license: MIT
   license_family: MIT
-  size: 1634663
-  timestamp: 1699113889566
+  size: 1617318
+  timestamp: 1699855565261
 - platform: osx-arm64
   name: gdal
   version: 3.7.3
@@ -7599,25 +7604,25 @@ package:
   - __osx >=10.9
   - hdf5 >=1.14.2,<1.14.3.0a0
   - libcxx >=16.0.6
-  - libgdal 3.7.3 h116f65a_2
+  - libgdal 3.7.3 h116f65a_3
   - libxml2 >=2.11.5,<2.12.0a0
-  - numpy >=1.23.5,<2.0a0
+  - numpy >=1.26.0,<2.0a0
   - openssl >=3.1.4,<4.0a0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.7.3-py311h32a4f3d_2.conda
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.7.3-py312hb8631af_3.conda
   hash:
-    md5: 2524c7bddcc1cdae315c698423bb351e
-    sha256: fcd41f2b33cd7f8cb574428106b5afe9355dcf09b72a9bf9b27e2094ac6509c8
-  build: py311h32a4f3d_2
+    md5: 2a75bc9f3cd6c3897588c2aa68b82ecd
+    sha256: fe6375b9dbd576f7d1004837d4f37a45b1feb13fa36ebb8a42985776e455e822
+  build: py312hb8631af_3
   arch: aarch64
   subdir: osx-arm64
-  build_number: 2
+  build_number: 3
   license: MIT
   license_family: MIT
-  size: 1617737
-  timestamp: 1699113964198
+  size: 1601676
+  timestamp: 1699856252967
 - platform: win-64
   name: gdal
   version: 3.7.3
@@ -7625,27 +7630,27 @@ package:
   manager: conda
   dependencies:
   - hdf5 >=1.14.2,<1.14.3.0a0
-  - libgdal 3.7.3 h3217549_2
+  - libgdal 3.7.3 h3217549_3
   - libxml2 >=2.11.5,<2.12.0a0
-  - numpy >=1.23.5,<2.0a0
+  - numpy >=1.26.0,<2.0a0
   - openssl >=3.1.4,<4.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/gdal-3.7.3-py311h9601e46_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/gdal-3.7.3-py312hb5f3cee_3.conda
   hash:
-    md5: e3954e8ada1c877c31b6d281868a36da
-    sha256: 32d30ac0771ec7af08a348acf8a51cb56b6f627c0c96fb92abb26df69f91f717
-  build: py311h9601e46_2
+    md5: 878d8afc7ddeacd0c4f4f2d307c2a6f8
+    sha256: e2bd819aa7cc9277c5dfe18470f45ef6493b3aeefeb475de582ccaac076811d8
+  build: py312hb5f3cee_3
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 3
   license: MIT
   license_family: MIT
-  size: 1598898
-  timestamp: 1699114244458
+  size: 1581741
+  timestamp: 1699856150751
 - platform: linux-64
   name: genson
   version: 1.2.2
@@ -7728,115 +7733,115 @@ package:
   timestamp: 1601490140447
 - platform: linux-64
   name: geopandas
-  version: 0.14.0
+  version: 0.14.1
   category: main
   manager: conda
   dependencies:
   - fiona >=1.8.21
   - folium
-  - geopandas-base 0.14.0 pyha770c72_1
+  - geopandas-base 0.14.1 pyha770c72_0
   - mapclassify >=2.4.0
   - matplotlib-base
   - python >=3.9
   - rtree
   - xyzservices
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.1-pyhd8ed1ab_0.conda
   hash:
-    md5: d3617cddba7ea3dd3234d28faa3bc3b4
-    sha256: 2acdc39438b7152da0a08b3daad9b5b066d7b6005beb4cb176c0ef654ef79668
-  build: pyhd8ed1ab_1
+    md5: 6ce5f89fb1e2aa7e04d12c0008b3a745
+    sha256: f3563ad6f1a55587c097337ece863e583c796c9a9df3ecb396bbfeec4ec309fb
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 7566
-  timestamp: 1697032162340
+  size: 7525
+  timestamp: 1699712300019
 - platform: osx-64
   name: geopandas
-  version: 0.14.0
+  version: 0.14.1
   category: main
   manager: conda
   dependencies:
   - fiona >=1.8.21
   - folium
-  - geopandas-base 0.14.0 pyha770c72_1
+  - geopandas-base 0.14.1 pyha770c72_0
   - mapclassify >=2.4.0
   - matplotlib-base
   - python >=3.9
   - rtree
   - xyzservices
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.1-pyhd8ed1ab_0.conda
   hash:
-    md5: d3617cddba7ea3dd3234d28faa3bc3b4
-    sha256: 2acdc39438b7152da0a08b3daad9b5b066d7b6005beb4cb176c0ef654ef79668
-  build: pyhd8ed1ab_1
+    md5: 6ce5f89fb1e2aa7e04d12c0008b3a745
+    sha256: f3563ad6f1a55587c097337ece863e583c796c9a9df3ecb396bbfeec4ec309fb
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 7566
-  timestamp: 1697032162340
+  size: 7525
+  timestamp: 1699712300019
 - platform: osx-arm64
   name: geopandas
-  version: 0.14.0
+  version: 0.14.1
   category: main
   manager: conda
   dependencies:
   - fiona >=1.8.21
   - folium
-  - geopandas-base 0.14.0 pyha770c72_1
+  - geopandas-base 0.14.1 pyha770c72_0
   - mapclassify >=2.4.0
   - matplotlib-base
   - python >=3.9
   - rtree
   - xyzservices
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.1-pyhd8ed1ab_0.conda
   hash:
-    md5: d3617cddba7ea3dd3234d28faa3bc3b4
-    sha256: 2acdc39438b7152da0a08b3daad9b5b066d7b6005beb4cb176c0ef654ef79668
-  build: pyhd8ed1ab_1
+    md5: 6ce5f89fb1e2aa7e04d12c0008b3a745
+    sha256: f3563ad6f1a55587c097337ece863e583c796c9a9df3ecb396bbfeec4ec309fb
+  build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 7566
-  timestamp: 1697032162340
+  size: 7525
+  timestamp: 1699712300019
 - platform: win-64
   name: geopandas
-  version: 0.14.0
+  version: 0.14.1
   category: main
   manager: conda
   dependencies:
   - fiona >=1.8.21
   - folium
-  - geopandas-base 0.14.0 pyha770c72_1
+  - geopandas-base 0.14.1 pyha770c72_0
   - mapclassify >=2.4.0
   - matplotlib-base
   - python >=3.9
   - rtree
   - xyzservices
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.1-pyhd8ed1ab_0.conda
   hash:
-    md5: d3617cddba7ea3dd3234d28faa3bc3b4
-    sha256: 2acdc39438b7152da0a08b3daad9b5b066d7b6005beb4cb176c0ef654ef79668
-  build: pyhd8ed1ab_1
+    md5: 6ce5f89fb1e2aa7e04d12c0008b3a745
+    sha256: f3563ad6f1a55587c097337ece863e583c796c9a9df3ecb396bbfeec4ec309fb
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 7566
-  timestamp: 1697032162340
+  size: 7525
+  timestamp: 1699712300019
 - platform: linux-64
   name: geopandas-base
-  version: 0.14.0
+  version: 0.14.1
   category: main
   manager: conda
   dependencies:
@@ -7845,22 +7850,22 @@ package:
   - pyproj >=3.3.0
   - python >=3.9
   - shapely >=1.8.0
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.0-pyha770c72_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.1-pyha770c72_0.conda
   hash:
-    md5: 614a383c5f4350e0606689f54c6497b1
-    sha256: 97fe438e399d9106998e38fc700fdd6f90f15ea92d1e20cf0a01e74436aa24ba
-  build: pyha770c72_1
+    md5: d65c6f458bfdaa181f388d91e858ea67
+    sha256: c813004bb84e50de19f599b188719e40106c858c7da22e504b29ce66e5043361
+  build: pyha770c72_0
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 1017514
-  timestamp: 1697032153699
+  size: 1018566
+  timestamp: 1699712289660
 - platform: osx-64
   name: geopandas-base
-  version: 0.14.0
+  version: 0.14.1
   category: main
   manager: conda
   dependencies:
@@ -7869,22 +7874,22 @@ package:
   - pyproj >=3.3.0
   - python >=3.9
   - shapely >=1.8.0
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.0-pyha770c72_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.1-pyha770c72_0.conda
   hash:
-    md5: 614a383c5f4350e0606689f54c6497b1
-    sha256: 97fe438e399d9106998e38fc700fdd6f90f15ea92d1e20cf0a01e74436aa24ba
-  build: pyha770c72_1
+    md5: d65c6f458bfdaa181f388d91e858ea67
+    sha256: c813004bb84e50de19f599b188719e40106c858c7da22e504b29ce66e5043361
+  build: pyha770c72_0
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 1017514
-  timestamp: 1697032153699
+  size: 1018566
+  timestamp: 1699712289660
 - platform: osx-arm64
   name: geopandas-base
-  version: 0.14.0
+  version: 0.14.1
   category: main
   manager: conda
   dependencies:
@@ -7893,22 +7898,22 @@ package:
   - pyproj >=3.3.0
   - python >=3.9
   - shapely >=1.8.0
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.0-pyha770c72_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.1-pyha770c72_0.conda
   hash:
-    md5: 614a383c5f4350e0606689f54c6497b1
-    sha256: 97fe438e399d9106998e38fc700fdd6f90f15ea92d1e20cf0a01e74436aa24ba
-  build: pyha770c72_1
+    md5: d65c6f458bfdaa181f388d91e858ea67
+    sha256: c813004bb84e50de19f599b188719e40106c858c7da22e504b29ce66e5043361
+  build: pyha770c72_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 1017514
-  timestamp: 1697032153699
+  size: 1018566
+  timestamp: 1699712289660
 - platform: win-64
   name: geopandas-base
-  version: 0.14.0
+  version: 0.14.1
   category: main
   manager: conda
   dependencies:
@@ -7917,19 +7922,19 @@ package:
   - pyproj >=3.3.0
   - python >=3.9
   - shapely >=1.8.0
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.0-pyha770c72_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.1-pyha770c72_0.conda
   hash:
-    md5: 614a383c5f4350e0606689f54c6497b1
-    sha256: 97fe438e399d9106998e38fc700fdd6f90f15ea92d1e20cf0a01e74436aa24ba
-  build: pyha770c72_1
+    md5: d65c6f458bfdaa181f388d91e858ea67
+    sha256: c813004bb84e50de19f599b188719e40106c858c7da22e504b29ce66e5043361
+  build: pyha770c72_0
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 1017514
-  timestamp: 1697032153699
+  size: 1018566
+  timestamp: 1699712289660
 - platform: linux-64
   name: geos
   version: 3.12.0
@@ -8547,17 +8552,17 @@ package:
   timestamp: 1689627974018
 - platform: linux-64
   name: gst-plugins-base
-  version: 1.22.6
+  version: 1.22.7
   category: main
   manager: conda
   dependencies:
   - __glibc >=2.17,<3.0.a0
   - alsa-lib >=1.2.10,<1.2.11.0a0
   - gettext >=0.21.1,<1.0a0
-  - gstreamer 1.22.6 h98fc4e7_2
+  - gstreamer 1.22.7 h98fc4e7_0
   - libexpat >=2.5.0,<3.0a0
   - libgcc-ng >=12
-  - libglib >=2.78.0,<3.0a0
+  - libglib >=2.78.1,<3.0a0
   - libogg >=1.3.4,<1.4.0a0
   - libopus >=1.3.1,<2.0a0
   - libpng >=1.6.39,<1.7.0a0
@@ -8565,124 +8570,119 @@ package:
   - libvorbis >=1.3.7,<1.4.0a0
   - libxcb >=1.15,<1.16.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
   - xorg-libxau >=1.0.11,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
   - xorg-libxrender >=0.9.11,<0.10.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.6-h8e1006c_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.7-h8e1006c_0.conda
   hash:
-    md5: 3d8e98279bad55287f2ef9047996f33c
-    sha256: 07e71ef8ad4d1516695132ed142ef6bc6393243fee54f950aa0944561f2f277f
-  build: h8e1006c_2
+    md5: 065e2c1d49afa3fdc1a01f1dacd6ab09
+    sha256: 190151790cedc719199c783123a9f3ee4e86acd09fee3a6ec33a21cbac20494e
+  build: h8e1006c_0
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 0
   license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 2704605
-  timestamp: 1696222053755
+  size: 2713065
+  timestamp: 1699936047150
 - platform: win-64
   name: gst-plugins-base
-  version: 1.22.6
+  version: 1.22.7
   category: main
   manager: conda
   dependencies:
   - gettext >=0.21.1,<1.0a0
-  - gstreamer 1.22.6 hb4038d2_2
-  - libglib >=2.78.0,<3.0a0
+  - gstreamer 1.22.7 hb4038d2_0
+  - libglib >=2.78.1,<3.0a0
   - libogg >=1.3.4,<1.4.0a0
   - libvorbis >=1.3.7,<1.4.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.22.6-h001b923_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.22.7-h001b923_0.conda
   hash:
-    md5: 20e57b894392cb792cdf5c501b35a8f6
-    sha256: 34816d0335e796ea3610022756b3b0832f5699007adc2819a08e068120dd3a8f
-  build: h001b923_2
+    md5: e4b56ad6c21e861456f32bfc79b43c4b
+    sha256: aa9315d943f1f0c224fbebb72ff802701161d3365415c1ebf3758fac1b5ae214
+  build: h001b923_0
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 0
   license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 2032915
-  timestamp: 1696222439891
+  size: 2035099
+  timestamp: 1699936715537
 - platform: linux-64
   name: gstreamer
-  version: 1.22.6
+  version: 1.22.7
   category: main
   manager: conda
   dependencies:
   - __glibc >=2.17,<3.0.a0
   - gettext >=0.21.1,<1.0a0
-  - glib >=2.78.0,<3.0a0
+  - glib >=2.78.1,<3.0a0
   - libgcc-ng >=12
-  - libglib >=2.78.0,<3.0a0
+  - libglib >=2.78.1,<3.0a0
   - libiconv >=1.17,<2.0a0
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.6-h98fc4e7_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.7-h98fc4e7_0.conda
   hash:
-    md5: 1c95f7c612f9121353c4ef764678113e
-    sha256: 5578119cec4e86b7b607678781026ebe1170cb851b4f784c49b09bed1c92566c
-  build: h98fc4e7_2
+    md5: 6c919bafe5e03428a8e2ef319d7ef990
+    sha256: d77b2a740acd59c4dd6c9d8fe6e008ee96407b6dcc5cc0b5e27e8c1eec5d22ef
+  build: h98fc4e7_0
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 0
   license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 1972133
-  timestamp: 1696221935494
+  size: 1977893
+  timestamp: 1699935901784
 - platform: win-64
   name: gstreamer
-  version: 1.22.6
+  version: 1.22.7
   category: main
   manager: conda
   dependencies:
   - gettext >=0.21.1,<1.0a0
-  - glib >=2.78.0,<3.0a0
-  - libglib >=2.78.0,<3.0a0
+  - glib >=2.78.1,<3.0a0
+  - libglib >=2.78.1,<3.0a0
   - libiconv >=1.17,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.22.6-hb4038d2_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.22.7-hb4038d2_0.conda
   hash:
-    md5: e6d2009457a1e5d9653fd06873a7a367
-    sha256: 08600f04d220a43f0ef5c383bb586cdd05ec482aceadb397fcd43a233b946144
-  build: hb4038d2_2
+    md5: 9b2f6622276ed34d20eb36e6a4ce2f50
+    sha256: 5cb018ed96727ca7a7f8e782f0e2603135541dc011c926e1837f4cf536fc2341
+  build: hb4038d2_0
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 0
   license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 1939400
-  timestamp: 1696222270363
+  size: 1932223
+  timestamp: 1699936472411
 - platform: linux-64
   name: harfbuzz
-  version: 8.2.1
+  version: 8.3.0
   category: main
   manager: conda
   dependencies:
-  - cairo >=1.16.0,<2.0a0
+  - cairo >=1.18.0,<2.0a0
   - freetype >=2.12.1,<3.0a0
   - graphite2
   - icu >=73.2,<74.0a0
   - libgcc-ng >=12
-  - libglib >=2.78.0,<3.0a0
+  - libglib >=2.78.1,<3.0a0
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.2.1-h3d44ed6_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.3.0-h3d44ed6_0.conda
   hash:
-    md5: 98db5f8813f45e2b29766aff0e4a499c
-    sha256: 5ca6585e6a4348bcbe214d57f5d6f560d15d23a6650770a2909475848b214edb
+    md5: 5a6f6c00ef982a9bc83558d9ac8f64a0
+    sha256: 4b55aea03b18a4084b750eee531ad978d4a3690f63019132c26c6ad26bbe3aed
   build: h3d44ed6_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
-  license_family: MIT
-  size: 1526592
-  timestamp: 1695089914042
+  size: 1547473
+  timestamp: 1699925311766
 - platform: linux-64
   name: hdf4
   version: 4.2.15
@@ -10563,98 +10563,98 @@ package:
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-2.4-py311h38be061_3.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-2.4-py312h7900ff3_3.conda
   hash:
-    md5: 41d52d822edf991bf0e6b08c1921a8ec
-    sha256: 976f7bf3c3a49c3066f36b67c12ae06b31542e53b843bb4362f31c9e449c6c46
-  build: py311h38be061_3
+    md5: 50f62bdb9b60b13c2f6ae69957342e4d
+    sha256: c211a79cff8aa001a6e14e923c37278231dca7f0970d8db155c4b9e48ac87a5a
+  build: py312h7900ff3_3
   arch: x86_64
   subdir: linux-64
   build_number: 3
   license: BSD-3-Clause
   license_family: BSD
-  size: 18389
-  timestamp: 1695397377176
+  size: 18033
+  timestamp: 1695397448370
 - platform: osx-64
   name: jsonpointer
   version: '2.4'
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-2.4-py311h6eed73b_3.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-2.4-py312hb401068_3.conda
   hash:
-    md5: ed1c23d0e55abd27d8b9e31c58105140
-    sha256: b0ba738e1dbf3b69558557cd1e63310364e045b8c8e7f73fdce7e71928b5f22a
-  build: py311h6eed73b_3
+    md5: 637aa8f6c1c61f659f1496e9b2dc7552
+    sha256: 883f6d635e58f49359f393e853e4e0043731fb0ce671283a2024db02a1ebc8f6
+  build: py312hb401068_3
   arch: x86_64
   subdir: osx-64
   build_number: 3
   license: BSD-3-Clause
   license_family: BSD
-  size: 18557
-  timestamp: 1695397765266
+  size: 18184
+  timestamp: 1695397820416
 - platform: osx-arm64
   name: jsonpointer
   version: '2.4'
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-2.4-py311h267d04e_3.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-2.4-py312h81bd7bf_3.conda
   hash:
-    md5: b6008a5b9180e58a235f5e45432dfe2e
-    sha256: 807d6c44f3e34139bfd25db4409381a6ce37fad2902c58f10fa7e1c30a64333d
-  build: py311h267d04e_3
+    md5: 327361b24f5348cab04ad9b1f74e831d
+    sha256: 6cb2d17da9083e05f5ead7902a5cd6ec9567cd3da972c65c03f090515c9fa176
+  build: py312h81bd7bf_3
   arch: aarch64
   subdir: osx-arm64
   build_number: 3
   license: BSD-3-Clause
   license_family: BSD
-  size: 18841
-  timestamp: 1695397944650
+  size: 18542
+  timestamp: 1695397720755
 - platform: win-64
   name: jsonpointer
   version: '2.4'
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-2.4-py311h1ea47a8_3.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-2.4-py312h2e8e312_3.conda
   hash:
-    md5: db8fc59f9215e668e602f769d0bf67bb
-    sha256: 13042586b08e8caa60615e7c42d05601f9421e8bda5df932e3ef9d2401bf2435
-  build: py311h1ea47a8_3
+    md5: 9d9572e257bf4559f20629efb0d3511d
+    sha256: 98d86d5ccb3a95da2cd96b394c157aa6fef0d4908b8878c3e2b5931f6bc5fd57
+  build: py312h2e8e312_3
   arch: x86_64
   subdir: win-64
   build_number: 3
   license: BSD-3-Clause
   license_family: BSD
-  size: 34654
-  timestamp: 1695397742357
+  size: 34602
+  timestamp: 1695397923441
 - platform: linux-64
   name: jsonschema
-  version: 4.17.3
+  version: 4.19.2
   category: main
   manager: conda
   dependencies:
-  - attrs >=17.4.0
-  - importlib-metadata
+  - attrs >=22.2.0
   - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
   - pkgutil-resolve-name >=1.3.10
-  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
-  - python >=3.7
-  - typing_extensions
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.17.3-pyhd8ed1ab_0.conda
+  - python >=3.8
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 723268a468177cd44568eb8f794e0d80
-    sha256: 4f68a23430d1afc5c9b41c46fbac0ade33c0bf57a293c646bfdd6dc65350eada
+    md5: 24d41c2f9cc199d0a180ecf7ef54739c
+    sha256: 07e5d395d83c4b12a7abe3989fb42abdcd3b1c51cd27549e5eab390bb8c7bf0f
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -10662,25 +10662,25 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 70487
-  timestamp: 1669810556169
+  size: 71509
+  timestamp: 1698678642652
 - platform: osx-64
   name: jsonschema
-  version: 4.17.3
+  version: 4.19.2
   category: main
   manager: conda
   dependencies:
-  - attrs >=17.4.0
-  - importlib-metadata
+  - attrs >=22.2.0
   - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
   - pkgutil-resolve-name >=1.3.10
-  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
-  - python >=3.7
-  - typing_extensions
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.17.3-pyhd8ed1ab_0.conda
+  - python >=3.8
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 723268a468177cd44568eb8f794e0d80
-    sha256: 4f68a23430d1afc5c9b41c46fbac0ade33c0bf57a293c646bfdd6dc65350eada
+    md5: 24d41c2f9cc199d0a180ecf7ef54739c
+    sha256: 07e5d395d83c4b12a7abe3989fb42abdcd3b1c51cd27549e5eab390bb8c7bf0f
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -10688,25 +10688,25 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 70487
-  timestamp: 1669810556169
+  size: 71509
+  timestamp: 1698678642652
 - platform: osx-arm64
   name: jsonschema
-  version: 4.17.3
+  version: 4.19.2
   category: main
   manager: conda
   dependencies:
-  - attrs >=17.4.0
-  - importlib-metadata
+  - attrs >=22.2.0
   - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
   - pkgutil-resolve-name >=1.3.10
-  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
-  - python >=3.7
-  - typing_extensions
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.17.3-pyhd8ed1ab_0.conda
+  - python >=3.8
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 723268a468177cd44568eb8f794e0d80
-    sha256: 4f68a23430d1afc5c9b41c46fbac0ade33c0bf57a293c646bfdd6dc65350eada
+    md5: 24d41c2f9cc199d0a180ecf7ef54739c
+    sha256: 07e5d395d83c4b12a7abe3989fb42abdcd3b1c51cd27549e5eab390bb8c7bf0f
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -10714,25 +10714,25 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 70487
-  timestamp: 1669810556169
+  size: 71509
+  timestamp: 1698678642652
 - platform: win-64
   name: jsonschema
-  version: 4.17.3
+  version: 4.19.2
   category: main
   manager: conda
   dependencies:
-  - attrs >=17.4.0
-  - importlib-metadata
+  - attrs >=22.2.0
   - importlib_resources >=1.4.0
+  - jsonschema-specifications >=2023.03.6
   - pkgutil-resolve-name >=1.3.10
-  - pyrsistent !=0.17.0,!=0.17.1,!=0.17.2,>=0.14.0
-  - python >=3.7
-  - typing_extensions
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.17.3-pyhd8ed1ab_0.conda
+  - python >=3.8
+  - referencing >=0.28.4
+  - rpds-py >=0.7.1
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 723268a468177cd44568eb8f794e0d80
-    sha256: 4f68a23430d1afc5c9b41c46fbac0ade33c0bf57a293c646bfdd6dc65350eada
+    md5: 24d41c2f9cc199d0a180ecf7ef54739c
+    sha256: 07e5d395d83c4b12a7abe3989fb42abdcd3b1c51cd27549e5eab390bb8c7bf0f
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -10740,28 +10740,21 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 70487
-  timestamp: 1669810556169
+  size: 71509
+  timestamp: 1698678642652
 - platform: linux-64
-  name: jsonschema-with-format-nongpl
-  version: 4.17.3
+  name: jsonschema-specifications
+  version: 2023.7.1
   category: main
   manager: conda
   dependencies:
-  - fqdn
-  - idna
-  - isoduration
-  - jsonpointer >1.13
-  - jsonschema >=4.17.3,<4.17.4.0a0
-  - python
-  - rfc3339-validator
-  - rfc3986-validator >0.1.0
-  - uri-template
-  - webcolors >=1.11
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.17.3-pyhd8ed1ab_0.conda
+  - importlib_resources >=1.4.0
+  - python >=3.8
+  - referencing >=0.25.0
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 7a709748e93f0b2c33d6b5b676b6d9d0
-    sha256: 767da9c47d64e1dc826d3173e46ff6fd4e858c94ff61d67ff4f976c7bc9502a2
+    md5: 7c27ea1bdbe520bb830dcadd59f55cbf
+    sha256: 7b0061e106674f27cc718f79a095e90a5667a3635ec6626dd23b3be0fd2bfbdc
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -10769,28 +10762,21 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 6612
-  timestamp: 1669810577413
+  size: 15296
+  timestamp: 1689701341221
 - platform: osx-64
-  name: jsonschema-with-format-nongpl
-  version: 4.17.3
+  name: jsonschema-specifications
+  version: 2023.7.1
   category: main
   manager: conda
   dependencies:
-  - fqdn
-  - idna
-  - isoduration
-  - jsonpointer >1.13
-  - jsonschema >=4.17.3,<4.17.4.0a0
-  - python
-  - rfc3339-validator
-  - rfc3986-validator >0.1.0
-  - uri-template
-  - webcolors >=1.11
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.17.3-pyhd8ed1ab_0.conda
+  - importlib_resources >=1.4.0
+  - python >=3.8
+  - referencing >=0.25.0
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 7a709748e93f0b2c33d6b5b676b6d9d0
-    sha256: 767da9c47d64e1dc826d3173e46ff6fd4e858c94ff61d67ff4f976c7bc9502a2
+    md5: 7c27ea1bdbe520bb830dcadd59f55cbf
+    sha256: 7b0061e106674f27cc718f79a095e90a5667a3635ec6626dd23b3be0fd2bfbdc
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -10798,28 +10784,21 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 6612
-  timestamp: 1669810577413
+  size: 15296
+  timestamp: 1689701341221
 - platform: osx-arm64
-  name: jsonschema-with-format-nongpl
-  version: 4.17.3
+  name: jsonschema-specifications
+  version: 2023.7.1
   category: main
   manager: conda
   dependencies:
-  - fqdn
-  - idna
-  - isoduration
-  - jsonpointer >1.13
-  - jsonschema >=4.17.3,<4.17.4.0a0
-  - python
-  - rfc3339-validator
-  - rfc3986-validator >0.1.0
-  - uri-template
-  - webcolors >=1.11
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.17.3-pyhd8ed1ab_0.conda
+  - importlib_resources >=1.4.0
+  - python >=3.8
+  - referencing >=0.25.0
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 7a709748e93f0b2c33d6b5b676b6d9d0
-    sha256: 767da9c47d64e1dc826d3173e46ff6fd4e858c94ff61d67ff4f976c7bc9502a2
+    md5: 7c27ea1bdbe520bb830dcadd59f55cbf
+    sha256: 7b0061e106674f27cc718f79a095e90a5667a3635ec6626dd23b3be0fd2bfbdc
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -10827,28 +10806,21 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 6612
-  timestamp: 1669810577413
+  size: 15296
+  timestamp: 1689701341221
 - platform: win-64
-  name: jsonschema-with-format-nongpl
-  version: 4.17.3
+  name: jsonschema-specifications
+  version: 2023.7.1
   category: main
   manager: conda
   dependencies:
-  - fqdn
-  - idna
-  - isoduration
-  - jsonpointer >1.13
-  - jsonschema >=4.17.3,<4.17.4.0a0
-  - python
-  - rfc3339-validator
-  - rfc3986-validator >0.1.0
-  - uri-template
-  - webcolors >=1.11
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.17.3-pyhd8ed1ab_0.conda
+  - importlib_resources >=1.4.0
+  - python >=3.8
+  - referencing >=0.25.0
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 7a709748e93f0b2c33d6b5b676b6d9d0
-    sha256: 767da9c47d64e1dc826d3173e46ff6fd4e858c94ff61d67ff4f976c7bc9502a2
+    md5: 7c27ea1bdbe520bb830dcadd59f55cbf
+    sha256: 7b0061e106674f27cc718f79a095e90a5667a3635ec6626dd23b3be0fd2bfbdc
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -10856,8 +10828,124 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 6612
-  timestamp: 1669810577413
+  size: 15296
+  timestamp: 1689701341221
+- platform: linux-64
+  name: jsonschema-with-format-nongpl
+  version: 4.19.2
+  category: main
+  manager: conda
+  dependencies:
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - jsonschema >=4.19.2,<4.19.3.0a0
+  - python
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - uri-template
+  - webcolors >=1.11
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: c447b7c28ad6bb3306f0015f1195c721
+    sha256: b06681b4499635f0ed901f4879122bfd3ff6ef28de1797367769a4ba6b990b0d
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 7389
+  timestamp: 1698678669876
+- platform: osx-64
+  name: jsonschema-with-format-nongpl
+  version: 4.19.2
+  category: main
+  manager: conda
+  dependencies:
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - jsonschema >=4.19.2,<4.19.3.0a0
+  - python
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - uri-template
+  - webcolors >=1.11
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: c447b7c28ad6bb3306f0015f1195c721
+    sha256: b06681b4499635f0ed901f4879122bfd3ff6ef28de1797367769a4ba6b990b0d
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 7389
+  timestamp: 1698678669876
+- platform: osx-arm64
+  name: jsonschema-with-format-nongpl
+  version: 4.19.2
+  category: main
+  manager: conda
+  dependencies:
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - jsonschema >=4.19.2,<4.19.3.0a0
+  - python
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - uri-template
+  - webcolors >=1.11
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: c447b7c28ad6bb3306f0015f1195c721
+    sha256: b06681b4499635f0ed901f4879122bfd3ff6ef28de1797367769a4ba6b990b0d
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 7389
+  timestamp: 1698678669876
+- platform: win-64
+  name: jsonschema-with-format-nongpl
+  version: 4.19.2
+  category: main
+  manager: conda
+  dependencies:
+  - fqdn
+  - idna
+  - isoduration
+  - jsonpointer >1.13
+  - jsonschema >=4.19.2,<4.19.3.0a0
+  - python
+  - rfc3339-validator
+  - rfc3986-validator >0.1.0
+  - uri-template
+  - webcolors >=1.11
+  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: c447b7c28ad6bb3306f0015f1195c721
+    sha256: b06681b4499635f0ed901f4879122bfd3ff6ef28de1797367769a4ba6b990b0d
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 7389
+  timestamp: 1698678669876
 - platform: linux-64
   name: jupyter-lsp
   version: 2.2.0
@@ -11057,21 +11145,21 @@ package:
   manager: conda
   dependencies:
   - platformdirs >=2.5
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - traitlets >=5.3
-  url: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.5.0-py311h38be061_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.5.0-py312h7900ff3_0.conda
   hash:
-    md5: cee83be29258275f75029125e186ab6d
-    sha256: 60bfaec278b3ea4462abd8321b47412864c54bd63575e2698da81c5755e617c1
-  build: py311h38be061_0
+    md5: b0db32b94447bb0300deff1a74406653
+    sha256: 3c93fc1b2de9a184f073e87806ad9b1a12f55f028171570190299cde9a021eb0
+  build: py312h7900ff3_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 93811
-  timestamp: 1698673782880
+  size: 91916
+  timestamp: 1698673784826
 - platform: osx-64
   name: jupyter_core
   version: 5.5.0
@@ -11079,21 +11167,21 @@ package:
   manager: conda
   dependencies:
   - platformdirs >=2.5
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - traitlets >=5.3
-  url: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.5.0-py311h6eed73b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.5.0-py312hb401068_0.conda
   hash:
-    md5: d7ee59df3fd2eec8dd60c1fcfa29a73d
-    sha256: d570b1554e3fd90085db1eb23ba61d595f1e588865b603ab193c73a2db50b64d
-  build: py311h6eed73b_0
+    md5: 5b0e6b098a2237f805bbd15c082bd327
+    sha256: 2e3c41898cb0ce9f2edae0d622f53e76bbe9329712f68547b9337fa649890e75
+  build: py312hb401068_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 94066
-  timestamp: 1698675917939
+  size: 92013
+  timestamp: 1698674097105
 - platform: osx-arm64
   name: jupyter_core
   version: 5.5.0
@@ -11101,22 +11189,22 @@ package:
   manager: conda
   dependencies:
   - platformdirs >=2.5
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
   - traitlets >=5.3
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter_core-5.5.0-py311h267d04e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter_core-5.5.0-py312h81bd7bf_0.conda
   hash:
-    md5: e8e88dea6f85c4efad941afd8c972376
-    sha256: 447426241b1d8dc1a468ecd4501469f39e2f6967a9c8698edbe20615ba8735ad
-  build: py311h267d04e_0
+    md5: 1bc6be6e906d8046c50809770aaefb6e
+    sha256: b87b64b4a6851f56736b2574f1264669a3d8c9b105b0be32d2b46f15c2247110
+  build: py312h81bd7bf_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 93517
-  timestamp: 1698674151360
+  size: 92369
+  timestamp: 1698674061824
 - platform: win-64
   name: jupyter_core
   version: 5.5.0
@@ -11124,126 +11212,130 @@ package:
   manager: conda
   dependencies:
   - platformdirs >=2.5
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - pywin32 >=300
   - traitlets >=5.3
-  url: https://conda.anaconda.org/conda-forge/win-64/jupyter_core-5.5.0-py311h1ea47a8_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/jupyter_core-5.5.0-py312h2e8e312_0.conda
   hash:
-    md5: 8204454e085013b1b6908f04c63eaa36
-    sha256: 2cddd12760fa4a14eb5f448e7e3f961b835b8c7ef4bc47e89a9fdd03f4ffac04
-  build: py311h1ea47a8_0
+    md5: 7efc892ee9ec1db65f2480cc79bb01ee
+    sha256: 7b3de5dd7484ddc4316c6cbd67521f257e5fceb8df3b079222b8616714de3a47
+  build: py312h2e8e312_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 110149
-  timestamp: 1698674340148
+  size: 108300
+  timestamp: 1698674327608
 - platform: linux-64
   name: jupyter_events
-  version: 0.6.3
+  version: 0.9.0
   category: main
   manager: conda
   dependencies:
-  - jsonschema-with-format-nongpl >=3.2
-  - python >=3.7
+  - jsonschema-with-format-nongpl >=4.18.0
+  - python >=3.8
   - python-json-logger >=2.0.4
   - pyyaml >=5.3
+  - referencing
   - rfc3339-validator
   - rfc3986-validator >=0.1.1
   - traitlets >=5.3
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.6.3-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2ac0d00a0fb3f1a4c81c460ba56bb23b
-    sha256: 457e05bfcd6a37fbb8b4a44a500be7512e23bf1ef507e46fbd07497c217a2787
-  build: pyhd8ed1ab_1
+    md5: 00ba25993f0dba38cf72a7224e33289f
+    sha256: 713f0cc927a862862a6d35bfb29c4114f987e4f59e2a8a14f71f23fcd7edfec3
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 21261
-  timestamp: 1690301765018
+  size: 21354
+  timestamp: 1699286038042
 - platform: osx-64
   name: jupyter_events
-  version: 0.6.3
+  version: 0.9.0
   category: main
   manager: conda
   dependencies:
-  - jsonschema-with-format-nongpl >=3.2
-  - python >=3.7
+  - jsonschema-with-format-nongpl >=4.18.0
+  - python >=3.8
   - python-json-logger >=2.0.4
   - pyyaml >=5.3
+  - referencing
   - rfc3339-validator
   - rfc3986-validator >=0.1.1
   - traitlets >=5.3
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.6.3-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2ac0d00a0fb3f1a4c81c460ba56bb23b
-    sha256: 457e05bfcd6a37fbb8b4a44a500be7512e23bf1ef507e46fbd07497c217a2787
-  build: pyhd8ed1ab_1
+    md5: 00ba25993f0dba38cf72a7224e33289f
+    sha256: 713f0cc927a862862a6d35bfb29c4114f987e4f59e2a8a14f71f23fcd7edfec3
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 21261
-  timestamp: 1690301765018
+  size: 21354
+  timestamp: 1699286038042
 - platform: osx-arm64
   name: jupyter_events
-  version: 0.6.3
+  version: 0.9.0
   category: main
   manager: conda
   dependencies:
-  - jsonschema-with-format-nongpl >=3.2
-  - python >=3.7
+  - jsonschema-with-format-nongpl >=4.18.0
+  - python >=3.8
   - python-json-logger >=2.0.4
   - pyyaml >=5.3
+  - referencing
   - rfc3339-validator
   - rfc3986-validator >=0.1.1
   - traitlets >=5.3
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.6.3-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2ac0d00a0fb3f1a4c81c460ba56bb23b
-    sha256: 457e05bfcd6a37fbb8b4a44a500be7512e23bf1ef507e46fbd07497c217a2787
-  build: pyhd8ed1ab_1
+    md5: 00ba25993f0dba38cf72a7224e33289f
+    sha256: 713f0cc927a862862a6d35bfb29c4114f987e4f59e2a8a14f71f23fcd7edfec3
+  build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 21261
-  timestamp: 1690301765018
+  size: 21354
+  timestamp: 1699286038042
 - platform: win-64
   name: jupyter_events
-  version: 0.6.3
+  version: 0.9.0
   category: main
   manager: conda
   dependencies:
-  - jsonschema-with-format-nongpl >=3.2
-  - python >=3.7
+  - jsonschema-with-format-nongpl >=4.18.0
+  - python >=3.8
   - python-json-logger >=2.0.4
   - pyyaml >=5.3
+  - referencing
   - rfc3339-validator
   - rfc3986-validator >=0.1.1
   - traitlets >=5.3
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.6.3-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 2ac0d00a0fb3f1a4c81c460ba56bb23b
-    sha256: 457e05bfcd6a37fbb8b4a44a500be7512e23bf1ef507e46fbd07497c217a2787
-  build: pyhd8ed1ab_1
+    md5: 00ba25993f0dba38cf72a7224e33289f
+    sha256: 713f0cc927a862862a6d35bfb29c4114f987e4f59e2a8a14f71f23fcd7edfec3
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 21261
-  timestamp: 1690301765018
+  size: 21354
+  timestamp: 1699286038042
 - platform: linux-64
   name: jupyter_server
   version: 2.10.0
@@ -11702,7 +11794,7 @@ package:
   timestamp: 1649936689608
 - platform: linux-64
   name: jupyterlab_server
-  version: 2.24.0
+  version: 2.25.1
   category: main
   manager: conda
   dependencies:
@@ -11710,27 +11802,29 @@ package:
   - importlib-metadata >=4.8.3
   - jinja2 >=3.0.3
   - json5 >=0.9.0
-  - jsonschema >=4.17.3
+  - jsonschema >=4.18
   - jupyter_server >=1.21,<3
   - packaging >=21.3
-  - python >=3.7
-  - requests >=2.28
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.24.0-pyhd8ed1ab_0.conda
+  - python >=3.8
+  - requests >=2.31
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 327bfe1c99154f02259d29810bd70afc
-    sha256: 7084223bb168268ba93334fc27410885bdc6e537020d6a91ab0f46f37a3f3ded
+    md5: 5cf15f8fd42c77af4eb1611fe614df2f
+    sha256: 5f373d9adc11b6d49bee06a4c6bea9623fff1d2a0b798edc2e3f594680aa18f3
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 60108
-  timestamp: 1690206297277
+  size: 48817
+  timestamp: 1699455046539
 - platform: osx-64
   name: jupyterlab_server
-  version: 2.24.0
+  version: 2.25.1
   category: main
   manager: conda
   dependencies:
@@ -11738,27 +11832,29 @@ package:
   - importlib-metadata >=4.8.3
   - jinja2 >=3.0.3
   - json5 >=0.9.0
-  - jsonschema >=4.17.3
+  - jsonschema >=4.18
   - jupyter_server >=1.21,<3
   - packaging >=21.3
-  - python >=3.7
-  - requests >=2.28
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.24.0-pyhd8ed1ab_0.conda
+  - python >=3.8
+  - requests >=2.31
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 327bfe1c99154f02259d29810bd70afc
-    sha256: 7084223bb168268ba93334fc27410885bdc6e537020d6a91ab0f46f37a3f3ded
+    md5: 5cf15f8fd42c77af4eb1611fe614df2f
+    sha256: 5f373d9adc11b6d49bee06a4c6bea9623fff1d2a0b798edc2e3f594680aa18f3
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 60108
-  timestamp: 1690206297277
+  size: 48817
+  timestamp: 1699455046539
 - platform: osx-arm64
   name: jupyterlab_server
-  version: 2.24.0
+  version: 2.25.1
   category: main
   manager: conda
   dependencies:
@@ -11766,27 +11862,29 @@ package:
   - importlib-metadata >=4.8.3
   - jinja2 >=3.0.3
   - json5 >=0.9.0
-  - jsonschema >=4.17.3
+  - jsonschema >=4.18
   - jupyter_server >=1.21,<3
   - packaging >=21.3
-  - python >=3.7
-  - requests >=2.28
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.24.0-pyhd8ed1ab_0.conda
+  - python >=3.8
+  - requests >=2.31
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 327bfe1c99154f02259d29810bd70afc
-    sha256: 7084223bb168268ba93334fc27410885bdc6e537020d6a91ab0f46f37a3f3ded
+    md5: 5cf15f8fd42c77af4eb1611fe614df2f
+    sha256: 5f373d9adc11b6d49bee06a4c6bea9623fff1d2a0b798edc2e3f594680aa18f3
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 60108
-  timestamp: 1690206297277
+  size: 48817
+  timestamp: 1699455046539
 - platform: win-64
   name: jupyterlab_server
-  version: 2.24.0
+  version: 2.25.1
   category: main
   manager: conda
   dependencies:
@@ -11794,24 +11892,26 @@ package:
   - importlib-metadata >=4.8.3
   - jinja2 >=3.0.3
   - json5 >=0.9.0
-  - jsonschema >=4.17.3
+  - jsonschema >=4.18
   - jupyter_server >=1.21,<3
   - packaging >=21.3
-  - python >=3.7
-  - requests >=2.28
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.24.0-pyhd8ed1ab_0.conda
+  - python >=3.8
+  - requests >=2.31
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 327bfe1c99154f02259d29810bd70afc
-    sha256: 7084223bb168268ba93334fc27410885bdc6e537020d6a91ab0f46f37a3f3ded
+    md5: 5cf15f8fd42c77af4eb1611fe614df2f
+    sha256: 5f373d9adc11b6d49bee06a4c6bea9623fff1d2a0b798edc2e3f594680aa18f3
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
   build_number: 0
+  constrains:
+  - openapi-core >=0.18.0,<0.19.0
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 60108
-  timestamp: 1690206297277
+  size: 48817
+  timestamp: 1699455046539
 - platform: linux-64
   name: kealib
   version: 1.5.2
@@ -11897,96 +11997,92 @@ package:
   timestamp: 1696011596185
 - platform: linux-64
   name: keyring
-  version: 24.2.0
+  version: 24.3.0
   category: main
   manager: conda
   dependencies:
-  - importlib_metadata >=4.11.4
   - jaraco.classes
   - jeepney >=0.4.2
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - secretstorage >=3.2
-  url: https://conda.anaconda.org/conda-forge/linux-64/keyring-24.2.0-py311h38be061_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/keyring-24.3.0-py312h7900ff3_0.conda
   hash:
-    md5: 656d1107cb4934fd950eea244affd3c5
-    sha256: 495b04b64d897361b4336e6954ef66a2287191344c573d37c4217738b75bbc44
-  build: py311h38be061_1
+    md5: c303e2ddfc697a70a137940f8a6b2e1d
+    sha256: 312656da4f0b4b0aacee5914735fdc781bc8412edee6cc90b937a279975d8b1e
+  build: py312h7900ff3_0
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 0
   license: MIT
   license_family: MIT
-  size: 77805
-  timestamp: 1696001739370
+  size: 76016
+  timestamp: 1699923914435
 - platform: osx-64
   name: keyring
-  version: 24.2.0
+  version: 24.3.0
   category: main
   manager: conda
   dependencies:
-  - importlib_metadata >=4.11.4
   - jaraco.classes
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/keyring-24.2.0-py311h6eed73b_1.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/keyring-24.3.0-py312hb401068_0.conda
   hash:
-    md5: dc0383887b837540194b65204521b8b3
-    sha256: dedbbb7d109ad054eb80419aaa9aae6f86d39c892bc278aa04a3980c3bddbbea
-  build: py311h6eed73b_1
+    md5: 5b28534ef3af5f98470c318f29cdc375
+    sha256: 82beac052bdfe0a199103012b8f8dc40f8e878f859ba9b762ce32cdb30877d15
+  build: py312hb401068_0
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 0
   license: MIT
   license_family: MIT
-  size: 78006
-  timestamp: 1696001763015
+  size: 76447
+  timestamp: 1699924137579
 - platform: osx-arm64
   name: keyring
-  version: 24.2.0
+  version: 24.3.0
   category: main
   manager: conda
   dependencies:
-  - importlib_metadata >=4.11.4
   - jaraco.classes
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/keyring-24.2.0-py311h267d04e_1.conda
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/keyring-24.3.0-py312h81bd7bf_0.conda
   hash:
-    md5: cf1ad9e696467ea813f92994a7d1ccd4
-    sha256: a5b5a9a00d041f72fe52d51b39c640ecad831eda6b1f876909f9b3d3cebcd229
-  build: py311h267d04e_1
+    md5: 3a6735f11d9604cbafd0ab1c3e9ac77e
+    sha256: 6d7fd6cb2310674f0736ee6ddd5f752663df92db9e9e0bfd43fa4bb06c6a2b7b
+  build: py312h81bd7bf_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 0
   license: MIT
   license_family: MIT
-  size: 78562
-  timestamp: 1696001946737
+  size: 77030
+  timestamp: 1699924369964
 - platform: win-64
   name: keyring
-  version: 24.2.0
+  version: 24.3.0
   category: main
   manager: conda
   dependencies:
-  - importlib_metadata >=4.11.4
   - jaraco.classes
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - pywin32-ctypes >=0.2.0
-  url: https://conda.anaconda.org/conda-forge/win-64/keyring-24.2.0-py311h1ea47a8_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/keyring-24.3.0-py312h2e8e312_0.conda
   hash:
-    md5: d48701e08cf146d16560cbcf52e27d4d
-    sha256: ee5ebe93d9a141f19b3001c44d4007e6cdd52cfb8003d0c53c9ce17ee9121290
-  build: py311h1ea47a8_1
+    md5: b2ad5f984537e2705416e9de60e9bf52
+    sha256: 2d8d39105c1ad26c2f0b518bc0f35134879231acf9a8717094f50b5cc2d2255a
+  build: py312h2e8e312_0
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 0
   license: MIT
   license_family: MIT
-  size: 93917
-  timestamp: 1696002026395
+  size: 92690
+  timestamp: 1699924378187
 - platform: linux-64
   name: keyutils
   version: 1.6.1
@@ -12013,20 +12109,20 @@ package:
   dependencies:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py311h9547e67_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.5-py312h8572e83_1.conda
   hash:
-    md5: 2c65bdf442b0d37aad080c8a4e0d452f
-    sha256: 723b0894d2d2b05a38f9c5a285d5a0a5baa27235ceab6531dbf262ba7c6955c1
-  build: py311h9547e67_1
+    md5: c1e71f2bc05d8e8e033aefac2c490d05
+    sha256: 2ffd3f6726392591c6794ab130f6701f5ffba0ec8658ef40db5a95ec8d583143
+  build: py312h8572e83_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 73273
-  timestamp: 1695380140676
+  size: 72099
+  timestamp: 1695380122482
 - platform: osx-64
   name: kiwisolver
   version: 1.4.5
@@ -12034,20 +12130,20 @@ package:
   manager: conda
   dependencies:
   - libcxx >=15.0.7
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.5-py311h5fe6e05_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/kiwisolver-1.4.5-py312h49ebfd2_1.conda
   hash:
-    md5: 24305b23f7995de72bbd53b7c01242a2
-    sha256: 586a4d0a17e6cfd9f8fdee56106d263ee40ca156832774d6e899f82ad68ac8d0
-  build: py311h5fe6e05_1
+    md5: 21f174a5cfb5964069c374171a979157
+    sha256: 11d9daa79051a7ae52881d11f48816366fd3d46018281431abe507da7b45f69c
+  build: py312h49ebfd2_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 60694
-  timestamp: 1695380246398
+  size: 60227
+  timestamp: 1695380392812
 - platform: osx-arm64
   name: kiwisolver
   version: 1.4.5
@@ -12055,44 +12151,44 @@ package:
   manager: conda
   dependencies:
   - libcxx >=15.0.7
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.5-py311he4fd1f5_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.5-py312h389731b_1.conda
   hash:
-    md5: 4c871d65040b8c7bbb914df7f8f11492
-    sha256: 907af50734789d47b3e8b2148dde763699dc746c64e5849baf6bd720c8cd0235
-  build: py311he4fd1f5_1
+    md5: 77eeca70c1c4f4187d6b199015c99ee5
+    sha256: ee1a2189dc405f59c27ee1f061076d8761684c0fcd38cccc215630d8debf9f85
+  build: py312h389731b_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 61946
-  timestamp: 1695380538042
+  size: 61747
+  timestamp: 1695380538266
 - platform: win-64
   name: kiwisolver
   version: 1.4.5
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.5-py311h005e61a_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.5-py312h0d7def4_1.conda
   hash:
-    md5: de0b3f37405f8386ac8be18fdc06ff92
-    sha256: 8fdd1bff75c24ac6a2a13be4db1c9abcfa39ab50b81539e8bd01131141df271a
-  build: py311h005e61a_1
+    md5: 77c9d46fc8680bb08f4e1ebb6669e44e
+    sha256: 07021ffc3bbf42922694c23634e028950547d088717b448b46296b3ca5a26068
+  build: py312h0d7def4_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 55822
-  timestamp: 1695380386563
+  size: 55576
+  timestamp: 1695380565733
 - platform: linux-64
   name: krb5
   version: 1.21.2
@@ -12671,7 +12767,7 @@ package:
   category: main
   manager: conda
   dependencies:
-  - aws-crt-cpp >=0.24.5,<0.24.6.0a0
+  - aws-crt-cpp >=0.24.6,<0.24.7.0a0
   - aws-sdk-cpp >=1.11.182,<1.11.183.0a0
   - bzip2 >=1.0.8,<2.0a0
   - glog >=0.6.0,<0.7.0a0
@@ -12690,21 +12786,21 @@ package:
   - re2
   - snappy >=1.1.10,<2.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.1-h0406937_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.1-he5826ec_2_cpu.conda
   hash:
-    md5: 6cd542d836507e0c9bec0c0d6112b024
-    sha256: 461384bb5fba971abc5d43a986222d73ae72e15034e7b403e0ba94c5712db887
-  build: h0406937_1_cpu
+    md5: de46063f85dda71f4d63f7eabf817d38
+    sha256: 05678a4cd3417ff0c3cfeaf298fbb572cf62a8df8183ae9d8016cf26f8bb5ad9
+  build: he5826ec_2_cpu
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 2
   constrains:
   - apache-arrow-proc =*=cpu
   - parquet-cpp <0.0a0
   - arrow-cpp <0.0a0
   license: Apache-2.0
-  size: 22755382
-  timestamp: 1699523401334
+  size: 22733439
+  timestamp: 1699952996350
 - platform: osx-64
   name: libarrow
   version: 14.0.1
@@ -12713,7 +12809,7 @@ package:
   dependencies:
   - __osx >=10.13
   - __osx >=10.9
-  - aws-crt-cpp >=0.24.5,<0.24.6.0a0
+  - aws-crt-cpp >=0.24.6,<0.24.7.0a0
   - aws-sdk-cpp >=1.11.182,<1.11.183.0a0
   - bzip2 >=1.0.8,<2.0a0
   - glog >=0.6.0,<0.7.0a0
@@ -12731,21 +12827,21 @@ package:
   - re2
   - snappy >=1.1.10,<2.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-14.0.1-hcf474e5_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-14.0.1-h3b78187_2_cpu.conda
   hash:
-    md5: 6758ff6dd9702d433fae4f19d93fe30e
-    sha256: 1f3e17a1b8a32a31eb95c8300a899c6946a7677bf1351b072a270bfd2c0ceb21
-  build: hcf474e5_1_cpu
+    md5: 4019faa1f37173f65a63ab72f6de7b9b
+    sha256: 7f3d3522779cfe412ad06609a98a9aa49e7f08826486abc5f48427e92c4dd5c2
+  build: h3b78187_2_cpu
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 2
   constrains:
-  - parquet-cpp <0.0a0
-  - apache-arrow-proc =*=cpu
   - arrow-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
   license: Apache-2.0
-  size: 15794001
-  timestamp: 1699524184970
+  size: 15793644
+  timestamp: 1699954449716
 - platform: osx-arm64
   name: libarrow
   version: 14.0.1
@@ -12753,7 +12849,7 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.9
-  - aws-crt-cpp >=0.24.5,<0.24.6.0a0
+  - aws-crt-cpp >=0.24.6,<0.24.7.0a0
   - aws-sdk-cpp >=1.11.182,<1.11.183.0a0
   - bzip2 >=1.0.8,<2.0a0
   - glog >=0.6.0,<0.7.0a0
@@ -12771,28 +12867,28 @@ package:
   - re2
   - snappy >=1.1.10,<2.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-14.0.1-h7bb5718_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-14.0.1-ha4caa07_2_cpu.conda
   hash:
-    md5: 11122c7985ba7511d63df5f2cad917fa
-    sha256: b07036659cb3492f753c93fdd0da6b8ae177e1ec55cb1208b5d02d63bf80723d
-  build: h7bb5718_1_cpu
+    md5: 61cad580ddef421f34e9bace97333c76
+    sha256: e1821f374860561f52d096bed640edc813182f406a6c69b41fdd1927587c4410
+  build: ha4caa07_2_cpu
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 2
   constrains:
-  - parquet-cpp <0.0a0
   - arrow-cpp <0.0a0
   - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
   license: Apache-2.0
-  size: 14648493
-  timestamp: 1699524346022
+  size: 14653418
+  timestamp: 1699954025717
 - platform: win-64
   name: libarrow
   version: 14.0.1
   category: main
   manager: conda
   dependencies:
-  - aws-crt-cpp >=0.24.5,<0.24.6.0a0
+  - aws-crt-cpp >=0.24.6,<0.24.7.0a0
   - aws-sdk-cpp >=1.11.182,<1.11.183.0a0
   - bzip2 >=1.0.8,<2.0a0
   - libabseil * cxx17*
@@ -12814,41 +12910,41 @@ package:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-14.0.1-h85f1704_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-14.0.1-h0850d3a_2_cpu.conda
   hash:
-    md5: 95b0d01f541c47a64c93cb463fadb0e3
-    sha256: cda792996942212f4767686243407ea85cbffbe6d68b4e84711fb4cb18fe1c2e
-  build: h85f1704_1_cpu
+    md5: 2db754974c74e3071ad2511ea917e370
+    sha256: 0dbe8347a052c0a2fb69ae59e3aa3dc22873bafdc1d6b18a3018a2b038c7f0ab
+  build: h0850d3a_2_cpu
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 2
   constrains:
   - apache-arrow-proc =*=cpu
-  - arrow-cpp <0.0a0
   - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
   license: Apache-2.0
-  size: 5006246
-  timestamp: 1699523933221
+  size: 4948158
+  timestamp: 1699954330616
 - platform: linux-64
   name: libarrow-acero
   version: 14.0.1
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.1 h0406937_1_cpu
+  - libarrow 14.0.1 he5826ec_2_cpu
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.1-h59595ed_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.1-h59595ed_2_cpu.conda
   hash:
-    md5: dc5eb5026d43d5a9cebd03b335f190c8
-    sha256: 9d8e19f90f463ca85254d8e16181d65fa1c01b7a4833cbb72ed911a509dd9f12
-  build: h59595ed_1_cpu
+    md5: e59c90dcc94a1662d951bdd9ed489e91
+    sha256: 789c909cadb76d2936c946acf116d508a8132babe6aaeb6326f73ec9dac8e023
+  build: h59595ed_2_cpu
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 578932
-  timestamp: 1699523484485
+  size: 579112
+  timestamp: 1699953070354
 - platform: osx-64
   name: libarrow-acero
   version: 14.0.1
@@ -12856,19 +12952,19 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.9
-  - libarrow 14.0.1 hcf474e5_1_cpu
+  - libarrow 14.0.1 h3b78187_2_cpu
   - libcxx >=15.0.7
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-14.0.1-hc222712_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-14.0.1-hc222712_2_cpu.conda
   hash:
-    md5: 83f09cbc08a7a741032aca28067aabfa
-    sha256: 2b47502dcefbdd645b130369515551a77ee317f133b1a0ccbb157dfdb11155d6
-  build: hc222712_1_cpu
+    md5: 7842ca98457c1ffa601dc7e9fd2e92ef
+    sha256: 27cbb0b3a1d6757c20d7d7f9e33dcfb6f119981a1d3fbfef5f55b52da22c2955
+  build: hc222712_2_cpu
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 512556
-  timestamp: 1699524309594
+  size: 513270
+  timestamp: 1699954589612
 - platform: osx-arm64
   name: libarrow-acero
   version: 14.0.1
@@ -12876,62 +12972,62 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.9
-  - libarrow 14.0.1 h7bb5718_1_cpu
+  - libarrow 14.0.1 ha4caa07_2_cpu
   - libcxx >=15.0.7
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-14.0.1-had9dd58_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-14.0.1-had9dd58_2_cpu.conda
   hash:
-    md5: dab478b07c494888aa403fb439a5dada
-    sha256: c1be980876224a1de110688ae1288de10cce5a982c110341e982e6e1654ff596
-  build: had9dd58_1_cpu
+    md5: be4b7c7babb11221103af17991d384ee
+    sha256: e732caa5149d472a145fb91fae880d26fd4ad896a1bfb5ae74cafef408cb8152
+  build: had9dd58_2_cpu
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 496611
-  timestamp: 1699524481824
+  size: 496475
+  timestamp: 1699954162741
 - platform: win-64
   name: libarrow-acero
   version: 14.0.1
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.1 h85f1704_1_cpu
+  - libarrow 14.0.1 h0850d3a_2_cpu
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-14.0.1-h63175ca_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-14.0.1-h63175ca_2_cpu.conda
   hash:
-    md5: 4759a17dda5d98bb3aa8068bc13679df
-    sha256: e6b47b8796d1ec3b1ddc00e70a2930af89ea188a5232f0df3909aa97df629e52
-  build: h63175ca_1_cpu
+    md5: 73d5ddf703fd5385ae717ac64f9c91e6
+    sha256: b78218644a78363924fe5a0390f6ef8cf9bec5d88c5d65fde9926688497b9030
+  build: h63175ca_2_cpu
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 431380
-  timestamp: 1699524017095
+  size: 431441
+  timestamp: 1699954446795
 - platform: linux-64
   name: libarrow-dataset
   version: 14.0.1
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.1 h0406937_1_cpu
-  - libarrow-acero 14.0.1 h59595ed_1_cpu
+  - libarrow 14.0.1 he5826ec_2_cpu
+  - libarrow-acero 14.0.1 h59595ed_2_cpu
   - libgcc-ng >=12
-  - libparquet 14.0.1 h352af49_1_cpu
+  - libparquet 14.0.1 h352af49_2_cpu
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.1-h59595ed_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.1-h59595ed_2_cpu.conda
   hash:
-    md5: b7948e05ad29fb89dfe18f23f445bc86
-    sha256: 9b246befad12c156dd10b7e91d32a4515abee2fc8c5e2b408d6bc1c2ea73edb0
-  build: h59595ed_1_cpu
+    md5: c2b9d36bb74f3c241c1437a1b7f8a97b
+    sha256: 0cfaf0553474379df317fbb117dd8176d560c4fe8b27d4bc5c5b95395f6e535d
+  build: h59595ed_2_cpu
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 583067
-  timestamp: 1699523609562
+  size: 581207
+  timestamp: 1699953172985
 - platform: osx-64
   name: libarrow-dataset
   version: 14.0.1
@@ -12939,21 +13035,21 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.9
-  - libarrow 14.0.1 hcf474e5_1_cpu
-  - libarrow-acero 14.0.1 hc222712_1_cpu
+  - libarrow 14.0.1 h3b78187_2_cpu
+  - libarrow-acero 14.0.1 hc222712_2_cpu
   - libcxx >=15.0.7
-  - libparquet 14.0.1 h27bd29f_1_cpu
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-14.0.1-hc222712_1_cpu.conda
+  - libparquet 14.0.1 h27bd29f_2_cpu
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-14.0.1-hc222712_2_cpu.conda
   hash:
-    md5: 0d9e315f65d1c5c7cc63a9432203d594
-    sha256: 039e4f1b794bbde296d3d774ace3e82276d1b8255bafe8e52657d2bee69d0792
-  build: hc222712_1_cpu
+    md5: da79e5862e4264f7df2fe5d3643b0c89
+    sha256: 7ce93a7d13401379a0c8ef22fcff128005f2ccfce5196db665c373eae5adeca1
+  build: hc222712_2_cpu
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 514111
-  timestamp: 1699524548663
+  size: 513597
+  timestamp: 1699954847260
 - platform: osx-arm64
   name: libarrow-dataset
   version: 14.0.1
@@ -12961,44 +13057,44 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.9
-  - libarrow 14.0.1 h7bb5718_1_cpu
-  - libarrow-acero 14.0.1 had9dd58_1_cpu
+  - libarrow 14.0.1 ha4caa07_2_cpu
+  - libarrow-acero 14.0.1 had9dd58_2_cpu
   - libcxx >=15.0.7
-  - libparquet 14.0.1 heaab74a_1_cpu
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-14.0.1-had9dd58_1_cpu.conda
+  - libparquet 14.0.1 heaab74a_2_cpu
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-14.0.1-had9dd58_2_cpu.conda
   hash:
-    md5: 710b15572b65ca7f7fae5e53ea10576a
-    sha256: 90230a77d8c7752ede5a3742d7e58af4da490dd0adfd6d1108b1d2b8e7f51147
-  build: had9dd58_1_cpu
+    md5: e8f58acc13e388e71be3e6b298703361
+    sha256: a1fa2fa37fadff49d56df93d2654933d3edca0b2f1e59c9a93009fa9aaf40fcb
+  build: had9dd58_2_cpu
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 528859
-  timestamp: 1699524826768
+  size: 528772
+  timestamp: 1699954499593
 - platform: win-64
   name: libarrow-dataset
   version: 14.0.1
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.1 h85f1704_1_cpu
-  - libarrow-acero 14.0.1 h63175ca_1_cpu
-  - libparquet 14.0.1 h7ec3a38_1_cpu
+  - libarrow 14.0.1 h0850d3a_2_cpu
+  - libarrow-acero 14.0.1 h63175ca_2_cpu
+  - libparquet 14.0.1 h7ec3a38_2_cpu
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-14.0.1-h63175ca_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-14.0.1-h63175ca_2_cpu.conda
   hash:
-    md5: 450f52e659888a270c3310274f5339a2
-    sha256: df192d1bc9bf3b8fa7253aa74b4e6f3b1e1f323e5a950e884fbe2b3bd381d697
-  build: h63175ca_1_cpu
+    md5: de161cf6369efb4a830942942e8d2007
+    sha256: b4dd8e4ee9c89c4361bb865e0ff3978b833ea2d3956c6fdd84676fef01d6840e
+  build: h63175ca_2_cpu
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 429847
-  timestamp: 1699524264104
+  size: 429473
+  timestamp: 1699954752528
 - platform: linux-64
   name: libarrow-flight
   version: 14.0.1
@@ -13007,23 +13103,23 @@ package:
   dependencies:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libarrow 14.0.1 h0406937_1_cpu
+  - libarrow 14.0.1 he5826ec_2_cpu
   - libgcc-ng >=12
   - libgrpc >=1.59.2,<1.60.0a0
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - libstdcxx-ng >=12
   - ucx >=1.15.0,<1.16.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.1-h120cb0d_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.1-h120cb0d_2_cpu.conda
   hash:
-    md5: cf189c716cd96362c7c91d6d9fda6b0b
-    sha256: 7df11fe1fc0a6b8ca633c718fec92aa28a2bbe07f74d114b1bd2cd267439311c
-  build: h120cb0d_1_cpu
+    md5: 4b0ac222c6c8f25f2f4d0f9921c4eddb
+    sha256: 30f36492a0c1bcbfbe9b33ac418ca261e45d80d182147e665a91ebb6f5b82c88
+  build: h120cb0d_2_cpu
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 501349
-  timestamp: 1699523516343
+  size: 506497
+  timestamp: 1699953095530
 - platform: osx-64
   name: libarrow-flight
   version: 14.0.1
@@ -13034,21 +13130,21 @@ package:
   - __osx >=10.9
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libarrow 14.0.1 hcf474e5_1_cpu
+  - libarrow 14.0.1 h3b78187_2_cpu
   - libcxx >=15.0.7
   - libgrpc >=1.59.2,<1.60.0a0
   - libprotobuf >=4.24.4,<4.24.5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-14.0.1-ha1803ca_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-14.0.1-h440f1c2_2_cpu.conda
   hash:
-    md5: ccd6cd093e56dbc1944e92f432fdb01d
-    sha256: 77cc93641b8e5bd0111f9d6c842ff88e59593130d1e6c7089b36d6def35bf24f
-  build: ha1803ca_1_cpu
+    md5: 8094cb0672ae6dff49fe1fb8e418e24d
+    sha256: fd2929c68da7c8dbad7416cb1352b3b486a586c4d0ebd498ae02d1894fc2513e
+  build: h440f1c2_2_cpu
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 321239
-  timestamp: 1699524367520
+  size: 321418
+  timestamp: 1699954649525
 - platform: osx-arm64
   name: libarrow-flight
   version: 14.0.1
@@ -13058,21 +13154,21 @@ package:
   - __osx >=10.9
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libarrow 14.0.1 h7bb5718_1_cpu
+  - libarrow 14.0.1 ha4caa07_2_cpu
   - libcxx >=15.0.7
   - libgrpc >=1.59.2,<1.60.0a0
   - libprotobuf >=4.24.4,<4.24.5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-14.0.1-h1011bfc_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-14.0.1-h1011bfc_2_cpu.conda
   hash:
-    md5: 795d8f2bb1049ab37dab1e2656df6a23
-    sha256: fff9bd3f6c91f44aaa84cd4319c3ef1dd730e08108416fac7be8f70601fe176c
-  build: h1011bfc_1_cpu
+    md5: 06a7b8b47c0f8e7d456ee00b43dc0859
+    sha256: d0b274b8f845ec8f98a51ea560f702342b7a04a1e06281aeec8bc0b5fcc93465
+  build: h1011bfc_2_cpu
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 333408
-  timestamp: 1699524576779
+  size: 334005
+  timestamp: 1699954251497
 - platform: win-64
   name: libarrow-flight
   version: 14.0.1
@@ -13081,45 +13177,45 @@ package:
   dependencies:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libarrow 14.0.1 h85f1704_1_cpu
+  - libarrow 14.0.1 h0850d3a_2_cpu
   - libgrpc >=1.59.2,<1.60.0a0
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-14.0.1-h53b1db0_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-14.0.1-h53b1db0_2_cpu.conda
   hash:
-    md5: 684f4c0fd6e02276c4b59f446ac29cd9
-    sha256: b8063a4965a612eaf8f5805a81f04c8e8c5a4b1eebd0a0644321673901934aa1
-  build: h53b1db0_1_cpu
+    md5: 40fd731f9354f504fa5055e15b39fdbf
+    sha256: 23dab94ea8304272967f825732986c7cf3dcca76297a36b04b262b7d8bafa86a
+  build: h53b1db0_2_cpu
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 287174
-  timestamp: 1699524078657
+  size: 286549
+  timestamp: 1699954522564
 - platform: linux-64
   name: libarrow-flight-sql
   version: 14.0.1
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.1 h0406937_1_cpu
-  - libarrow-flight 14.0.1 h120cb0d_1_cpu
+  - libarrow 14.0.1 he5826ec_2_cpu
+  - libarrow-flight 14.0.1 h120cb0d_2_cpu
   - libgcc-ng >=12
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.1-h61ff412_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.1-h61ff412_2_cpu.conda
   hash:
-    md5: fa7db8ca53a9eb0ca62893209d4a52d6
-    sha256: b34f3e189572c8009b22e3920229eb8cf6e37897d632e2729a966236b5bc9746
-  build: h61ff412_1_cpu
+    md5: 7315191986ea5c5f452f367848654937
+    sha256: 6f15d91ef2c408f272aab9188c27ae9843f40ef8c44bcfdafc7deaaa70710bc1
+  build: h61ff412_2_cpu
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 194775
-  timestamp: 1699523638979
+  size: 195483
+  timestamp: 1699953198622
 - platform: osx-64
   name: libarrow-flight-sql
   version: 14.0.1
@@ -13128,21 +13224,21 @@ package:
   dependencies:
   - __osx >=10.13
   - __osx >=10.9
-  - libarrow 14.0.1 hcf474e5_1_cpu
-  - libarrow-flight 14.0.1 ha1803ca_1_cpu
+  - libarrow 14.0.1 h3b78187_2_cpu
+  - libarrow-flight 14.0.1 h440f1c2_2_cpu
   - libcxx >=15.0.7
   - libprotobuf >=4.24.4,<4.24.5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-14.0.1-h8ec153b_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-14.0.1-h2cc6c1c_2_cpu.conda
   hash:
-    md5: d2a114707a9c584a92aa509227850804
-    sha256: 6bf424addfea70b21d2386a8d0dd0e9ace56c47b7bbdcd9b2c7fe1ccb594aad9
-  build: h8ec153b_1_cpu
+    md5: 0d0ef77169ffb6d0bdb505dcaaa2e29e
+    sha256: 7a2860ee6e3327a12f85c3a2837e2546767c086fd43c869ec8987cd1d96149ce
+  build: h2cc6c1c_2_cpu
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 155535
-  timestamp: 1699524605260
+  size: 156046
+  timestamp: 1699954914290
 - platform: osx-arm64
   name: libarrow-flight-sql
   version: 14.0.1
@@ -13150,51 +13246,51 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.9
-  - libarrow 14.0.1 h7bb5718_1_cpu
-  - libarrow-flight 14.0.1 h1011bfc_1_cpu
+  - libarrow 14.0.1 ha4caa07_2_cpu
+  - libarrow-flight 14.0.1 h1011bfc_2_cpu
   - libcxx >=15.0.7
   - libprotobuf >=4.24.4,<4.24.5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-14.0.1-h660fe36_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-14.0.1-h660fe36_2_cpu.conda
   hash:
-    md5: 369f206a2b446232c90963a9545d3cbc
-    sha256: 03a96a17e0202be09864c15b4e9729c27ca15b192ad021bbdf4c5b1355fea51a
-  build: h660fe36_1_cpu
+    md5: 636178a9d5ba0954ef8883720be924a9
+    sha256: 96897ff47ab865433c377835a7939af2ceb0c2777999c0f1805d60d34d67f6a6
+  build: h660fe36_2_cpu
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 163720
-  timestamp: 1699524909612
+  size: 163912
+  timestamp: 1699954584002
 - platform: win-64
   name: libarrow-flight-sql
   version: 14.0.1
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.1 h85f1704_1_cpu
-  - libarrow-flight 14.0.1 h53b1db0_1_cpu
+  - libarrow 14.0.1 h0850d3a_2_cpu
+  - libarrow-flight 14.0.1 h53b1db0_2_cpu
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-sql-14.0.1-h78eab7c_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-sql-14.0.1-h78eab7c_2_cpu.conda
   hash:
-    md5: 59e97adbfb14ae97eefa91b74aa2452b
-    sha256: 8a784ee46a1343873495da5a96fc6598723162b909cac5014eb409510ac9c737
-  build: h78eab7c_1_cpu
+    md5: 301ddce90de46951f2a8ffaa8f2c809c
+    sha256: f980adc2de3c2374b45f5b679fca9955ae3ed75097e341a5ac9a70387201dff0
+  build: h78eab7c_2_cpu
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 223652
-  timestamp: 1699524315392
+  size: 223141
+  timestamp: 1699954814311
 - platform: linux-64
   name: libarrow-gandiva
   version: 14.0.1
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.1 h0406937_1_cpu
+  - libarrow 14.0.1 he5826ec_2_cpu
   - libgcc-ng >=12
   - libllvm15 >=15.0.7,<15.1.0a0
   - libre2-11 >=2023.6.2,<2024.0a0
@@ -13202,17 +13298,17 @@ package:
   - libutf8proc >=2.8.0,<3.0a0
   - openssl >=3.1.4,<4.0a0
   - re2
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.1-hacb8726_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.1-hacb8726_2_cpu.conda
   hash:
-    md5: 05d9955c98398a0978eca62e526fc0ee
-    sha256: 984435cf158cecf05ee9dcbaf47e0825aa4a7ae32809c7d6bf0d1d1654f2236f
-  build: hacb8726_1_cpu
+    md5: a7501248d25b3afded9602b86669be62
+    sha256: da3f84d7b67571b39e5f98c2ad4708b7fbc0831502210ebb05613f5e3dffcf3a
+  build: hacb8726_2_cpu
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 896426
-  timestamp: 1699523547937
+  size: 896215
+  timestamp: 1699953123227
 - platform: osx-64
   name: libarrow-gandiva
   version: 14.0.1
@@ -13220,24 +13316,24 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.9
-  - libarrow 14.0.1 hcf474e5_1_cpu
+  - libarrow 14.0.1 h3b78187_2_cpu
   - libcxx >=15.0.7
   - libllvm15 >=15.0.7,<15.1.0a0
   - libre2-11 >=2023.6.2,<2024.0a0
   - libutf8proc >=2.8.0,<3.0a0
   - openssl >=3.1.4,<4.0a0
   - re2
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-14.0.1-heeebe7c_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-14.0.1-heeebe7c_2_cpu.conda
   hash:
-    md5: 2db588f0db2fe7c36bd1c065b52b5081
-    sha256: e2eb050c553dc9be5917e35c0f661908fbf142e156cc80bc2fa792f85db7559f
-  build: heeebe7c_1_cpu
+    md5: 6755738a16ce967f8c9567890a273200
+    sha256: ca1b565c6c15137a7f6d149a50652616f7bd3938816f7f39f3546a15d55c2a2b
+  build: heeebe7c_2_cpu
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 700841
-  timestamp: 1699524428676
+  size: 700387
+  timestamp: 1699954720330
 - platform: osx-arm64
   name: libarrow-gandiva
   version: 14.0.1
@@ -13245,31 +13341,31 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.9
-  - libarrow 14.0.1 h7bb5718_1_cpu
+  - libarrow 14.0.1 ha4caa07_2_cpu
   - libcxx >=15.0.7
   - libllvm15 >=15.0.7,<15.1.0a0
   - libre2-11 >=2023.6.2,<2024.0a0
   - libutf8proc >=2.8.0,<3.0a0
   - openssl >=3.1.4,<4.0a0
   - re2
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-14.0.1-h2b96968_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-14.0.1-h2b96968_2_cpu.conda
   hash:
-    md5: 7b44f16df2e1955867a7930a9bda72c5
-    sha256: f73bd5e13ff048cdc8ad5506a3fa3e8f079bb5276db080edb225c1de74abb094
-  build: h2b96968_1_cpu
+    md5: 3531c5fa3be17c18d8d2d4f692d43bba
+    sha256: 67a6d8971980a939ba39b28c1d138d019e4db82417b4abfce7922be271049c7d
+  build: h2b96968_2_cpu
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 690114
-  timestamp: 1699524663585
+  size: 690053
+  timestamp: 1699954337479
 - platform: win-64
   name: libarrow-gandiva
   version: 14.0.1
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.1 h85f1704_1_cpu
+  - libarrow 14.0.1 h0850d3a_2_cpu
   - libre2-11 >=2023.6.2,<2024.0a0
   - libutf8proc >=2.8.0,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
@@ -13278,40 +13374,40 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-14.0.1-hb2eaab1_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-14.0.1-hb2eaab1_2_cpu.conda
   hash:
-    md5: 566abbb24feff0c809560af5e7ee412e
-    sha256: d5a014e3af3b7480ee0140458ef6de4c96d437ea8937fbf82a3d6046692343d8
-  build: hb2eaab1_1_cpu
+    md5: a6a4c7271e47ae65b83f06449d00e4f8
+    sha256: aecf4a66a884820efac310f5d942dd56a16e84727dc1d37001022d4ecbc18eb6
+  build: hb2eaab1_2_cpu
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 10175063
-  timestamp: 1699524142840
+  size: 10174483
+  timestamp: 1699954593436
 - platform: linux-64
   name: libarrow-substrait
   version: 14.0.1
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.1 h0406937_1_cpu
-  - libarrow-acero 14.0.1 h59595ed_1_cpu
-  - libarrow-dataset 14.0.1 h59595ed_1_cpu
+  - libarrow 14.0.1 he5826ec_2_cpu
+  - libarrow-acero 14.0.1 h59595ed_2_cpu
+  - libarrow-dataset 14.0.1 h59595ed_2_cpu
   - libgcc-ng >=12
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.1-h61ff412_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.1-h61ff412_2_cpu.conda
   hash:
-    md5: 279bf5749bd65e468b2b564d29ca95c0
-    sha256: 427889bb5091aaba58b3cd5d5ffbcc5936811af3084fa8a16bc885ecfee137d0
-  build: h61ff412_1_cpu
+    md5: 4a660acddf1dde96a4e1afd721d6c676
+    sha256: daf940a8eabd896137d7f049afd3b84bdd8874b19d7aaf7f16fdb71a71c31413
+  build: h61ff412_2_cpu
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 510608
-  timestamp: 1699523667240
+  size: 509432
+  timestamp: 1699953222076
 - platform: osx-64
   name: libarrow-substrait
   version: 14.0.1
@@ -13320,22 +13416,22 @@ package:
   dependencies:
   - __osx >=10.13
   - __osx >=10.9
-  - libarrow 14.0.1 hcf474e5_1_cpu
-  - libarrow-acero 14.0.1 hc222712_1_cpu
-  - libarrow-dataset 14.0.1 hc222712_1_cpu
+  - libarrow 14.0.1 h3b78187_2_cpu
+  - libarrow-acero 14.0.1 hc222712_2_cpu
+  - libarrow-dataset 14.0.1 hc222712_2_cpu
   - libcxx >=15.0.7
   - libprotobuf >=4.24.4,<4.24.5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-14.0.1-h8ec153b_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-14.0.1-h2cc6c1c_2_cpu.conda
   hash:
-    md5: 9f5c9e8bfbbcc4f0c432bed4974ed708
-    sha256: 604ef1ca26610092f29b1b2a69945158d8b7dd2ccdb3ac976d24edde6f826ea0
-  build: h8ec153b_1_cpu
+    md5: a1ef4ed049070f00fff873e191cfc963
+    sha256: 0b2b7ca6d1bfed324bf38d3e884ec27a35bdc72f91962835db804d4fefc8bdfd
+  build: h2cc6c1c_2_cpu
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 454310
-  timestamp: 1699524662962
+  size: 454922
+  timestamp: 1699954978847
 - platform: osx-arm64
   name: libarrow-substrait
   version: 14.0.1
@@ -13343,22 +13439,22 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.9
-  - libarrow 14.0.1 h7bb5718_1_cpu
-  - libarrow-acero 14.0.1 had9dd58_1_cpu
-  - libarrow-dataset 14.0.1 had9dd58_1_cpu
+  - libarrow 14.0.1 ha4caa07_2_cpu
+  - libarrow-acero 14.0.1 had9dd58_2_cpu
+  - libarrow-dataset 14.0.1 had9dd58_2_cpu
   - libcxx >=15.0.7
   - libprotobuf >=4.24.4,<4.24.5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-14.0.1-h594d712_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-14.0.1-h594d712_2_cpu.conda
   hash:
-    md5: c727e569e0812a90c7321ae79e387843
-    sha256: 49c6e1477c59334222fd25730b942e0dfb4b5bfba79fc173bc5ab5ba09e7a671
-  build: h594d712_1_cpu
+    md5: ed5296f02f1d32d5c7a3b67d5da3135d
+    sha256: 717c656d250ee2f4d3cce91617b7c2afc1ba0a1cbf437f634f1cd33a3d1d870d
+  build: h594d712_2_cpu
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 475366
-  timestamp: 1699524998776
+  size: 475619
+  timestamp: 1699954669839
 - platform: win-64
   name: libarrow-substrait
   version: 14.0.1
@@ -13367,24 +13463,24 @@ package:
   dependencies:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libarrow 14.0.1 h85f1704_1_cpu
-  - libarrow-acero 14.0.1 h63175ca_1_cpu
-  - libarrow-dataset 14.0.1 h63175ca_1_cpu
+  - libarrow 14.0.1 h0850d3a_2_cpu
+  - libarrow-acero 14.0.1 h63175ca_2_cpu
+  - libarrow-dataset 14.0.1 h63175ca_2_cpu
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-14.0.1-hd4c9904_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-14.0.1-hd4c9904_2_cpu.conda
   hash:
-    md5: 5bdb8100ce0267c80ac3844b8486e90a
-    sha256: f0cb407c0ec9d2716c057317dab96cfb567601a2856cd3cf6316571a4dfec96a
-  build: hd4c9904_1_cpu
+    md5: 55d3f374ec228a2dbe5bb8a2c3fc651b
+    sha256: 91ca6e247b5fc7a01eb30f546f105c94b5c3c493fe19fa742c839916be79a537
+  build: hd4c9904_2_cpu
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 348656
-  timestamp: 1699524367780
+  size: 348336
+  timestamp: 1699954877818
 - platform: linux-64
   name: libblas
   version: 3.9.0
@@ -14687,20 +14783,20 @@ package:
   dependencies:
   - _libgcc_mutex 0.1 conda_forge
   - _openmp_mutex >=4.5
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_3.conda
   hash:
-    md5: c28003b0be0494f9a7664389146716ff
-    sha256: d361d3c87c376642b99c1fc25cddec4b9905d3d9b9203c1c545b8c8c1b04539a
-  build: h807b86a_2
+    md5: 23fdf1fef05baeb7eadc2aed5fb0011f
+    sha256: 5e88f658e07a30ab41b154b42c59f079b168acfa9551a75bdc972099453f4105
+  build: h807b86a_3
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 3
   constrains:
-  - libgomp 13.2.0 h807b86a_2
+  - libgomp 13.2.0 h807b86a_3
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 771133
-  timestamp: 1695219384393
+  size: 773629
+  timestamp: 1699753612541
 - platform: linux-64
   name: libgcrypt
   version: 1.10.2
@@ -14749,7 +14845,7 @@ package:
   - libkml >=1.3.0,<1.4.0a0
   - libnetcdf >=4.9.2,<4.9.3.0a0
   - libpng >=1.6.39,<1.7.0a0
-  - libpq >=16.0,<17.0a0
+  - libpq >=16.1,<17.0a0
   - libspatialite >=5.1.0,<5.2.0a0
   - libsqlite >=3.44.0,<4.0a0
   - libstdcxx-ng >=12
@@ -14769,18 +14865,18 @@ package:
   - xerces-c >=3.2.4,<3.3.0a0
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.7.3-h6f3d308_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.7.3-h6f3d308_3.conda
   hash:
-    md5: 267f4fae4ab6352f9e74b06cc75d3341
-    sha256: 9f5bea2846012b86693dd60f11b9cfc7f36569a6820e4ebf288288e4e7b44170
-  build: h6f3d308_2
+    md5: 4e54b97f9e8a71f8a9945cbd2d905252
+    sha256: f17f7e3926894867b9eb048f7a3032b67d59600fb1d0f0555bf0a32b1d4deefa
+  build: h6f3d308_3
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 3
   license: MIT
   license_family: MIT
-  size: 10588505
-  timestamp: 1699112162770
+  size: 10626102
+  timestamp: 1699853802742
 - platform: osx-64
   name: libgdal
   version: 3.7.3
@@ -14809,7 +14905,7 @@ package:
   - libkml >=1.3.0,<1.4.0a0
   - libnetcdf >=4.9.2,<4.9.3.0a0
   - libpng >=1.6.39,<1.7.0a0
-  - libpq >=16.0,<17.0a0
+  - libpq >=16.1,<17.0a0
   - libspatialite >=5.1.0,<5.2.0a0
   - libsqlite >=3.44.0,<4.0a0
   - libtiff >=4.6.0,<4.7.0a0
@@ -14827,18 +14923,18 @@ package:
   - xerces-c >=3.2.4,<3.3.0a0
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.7.3-h926149b_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.7.3-h926149b_3.conda
   hash:
-    md5: 6acf790f6e56f4b8c86f28fd18932af3
-    sha256: 05f04a02d6fc654a60c8ef138435e9ea54938ec250876bfc5d95191cbd4c32f5
-  build: h926149b_2
+    md5: 3f4e1c554592171712c377cc74f302fc
+    sha256: 67667053ddb83c0ad45d0927b3c597dbeea89105ee6c73938f7fee570fd9b50f
+  build: h926149b_3
   arch: x86_64
   subdir: osx-64
-  build_number: 2
+  build_number: 3
   license: MIT
   license_family: MIT
-  size: 8974975
-  timestamp: 1699113079107
+  size: 8973148
+  timestamp: 1699855015179
 - platform: osx-arm64
   name: libgdal
   version: 3.7.3
@@ -14867,7 +14963,7 @@ package:
   - libkml >=1.3.0,<1.4.0a0
   - libnetcdf >=4.9.2,<4.9.3.0a0
   - libpng >=1.6.39,<1.7.0a0
-  - libpq >=16.0,<17.0a0
+  - libpq >=16.1,<17.0a0
   - libspatialite >=5.1.0,<5.2.0a0
   - libsqlite >=3.44.0,<4.0a0
   - libtiff >=4.6.0,<4.7.0a0
@@ -14885,18 +14981,18 @@ package:
   - xerces-c >=3.2.4,<3.3.0a0
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-3.7.3-h116f65a_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-3.7.3-h116f65a_3.conda
   hash:
-    md5: 443049f0504187a1d7665ddda55aee20
-    sha256: a45afe33e6969de792e704de805878a34b3641a81fc45764acb467a529f17ade
-  build: h116f65a_2
+    md5: 5f76d0484e404f7e20c0b7eac61b44ab
+    sha256: 770126ba22c71572ee817f24171e01038bc43857d52842ab4b24a354b6c5f658
+  build: h116f65a_3
   arch: aarch64
   subdir: osx-arm64
-  build_number: 2
+  build_number: 3
   license: MIT
   license_family: MIT
-  size: 8183216
-  timestamp: 1699113267013
+  size: 8170459
+  timestamp: 1699855130834
 - platform: win-64
   name: libgdal
   version: 3.7.3
@@ -14921,7 +15017,7 @@ package:
   - libkml >=1.3.0,<1.4.0a0
   - libnetcdf >=4.9.2,<4.9.3.0a0
   - libpng >=1.6.39,<1.7.0a0
-  - libpq >=16.0,<17.0a0
+  - libpq >=16.1,<17.0a0
   - libspatialite >=5.1.0,<5.2.0a0
   - libsqlite >=3.44.0,<4.0a0
   - libtiff >=4.6.0,<4.7.0a0
@@ -14942,18 +15038,18 @@ package:
   - xerces-c >=3.2.4,<3.3.0a0
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.7.3-h3217549_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.7.3-h3217549_3.conda
   hash:
-    md5: fdf86abe5276a43f453e5f6f066efc98
-    sha256: bf4e47c0cc1c0208ec394fe6cebf789e75b5c72555d63aff721a55e1a6be25f8
-  build: h3217549_2
+    md5: 9f04fc54f50770d3bd66a8ded2d7378d
+    sha256: a12cff0cbc52f1c479745c6a693614ef2b4588b84960e1791ee79ef2ef6e49f3
+  build: h3217549_3
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 3
   license: MIT
   license_family: MIT
-  size: 8406778
-  timestamp: 1699113058758
+  size: 8432103
+  timestamp: 1699855119123
 - platform: osx-64
   name: libgfortran
   version: 5.0.0
@@ -14998,19 +15094,19 @@ package:
   category: main
   manager: conda
   dependencies:
-  - libgfortran5 13.2.0 ha4646dd_2
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
+  - libgfortran5 13.2.0 ha4646dd_3
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_3.conda
   hash:
-    md5: e75a75a6eaf6f318dae2631158c46575
-    sha256: 767d71999e5386210fe2acaf1b67073e7943c2af538efa85c101e3401e94ff62
-  build: h69a702a_2
+    md5: 73031c79546ad06f1fe62e57fdd021bc
+    sha256: 5b918950b84605b6865de438757f507b1eff73c96fd562f7022c80028b088c14
+  build: h69a702a_3
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 3
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 23722
-  timestamp: 1695219642066
+  size: 23837
+  timestamp: 1699753845201
 - platform: linux-64
   name: libgfortran5
   version: 13.2.0
@@ -15018,20 +15114,20 @@ package:
   manager: conda
   dependencies:
   - libgcc-ng >=13.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_3.conda
   hash:
-    md5: 78fdab09d9138851dde2b5fe2a11019e
-    sha256: 55ecf5c46c05a98b4822a041d6e1cb196a7b0606126eb96b24131b7d2c8ca561
-  build: ha4646dd_2
+    md5: c714d905cdfa0e70200f68b80cc04764
+    sha256: 0084a1d29a4f8ee3b8edad80eb6c42e5f0480f054f28cf713fb314bebb347a50
+  build: ha4646dd_3
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 3
   constrains:
   - libgfortran-ng 13.2.0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 1441830
-  timestamp: 1695219403435
+  size: 1436929
+  timestamp: 1699753630186
 - platform: osx-64
   name: libgfortran5
   version: 13.2.0
@@ -15186,18 +15282,18 @@ package:
   manager: conda
   dependencies:
   - _libgcc_mutex 0.1 conda_forge
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_3.conda
   hash:
-    md5: e2042154faafe61969556f28bade94b9
-    sha256: e1e82348f8296abfe344162b3b5f0ddc2f504759ebeb8b337ba99beaae583b15
-  build: h807b86a_2
+    md5: 7124cbb46b13d395bdde68f2d215c989
+    sha256: 6ebedee39b6bbbc969715d0d7fa4b381cce67e1139862604ffa393f821c08e81
+  build: h807b86a_3
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 3
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 421133
-  timestamp: 1695219303065
+  size: 421834
+  timestamp: 1699753531479
 - platform: linux-64
   name: libgoogle-cloud
   version: 2.12.0
@@ -16254,22 +16350,22 @@ package:
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.1 h0406937_1_cpu
+  - libarrow 14.0.1 he5826ec_2_cpu
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libthrift >=0.19.0,<0.19.1.0a0
   - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.1-h352af49_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.1-h352af49_2_cpu.conda
   hash:
-    md5: 5b5c9968e5872bc65a3f69a38c389003
-    sha256: 9d3e94b10d0cf5c71420a8f22ffd9f58189bc52a937296798b9c3bb5b5c75809
-  build: h352af49_1_cpu
+    md5: c8e0b6b4e56aa4767727db2f6a0b0282
+    sha256: 3b2a23163a8c9dae3d536e96035129708adf205dd1b00437ebeb4ec4ba61cd8c
+  build: h352af49_2_cpu
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 1165164
-  timestamp: 1699523578961
+  size: 1164190
+  timestamp: 1699953147691
 - platform: osx-64
   name: libparquet
   version: 14.0.1
@@ -16277,21 +16373,21 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.9
-  - libarrow 14.0.1 hcf474e5_1_cpu
+  - libarrow 14.0.1 h3b78187_2_cpu
   - libcxx >=15.0.7
   - libthrift >=0.19.0,<0.19.1.0a0
   - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-14.0.1-h27bd29f_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-14.0.1-h27bd29f_2_cpu.conda
   hash:
-    md5: cdce7ef09dd1e78dc91c7b74854f8951
-    sha256: fae3fee3837aef40c973c4de0bd03d7bdcc4eeaeae65d1b8cdd0256d92284619
-  build: h27bd29f_1_cpu
+    md5: b00156dd2ef6c9c5c4f61493a46ea5e2
+    sha256: 9a2b234522ff85e23b1d74d048136f016e9c04040ed248a17e29fabeab9f218b
+  build: h27bd29f_2_cpu
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 930270
-  timestamp: 1699524487672
+  size: 929770
+  timestamp: 1699954782441
 - platform: osx-arm64
   name: libparquet
   version: 14.0.1
@@ -16299,44 +16395,44 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.9
-  - libarrow 14.0.1 h7bb5718_1_cpu
+  - libarrow 14.0.1 ha4caa07_2_cpu
   - libcxx >=15.0.7
   - libthrift >=0.19.0,<0.19.1.0a0
   - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-14.0.1-heaab74a_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-14.0.1-heaab74a_2_cpu.conda
   hash:
-    md5: 29ec8382d4d8da63ded09a173c635087
-    sha256: a9cbe2f62f01fd6ab974f3ba65995e8d64bf53b65c9fad26f9e1ad403dce0ea8
-  build: heaab74a_1_cpu
+    md5: ceb10b8adde9de6f3bf01a945b248f4d
+    sha256: 308ae959e9223dc3862a5d9aefe24a6918b84f511d08cfe1b8236366ddf5facf
+  build: heaab74a_2_cpu
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 915916
-  timestamp: 1699524745535
+  size: 914213
+  timestamp: 1699954415535
 - platform: win-64
   name: libparquet
   version: 14.0.1
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.1 h85f1704_1_cpu
+  - libarrow 14.0.1 h0850d3a_2_cpu
   - libthrift >=0.19.0,<0.19.1.0a0
   - openssl >=3.1.4,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-14.0.1-h7ec3a38_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-14.0.1-h7ec3a38_2_cpu.conda
   hash:
-    md5: c2290b2f18c536f1e5db23e82e6fc9a5
-    sha256: 2d3410fe40bb3580788ddf48167b8e9d6a010fef15b58a0127c70ab751958e1d
-  build: h7ec3a38_1_cpu
+    md5: 807d38dd0a7b903c5f551da05388827a
+    sha256: 6518cf7276aaec254d07e0e6bd69f5812f26651a85f48c70918604d731d25b98
+  build: h7ec3a38_2_cpu
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 2
   license: Apache-2.0
-  size: 783950
-  timestamp: 1699524211045
+  size: 782702
+  timestamp: 1699954688495
 - platform: linux-64
   name: libpng
   version: 1.6.39
@@ -17235,18 +17331,18 @@ package:
   category: main
   manager: conda
   dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_3.conda
   hash:
-    md5: 9172c297304f2a20134fc56c97fbe229
-    sha256: ab22ecdc974cdbe148874ea876d9c564294d5eafa760f403ed4fd495307b4243
-  build: h7e041cc_2
+    md5: 937eaed008f6bf2191c5fe76f87755e9
+    sha256: 6c6c49efedcc5709a66f19fb6b26b69c6a5245310fd1d9a901fd5e38aaf7f882
+  build: h7e041cc_3
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 3
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 3842773
-  timestamp: 1695219454837
+  size: 3842940
+  timestamp: 1699753676253
 - platform: linux-64
   name: libsystemd0
   version: '254'
@@ -18540,13 +18636,13 @@ package:
   manager: conda
   dependencies:
   - libgcc-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py311h459d7ec_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py312h98912ed_1.conda
   hash:
-    md5: 71120b5155a0c500826cf81536721a15
-    sha256: e1a9930f35e39bf65bc293e24160b83ebf9f800f02749f65358e1c04882ee6b0
-  build: py311h459d7ec_1
+    md5: 79d118a8f1da01773dd5b334af5ce8d4
+    sha256: 2da8fc396399cd3dec8e1464d6b592adca0498e353dc3cdfac34f7eb563956c9
+  build: py312h98912ed_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
@@ -18554,21 +18650,21 @@ package:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 27174
-  timestamp: 1695367575909
+  size: 26655
+  timestamp: 1695367675021
 - platform: osx-64
   name: markupsafe
   version: 2.1.3
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py311h2725bcf_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py312h104f124_1.conda
   hash:
-    md5: 52ee86f482b552e547e2b1d6c01adf55
-    sha256: 5a8f8caa89eeba6ea6e9e96d3e7c109b675bc3c6ed4b109b8931757da2411d48
-  build: py311h2725bcf_1
+    md5: 75ef15f68d5ed9890b0047faac90e3c2
+    sha256: 8133ad1fe532ac2c06e02b9cdd1cc0a744c6eadc231a3726ed2f584d1034e661
+  build: py312h104f124_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
@@ -18576,22 +18672,22 @@ package:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 25917
-  timestamp: 1695367980802
+  size: 25397
+  timestamp: 1695367877868
 - platform: osx-arm64
   name: markupsafe
   version: 2.1.3
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py311heffc1b2_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py312h02f2b3b_1.conda
   hash:
-    md5: 5a7b68cb9eea46bea31aaf2d11d0dd2f
-    sha256: 307c1e3b2e4a2a992a6c94975910adff88cc523e2c9a41e81b2d506d8c9e7359
-  build: py311heffc1b2_1
+    md5: b96439c0c4c8b5e098629d1a4211a996
+    sha256: 5d1505cbc95f7c41c229e7e7db61e1faf9fcd174d8f09debbf113fe7ee174062
+  build: py312h02f2b3b_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
@@ -18599,24 +18695,24 @@ package:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 26764
-  timestamp: 1695368008221
+  size: 26318
+  timestamp: 1695368020481
 - platform: win-64
   name: markupsafe
   version: 2.1.3
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py311ha68e1ae_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py312he70551f_1.conda
   hash:
-    md5: bc93b9d445824cfce3933b5dcc1087b4
-    sha256: 435c4c2df8d98cd49d8332d22b6f4847fc4b594500f0cdf0f9437274c668642b
-  build: py311ha68e1ae_1
+    md5: 1615e2aa0daf737f06e0d1a3b39d74a8
+    sha256: 013cc2303b0bdfc4c3f43a363b8a208ce3971c727ebd870198db5c6c1f36c7c0
+  build: py312he70551f_1
   arch: x86_64
   subdir: win-64
   build_number: 1
@@ -18624,8 +18720,8 @@ package:
   - jinja2 >=3.0.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 29466
-  timestamp: 1695367841578
+  size: 28973
+  timestamp: 1695367885602
 - platform: linux-64
   name: matplotlib
   version: 3.8.1
@@ -18634,21 +18730,21 @@ package:
   dependencies:
   - matplotlib-base >=3.8.1,<3.8.2.0a0
   - pyqt >=5.10
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - tornado >=5
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.8.1-py311h38be061_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-3.8.1-py312h7900ff3_0.conda
   hash:
-    md5: 8a21cbbb87357c701fa44f4cfa4e23d7
-    sha256: cbbd4cf75001616f675dfdec103e4580c41221ece4237f2af8b5a775c6ee63dd
-  build: py311h38be061_0
+    md5: 0e03f9e54c27035d4a5f9a4c64cd7a1e
+    sha256: 49f8bd23ea598cade963783a8bc16a84c1f3bf4ff74e15ab62cb57c63f3b4095
+  build: py312h7900ff3_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: PSF-2.0
   license_family: PSF
-  size: 8433
-  timestamp: 1698868770040
+  size: 8443
+  timestamp: 1698868842552
 - platform: osx-64
   name: matplotlib
   version: 3.8.1
@@ -18656,21 +18752,21 @@ package:
   manager: conda
   dependencies:
   - matplotlib-base >=3.8.1,<3.8.2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - tornado >=5
-  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.8.1-py311h6eed73b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-3.8.1-py312hb401068_0.conda
   hash:
-    md5: ecb3b48ca1bfb16ea92f42971f6db317
-    sha256: f53c5672ee053fc026d50320537ef8ee9c52f8e2194f751e43e6d921f1c3faca
-  build: py311h6eed73b_0
+    md5: 4f126c98b24e3276ba80f95efb696737
+    sha256: ed3a0bacdd55003f4461c810c733cd6acb1444ecff88ec2571b8fc0f00e6153f
+  build: py312hb401068_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: PSF-2.0
   license_family: PSF
-  size: 8540
-  timestamp: 1698869065085
+  size: 8509
+  timestamp: 1698869072321
 - platform: osx-arm64
   name: matplotlib
   version: 3.8.1
@@ -18678,21 +18774,21 @@ package:
   manager: conda
   dependencies:
   - matplotlib-base >=3.8.1,<3.8.2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - tornado >=5
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.8.1-py311ha1ab1f8_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-3.8.1-py312h1f38498_0.conda
   hash:
-    md5: 797f33cafe2b7fed2ab1ce7e261c4c81
-    sha256: bcf6e3eea9a8693e477b1b4ceeda6e124dc2cfd6e6c8313f82982d73332b36d2
-  build: py311ha1ab1f8_0
+    md5: b88ebb3336d5505734e78686fca3e018
+    sha256: 4d0519e9f864d855d12f6e9ed8f01ecacce88b8d14e7cb27d174204c7f2b9a9c
+  build: py312h1f38498_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: PSF-2.0
   license_family: PSF
-  size: 8589
-  timestamp: 1698869242307
+  size: 8607
+  timestamp: 1698869193101
 - platform: win-64
   name: matplotlib
   version: 3.8.1
@@ -18701,21 +18797,21 @@ package:
   dependencies:
   - matplotlib-base >=3.8.1,<3.8.2.0a0
   - pyqt >=5.10
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - tornado >=5
-  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.8.1-py311h1ea47a8_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.8.1-py312h2e8e312_0.conda
   hash:
-    md5: 1839b8c39f09d94b734d5e627eeb79ea
-    sha256: d236fcbbecd9d99bf254a7a7105bcddb754552be8d2237574d8cfb4edca0d76c
-  build: py311h1ea47a8_0
+    md5: 0ff81663c589522d5e174abb020849fc
+    sha256: 2166e0f9fc394b92d87f01039f7bdeaedf23d3c0bab52b729c276522c14d9fc3
+  build: py312h2e8e312_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: PSF-2.0
   license_family: PSF
-  size: 8809
-  timestamp: 1698869468994
+  size: 8842
+  timestamp: 1698869464882
 - platform: linux-64
   name: matplotlib-base
   version: 3.8.1
@@ -18731,26 +18827,26 @@ package:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - numpy >=1.21,<2
-  - numpy >=1.23.5,<2.0a0
+  - numpy >=1.26.0,<2.0a0
   - packaging >=20.0
   - pillow >=8
   - pyparsing >=2.3.1
-  - python >=3.11,<3.12.0a0
+  - python >=3.12,<3.13.0a0
   - python-dateutil >=2.7
-  - python_abi 3.11.* *_cp311
+  - python_abi 3.12.* *_cp312
   - tk >=8.6.13,<8.7.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.8.1-py311h54ef318_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.8.1-py312he5832f3_0.conda
   hash:
-    md5: 201fdabdb86bb8fb6e99fa3f0dab8122
-    sha256: 9340ef0ba720e550c702fd25611884c79bfc419a85027d69900be5aa2ddbe3a9
-  build: py311h54ef318_0
+    md5: 8c5aef130bf0c6590202719cff450402
+    sha256: 870ec5a60225eadcb4615c41b5c692c77f9748a9e429ff6aa807b1849eb0deb8
+  build: py312he5832f3_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: PSF-2.0
   license_family: PSF
-  size: 7828462
-  timestamp: 1698868747853
+  size: 7813796
+  timestamp: 1698868817347
 - platform: osx-64
   name: matplotlib-base
   version: 3.8.1
@@ -18767,25 +18863,25 @@ package:
   - kiwisolver >=1.3.1
   - libcxx >=16.0.6
   - numpy >=1.21,<2
-  - numpy >=1.23.5,<2.0a0
+  - numpy >=1.26.0,<2.0a0
   - packaging >=20.0
   - pillow >=8
   - pyparsing >=2.3.1
-  - python >=3.11,<3.12.0a0
+  - python >=3.12,<3.13.0a0
   - python-dateutil >=2.7
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.8.1-py311hd316c10_0.conda
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.8.1-py312h1fe5000_0.conda
   hash:
-    md5: 8952515c597009d2dfadf9ecaec30447
-    sha256: 5976a3c061b7918ac84a7e38fec1af297fe29b5e2ec9405f43feb55f77b4f6fb
-  build: py311hd316c10_0
+    md5: f384d9472c380eea6a14ab5dc6cb77c4
+    sha256: dd95501a0d7fc578e3438952bde8c664aa53b7ab0958a31eac1543fac5d12f1d
+  build: py312h1fe5000_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: PSF-2.0
   license_family: PSF
-  size: 8059734
-  timestamp: 1698869029832
+  size: 7711925
+  timestamp: 1698869034419
 - platform: osx-arm64
   name: matplotlib-base
   version: 3.8.1
@@ -18801,26 +18897,26 @@ package:
   - kiwisolver >=1.3.1
   - libcxx >=16.0.6
   - numpy >=1.21,<2
-  - numpy >=1.23.5,<2.0a0
+  - numpy >=1.26.0,<2.0a0
   - packaging >=20.0
   - pillow >=8
   - pyparsing >=2.3.1
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
   - python-dateutil >=2.7
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.8.1-py311hfdba5f6_0.conda
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.8.1-py312hba9b818_0.conda
   hash:
-    md5: 7b2974aa0ecc495f1cb9f269fadf9981
-    sha256: 2d61f4697a9906c4f56b8ffdcdd66edf64f7db9c5084827848f43390c203ee24
-  build: py311hfdba5f6_0
+    md5: 8a6a25faa366216bf78a4a22eb3f5772
+    sha256: 773bf54a6d84234bc1c7abb22a8b4545fd0b8c2c3818a2818664f57c2fa4295e
+  build: py312hba9b818_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: PSF-2.0
   license_family: PSF
-  size: 7711426
-  timestamp: 1698869195412
+  size: 7699618
+  timestamp: 1698869142345
 - platform: win-64
   name: matplotlib-base
   version: 3.8.1
@@ -18834,28 +18930,28 @@ package:
   - freetype >=2.12.1,<3.0a0
   - kiwisolver >=1.3.1
   - numpy >=1.21,<2
-  - numpy >=1.23.5,<2.0a0
+  - numpy >=1.26.0,<2.0a0
   - packaging >=20.0
   - pillow >=8
   - pyparsing >=2.3.1
-  - python >=3.11,<3.12.0a0
+  - python >=3.12,<3.13.0a0
   - python-dateutil >=2.7
-  - python_abi 3.11.* *_cp311
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.8.1-py311h6e989c2_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.8.1-py312h26ecaf7_0.conda
   hash:
-    md5: d4e4b5785fdfd969303cdf55256378e0
-    sha256: c153b558ff258c2ab2f654c7557f89e3804f7928ca2dfa8c77acfac6f0cab44d
-  build: py311h6e989c2_0
+    md5: 218eaaffeca3bb344fcac0038f79c765
+    sha256: a039faed2dfe6805d2bc0cdb6d5e45bcd5ab8aeea1818f78c63e2e2438ac972e
+  build: py312h26ecaf7_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: PSF-2.0
   license_family: PSF
-  size: 7828413
-  timestamp: 1698869423233
+  size: 7660592
+  timestamp: 1698869417798
 - platform: linux-64
   name: matplotlib-inline
   version: 0.1.6
@@ -19022,7 +19118,7 @@ package:
   timestamp: 1639515992326
 - platform: linux-64
   name: minizip
-  version: 4.0.2
+  version: 4.0.3
   category: main
   manager: conda
   dependencies:
@@ -19034,21 +19130,21 @@ package:
   - openssl >=3.1.4,<4.0a0
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.2-h0ab5242_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.3-h0ab5242_0.conda
   hash:
-    md5: c6eafb51b60db59fd2132f6bbaada9b3
-    sha256: 97bc17dd33c8339bd380cbddaa3256b7b77b08a7db6fd70e5a54519d237e8939
+    md5: 3f9b5f4400be3cee11b426a8cd653b7c
+    sha256: cf33c24fa8375d17fad4e1da631b4c2e8ed9a109480fa45c82fbfa2a7c5bdd41
   build: h0ab5242_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: Zlib
   license_family: Other
-  size: 91289
-  timestamp: 1698348512961
+  size: 92378
+  timestamp: 1699930958451
 - platform: osx-64
   name: minizip
-  version: 4.0.2
+  version: 4.0.3
   category: main
   manager: conda
   dependencies:
@@ -19060,21 +19156,21 @@ package:
   - openssl >=3.1.4,<4.0a0
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.2-h23f18a7_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.3-h23f18a7_0.conda
   hash:
-    md5: 86f4435be14480ce928083cde62e9194
-    sha256: 15f1f8340693710d726a4d9063248119561c24c5922df268fad289028352dadc
+    md5: 2facac17555d3078a0abfbe20a331086
+    sha256: 779cdb3ee14c653b6094414c251164b2398e50b825ba44455c67e7deeb6e48e1
   build: h23f18a7_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: Zlib
   license_family: Other
-  size: 79162
-  timestamp: 1698348786967
+  size: 78841
+  timestamp: 1699931181751
 - platform: osx-arm64
   name: minizip
-  version: 4.0.2
+  version: 4.0.3
   category: main
   manager: conda
   dependencies:
@@ -19086,21 +19182,21 @@ package:
   - openssl >=3.1.4,<4.0a0
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.2-hd5cad61_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.3-hd5cad61_0.conda
   hash:
-    md5: 90adaefb38030b00a28dd07140ae7335
-    sha256: 57051f3bc2dedc7a4bcf31f36a463a683d3c131d8ff7a77bcf8be91455e70581
+    md5: 8f1bf9ea12bca129b7a3d49eec9efd76
+    sha256: 9db88831aa3485d98cad155d989d4de45edfec13e6cbe81b0093ba7e6ba8817d
   build: hd5cad61_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: Zlib
   license_family: Other
-  size: 78361
-  timestamp: 1698348818338
+  size: 77965
+  timestamp: 1699931186188
 - platform: win-64
   name: minizip
-  version: 4.0.2
+  version: 4.0.3
   category: main
   manager: conda
   dependencies:
@@ -19111,18 +19207,18 @@ package:
   - vc14_runtime >=14.29.30139
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.2-h5bed578_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.3-h5bed578_0.conda
   hash:
-    md5: b3fe453a894825361294e3fe57bb9022
-    sha256: 2e75ba252b81e4c3c10ffb513015b9a50a427206497c24f54c378ecf10faf1ac
+    md5: 958b153628ecd3bf3cfd1644e2385bb4
+    sha256: 317c43e644024f4ac820468f09c49d1f8491b14650e11d5c3516116320273c4b
   build: h5bed578_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: Zlib
   license_family: Other
-  size: 84673
-  timestamp: 1698349061388
+  size: 84913
+  timestamp: 1699931497035
 - platform: linux-64
   name: mistune
   version: 3.0.2
@@ -19588,21 +19684,21 @@ package:
   - libgcc-ng >=12
   - mypy_extensions >=1.0.0
   - psutil >=4.0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - typing_extensions >=4.1.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.7.0-py311h459d7ec_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.7.0-py312h98912ed_0.conda
   hash:
-    md5: 220a9ebafcc0f1b1f2c0b9c4da26687e
-    sha256: d1e526e0a943b4ded2bff07dfad38209b54bbd6cebc461e212ccc2ecb8f9c51d
-  build: py311h459d7ec_0
+    md5: 8983c781f7262f3128782af89b99bf32
+    sha256: 9ea860676ba4195cac2876dfac92594344a506fc98b05d98e06652bbf6fda1f5
+  build: py312h98912ed_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 17536667
-  timestamp: 1699638313158
+  size: 16318531
+  timestamp: 1699638442049
 - platform: osx-64
   name: mypy
   version: 1.7.0
@@ -19611,21 +19707,21 @@ package:
   dependencies:
   - mypy_extensions >=1.0.0
   - psutil >=4.0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - typing_extensions >=4.1.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.7.0-py311he705e18_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.7.0-py312h41838bb_0.conda
   hash:
-    md5: 693b52d72447772c2d85e7016b8711aa
-    sha256: 1bb6dd753dcbf487ef0b82755379e6ca23cf45cde3786bfec99028dbaa8afcd8
-  build: py311he705e18_0
+    md5: 8ed6dd59367040a076ca6e9d6318d5c7
+    sha256: 17303e31814d47ec3d363735d5ed1aca9db4d43fc9d09ace97479f119c7629c3
+  build: py312h41838bb_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 11857181
-  timestamp: 1699638473833
+  size: 10185802
+  timestamp: 1699638517323
 - platform: osx-arm64
   name: mypy
   version: 1.7.0
@@ -19634,22 +19730,22 @@ package:
   dependencies:
   - mypy_extensions >=1.0.0
   - psutil >=4.0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
   - typing_extensions >=4.1.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.7.0-py311h05b510d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.7.0-py312he37b823_0.conda
   hash:
-    md5: 19960a9945b980ef34f30c1d90d28c93
-    sha256: 6a77b884c89e0176f6ecf6965d2d737774cdbf208acd1b4310a37a2c4d660a05
-  build: py311h05b510d_0
+    md5: b47b01bc28612fc9ae8edb5fc88c3613
+    sha256: 60c60e94f5ed7e6921da97286bf946282b2e1bfa753a339d3c09d33626934709
+  build: py312he37b823_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 9642540
-  timestamp: 1699638565018
+  size: 9518269
+  timestamp: 1699639141957
 - platform: win-64
   name: mypy
   version: 1.7.0
@@ -19658,24 +19754,24 @@ package:
   dependencies:
   - mypy_extensions >=1.0.0
   - psutil >=4.0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - typing_extensions >=4.1.0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/mypy-1.7.0-py311ha68e1ae_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/mypy-1.7.0-py312he70551f_0.conda
   hash:
-    md5: c58cf58cc73b8e67bcdb84ab4e7a1d91
-    sha256: 0f537dc06b0210760aa50cd685fcd138d1490c1f339fc2d92365ddf4f1aede9e
-  build: py311ha68e1ae_0
+    md5: 01c03fdd9a4f3ce7fd0d6a7e52d93ba0
+    sha256: 9aabdbac343f35b1deb2da601727599aff6491fdb6c3c6c03faf6ef921406981
+  build: py312he70551f_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 9820922
-  timestamp: 1699638398847
+  size: 8239186
+  timestamp: 1699638398808
 - platform: linux-64
   name: mypy_extensions
   version: 1.0.0
@@ -20386,81 +20482,81 @@ package:
   manager: conda
   dependencies:
   - libgcc-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/nh3-0.2.14-py311h46250e7_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/nh3-0.2.14-py312h4b3b743_1.conda
   hash:
-    md5: 8faffafe1f60438f96710edef4fdafe5
-    sha256: 31e5270ba8ec992dedd02a36ba56d786729b8e372c171170c611d79a6e5c458d
-  build: py311h46250e7_1
+    md5: 41bf8d6d36ad4d33b6f8cf741648cddd
+    sha256: 056579eeca71e809549f9b6786b71385ae71d9150e3a3caf35eb9a829ee366d0
+  build: py312h4b3b743_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   license: MIT
   license_family: MIT
-  size: 623877
-  timestamp: 1695423349623
+  size: 621567
+  timestamp: 1695423328803
 - platform: osx-64
   name: nh3
   version: 0.2.14
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/nh3-0.2.14-py311h299eb51_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/nh3-0.2.14-py312hc405983_1.conda
   hash:
-    md5: 37047d1fc213d1dc07a2e140fc60e95e
-    sha256: e9b2e7be185fa7aeeba8207f39ee9cc5f361cc455febbbe7b63126ff217be135
-  build: py311h299eb51_1
+    md5: 03a6d5a5b02ad0ae5ec84cc6d9cb757c
+    sha256: e9cb4df75971b2463645c013c4d88c74acf6f98ad2e5ac03e584975b5c393fae
+  build: py312hc405983_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   license: MIT
   license_family: MIT
-  size: 548514
-  timestamp: 1695423816927
+  size: 547702
+  timestamp: 1695423763386
 - platform: osx-arm64
   name: nh3
   version: 0.2.14
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nh3-0.2.14-py311h0563b04_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nh3-0.2.14-py312h0002256_1.conda
   hash:
-    md5: 5a8f322ffa65f7c06fd539f3851b6eba
-    sha256: 59c3cd5df65671a5ffc586a4cb89f4d1a343dcb0289437403203327947348794
-  build: py311h0563b04_1
+    md5: 3f1e6655316e5ed6124f4a4f095d2a05
+    sha256: cec13149621338e43da27aac0795326c07d1d9c2b640b42cfb2bc99c2983a9d8
+  build: py312h0002256_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   license: MIT
   license_family: MIT
-  size: 609961
-  timestamp: 1695423915817
+  size: 609888
+  timestamp: 1695423938984
 - platform: win-64
   name: nh3
   version: 0.2.14
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/win-64/nh3-0.2.14-py311h633b200_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/win-64/nh3-0.2.14-py312h426fad5_1.conda
   hash:
-    md5: b06c8f68899f0971c10c0b641d7c017e
-    sha256: 5de65e0d0dda06821f20c167de150284f337d5b34a1aa7f4ce04892b4d640022
-  build: py311h633b200_1
+    md5: 27029a8cd7698df4bd7a171a156c5f7a
+    sha256: 404739aab4d8250da13b9d59da288ac4d5843c2a9cd7976b0cd4ef8bd9be42b2
+  build: py312h426fad5_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   license: MIT
   license_family: MIT
-  size: 502204
-  timestamp: 1695424156734
+  size: 500452
+  timestamp: 1695424134011
 - platform: linux-64
   name: nodeenv
   version: 1.8.0
@@ -20766,13 +20862,13 @@ package:
   - libgcc-ng >=12
   - liblapack >=3.9.0,<4.0a0
   - libstdcxx-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.0-py311h64a7726_0.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.0-py312heda63a1_0.conda
   hash:
-    md5: bf16a9f625126e378302f08e7ed67517
-    sha256: 0aab5cef67cc2a1cd584f6e9cc6f2065c7a28c142d7defcb8096e8f719d9b3bf
-  build: py311h64a7726_0
+    md5: 9b4f35e4d83e2a8b17868b65beb438d9
+    sha256: 83c8770959c096639973dd91dae7001adf8ec4cea374c125388c22314e92cf3a
+  build: py312heda63a1_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
@@ -20780,8 +20876,8 @@ package:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 8039946
-  timestamp: 1694920380273
+  size: 7452952
+  timestamp: 1695291296202
 - platform: osx-64
   name: numpy
   version: 1.26.0
@@ -20792,13 +20888,13 @@ package:
   - libcblas >=3.9.0,<4.0a0
   - libcxx >=15.0.7
   - liblapack >=3.9.0,<4.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.0-py311hc44ba51_0.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.0-py312h5df92dc_0.conda
   hash:
-    md5: f95605c5b73f5f6a0f5f1b0aabfc2f39
-    sha256: 517cb22d5594fdb934523dd1951929961f686b5d994c684201acbf282433ec9b
-  build: py311hc44ba51_0
+    md5: aec65f472e6633e23844b555bf640a3f
+    sha256: 537ad31f441b60e6f7f8776a5b6b6a2158b051a6d423b84b6aa3bf75bed35d33
+  build: py312h5df92dc_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
@@ -20806,8 +20902,8 @@ package:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 7616817
-  timestamp: 1694920728660
+  size: 7010122
+  timestamp: 1695291869411
 - platform: osx-arm64
   name: numpy
   version: 1.26.0
@@ -20818,14 +20914,14 @@ package:
   - libcblas >=3.9.0,<4.0a0
   - libcxx >=15.0.7
   - liblapack >=3.9.0,<4.0a0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.0-py311hb8f3215_0.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.0-py312h696b312_0.conda
   hash:
-    md5: 97f8632bf2ad5c179ff68fc90c71c2ae
-    sha256: fca5ee1363f22a160c97e92d6400d4636f4b05987b08085e4f79fb6efb75fd0a
-  build: py311hb8f3215_0
+    md5: 6281cf23af141e1bc06f6c705e4cc281
+    sha256: 3cdffc4a7775a0159f4e259814dfc86e80590ddd13114468e1abe5b0bcada96a
+  build: py312h696b312_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
@@ -20833,8 +20929,8 @@ package:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 6780798
-  timestamp: 1694920700859
+  size: 6149084
+  timestamp: 1695291913048
 - platform: win-64
   name: numpy
   version: 1.26.0
@@ -20844,16 +20940,16 @@ package:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.0-py311h0b4df5a_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.0-py312h8753938_0.conda
   hash:
-    md5: a65e57fff208fd1d0f632e0afa8985d4
-    sha256: 3da6bcf524a4418d7d0dbc084c23c74e1f2fc4b19c34a5805f5e201e5d7fcd8f
-  build: py311h0b4df5a_0
+    md5: 341c2575404e3f96ea2cf78f152563dc
+    sha256: 3d61870e3ccaffee2371a4a93ddc7ee64c16df154a9dd6e5c93c8cb4b1e657ec
+  build: py312h8753938_0
   arch: x86_64
   subdir: win-64
   build_number: 0
@@ -20861,8 +20957,8 @@ package:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 7085715
-  timestamp: 1694920741486
+  size: 6454001
+  timestamp: 1695291651104
 - platform: linux-64
   name: openapi-schema-validator
   version: 0.2.3
@@ -21496,23 +21592,24 @@ package:
   dependencies:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
   - python-dateutil >=2.8.1
   - python-tzdata >=2022a
-  - python_abi 3.11.* *_cp311
+  - python_abi 3.12.* *_cp312
   - pytz >=2020.1
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.1.3-py311h320fe9a_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.1.3-py312hfb8ada1_0.conda
   hash:
-    md5: 3ea3486e16d559dfcb539070ed330a1e
-    sha256: d69759f8e5f3dcae2562e177cdfde5a45e4cd38db732301812aa558c1c80db57
-  build: py311h320fe9a_0
+    md5: ef74af58f348d62a35c58e82aef5f868
+    sha256: 9dbdcf22a8e85b5c1794e3ccba46c3c8d18a3e985da05a84387fe8f98f4a0124
+  build: py312hfb8ada1_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: BSD-3-Clause
-  size: 14913343
-  timestamp: 1699670668363
+  license_family: BSD
+  size: 14692219
+  timestamp: 1699670548374
 - platform: osx-64
   name: pandas
   version: 2.1.3
@@ -21521,23 +21618,24 @@ package:
   dependencies:
   - __osx >=10.9
   - libcxx >=16.0.6
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
   - python-dateutil >=2.8.1
   - python-tzdata >=2022a
-  - python_abi 3.11.* *_cp311
+  - python_abi 3.12.* *_cp312
   - pytz >=2020.1
-  url: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.1.3-py311h1eadf79_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.1.3-py312haf8ecfc_0.conda
   hash:
-    md5: 0a1ea4be8bcc907018694b5d04ac3036
-    sha256: 2ca591570ce60be45eae8e5d39a07f08390e9ecc18997f66cb3d712953c09724
-  build: py311h1eadf79_0
+    md5: d96a4b2b3dc4ae11f7fc8b736a12c3fb
+    sha256: de8ed7207373a5f8d5393c1a5b4478c52fb1ebcc233894205d7640131bbcdfcb
+  build: py312haf8ecfc_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: BSD-3-Clause
-  size: 14349057
-  timestamp: 1699671155233
+  license_family: BSD
+  size: 14009292
+  timestamp: 1699671183218
 - platform: osx-arm64
   name: pandas
   version: 2.1.3
@@ -21546,50 +21644,52 @@ package:
   dependencies:
   - __osx >=10.9
   - libcxx >=16.0.6
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
   - python-dateutil >=2.8.1
   - python-tzdata >=2022a
-  - python_abi 3.11.* *_cp311
+  - python_abi 3.12.* *_cp312
   - pytz >=2020.1
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.1.3-py311h6e08293_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.1.3-py312h9e53831_0.conda
   hash:
-    md5: 0d0ecc6bac2b7a4007bf4d96b125d674
-    sha256: eacddc0866e26372578fdeb5059e6f7edf4c6c8f59f494a8d5e64caa032b2600
-  build: py311h6e08293_0
+    md5: 7d6935d78f7582a78c1b57b82a538db5
+    sha256: 83aff89ff45ebec68adfad5bfec4a7f8a77b3974a60eb8ccf0a1e350b8af845c
+  build: py312h9e53831_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: BSD-3-Clause
-  size: 14268243
-  timestamp: 1699670980750
+  license_family: BSD
+  size: 13897581
+  timestamp: 1699671080166
 - platform: win-64
   name: pandas
   version: 2.1.3
   category: main
   manager: conda
   dependencies:
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
   - python-dateutil >=2.8.1
   - python-tzdata >=2022a
-  - python_abi 3.11.* *_cp311
+  - python_abi 3.12.* *_cp312
   - pytz >=2020.1
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/pandas-2.1.3-py311hf63dbb6_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pandas-2.1.3-py312h2ab9e98_0.conda
   hash:
-    md5: 8b00388ee5e71f4aa4364bf2264ee6c6
-    sha256: 998f48aedd7c01de4d9d519f9148ee90c09d0fd25221a40d7c6222e5362f73d5
-  build: py311hf63dbb6_0
+    md5: 9719f7ff92b362df61e8e6abf5886742
+    sha256: a4207972ce906f6647c48fca868116cc243c87a391307544e3a270c7edb7f317
+  build: py312h2ab9e98_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: BSD-3-Clause
-  size: 13825386
-  timestamp: 1699670895483
+  license_family: BSD
+  size: 13538431
+  timestamp: 1699670949801
 - platform: linux-64
   name: pandas-stubs
   version: 2.1.1.230928
@@ -22489,20 +22589,20 @@ package:
   - libxcb >=1.15,<1.16.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - openjpeg >=2.5.0,<3.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - tk >=8.6.13,<8.7.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.1.0-py311ha6c5da5_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.1.0-py312hf3581a9_0.conda
   hash:
-    md5: 83a988daf5c49e57f7d2086fb6781fe8
-    sha256: 5b037243f76644fe2e565aa6a3764039dba47cddf8bbef8ef01643775a459b60
-  build: py311ha6c5da5_0
+    md5: c04d3de9d831a69a5fdfab1413ec2fb6
+    sha256: b8ca07308602b12c533f09e00d1ecb75288367d1f1506e34d0f12dd7abb01726
+  build: py312hf3581a9_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: HPND
-  size: 46400469
-  timestamp: 1697423839735
+  size: 46418602
+  timestamp: 1697423804634
 - platform: osx-64
   name: pillow
   version: 10.1.0
@@ -22517,20 +22617,20 @@ package:
   - libxcb >=1.15,<1.16.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - openjpeg >=2.5.0,<3.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - tk >=8.6.13,<8.7.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.1.0-py311hea5c87a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.1.0-py312h0c70c2f_0.conda
   hash:
-    md5: ffff517d90b21a5d44ef907a5a01f695
-    sha256: 44bb951ae60cc96ab9273592ede9ee94a422857e857e52c55c261ad5f1525686
-  build: py311hea5c87a_0
+    md5: 50fc3446a464ff986aa4496e1eebf60b
+    sha256: b108b032f4ef7ddc34e12d357977c5a0eaf87ca916cc5fd9596d8ecd582820b3
+  build: py312h0c70c2f_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: HPND
-  size: 46474850
-  timestamp: 1697423945362
+  size: 45453994
+  timestamp: 1697423996936
 - platform: osx-arm64
   name: pillow
   version: 10.1.0
@@ -22545,21 +22645,21 @@ package:
   - libxcb >=1.15,<1.16.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - openjpeg >=2.5.0,<3.0a0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
   - tk >=8.6.13,<8.7.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.1.0-py311hb9c5795_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.1.0-py312hac22aec_0.conda
   hash:
-    md5: 90fd1f60da9f3d5eccdece0945043037
-    sha256: 9699ba6886e94e32eb949009195ed78c2c949f74450235af491cd4cbe390d7b4
-  build: py311hb9c5795_0
+    md5: bd269d9481143d3dda73a1c136d8844a
+    sha256: 3fa3a5a45ce000c3dc37419d38a469272984b2d5d600e5c24ea4cab192ddae97
+  build: py312hac22aec_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: HPND
-  size: 45850858
-  timestamp: 1697424033737
+  size: 47015006
+  timestamp: 1697424032123
 - platform: win-64
   name: pillow
   version: 10.1.0
@@ -22574,23 +22674,23 @@ package:
   - libxcb >=1.15,<1.16.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - openjpeg >=2.5.0,<3.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - tk >=8.6.13,<8.7.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/pillow-10.1.0-py311h4dd8a23_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pillow-10.1.0-py312he768995_0.conda
   hash:
-    md5: c03c410ca23313c36381a128737ac25f
-    sha256: 494426ecfcbf5f177b5350dfdb5ca93a529a1873247c38beda25a70ad369fe36
-  build: py311h4dd8a23_0
+    md5: 8a75d2c04292df2214c72254dcdfb90a
+    sha256: 4499a36519aace44a4c838963b78fd9a136c10a48b903ee5daa34157ab018d94
+  build: py312he768995_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: HPND
-  size: 46022436
-  timestamp: 1697424195333
+  size: 46459057
+  timestamp: 1697424191106
 - platform: linux-64
   name: pip
   version: 23.3.1
@@ -23833,252 +23933,244 @@ package:
   category: main
   manager: conda
   dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_0.conda
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_1.conda
   hash:
-    md5: ade903cbe0b4440ca6bed64932d124b5
-    sha256: 0e0257eee11d3e0b3f73566283fd6c705b1b2a5dbc7d9a609fa885519a62913e
-  build: pyhd8ed1ab_0
+    md5: 46f6be657443caffcc7201d51c07aadf
+    sha256: dca35462761fe9a06f348a0e6216a7a5934e3e29c33bc8e173fb344116568a95
+  build: pyhd8ed1ab_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
   noarch: python
-  size: 53959
-  timestamp: 1698692692135
+  size: 53871
+  timestamp: 1699962321058
 - platform: osx-64
   name: prometheus_client
   version: 0.18.0
   category: main
   manager: conda
   dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_0.conda
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_1.conda
   hash:
-    md5: ade903cbe0b4440ca6bed64932d124b5
-    sha256: 0e0257eee11d3e0b3f73566283fd6c705b1b2a5dbc7d9a609fa885519a62913e
-  build: pyhd8ed1ab_0
+    md5: 46f6be657443caffcc7201d51c07aadf
+    sha256: dca35462761fe9a06f348a0e6216a7a5934e3e29c33bc8e173fb344116568a95
+  build: pyhd8ed1ab_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
   noarch: python
-  size: 53959
-  timestamp: 1698692692135
+  size: 53871
+  timestamp: 1699962321058
 - platform: osx-arm64
   name: prometheus_client
   version: 0.18.0
   category: main
   manager: conda
   dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_0.conda
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_1.conda
   hash:
-    md5: ade903cbe0b4440ca6bed64932d124b5
-    sha256: 0e0257eee11d3e0b3f73566283fd6c705b1b2a5dbc7d9a609fa885519a62913e
-  build: pyhd8ed1ab_0
+    md5: 46f6be657443caffcc7201d51c07aadf
+    sha256: dca35462761fe9a06f348a0e6216a7a5934e3e29c33bc8e173fb344116568a95
+  build: pyhd8ed1ab_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
   noarch: python
-  size: 53959
-  timestamp: 1698692692135
+  size: 53871
+  timestamp: 1699962321058
 - platform: win-64
   name: prometheus_client
   version: 0.18.0
   category: main
   manager: conda
   dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_0.conda
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_1.conda
   hash:
-    md5: ade903cbe0b4440ca6bed64932d124b5
-    sha256: 0e0257eee11d3e0b3f73566283fd6c705b1b2a5dbc7d9a609fa885519a62913e
-  build: pyhd8ed1ab_0
+    md5: 46f6be657443caffcc7201d51c07aadf
+    sha256: dca35462761fe9a06f348a0e6216a7a5934e3e29c33bc8e173fb344116568a95
+  build: pyhd8ed1ab_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
   noarch: python
-  size: 53959
-  timestamp: 1698692692135
+  size: 53871
+  timestamp: 1699962321058
 - platform: linux-64
   name: prompt-toolkit
-  version: 3.0.39
+  version: 3.0.41
   category: main
   manager: conda
   dependencies:
   - python >=3.7
   - wcwidth
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.41-pyha770c72_0.conda
   hash:
-    md5: a4986c6bb5b0d05a38855b0880a5f425
-    sha256: 10e7fdc75d4b85633be6b12a70b857053987127a808caa0f88b2cba4b3ce6359
+    md5: f511a993aa4336bef9dd874ee3403e67
+    sha256: e26a5554883a0eada3641b6d861d8cb4895e2c7fcc17a587de07b8b1ecbfff0f
   build: pyha770c72_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   constrains:
-  - prompt_toolkit 3.0.39
+  - prompt_toolkit 3.0.41
   license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 269068
-  timestamp: 1688566090973
+  size: 269969
+  timestamp: 1699963207861
 - platform: osx-64
   name: prompt-toolkit
-  version: 3.0.39
+  version: 3.0.41
   category: main
   manager: conda
   dependencies:
   - python >=3.7
   - wcwidth
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.41-pyha770c72_0.conda
   hash:
-    md5: a4986c6bb5b0d05a38855b0880a5f425
-    sha256: 10e7fdc75d4b85633be6b12a70b857053987127a808caa0f88b2cba4b3ce6359
+    md5: f511a993aa4336bef9dd874ee3403e67
+    sha256: e26a5554883a0eada3641b6d861d8cb4895e2c7fcc17a587de07b8b1ecbfff0f
   build: pyha770c72_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   constrains:
-  - prompt_toolkit 3.0.39
+  - prompt_toolkit 3.0.41
   license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 269068
-  timestamp: 1688566090973
+  size: 269969
+  timestamp: 1699963207861
 - platform: osx-arm64
   name: prompt-toolkit
-  version: 3.0.39
+  version: 3.0.41
   category: main
   manager: conda
   dependencies:
   - python >=3.7
   - wcwidth
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.41-pyha770c72_0.conda
   hash:
-    md5: a4986c6bb5b0d05a38855b0880a5f425
-    sha256: 10e7fdc75d4b85633be6b12a70b857053987127a808caa0f88b2cba4b3ce6359
+    md5: f511a993aa4336bef9dd874ee3403e67
+    sha256: e26a5554883a0eada3641b6d861d8cb4895e2c7fcc17a587de07b8b1ecbfff0f
   build: pyha770c72_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   constrains:
-  - prompt_toolkit 3.0.39
+  - prompt_toolkit 3.0.41
   license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 269068
-  timestamp: 1688566090973
+  size: 269969
+  timestamp: 1699963207861
 - platform: win-64
   name: prompt-toolkit
-  version: 3.0.39
+  version: 3.0.41
   category: main
   manager: conda
   dependencies:
   - python >=3.7
   - wcwidth
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.41-pyha770c72_0.conda
   hash:
-    md5: a4986c6bb5b0d05a38855b0880a5f425
-    sha256: 10e7fdc75d4b85633be6b12a70b857053987127a808caa0f88b2cba4b3ce6359
+    md5: f511a993aa4336bef9dd874ee3403e67
+    sha256: e26a5554883a0eada3641b6d861d8cb4895e2c7fcc17a587de07b8b1ecbfff0f
   build: pyha770c72_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   constrains:
-  - prompt_toolkit 3.0.39
+  - prompt_toolkit 3.0.41
   license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 269068
-  timestamp: 1688566090973
+  size: 269969
+  timestamp: 1699963207861
 - platform: linux-64
   name: prompt_toolkit
-  version: 3.0.39
+  version: 3.0.41
   category: main
   manager: conda
   dependencies:
-  - prompt-toolkit >=3.0.39,<3.0.40.0a0
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+  - prompt-toolkit >=3.0.41,<3.0.42.0a0
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.41-hd8ed1ab_0.conda
   hash:
-    md5: 4bbbe67d5df19db30f04b8e344dc9976
-    sha256: 89f7fecc7355181dbc2ab851e668a2fce6aa4830b336a34c93b59bda93206270
+    md5: b1387bd091fa0420557f801a78587678
+    sha256: dd2fea25930d258159441ad4a45e5d3274f0d2f1dea92fe25b44b48c486aa969
   build: hd8ed1ab_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: BSD-3-Clause
-  license_family: BSD
   noarch: generic
-  size: 6731
-  timestamp: 1688566099039
+  size: 6704
+  timestamp: 1699963217068
 - platform: osx-64
   name: prompt_toolkit
-  version: 3.0.39
+  version: 3.0.41
   category: main
   manager: conda
   dependencies:
-  - prompt-toolkit >=3.0.39,<3.0.40.0a0
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+  - prompt-toolkit >=3.0.41,<3.0.42.0a0
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.41-hd8ed1ab_0.conda
   hash:
-    md5: 4bbbe67d5df19db30f04b8e344dc9976
-    sha256: 89f7fecc7355181dbc2ab851e668a2fce6aa4830b336a34c93b59bda93206270
+    md5: b1387bd091fa0420557f801a78587678
+    sha256: dd2fea25930d258159441ad4a45e5d3274f0d2f1dea92fe25b44b48c486aa969
   build: hd8ed1ab_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: BSD-3-Clause
-  license_family: BSD
   noarch: generic
-  size: 6731
-  timestamp: 1688566099039
+  size: 6704
+  timestamp: 1699963217068
 - platform: osx-arm64
   name: prompt_toolkit
-  version: 3.0.39
+  version: 3.0.41
   category: main
   manager: conda
   dependencies:
-  - prompt-toolkit >=3.0.39,<3.0.40.0a0
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+  - prompt-toolkit >=3.0.41,<3.0.42.0a0
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.41-hd8ed1ab_0.conda
   hash:
-    md5: 4bbbe67d5df19db30f04b8e344dc9976
-    sha256: 89f7fecc7355181dbc2ab851e668a2fce6aa4830b336a34c93b59bda93206270
+    md5: b1387bd091fa0420557f801a78587678
+    sha256: dd2fea25930d258159441ad4a45e5d3274f0d2f1dea92fe25b44b48c486aa969
   build: hd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: BSD-3-Clause
-  license_family: BSD
   noarch: generic
-  size: 6731
-  timestamp: 1688566099039
+  size: 6704
+  timestamp: 1699963217068
 - platform: win-64
   name: prompt_toolkit
-  version: 3.0.39
+  version: 3.0.41
   category: main
   manager: conda
   dependencies:
-  - prompt-toolkit >=3.0.39,<3.0.40.0a0
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
+  - prompt-toolkit >=3.0.41,<3.0.42.0a0
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.41-hd8ed1ab_0.conda
   hash:
-    md5: 4bbbe67d5df19db30f04b8e344dc9976
-    sha256: 89f7fecc7355181dbc2ab851e668a2fce6aa4830b336a34c93b59bda93206270
+    md5: b1387bd091fa0420557f801a78587678
+    sha256: dd2fea25930d258159441ad4a45e5d3274f0d2f1dea92fe25b44b48c486aa969
   build: hd8ed1ab_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: BSD-3-Clause
-  license_family: BSD
   noarch: generic
-  size: 6731
-  timestamp: 1688566099039
+  size: 6704
+  timestamp: 1699963217068
 - platform: linux-64
   name: psutil
   version: 5.9.5
@@ -24086,84 +24178,84 @@ package:
   manager: conda
   dependencies:
   - libgcc-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py311h459d7ec_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py312h98912ed_1.conda
   hash:
-    md5: 490d7fa8675afd1aa6f1b2332d156a45
-    sha256: e92d2120fc4b98fe838b3d52d4907fae97808bdd504fb84aa33aea8c4be7bc61
-  build: py311h459d7ec_1
+    md5: 2cbc379aed0482f51e7a3477e8a91ecc
+    sha256: ef5af757dd7a5f5ee97df4189937a1536b7a6f43565caaae5261c39d35d03f1e
+  build: py312h98912ed_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 498698
-  timestamp: 1695367306421
+  size: 481280
+  timestamp: 1695367314196
 - platform: osx-64
   name: psutil
   version: 5.9.5
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py311h2725bcf_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py312h104f124_1.conda
   hash:
-    md5: 16221cd0488a32152a6b3f1a301ccf19
-    sha256: 2eee900e0e5a103cff0159cdd81d401b67ccfb919be6cd868fc34c22dab981f1
-  build: py311h2725bcf_1
+    md5: 3f9a16e777cc6efcf5ef6a04492f7db4
+    sha256: 44f4472eb794c1f702a402229df7cbd246c607f3c6b69b6d643c5224ea839adf
+  build: py312h104f124_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 506611
-  timestamp: 1695367402674
+  size: 489190
+  timestamp: 1695367517429
 - platform: osx-arm64
   name: psutil
   version: 5.9.5
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py311heffc1b2_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py312h02f2b3b_1.conda
   hash:
-    md5: a40123b40642b8b08b3830a3f6bc7fd9
-    sha256: a12a525d3bcaed04e0885b2bd00f4f626c80c19d7c0ae8bb7cf7121aefb39e52
-  build: py311heffc1b2_1
+    md5: da7fbd956111473b106daf37d1a45b5f
+    sha256: 6e86f17a5a6fb6bcf48b0b3aa455b530faee306809ae6e4107ff072fccdc5c9d
+  build: py312h02f2b3b_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 506971
-  timestamp: 1695367619126
+  size: 491988
+  timestamp: 1695367619913
 - platform: win-64
   name: psutil
   version: 5.9.5
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py311ha68e1ae_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py312he70551f_1.conda
   hash:
-    md5: f64b2d9577e753fea9662dae11339ac2
-    sha256: e5c09eee9902e0c56d89f88210009b34d819d241ac5b7dde38266324a85fde51
-  build: py311ha68e1ae_1
+    md5: 631c25a1f7fed57b0ccecdde40a8707b
+    sha256: b12f26ff47a30b7af9250693943c93ae8cef502beb013b173f07746df0da942f
+  build: py312he70551f_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 516106
-  timestamp: 1695367685028
+  size: 498865
+  timestamp: 1695367605546
 - platform: linux-64
   name: pthread-stubs
   version: '0.4'
@@ -24424,32 +24516,32 @@ package:
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.1 h0406937_1_cpu
-  - libarrow-acero 14.0.1 h59595ed_1_cpu
-  - libarrow-dataset 14.0.1 h59595ed_1_cpu
-  - libarrow-flight 14.0.1 h120cb0d_1_cpu
-  - libarrow-flight-sql 14.0.1 h61ff412_1_cpu
-  - libarrow-gandiva 14.0.1 hacb8726_1_cpu
-  - libarrow-substrait 14.0.1 h61ff412_1_cpu
+  - libarrow 14.0.1 he5826ec_2_cpu
+  - libarrow-acero 14.0.1 h59595ed_2_cpu
+  - libarrow-dataset 14.0.1 h59595ed_2_cpu
+  - libarrow-flight 14.0.1 h120cb0d_2_cpu
+  - libarrow-flight-sql 14.0.1 h61ff412_2_cpu
+  - libarrow-gandiva 14.0.1 hacb8726_2_cpu
+  - libarrow-substrait 14.0.1 h61ff412_2_cpu
   - libgcc-ng >=12
-  - libparquet 14.0.1 h352af49_1_cpu
+  - libparquet 14.0.1 h352af49_2_cpu
   - libstdcxx-ng >=12
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.1-py311h39c9aba_1_cpu.conda
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.1-py312h176e3d2_2_cpu.conda
   hash:
-    md5: ee5e344d03f1fe29c52f7cc55a755ac0
-    sha256: 1846ed170dca8ad173a5e461760d0455832caa4fa630e28b98fd3c1d0360c70b
-  build: py311h39c9aba_1_cpu
+    md5: 9f119da7381c83eb1e3ba063b1b71a1e
+    sha256: e75a60df14e162d3459710e2a2226261b0e68b5e7a4666d24feb50eec8c563b8
+  build: py312h176e3d2_2_cpu
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 2
   constrains:
   - apache-arrow-proc =*=cpu
   license: Apache-2.0
-  size: 4506977
-  timestamp: 1699524233524
+  size: 4500334
+  timestamp: 1699955464738
 - platform: osx-64
   name: pyarrow
   version: 14.0.1
@@ -24457,31 +24549,31 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.9
-  - libarrow 14.0.1 hcf474e5_1_cpu
-  - libarrow-acero 14.0.1 hc222712_1_cpu
-  - libarrow-dataset 14.0.1 hc222712_1_cpu
-  - libarrow-flight 14.0.1 ha1803ca_1_cpu
-  - libarrow-flight-sql 14.0.1 h8ec153b_1_cpu
-  - libarrow-gandiva 14.0.1 heeebe7c_1_cpu
-  - libarrow-substrait 14.0.1 h8ec153b_1_cpu
+  - libarrow 14.0.1 h3b78187_2_cpu
+  - libarrow-acero 14.0.1 hc222712_2_cpu
+  - libarrow-dataset 14.0.1 hc222712_2_cpu
+  - libarrow-flight 14.0.1 h440f1c2_2_cpu
+  - libarrow-flight-sql 14.0.1 h2cc6c1c_2_cpu
+  - libarrow-gandiva 14.0.1 heeebe7c_2_cpu
+  - libarrow-substrait 14.0.1 h2cc6c1c_2_cpu
   - libcxx >=15.0.7
-  - libparquet 14.0.1 h27bd29f_1_cpu
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-14.0.1-py311h98a0319_1_cpu.conda
+  - libparquet 14.0.1 h27bd29f_2_cpu
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-14.0.1-py312h10f8022_2_cpu.conda
   hash:
-    md5: e24dad73fe9135e0109e7a8e69bfe159
-    sha256: 2ad952aeffd3b4b8339ba187982e15e74e0d126d4297e86a2b89e0f4e9aa60c5
-  build: py311h98a0319_1_cpu
+    md5: f1e14c6c9e739e025a914c3550d5f7a4
+    sha256: 5119289982d9a6d29bb441725980398c28469f87ce77fc8f300bd29e7df82a15
+  build: py312h10f8022_2_cpu
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 2
   constrains:
   - apache-arrow-proc =*=cpu
   license: Apache-2.0
-  size: 4004259
-  timestamp: 1699525854316
+  size: 3989923
+  timestamp: 1699956846474
 - platform: osx-arm64
   name: pyarrow
   version: 14.0.1
@@ -24489,65 +24581,65 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.9
-  - libarrow 14.0.1 h7bb5718_1_cpu
-  - libarrow-acero 14.0.1 had9dd58_1_cpu
-  - libarrow-dataset 14.0.1 had9dd58_1_cpu
-  - libarrow-flight 14.0.1 h1011bfc_1_cpu
-  - libarrow-flight-sql 14.0.1 h660fe36_1_cpu
-  - libarrow-gandiva 14.0.1 h2b96968_1_cpu
-  - libarrow-substrait 14.0.1 h594d712_1_cpu
+  - libarrow 14.0.1 ha4caa07_2_cpu
+  - libarrow-acero 14.0.1 had9dd58_2_cpu
+  - libarrow-dataset 14.0.1 had9dd58_2_cpu
+  - libarrow-flight 14.0.1 h1011bfc_2_cpu
+  - libarrow-flight-sql 14.0.1 h660fe36_2_cpu
+  - libarrow-gandiva 14.0.1 h2b96968_2_cpu
+  - libarrow-substrait 14.0.1 h594d712_2_cpu
   - libcxx >=15.0.7
-  - libparquet 14.0.1 heaab74a_1_cpu
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-14.0.1-py311h637fcfe_1_cpu.conda
+  - libparquet 14.0.1 heaab74a_2_cpu
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-14.0.1-py312h01ffab7_2_cpu.conda
   hash:
-    md5: 2e1207c4a320d41c7676e46f33306483
-    sha256: d674b26018f29e37d3794124c79981c295642b389b9c3a55073cdeae71d0d606
-  build: py311h637fcfe_1_cpu
+    md5: 1e4a9a50de08930ceb240a6e45d86a1b
+    sha256: e010b381684772c833af8165a0877738fb0c0bde767c9b1a9b3a264726b8ba30
+  build: py312h01ffab7_2_cpu
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 2
   constrains:
   - apache-arrow-proc =*=cpu
   license: Apache-2.0
-  size: 4073439
-  timestamp: 1699526918604
+  size: 4021545
+  timestamp: 1699957160465
 - platform: win-64
   name: pyarrow
   version: 14.0.1
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.1 h85f1704_1_cpu
-  - libarrow-acero 14.0.1 h63175ca_1_cpu
-  - libarrow-dataset 14.0.1 h63175ca_1_cpu
-  - libarrow-flight 14.0.1 h53b1db0_1_cpu
-  - libarrow-flight-sql 14.0.1 h78eab7c_1_cpu
-  - libarrow-gandiva 14.0.1 hb2eaab1_1_cpu
-  - libarrow-substrait 14.0.1 hd4c9904_1_cpu
-  - libparquet 14.0.1 h7ec3a38_1_cpu
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - libarrow 14.0.1 h0850d3a_2_cpu
+  - libarrow-acero 14.0.1 h63175ca_2_cpu
+  - libarrow-dataset 14.0.1 h63175ca_2_cpu
+  - libarrow-flight 14.0.1 h53b1db0_2_cpu
+  - libarrow-flight-sql 14.0.1 h78eab7c_2_cpu
+  - libarrow-gandiva 14.0.1 hb2eaab1_2_cpu
+  - libarrow-substrait 14.0.1 hd4c9904_2_cpu
+  - libparquet 14.0.1 h7ec3a38_2_cpu
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-14.0.1-py311h6a6099b_1_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-14.0.1-py312h85e32bb_2_cpu.conda
   hash:
-    md5: 970851b5d18431596fb0058025dbc239
-    sha256: f94c7f1b6b69d501b0014efbe4cbf0ebf25ec6438eb67161a4ad796068692003
-  build: py311h6a6099b_1_cpu
+    md5: f7a8bcc4eb06c73b7760781a65d37378
+    sha256: 78433d266bf275276c84efb408ecd3dcf82887fb8e91510d339d439f7e4a4c16
+  build: py312h85e32bb_2_cpu
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 2
   constrains:
   - apache-arrow-proc =*=cpu
   license: Apache-2.0
-  size: 3474672
-  timestamp: 1699525415355
+  size: 3404603
+  timestamp: 1699958207127
 - platform: linux-64
   name: pycparser
   version: '2.21'
@@ -24630,185 +24722,185 @@ package:
   timestamp: 1636257201998
 - platform: linux-64
   name: pydantic
-  version: 2.4.2
+  version: 2.5.0
   category: main
   manager: conda
   dependencies:
   - annotated-types >=0.4.0
-  - pydantic-core 2.10.1
+  - pydantic-core 2.14.1
   - python >=3.7
   - typing-extensions >=4.6.1
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.4.2-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.5.0-pyhd8ed1ab_0.conda
   hash:
-    md5: aad1d187156725d52e1f8ee7756c20f6
-    sha256: dc6330364f92de95a315a19e842a26605d6ca5c7d346e77811d42ad0438e32d8
-  build: pyhd8ed1ab_1
+    md5: e0c41d8a5ecffc34d6b7f2b49687c665
+    sha256: d513a539cb199ff35269d633844bed03138a2451d536fc7a9044f05c5a6c3e66
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 0
   license: MIT
   license_family: MIT
   noarch: python
-  size: 273801
-  timestamp: 1697789747756
+  size: 283055
+  timestamp: 1699947684640
 - platform: osx-64
   name: pydantic
-  version: 2.4.2
+  version: 2.5.0
   category: main
   manager: conda
   dependencies:
   - annotated-types >=0.4.0
-  - pydantic-core 2.10.1
+  - pydantic-core 2.14.1
   - python >=3.7
   - typing-extensions >=4.6.1
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.4.2-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.5.0-pyhd8ed1ab_0.conda
   hash:
-    md5: aad1d187156725d52e1f8ee7756c20f6
-    sha256: dc6330364f92de95a315a19e842a26605d6ca5c7d346e77811d42ad0438e32d8
-  build: pyhd8ed1ab_1
+    md5: e0c41d8a5ecffc34d6b7f2b49687c665
+    sha256: d513a539cb199ff35269d633844bed03138a2451d536fc7a9044f05c5a6c3e66
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 0
   license: MIT
   license_family: MIT
   noarch: python
-  size: 273801
-  timestamp: 1697789747756
+  size: 283055
+  timestamp: 1699947684640
 - platform: osx-arm64
   name: pydantic
-  version: 2.4.2
+  version: 2.5.0
   category: main
   manager: conda
   dependencies:
   - annotated-types >=0.4.0
-  - pydantic-core 2.10.1
+  - pydantic-core 2.14.1
   - python >=3.7
   - typing-extensions >=4.6.1
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.4.2-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.5.0-pyhd8ed1ab_0.conda
   hash:
-    md5: aad1d187156725d52e1f8ee7756c20f6
-    sha256: dc6330364f92de95a315a19e842a26605d6ca5c7d346e77811d42ad0438e32d8
-  build: pyhd8ed1ab_1
+    md5: e0c41d8a5ecffc34d6b7f2b49687c665
+    sha256: d513a539cb199ff35269d633844bed03138a2451d536fc7a9044f05c5a6c3e66
+  build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 0
   license: MIT
   license_family: MIT
   noarch: python
-  size: 273801
-  timestamp: 1697789747756
+  size: 283055
+  timestamp: 1699947684640
 - platform: win-64
   name: pydantic
-  version: 2.4.2
+  version: 2.5.0
   category: main
   manager: conda
   dependencies:
   - annotated-types >=0.4.0
-  - pydantic-core 2.10.1
+  - pydantic-core 2.14.1
   - python >=3.7
   - typing-extensions >=4.6.1
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.4.2-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.5.0-pyhd8ed1ab_0.conda
   hash:
-    md5: aad1d187156725d52e1f8ee7756c20f6
-    sha256: dc6330364f92de95a315a19e842a26605d6ca5c7d346e77811d42ad0438e32d8
-  build: pyhd8ed1ab_1
+    md5: e0c41d8a5ecffc34d6b7f2b49687c665
+    sha256: d513a539cb199ff35269d633844bed03138a2451d536fc7a9044f05c5a6c3e66
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 0
   license: MIT
   license_family: MIT
   noarch: python
-  size: 273801
-  timestamp: 1697789747756
+  size: 283055
+  timestamp: 1699947684640
 - platform: linux-64
   name: pydantic-core
-  version: 2.10.1
+  version: 2.14.1
   category: main
   manager: conda
   dependencies:
   - libgcc-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - typing-extensions >=4.6.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.10.1-py311h46250e7_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.14.1-py312h4b3b743_0.conda
   hash:
-    md5: 36ee4237f8f9f97adb057974e8fee4c5
-    sha256: 871ec291dd2be9a38768c63ac94f3f959a9084aa75dd09b5657fc1c6a7a73e2f
-  build: py311h46250e7_0
+    md5: 4224110962fc21296eee49cbac258041
+    sha256: 3acbcaa8d76563c918d4bc61002939b178e4c56aef0b534c6fb38144025c45da
+  build: py312h4b3b743_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 1591970
-  timestamp: 1695733315193
+  size: 1598329
+  timestamp: 1699546546860
 - platform: osx-64
   name: pydantic-core
-  version: 2.10.1
+  version: 2.14.1
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - typing-extensions >=4.6.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.10.1-py311h299eb51_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.14.1-py312h6e28e45_0.conda
   hash:
-    md5: 580ad4783a19b4d9ec0640dc4d81f28e
-    sha256: 56fc2f264b078de740ae087fee48b9d32eb045da5676a2d4ef085080c243e727
-  build: py311h299eb51_0
+    md5: 3904e69387bec987ff4816268332714a
+    sha256: 8ad92a96b106ea6c7fd3666bb38e84bac6aa09abbc47b46ae2b54326c6bbd71d
+  build: py312h6e28e45_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 1494311
-  timestamp: 1695733841693
+  size: 1512982
+  timestamp: 1699546762612
 - platform: osx-arm64
   name: pydantic-core
-  version: 2.10.1
+  version: 2.14.1
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
   - typing-extensions >=4.6.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.10.1-py311h0563b04_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.14.1-py312h5280bc4_0.conda
   hash:
-    md5: 2aebd3db2e26ea6f0925f33677f91073
-    sha256: fbeb2fa52c11a48e925a72c847931f826eacb9a0abcbe4cca2c8da976f28641a
-  build: py311h0563b04_0
+    md5: 5a4048da8e007e085a0d4021d10e749b
+    sha256: 3e8b6135f7ee05c3f9e6f529c997989b11426cc13651641d635e49a3debf498c
+  build: py312h5280bc4_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 1404989
-  timestamp: 1695733821422
+  size: 1415842
+  timestamp: 1699546966200
 - platform: win-64
   name: pydantic-core
-  version: 2.10.1
+  version: 2.14.1
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - typing-extensions >=4.6.0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.10.1-py311hc37eb10_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.14.1-py312hfccd98a_0.conda
   hash:
-    md5: 03f6bd3dfa06738a8b1d23c34bd80395
-    sha256: 0434aa3f7dc0f9bb9ec31f91398d10a1f73fa23fa05fb5052f483a6a3a20d19d
-  build: py311hc37eb10_0
+    md5: 93099761407467630aa6bcb49e275b12
+    sha256: 15d548eff2ec2bf19d3b8625325f29b3dcab485db6d451ce08d3d9c64e9f419f
+  build: py312hfccd98a_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 1577312
-  timestamp: 1695734312960
+  size: 1606597
+  timestamp: 1699547480840
 - platform: linux-64
   name: pygments
   version: 2.16.1
@@ -24896,21 +24988,21 @@ package:
   manager: conda
   dependencies:
   - libffi >=3.4,<4.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - setuptools
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.0-py311hf110eff_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.0-py312h6b66c34_0.conda
   hash:
-    md5: d26705887703d13c655a6098516e06e2
-    sha256: 031b8c48866f1f97a4a12d6a3ea0dc94cb6a735918871460b26f4779f5a01125
-  build: py311hf110eff_0
+    md5: fd7c92dee0538319e99bdcc0fd42ba47
+    sha256: 04249ee7fb56bfa49999d285eeeb78ec8a946c7883955c2d4c327f5af5501327
+  build: py312h6b66c34_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 465753
-  timestamp: 1695560684232
+  size: 466428
+  timestamp: 1695560687687
 - platform: osx-arm64
   name: pyobjc-core
   version: '10.0'
@@ -24918,22 +25010,22 @@ package:
   manager: conda
   dependencies:
   - libffi >=3.4,<4.0a0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
   - setuptools
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.0-py311hb702dc4_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.0-py312h6168cce_0.conda
   hash:
-    md5: 5c441ab09e2d9faf6e875ea9c446b445
-    sha256: d3bb68f8da77bffad5fa690d2cc1aeb0be0608ed0b6e08a96d8fc3613f2e7135
-  build: py311hb702dc4_0
+    md5: cf98c421b2a25646ba0690eaabd47cde
+    sha256: 61fe85421c029cb229743703c34663dc6bd1ea789a45d250cbf45ff44d41bab7
+  build: py312h6168cce_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 473740
-  timestamp: 1695560759149
+  size: 473326
+  timestamp: 1695560768775
 - platform: osx-64
   name: pyobjc-framework-cocoa
   version: '10.0'
@@ -24942,20 +25034,20 @@ package:
   dependencies:
   - libffi >=3.4,<4.0a0
   - pyobjc-core 10.0.*
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.0-py311hf110eff_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.0-py312h6b66c34_1.conda
   hash:
-    md5: 8fb67274a648901045368717d6221aed
-    sha256: 54530c1b3bfc361e027adbd8f9d9a23e7c102c7f58c04a169da1457f82975724
-  build: py311hf110eff_1
+    md5: ea11ff8f5de0a351043b2fb412ec890c
+    sha256: 928d72e7754f2671801bf8e080189ec4d30a36b4edac79d3ae4d07af8aecdd98
+  build: py312h6b66c34_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   license: MIT
   license_family: MIT
-  size: 369966
-  timestamp: 1695716863742
+  size: 365872
+  timestamp: 1695716725136
 - platform: osx-arm64
   name: pyobjc-framework-cocoa
   version: '10.0'
@@ -24964,21 +25056,21 @@ package:
   dependencies:
   - libffi >=3.4,<4.0a0
   - pyobjc-core 10.0.*
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.0-py311hb702dc4_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.0-py312h6168cce_1.conda
   hash:
-    md5: ee9430e4e9b69a6270c966bb7439c9a0
-    sha256: 31a7542b8ced5cb3bc236be0b5777dab4bc0e57fbfc5423e9d0ae09ce8eae16c
-  build: py311hb702dc4_1
+    md5: 9f644d7ce8ea243551387746b7ee6918
+    sha256: e0e2d8103a5c8d575fef6dad97bec72a7cb06f3053982dc8328dca95672f6b18
+  build: py312h6168cce_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   license: MIT
   license_family: MIT
-  size: 374853
-  timestamp: 1695717128436
+  size: 369650
+  timestamp: 1695716991307
 - platform: linux-64
   name: pyogrio
   version: 0.7.2
@@ -24989,22 +25081,22 @@ package:
   - libgcc-ng >=12
   - libgdal >=3.7.2,<3.8.0a0
   - libstdcxx-ng >=12
-  - numpy >=1.23.5,<2.0a0
+  - numpy >=1.26.0,<2.0a0
   - packaging
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.7.2-py311hbac4ec9_0.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.7.2-py312hc770a3a_0.conda
   hash:
-    md5: 32ece393a98d3c626b4df46b33f7e6ec
-    sha256: 52508f64db7cdd9fc25cfcb754d1297bfeef1440894dc2d78b5e8963315a733d
-  build: py311hbac4ec9_0
+    md5: 3e1da726cc25f1005c0544af09f0ec3e
+    sha256: fa2ada5c57c160265f7856f7fbc1b19d7e600490f48ddae9b2c0b46b911f965c
+  build: py312hc770a3a_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 664732
-  timestamp: 1698734484198
+  size: 655552
+  timestamp: 1698734508344
 - platform: osx-64
   name: pyogrio
   version: 0.7.2
@@ -25015,22 +25107,22 @@ package:
   - gdal
   - libcxx >=16.0.6
   - libgdal >=3.7.2,<3.8.0a0
-  - numpy >=1.23.5,<2.0a0
+  - numpy >=1.26.0,<2.0a0
   - packaging
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.7.2-py311hf14a637_0.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.7.2-py312h8683509_0.conda
   hash:
-    md5: ee6ca8be940a54acc542d1b17dcde540
-    sha256: 93b86410bafb37404e516f5c3606f00e6b5ce634458c6e7f367e53fcb9be8f8a
-  build: py311hf14a637_0
+    md5: 61c7d2e07f9e42af53c8fd1912b7924f
+    sha256: 85220c4a062382a0db46c134e4de4cfb6784ac9fd3bd58c92e50072f8ae18dda
+  build: py312h8683509_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 605372
-  timestamp: 1698734743438
+  size: 598303
+  timestamp: 1698734652389
 - platform: osx-arm64
   name: pyogrio
   version: 0.7.2
@@ -25041,23 +25133,23 @@ package:
   - gdal
   - libcxx >=16.0.6
   - libgdal >=3.7.2,<3.8.0a0
-  - numpy >=1.23.5,<2.0a0
+  - numpy >=1.26.0,<2.0a0
   - packaging
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.7.2-py311h45231e3_0.conda
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.7.2-py312h0aea21f_0.conda
   hash:
-    md5: b4b270c5ebd3d712e08d84cd6bfbb470
-    sha256: 1d1cfb64c4fbb8b14c07036dea51632c4725f7be57f79078bd5c38a1bf5cad3b
-  build: py311h45231e3_0
+    md5: 921fc2177aa488e424c05e2d6601e1b9
+    sha256: f92bbee9dee5a51ab8243ff748dfe4774df2f554816134e4c55da552f2c6e629
+  build: py312h0aea21f_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 602571
-  timestamp: 1698734769702
+  size: 594481
+  timestamp: 1698734869641
 - platform: win-64
   name: pyogrio
   version: 0.7.2
@@ -25066,25 +25158,25 @@ package:
   dependencies:
   - gdal
   - libgdal >=3.7.2,<3.8.0a0
-  - numpy >=1.23.5,<2.0a0
+  - numpy >=1.26.0,<2.0a0
   - packaging
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.7.2-py311h03c997e_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.7.2-py312h49f85ea_0.conda
   hash:
-    md5: db81e56ad811acd096a598b649a7b903
-    sha256: 0d71c1a53f4852fca8f589d7c1b62090d11748fe8af95e8b659f4fa8036d3868
-  build: py311h03c997e_0
+    md5: 2318c526be2b57edf6bda6bdf7be9078
+    sha256: 40dc1bfd5f5ba41a32ea999f00380a2b2c8b5906b712859b458faf8eeb35d32d
+  build: py312h49f85ea_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 822552
-  timestamp: 1698735262251
+  size: 811158
+  timestamp: 1698734946689
 - platform: linux-64
   name: pyparsing
   version: 3.1.1
@@ -25174,20 +25266,20 @@ package:
   - certifi
   - libgcc-ng >=12
   - proj >=9.3.0,<9.3.1.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.6.1-py311h1facc83_4.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.6.1-py312hb113631_4.conda
   hash:
-    md5: 75d504c6787edc377ebdba087a26a61b
-    sha256: 4eb94c421b5c635b770e5fbd2774cf1dd4570ad69baf1c248f978943df352896
-  build: py311h1facc83_4
+    md5: fb0591cebf692e8e9829f23cfe0ee383
+    sha256: 3b64c77aa430110cb3c6c4756295391bf25c9b9ddd4770127415ca8997a54c57
+  build: py312hb113631_4
   arch: x86_64
   subdir: linux-64
   build_number: 4
   license: MIT
   license_family: MIT
-  size: 551801
-  timestamp: 1699268320734
+  size: 544184
+  timestamp: 1699268227404
 - platform: osx-64
   name: pyproj
   version: 3.6.1
@@ -25196,20 +25288,20 @@ package:
   dependencies:
   - certifi
   - proj >=9.3.0,<9.3.1.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py311he36daed_4.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyproj-3.6.1-py312h2025670_4.conda
   hash:
-    md5: 28930c73c9c05d44d053620d44397b79
-    sha256: d1d44bb257545006b128d30b4454c42e3f7cd133a1c53998afcf7253529f8263
-  build: py311he36daed_4
+    md5: b2130ed2a4d54577ef35626423f3b232
+    sha256: ada9be924df0f25d091b9a63594620431b0184c1594c0f9911b6048c3d8391a5
+  build: py312h2025670_4
   arch: x86_64
   subdir: osx-64
   build_number: 4
   license: MIT
   license_family: MIT
-  size: 488697
-  timestamp: 1699268417495
+  size: 482498
+  timestamp: 1699268544482
 - platform: osx-arm64
   name: pyproj
   version: 3.6.1
@@ -25218,21 +25310,21 @@ package:
   dependencies:
   - certifi
   - proj >=9.3.0,<9.3.1.0a0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.6.1-py311h20a9b75_4.conda
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.6.1-py312h33684bb_4.conda
   hash:
-    md5: c55fab7aa4252057e5e5efa90bd10cbe
-    sha256: 9d9923063e21aac5831b3dca820be3a824366f6871c839ea545f9b5e7358c844
-  build: py311h20a9b75_4
+    md5: 4bfc7162ce21ab011422b2c7a80eb39b
+    sha256: 49da8ca06968a4f4fe6f480709cb3fd346f0cf59f6bb5815e5bbc46d4f46ba34
+  build: py312h33684bb_4
   arch: aarch64
   subdir: osx-arm64
   build_number: 4
   license: MIT
   license_family: MIT
-  size: 493085
-  timestamp: 1699268531169
+  size: 487092
+  timestamp: 1699268630477
 - platform: win-64
   name: pyproj
   version: 3.6.1
@@ -25241,23 +25333,23 @@ package:
   dependencies:
   - certifi
   - proj >=9.3.0,<9.3.1.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.6.1-py311h517f58c_4.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.6.1-py312hb4fa1d0_4.conda
   hash:
-    md5: dae3c70f429ba572c615a54571904a55
-    sha256: 084f0685616b53903238d941611cfdfe6ba49650307220a78ec9f7d9d89c0056
-  build: py311h517f58c_4
+    md5: 721dac746d22ed44e6499ec24ce2b241
+    sha256: 5edc111864819a114853c3a5e74a3208cac6ad6846b2601d6f72fe0a075a6e2a
+  build: py312hb4fa1d0_4
   arch: x86_64
   subdir: win-64
   build_number: 4
   license: MIT
   license_family: MIT
-  size: 737448
-  timestamp: 1699268741548
+  size: 725079
+  timestamp: 1699268689992
 - platform: linux-64
   name: pyqt
   version: 5.15.9
@@ -25266,49 +25358,49 @@ package:
   dependencies:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - pyqt5-sip 12.12.2 py311hb755f60_5
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - pyqt5-sip 12.12.2 py312h30efb56_5
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - qt-main >=5.15.8,<5.16.0a0
   - sip >=6.7.11,<6.8.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.9-py311hf0fb5b6_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.9-py312h949fe66_5.conda
   hash:
-    md5: ec7e45bc76d9d0b69a74a2075932b8e8
-    sha256: 74fcdb8772c7eaf654b32922f77d9a8a1350b3446111c69a32ba4d15be74905a
-  build: py311hf0fb5b6_5
+    md5: f6548a564e2d01b2a42020259503945b
+    sha256: 22ccc59c03872fc680be597a1783d2c77e6b2d16953e2ec67df91f073820bebe
+  build: py312h949fe66_5
   arch: x86_64
   subdir: linux-64
   build_number: 5
   license: GPL-3.0-only
   license_family: GPL
-  size: 5315719
-  timestamp: 1695420475603
+  size: 5263946
+  timestamp: 1695421350577
 - platform: win-64
   name: pyqt
   version: 5.15.9
   category: main
   manager: conda
   dependencies:
-  - pyqt5-sip 12.12.2 py311h12c1d0e_5
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - pyqt5-sip 12.12.2 py312h53d5487_5
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - qt-main >=5.15.8,<5.16.0a0
   - sip >=6.7.11,<6.8.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.9-py311h125bc19_5.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.9-py312he09f080_5.conda
   hash:
-    md5: 29d36acae7ccbcb1f0ec4a39841b3197
-    sha256: 4608b9caafc4fa16d887f5af08e1bafe95f4cb07596ca8f5af184bf5de8f2c4c
-  build: py311h125bc19_5
+    md5: fb0861092c40e5d054e984abd88e5ea8
+    sha256: c524cafaf98661f3bd5819494b41563fe5a851f6e44a7d08631c99f1dfb961c7
+  build: py312he09f080_5
   arch: x86_64
   subdir: win-64
   build_number: 5
   license: GPL-3.0-only
   license_family: GPL
-  size: 3906427
-  timestamp: 1695422270104
+  size: 3894083
+  timestamp: 1695421066159
 - platform: linux-64
   name: pyqt5-sip
   version: 12.12.2
@@ -25318,22 +25410,22 @@ package:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - packaging
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - sip
   - toml
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.12.2-py311hb755f60_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.12.2-py312h30efb56_5.conda
   hash:
-    md5: e4d262cc3600e70b505a6761d29f6207
-    sha256: cf6936273d92e5213b085bfd9ce1a37defb46b317b6ee991f2712bf4a25b8456
-  build: py311hb755f60_5
+    md5: 8a2a122dc4fe14d8cff38f1cf426381f
+    sha256: c7154e1933360881b99687d580c4b941fb0cc6ad9574762d409a28196ef5e240
+  build: py312h30efb56_5
   arch: x86_64
   subdir: linux-64
   build_number: 5
   license: GPL-3.0-only
   license_family: GPL
-  size: 85162
-  timestamp: 1695418076285
+  size: 85809
+  timestamp: 1695418132533
 - platform: win-64
   name: pyqt5-sip
   version: 12.12.2
@@ -25341,110 +25433,25 @@ package:
   manager: conda
   dependencies:
   - packaging
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - sip
   - toml
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.12.2-py311h12c1d0e_5.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.12.2-py312h53d5487_5.conda
   hash:
-    md5: 1b53a20f311bd99a1e55b31b7219106f
-    sha256: 7130493794e4c65f4e78258619a6ef9d022ba9f9b0f61e70d2973d9bc5f10e11
-  build: py311h12c1d0e_5
+    md5: dbaa69d84f7da6ac3ec20de2a9529a4b
+    sha256: 56242d5203e7231ee5bdd25df417dfc60a4f38e335f922f7e00f8c518ba87bd1
+  build: py312h53d5487_5
   arch: x86_64
   subdir: win-64
   build_number: 5
   license: GPL-3.0-only
   license_family: GPL
-  size: 79724
-  timestamp: 1695418442619
-- platform: linux-64
-  name: pyrsistent
-  version: 0.20.0
-  category: main
-  manager: conda
-  dependencies:
-  - libgcc-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyrsistent-0.20.0-py311h459d7ec_0.conda
-  hash:
-    md5: f0bf96e61d58d4908a2f4ca68edde998
-    sha256: d38086adb82427e87b68c5131fbbbaa70cd11fbdb9ed9b4e4ad7f327e0ad028a
-  build: py311h459d7ec_0
-  arch: x86_64
-  subdir: linux-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 124761
-  timestamp: 1698754143681
-- platform: osx-64
-  name: pyrsistent
-  version: 0.20.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyrsistent-0.20.0-py311he705e18_0.conda
-  hash:
-    md5: f6b9d6f39bc3532e6ba449c06a47bbbc
-    sha256: 46f9daac23a122aaeb55628199e2519fe84dc221a497605e246a5be273631e7e
-  build: py311he705e18_0
-  arch: x86_64
-  subdir: osx-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 122492
-  timestamp: 1698754197864
-- platform: osx-arm64
-  name: pyrsistent
-  version: 0.20.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyrsistent-0.20.0-py311h05b510d_0.conda
-  hash:
-    md5: 332853e9bff566a413f1dc1c3d6e19a7
-    sha256: 724a65a47a32aca2967e7bbfb3178c6bf24bddba8fe0b3db8fa0efdaef754e69
-  build: py311h05b510d_0
-  arch: aarch64
-  subdir: osx-arm64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 123370
-  timestamp: 1698754370383
-- platform: win-64
-  name: pyrsistent
-  version: 0.20.0
-  category: main
-  manager: conda
-  dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/pyrsistent-0.20.0-py311ha68e1ae_0.conda
-  hash:
-    md5: 714feda9c353fa1ced16f11dc1fbf62a
-    sha256: 5851aea7ab4cf9d4535aeb2fd0941eddc7a9e9907e61857a1668a8ffb87c7791
-  build: py311ha68e1ae_0
-  arch: x86_64
-  subdir: win-64
-  build_number: 0
-  license: MIT
-  license_family: MIT
-  size: 117865
-  timestamp: 1698754395322
+  size: 79366
+  timestamp: 1695418564486
 - platform: linux-64
   name: pysnooper
   version: 1.2.0
@@ -25816,17 +25823,17 @@ package:
   timestamp: 1684965001294
 - platform: linux-64
   name: pytest-xdist
-  version: 3.3.1
+  version: 3.4.0
   category: main
   manager: conda
   dependencies:
   - execnet >=1.1
   - pytest >=6.2.0
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.3.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 816073bb54ef59f33f0f26c14f88311b
-    sha256: 5df2d0f1e42041476cbdf12b808890d668e7f0272b51f0f3fa7aab84732150b6
+    md5: b8dc6f9db1b9670e564b68277a79ffeb
+    sha256: b835170885a0d2b4bfdc7bc5d09e5a175518f41b6ffa1a0ac891797cd94e3292
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -25836,21 +25843,21 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 36169
-  timestamp: 1684499962909
+  size: 36371
+  timestamp: 1699728992127
 - platform: osx-64
   name: pytest-xdist
-  version: 3.3.1
+  version: 3.4.0
   category: main
   manager: conda
   dependencies:
   - execnet >=1.1
   - pytest >=6.2.0
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.3.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 816073bb54ef59f33f0f26c14f88311b
-    sha256: 5df2d0f1e42041476cbdf12b808890d668e7f0272b51f0f3fa7aab84732150b6
+    md5: b8dc6f9db1b9670e564b68277a79ffeb
+    sha256: b835170885a0d2b4bfdc7bc5d09e5a175518f41b6ffa1a0ac891797cd94e3292
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -25860,21 +25867,21 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 36169
-  timestamp: 1684499962909
+  size: 36371
+  timestamp: 1699728992127
 - platform: osx-arm64
   name: pytest-xdist
-  version: 3.3.1
+  version: 3.4.0
   category: main
   manager: conda
   dependencies:
   - execnet >=1.1
   - pytest >=6.2.0
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.3.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 816073bb54ef59f33f0f26c14f88311b
-    sha256: 5df2d0f1e42041476cbdf12b808890d668e7f0272b51f0f3fa7aab84732150b6
+    md5: b8dc6f9db1b9670e564b68277a79ffeb
+    sha256: b835170885a0d2b4bfdc7bc5d09e5a175518f41b6ffa1a0ac891797cd94e3292
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -25884,21 +25891,21 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 36169
-  timestamp: 1684499962909
+  size: 36371
+  timestamp: 1699728992127
 - platform: win-64
   name: pytest-xdist
-  version: 3.3.1
+  version: 3.4.0
   category: main
   manager: conda
   dependencies:
   - execnet >=1.1
   - pytest >=6.2.0
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.3.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 816073bb54ef59f33f0f26c14f88311b
-    sha256: 5df2d0f1e42041476cbdf12b808890d668e7f0272b51f0f3fa7aab84732150b6
+    md5: b8dc6f9db1b9670e564b68277a79ffeb
+    sha256: b835170885a0d2b4bfdc7bc5d09e5a175518f41b6ffa1a0ac891797cd94e3292
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -25908,11 +25915,11 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 36169
-  timestamp: 1684499962909
+  size: 36371
+  timestamp: 1699728992127
 - platform: linux-64
   name: python
-  version: 3.11.6
+  version: 3.12.0
   category: main
   manager: conda
   dependencies:
@@ -25931,22 +25938,22 @@ package:
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.6-hab00c5b_0_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0_cpython.conda
   hash:
-    md5: b0dfbe2fcbfdb097d321bfd50ecddab1
-    sha256: 84f13bd70cff5dcdaee19263b2d4291d5793856a718efc1b63a9cfa9eb6e2ca1
+    md5: 7f97faab5bebcc2580f4f299285323da
+    sha256: 5398ebae6a1ccbfd3f76361eac75f3ac071527a8072627c4bf9008c689034f48
   build: hab00c5b_0_cpython
   arch: x86_64
   subdir: linux-64
   build_number: 0
   constrains:
-  - python_abi 3.11.* *_cp311
+  - python_abi 3.12.* *_cp312
   license: Python-2.0
-  size: 30720625
-  timestamp: 1696331287478
+  size: 32123473
+  timestamp: 1696324522323
 - platform: osx-64
   name: python
-  version: 3.11.6
+  version: 3.12.0
   category: main
   manager: conda
   dependencies:
@@ -25961,22 +25968,22 @@ package:
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.6-h30d4d87_0_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.0-h30d4d87_0_cpython.conda
   hash:
-    md5: 4d66c5fc01e9be526afe5d828d4de24d
-    sha256: e3ed331204fbeb03a9a2c2fa834e74997ad4f732ba2124b36f327d38b0cded93
+    md5: d11dc8f4551011fb6baa2865f1ead48f
+    sha256: 0a1ed3983acbd0528bef5216179e46170f024f4409032875b27865568fef46a1
   build: h30d4d87_0_cpython
   arch: x86_64
   subdir: osx-64
   build_number: 0
   constrains:
-  - python_abi 3.11.* *_cp311
+  - python_abi 3.12.* *_cp312
   license: Python-2.0
-  size: 15393521
-  timestamp: 1696330855485
+  size: 14529683
+  timestamp: 1696323482650
 - platform: osx-arm64
   name: python
-  version: 3.11.6
+  version: 3.12.0
   category: main
   manager: conda
   dependencies:
@@ -25991,22 +25998,22 @@ package:
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.6-h47c9636_0_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0_cpython.conda
   hash:
-    md5: 2271df1db9534f5cac7c2d0820c3359d
-    sha256: 77054fa9a8fc30f71a18f599ee2897905a3c515202b614fa0f793add7a04a155
+    md5: ed8ae98b1b510de68392971b9367d18c
+    sha256: eb66f8f249caa9d5a956c3a407f079e4779d652ebfc2a4b4f50dcea078e84fa8
   build: h47c9636_0_cpython
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   constrains:
-  - python_abi 3.11.* *_cp311
+  - python_abi 3.12.* *_cp312
   license: Python-2.0
-  size: 14626958
-  timestamp: 1696329727433
+  size: 13306758
+  timestamp: 1696322682581
 - platform: win-64
   name: python
-  version: 3.11.6
+  version: 3.12.0
   category: main
   manager: conda
   dependencies:
@@ -26022,19 +26029,19 @@ package:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - xz >=5.2.6,<6.0a0
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.11.6-h2628c8c_0_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda
   hash:
-    md5: 80b761856b20383615a3fe8b1b13eef8
-    sha256: 7fb38fda8296b2651ef727bb57603f0952c07fc533b172044395744a2641a00a
+    md5: defd5d375853a2caff36a19d2d81a28e
+    sha256: 90553586879bf328f2f9efb8d8faa958ecba822faf379f0a20c3461467b9b955
   build: h2628c8c_0_cpython
   arch: x86_64
   subdir: win-64
   build_number: 0
   constrains:
-  - python_abi 3.11.* *_cp311
+  - python_abi 3.12.* *_cp312
   license: Python-2.0
-  size: 18121128
-  timestamp: 1696329396864
+  size: 16140836
+  timestamp: 1696321871976
 - platform: linux-64
   name: python-dateutil
   version: 2.8.2
@@ -26361,84 +26368,84 @@ package:
   timestamp: 1680081272948
 - platform: linux-64
   name: python_abi
-  version: '3.11'
+  version: '3.12'
   category: main
   manager: conda
   dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-4_cp312.conda
   hash:
-    md5: d786502c97404c94d7d58d258a445a65
-    sha256: 0be3ac1bf852d64f553220c7e6457e9c047dfb7412da9d22fbaa67e60858b3cf
-  build: 4_cp311
+    md5: dccc2d142812964fcc6abdc97b672dff
+    sha256: 182a329de10a4165f6e8a3804caf751f918f6ea6176dd4e5abcdae1ed3095bf6
+  build: 4_cp312
   arch: x86_64
   subdir: linux-64
   build_number: 4
   constrains:
-  - python 3.11.* *_cpython
+  - python 3.12.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
   size: 6385
-  timestamp: 1695147338551
+  timestamp: 1695147396604
 - platform: osx-64
   name: python_abi
-  version: '3.11'
+  version: '3.12'
   category: main
   manager: conda
   dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-4_cp311.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-4_cp312.conda
   hash:
-    md5: fef7a52f0eca6bae9e8e2e255bc86394
-    sha256: f56dfe2a57b3b27bad3f9527f943548e8b2526e949d9d6fc0a383020d9359afe
-  build: 4_cp311
+    md5: 87201ac4314b911b74197e588cca3639
+    sha256: 82c154d95c1637604671a02a89e72f1382e89a4269265a03506496bd928f6f14
+  build: 4_cp312
   arch: x86_64
   subdir: osx-64
   build_number: 4
   constrains:
-  - python 3.11.* *_cpython
+  - python 3.12.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6478
-  timestamp: 1695147518012
+  size: 6496
+  timestamp: 1695147498447
 - platform: osx-arm64
   name: python_abi
-  version: '3.11'
+  version: '3.12'
   category: main
   manager: conda
   dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-4_cp311.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-4_cp312.conda
   hash:
-    md5: 8d3751bc73d3bbb66f216fa2331d5649
-    sha256: 4837089c477b9b84fa38a17f453e6634e68237267211b27a8a2f5ccd847f4e55
-  build: 4_cp311
+    md5: bbb3a02c78b2d8219d7213f76d644a2a
+    sha256: db25428e4f24f8693ffa39f3ff6dfbb8fd53bc298764b775b57edab1c697560f
+  build: 4_cp312
   arch: aarch64
   subdir: osx-arm64
   build_number: 4
   constrains:
-  - python 3.11.* *_cpython
+  - python 3.12.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6492
-  timestamp: 1695147509940
+  size: 6508
+  timestamp: 1695147497048
 - platform: win-64
   name: python_abi
-  version: '3.11'
+  version: '3.12'
   category: main
   manager: conda
   dependencies: []
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-4_cp311.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-4_cp312.conda
   hash:
-    md5: 70513332c71b56eace4ee6441e66c012
-    sha256: 67c2aade3e2160642eec0742384e766b20c766055e3d99335681e3e05d88ed7b
-  build: 4_cp311
+    md5: 17f4ccf6be9ded08bd0a376f489ac1a6
+    sha256: 488f8519d04b48f59bd6fde21ebe2d7a527718ff28aac86a8b53aa63658bdef6
+  build: 4_cp312
   arch: x86_64
   subdir: win-64
   build_number: 4
   constrains:
-  - python 3.11.* *_cpython
+  - python 3.12.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6755
-  timestamp: 1695147711935
+  size: 6785
+  timestamp: 1695147430513
 - platform: linux-64
   name: pytz
   version: 2023.3.post1
@@ -26525,67 +26532,67 @@ package:
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py311h12c1d0e_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py312h53d5487_2.conda
   hash:
-    md5: 25df0fc55722ea1a94494f41302e2d1c
-    sha256: 79d942817bdaf384602113e5fcb9158dc45cae4044bed308918a5db97f141fdb
-  build: py311h12c1d0e_2
+    md5: f44c8f35c3f99eca30d6f5b68ddb0f42
+    sha256: d0ff1cd887b626a125f8323760736d8fab496bf2a400e825cce55361e7631264
+  build: py312h53d5487_2
   arch: x86_64
   subdir: win-64
   build_number: 2
   license: PSF-2.0
   license_family: PSF
-  size: 6124285
-  timestamp: 1695974706892
+  size: 6127499
+  timestamp: 1695974557413
 - platform: win-64
   name: pywin32-ctypes
   version: 0.2.2
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-ctypes-0.2.2-py311h1ea47a8_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-ctypes-0.2.2-py312h2e8e312_1.conda
   hash:
-    md5: e1270294a55b716f9b76900340e8fc82
-    sha256: 75a80bda3a87ae9387e8860be7a5271a67846d8929fe8c99799ed40eb085130a
-  build: py311h1ea47a8_1
+    md5: 93a37178188cd6521e5410763a18aaf4
+    sha256: 238fffa911c4b78fd2153cfd1d0d376326379c98821da4b0cd12a3c6fbf3e9a6
+  build: py312h2e8e312_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 57331
-  timestamp: 1695395348158
+  size: 55871
+  timestamp: 1695395307212
 - platform: win-64
   name: pywinpty
   version: 2.0.12
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - winpty
-  url: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.12-py311h12c1d0e_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.12-py312h53d5487_0.conda
   hash:
-    md5: 6561b01d9a25270af769d3defd007cc5
-    sha256: 611a59e4b078054ca8cf49e6fd18509345e5d3b1fc79d464dfe584d35a93e933
-  build: py311h12c1d0e_0
+    md5: 9d6df56b1b0e5ba19160932e6bac356f
+    sha256: d7ed8a8a798a4c43581cefa370d91b90aff2a279d0256c4b04331a4e357c3625
+  build: py312h53d5487_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 220505
-  timestamp: 1696657577118
+  size: 219627
+  timestamp: 1696657555549
 - platform: linux-64
   name: pyyaml
   version: 6.0.1
@@ -26593,88 +26600,88 @@ package:
   manager: conda
   dependencies:
   - libgcc-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - yaml >=0.2.5,<0.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py311h459d7ec_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py312h98912ed_1.conda
   hash:
-    md5: 52719a74ad130de8fb5d047dc91f247a
-    sha256: 28729ef1ffa7f6f9dfd54345a47c7faac5d34296d66a2b9891fb147f4efe1348
-  build: py311h459d7ec_1
+    md5: e3fd78d8d490af1d84763b9fe3f2e552
+    sha256: 7f347a10a7121b08d79d21cd4f438c07c23479ea0c74dfb89d6dc416f791bb7f
+  build: py312h98912ed_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   license: MIT
   license_family: MIT
-  size: 200626
-  timestamp: 1695373818537
+  size: 196583
+  timestamp: 1695373632212
 - platform: osx-64
   name: pyyaml
   version: 6.0.1
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - yaml >=0.2.5,<0.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py311h2725bcf_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py312h104f124_1.conda
   hash:
-    md5: 9283f991b5e5856a99f8aabba9927df5
-    sha256: 8ce2ba443414170a2570514d0ce6d03625a847e91af9763d48dc58c338e6f7f3
-  build: py311h2725bcf_1
+    md5: 260ed90aaf06061edabd7209638cf03b
+    sha256: 04aa180782cb675b960c0bf4aad439b4a7a08553c6af74d0b8e5df9a0c7cc4f4
+  build: py312h104f124_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   license: MIT
   license_family: MIT
-  size: 188606
-  timestamp: 1695373840022
+  size: 185636
+  timestamp: 1695373742454
 - platform: osx-arm64
   name: pyyaml
   version: 6.0.1
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
   - yaml >=0.2.5,<0.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.1-py311heffc1b2_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.1-py312h02f2b3b_1.conda
   hash:
-    md5: d310bfbb8230b9175c0cbc10189ad804
-    sha256: b155f5c27f0e2951256774628c4b91fdeee3267018eef29897a74e3d1316c8b0
-  build: py311heffc1b2_1
+    md5: a0c843e52a1c4422d8657dd76e9eb994
+    sha256: b6b4027b89c17b9bbd8089aec3e44bc29f802a7d5668d5a75b5358d7ed9705ca
+  build: py312h02f2b3b_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   license: MIT
   license_family: MIT
-  size: 187795
-  timestamp: 1695373829282
+  size: 182705
+  timestamp: 1695373895409
 - platform: win-64
   name: pyyaml
   version: 6.0.1
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - yaml >=0.2.5,<0.3.0a0
-  url: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.1-py311ha68e1ae_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.1-py312he70551f_1.conda
   hash:
-    md5: 2b4128962cd665153e946f2a88667a3b
-    sha256: 4fb0770fc70381a8ab3ced33413ad9dc5e82d4c535b593edd580113ce8760298
-  build: py311ha68e1ae_1
+    md5: f91e0baa89ba21166916624ba7bfb422
+    sha256: a72fa8152791b4738432f270e70b3a9a4d583ef059a78aa1c62f4b4ab7b15494
+  build: py312he70551f_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   license: MIT
   license_family: MIT
-  size: 175469
-  timestamp: 1695374086205
+  size: 167932
+  timestamp: 1695374097139
 - platform: linux-64
   name: pyzmq
   version: 25.1.1
@@ -26684,20 +26691,20 @@ package:
   - libgcc-ng >=12
   - libsodium >=1.0.18,<1.0.19.0a0
   - libstdcxx-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - zeromq >=4.3.5,<4.4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.1-py311h34ded2d_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.1-py312h886d080_2.conda
   hash:
-    md5: ea365280db99687905b4d76cf6a3568c
-    sha256: a5ed6592f32b0caf3883a2f863e8a6258845310d4eebeab2eaf1c5abed04d6b8
-  build: py311h34ded2d_2
+    md5: b07238948c49747387d699dd5dd596df
+    sha256: 9e64958131e6f2d2d3739604279befba4b1a25ecde6288f34a172ee1d4742c5b
+  build: py312h886d080_2
   arch: x86_64
   subdir: linux-64
   build_number: 2
   license: BSD-3-Clause AND LGPL-3.0-or-later
-  size: 538751
-  timestamp: 1698062661477
+  size: 528805
+  timestamp: 1698062675674
 - platform: osx-64
   name: pyzmq
   version: 25.1.1
@@ -26705,20 +26712,20 @@ package:
   manager: conda
   dependencies:
   - libsodium >=1.0.18,<1.0.19.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - zeromq >=4.3.5,<4.4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-25.1.1-py311he3804a1_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-25.1.1-py312hb81df1d_2.conda
   hash:
-    md5: 9b1ea037c51fcdb06bd2d95804270860
-    sha256: 7a9af16e04752c50675ca99ab06888aaf8305efb5d292f62f7268ad911c967f4
-  build: py311he3804a1_2
+    md5: 5281d541e2d1e91ba1737753c6e92ce3
+    sha256: 5731a8fd358385db210d9f8d50e24ff3eb43d79fb8df4e6d23f76eb9d9ea4047
+  build: py312hb81df1d_2
   arch: x86_64
   subdir: osx-64
   build_number: 2
   license: BSD-3-Clause AND LGPL-3.0-or-later
-  size: 498175
-  timestamp: 1698062892008
+  size: 493208
+  timestamp: 1698062750981
 - platform: osx-arm64
   name: pyzmq
   version: 25.1.1
@@ -26726,21 +26733,21 @@ package:
   manager: conda
   dependencies:
   - libsodium >=1.0.18,<1.0.19.0a0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
   - zeromq >=4.3.5,<4.4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-25.1.1-py311he9c0408_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-25.1.1-py312h2105c20_2.conda
   hash:
-    md5: 51b7458a36011c4982261478fcc62026
-    sha256: 03b78fe912c02547b284bc3404194bb4c1d9a2680e4b46f45c131a0d13d10b48
-  build: py311he9c0408_2
+    md5: 94728e562dbf6815a72be38c2eea1d31
+    sha256: 3ff6e9f69e76f165492a4215526bf879ec021603e7de2b86431162b230d196e3
+  build: py312h2105c20_2
   arch: aarch64
   subdir: osx-arm64
   build_number: 2
   license: BSD-3-Clause AND LGPL-3.0-or-later
-  size: 507069
-  timestamp: 1698062904960
+  size: 499382
+  timestamp: 1698062889773
 - platform: win-64
   name: pyzmq
   version: 25.1.1
@@ -26748,23 +26755,23 @@ package:
   manager: conda
   dependencies:
   - libsodium >=1.0.18,<1.0.19.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - zeromq >=4.3.5,<4.3.6.0a0
-  url: https://conda.anaconda.org/conda-forge/win-64/pyzmq-25.1.1-py311h9250fbb_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pyzmq-25.1.1-py312h1ac6f91_2.conda
   hash:
-    md5: e2e285b5528875d9008c0f1527f8436e
-    sha256: 11e347a6756cef1454322de743fc1c7aff634a5d0161dd57261c5c610cae2a40
-  build: py311h9250fbb_2
+    md5: b4c52a487df561ae97c8c67a8b1d5b37
+    sha256: 1ec5be6b13227604e4395d2187f52cf6ad803ab7feb8baa24afce65af9e8165e
+  build: py312h1ac6f91_2
   arch: x86_64
   subdir: win-64
   build_number: 2
   license: BSD-3-Clause AND LGPL-3.0-or-later
-  size: 491918
-  timestamp: 1698063170497
+  size: 483243
+  timestamp: 1698063163763
 - platform: linux-64
   name: qt-main
   version: 5.15.8
@@ -27309,6 +27316,94 @@ package:
   size: 17373
   timestamp: 1694242843889
 - platform: linux-64
+  name: referencing
+  version: 0.30.2
+  category: main
+  manager: conda
+  dependencies:
+  - attrs >=22.2.0
+  - python >=3.8
+  - rpds-py >=0.7.0
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: a33161b983172ba6ef69d5fc850650cd
+    sha256: a6768fabc12f1eed87fec68c5c65439e908655cded1e458d70a164abbce13287
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 38061
+  timestamp: 1691337409918
+- platform: osx-64
+  name: referencing
+  version: 0.30.2
+  category: main
+  manager: conda
+  dependencies:
+  - attrs >=22.2.0
+  - python >=3.8
+  - rpds-py >=0.7.0
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: a33161b983172ba6ef69d5fc850650cd
+    sha256: a6768fabc12f1eed87fec68c5c65439e908655cded1e458d70a164abbce13287
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 38061
+  timestamp: 1691337409918
+- platform: osx-arm64
+  name: referencing
+  version: 0.30.2
+  category: main
+  manager: conda
+  dependencies:
+  - attrs >=22.2.0
+  - python >=3.8
+  - rpds-py >=0.7.0
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: a33161b983172ba6ef69d5fc850650cd
+    sha256: a6768fabc12f1eed87fec68c5c65439e908655cded1e458d70a164abbce13287
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 38061
+  timestamp: 1691337409918
+- platform: win-64
+  name: referencing
+  version: 0.30.2
+  category: main
+  manager: conda
+  dependencies:
+  - attrs >=22.2.0
+  - python >=3.8
+  - rpds-py >=0.7.0
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
+  hash:
+    md5: a33161b983172ba6ef69d5fc850650cd
+    sha256: a6768fabc12f1eed87fec68c5c65439e908655cded1e458d70a164abbce13287
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 38061
+  timestamp: 1691337409918
+- platform: linux-64
   name: requests
   version: 2.31.0
   category: main
@@ -27833,26 +27928,111 @@ package:
   size: 183200
   timestamp: 1696096819794
 - platform: linux-64
+  name: rpds-py
+  version: 0.12.0
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.12.0-py312h4b3b743_0.conda
+  hash:
+    md5: 19e0573a4833ddeb1f2c6f0bef6bc8d2
+    sha256: 8a004f54e0ae64d951e20297ca9e3461b5c2384970d88381c63c34413c7cb2af
+  build: py312h4b3b743_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  size: 985109
+  timestamp: 1699110027579
+- platform: osx-64
+  name: rpds-py
+  version: 0.12.0
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.12.0-py312h6e28e45_0.conda
+  hash:
+    md5: 83eeae532de3a7782e9044609f6cfdc3
+    sha256: f1e2462d507ee8a1d1b13be0f1736fdfd012c153a48c2779fed844b9386d38c1
+  build: py312h6e28e45_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  size: 282267
+  timestamp: 1699110250813
+- platform: osx-arm64
+  name: rpds-py
+  version: 0.12.0
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.12.0-py312h5280bc4_0.conda
+  hash:
+    md5: 6d168f73909a3236400d55d69e6432e7
+    sha256: e90ba357c8b3ea8c2da4c158b198e2de0440d8b212553c8af808f016d48ca56a
+  build: py312h5280bc4_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  size: 281057
+  timestamp: 1699110351749
+- platform: win-64
+  name: rpds-py
+  version: 0.12.0
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.12.0-py312hfccd98a_0.conda
+  hash:
+    md5: 988e246be3583aaf22b34d4155c5b676
+    sha256: c48867e31bbc56c4e75ef8b8d8a4733c59dc0e5c85572f861ab65875168872bc
+  build: py312hfccd98a_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  size: 180234
+  timestamp: 1699110849265
+- platform: linux-64
   name: rtree
   version: 1.1.0
   category: main
   manager: conda
   dependencies:
   - libspatialindex >=1.9.3,<1.9.4.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/rtree-1.1.0-py311h3bb2b0f_0.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/rtree-1.1.0-py312hb0aae1a_0.conda
   hash:
-    md5: 341bbb97186f23835d2d0456d96c5aba
-    sha256: 555d5b653283380ed397f4bbfa47ab7c62c2173ca06f9dadc5eb0b1bd99c95a7
-  build: py311h3bb2b0f_0
+    md5: ec71270f74810599a7c05cd0ed9b4e63
+    sha256: 7144dae2a033196f2a9414e8ed38ef05ed47e3f8a86ab0742e5ddeaa2fb40d0e
+  build: py312hb0aae1a_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 62552
-  timestamp: 1697503426564
+  size: 61276
+  timestamp: 1697503351382
 - platform: osx-64
   name: rtree
   version: 1.1.0
@@ -27860,20 +28040,20 @@ package:
   manager: conda
   dependencies:
   - libspatialindex >=1.9.3,<1.9.4.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/rtree-1.1.0-py311hbc1f44b_0.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/rtree-1.1.0-py312h8974cf7_0.conda
   hash:
-    md5: 4cf922188989b372f053537cea29a5ec
-    sha256: 7421188ce73f9c1cfe4ba8d476570f04994c42e7a33a4ffa52dcd325f58d577c
-  build: py311hbc1f44b_0
+    md5: 9ba4d0650108193429a3f81d9529404f
+    sha256: 2c827a3fe65641790946f170442a8bf977911acceab3c7a9a7368fe645083f8f
+  build: py312h8974cf7_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 62672
-  timestamp: 1697503665618
+  size: 62310
+  timestamp: 1697503644928
 - platform: osx-arm64
   name: rtree
   version: 1.1.0
@@ -27881,21 +28061,21 @@ package:
   manager: conda
   dependencies:
   - libspatialindex >=1.9.3,<1.9.4.0a0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rtree-1.1.0-py311hd698ff7_0.conda
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rtree-1.1.0-py312h22f7183_0.conda
   hash:
-    md5: 957242aceae3dcf8049feabf99c18814
-    sha256: 3bfa6f07272e4a1311433097e3e2c071926f476b9c8bd38e9520053479fe3b14
-  build: py311hd698ff7_0
+    md5: 83f1320920b41cc90bccd8d43db3bec8
+    sha256: 8400720fac52072aab57d89879d864d9f4f56f2f6ac1f8adcae724792e7fe29e
+  build: py312h22f7183_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 63362
-  timestamp: 1697503597550
+  size: 62001
+  timestamp: 1697503661629
 - platform: win-64
   name: rtree
   version: 1.1.0
@@ -27903,20 +28083,20 @@ package:
   manager: conda
   dependencies:
   - libspatialindex >=1.9.3,<1.9.4.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/win-64/rtree-1.1.0-py311hcacb13a_0.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/win-64/rtree-1.1.0-py312h72b5f30_0.conda
   hash:
-    md5: d02d32b82431af0097bb0bce78720ad8
-    sha256: 97db7dd5cc1b36379468084796bbd49c7428f9f81677294f940a364505f6272c
-  build: py311hcacb13a_0
+    md5: c685acd130484537c08301b80077b32b
+    sha256: 66a76f830964f5b5d36c14ce4318dc6aff6c048224a21595f83740e013519dbd
+  build: py312h72b5f30_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 63487
-  timestamp: 1697503620756
+  size: 62578
+  timestamp: 1697503653077
 - platform: linux-64
   name: ruamel.yaml
   version: 0.18.5
@@ -27924,92 +28104,92 @@ package:
   manager: conda
   dependencies:
   - libgcc-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ruamel.yaml.clib >=0.1.2
   - setuptools
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.5-py311h459d7ec_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.18.5-py312h98912ed_0.conda
   hash:
-    md5: 1101ec27377f8e45d8431a5f21d744f1
-    sha256: c92e7bbb1d02286bcd3d3292208006f796ae45df82af3deec940339493415c04
-  build: py311h459d7ec_0
+    md5: 631213fb6dee32d9004779c5b6de3c49
+    sha256: 4ee323188e58fd2672f1d04c5dc184f3c5f0192bb6510856aa99031f9c0b9e3e
+  build: py312h98912ed_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 277088
-  timestamp: 1699007549765
+  size: 271907
+  timestamp: 1699007513506
 - platform: osx-64
   name: ruamel.yaml
   version: 0.18.5
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ruamel.yaml.clib >=0.1.2
   - setuptools
-  url: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.5-py311he705e18_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.18.5-py312h41838bb_0.conda
   hash:
-    md5: b8e2686abf5f980d52579b28441953f9
-    sha256: afdaab0d0f5a288b31450c3da260381da5916c61f122a0b3f5dea76d1ca863bb
-  build: py311he705e18_0
+    md5: 0dcf9f224125a95634f9f29dca9fd7a8
+    sha256: 458073e1940f3b2dc50a0d75dd05aeef977bf290671892817094a2a6d91cd98c
+  build: py312h41838bb_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 278639
-  timestamp: 1699007661916
+  size: 272434
+  timestamp: 1699007799926
 - platform: osx-arm64
   name: ruamel.yaml
   version: 0.18.5
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
   - ruamel.yaml.clib >=0.1.2
   - setuptools
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.5-py311h05b510d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.18.5-py312he37b823_0.conda
   hash:
-    md5: c51813780ac52059c1e472546022e7a5
-    sha256: 33c770e213c233e80b48256d17ce0e7bfe504576f2778307826cf1fd1db058d6
-  build: py311h05b510d_0
+    md5: bbda05ac095a271419f91ef133eddac3
+    sha256: 8f4744a698de42cfec04afe6e2246a07bdf7098366b1626e7c7aed24778b84e8
+  build: py312he37b823_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 277914
-  timestamp: 1699007830042
+  size: 272570
+  timestamp: 1699007959545
 - platform: win-64
   name: ruamel.yaml
   version: 0.18.5
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ruamel.yaml.clib >=0.1.2
   - setuptools
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.5-py311ha68e1ae_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml-0.18.5-py312he70551f_0.conda
   hash:
-    md5: c21c5fda85131862a99f9550aea3bfca
-    sha256: 1714147dd16e2340a43cb616adfb68c408237e4f8d1b0d3cb1da0c302715f2be
-  build: py311ha68e1ae_0
+    md5: e4d62d455007c8ffc251431a52bd9319
+    sha256: 66c6aaa56b8fe507861741ce3152ac973429a12eb533ebe163a6e2b5c3290929
+  build: py312he70551f_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 277863
-  timestamp: 1699007733106
+  size: 270789
+  timestamp: 1699007702255
 - platform: linux-64
   name: ruamel.yaml.clib
   version: 0.2.7
@@ -28017,84 +28197,84 @@ package:
   manager: conda
   dependencies:
   - libgcc-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.7-py311h459d7ec_2.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.7-py312h98912ed_2.conda
   hash:
-    md5: 56bc3fe5180c0b23e05c7a5708153ac7
-    sha256: cfd060725d39f136618547ecb8a593d82d460725fb447849815c26418c360c35
-  build: py311h459d7ec_2
+    md5: 17591efb6a03e1dea6567cb15c619d1c
+    sha256: 79c06eba98ed5f2ef44b41140c0eba5bf263ddc556dce57017a9c748d377e3d0
+  build: py312h98912ed_2
   arch: x86_64
   subdir: linux-64
   build_number: 2
   license: MIT
   license_family: MIT
-  size: 134322
-  timestamp: 1695997009048
+  size: 134659
+  timestamp: 1695996979046
 - platform: osx-64
   name: ruamel.yaml.clib
   version: 0.2.7
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.7-py311h2725bcf_2.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.7-py312h104f124_2.conda
   hash:
-    md5: cd953388469a8890dda83779d6ef6ffd
-    sha256: b529c2caf941ac1050d160f0b9c53202d634954dd7cc7f1469731e1bb6f2cccc
-  build: py311h2725bcf_2
+    md5: 07c5b620686d2fa9629374e8b4cf29ec
+    sha256: 22ff425b0de25ff28920174acf600732dede397ba2a5dd0953a7ef8b1c8308d2
+  build: py312h104f124_2
   arch: x86_64
   subdir: osx-64
   build_number: 2
   license: MIT
   license_family: MIT
-  size: 117447
-  timestamp: 1695997294294
+  size: 118792
+  timestamp: 1695997338028
 - platform: osx-arm64
   name: ruamel.yaml.clib
   version: 0.2.7
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.7-py311heffc1b2_2.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.7-py312h02f2b3b_2.conda
   hash:
-    md5: c167b931a12c70f9c1fbf927da7ff0be
-    sha256: 0c2d1a27afa009d3630b5944ac5fd10df95b92ab5c91c7390ddfc93ee5488349
-  build: py311heffc1b2_2
+    md5: 39478f82c46bd2fa4e974ef11cf2c0ae
+    sha256: e3b93abf4255fe1880435328e523b7147c5cf5859c731f643e00e0e598bb891c
+  build: py312h02f2b3b_2
   arch: aarch64
   subdir: osx-arm64
   build_number: 2
   license: MIT
   license_family: MIT
-  size: 113666
-  timestamp: 1695997356455
+  size: 113319
+  timestamp: 1695997421799
 - platform: win-64
   name: ruamel.yaml.clib
   version: 0.2.7
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.7-py311ha68e1ae_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/ruamel.yaml.clib-0.2.7-py312he70551f_2.conda
   hash:
-    md5: a19abbda796a7003308e1cba9b0c9905
-    sha256: 04d216c2f45f39987b0eb046a68702849668fb01c411de42af264809b838c3b9
-  build: py311ha68e1ae_2
+    md5: ef47a90d50c6d69c9697038f9c01a6cb
+    sha256: 27d45cc83b3f563d0e3f613225cce046781cef758127b9edd10e5e4503972413
+  build: py312he70551f_2
   arch: x86_64
   subdir: win-64
   build_number: 2
   license: MIT
   license_family: MIT
-  size: 97998
-  timestamp: 1695997456870
+  size: 95111
+  timestamp: 1695997251086
 - platform: linux-64
   name: ruff
   version: 0.1.5
@@ -28103,20 +28283,20 @@ package:
   dependencies:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.1.5-py311h7145743_0.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.1.5-py312h9118e91_0.conda
   hash:
-    md5: fb689551fcdea23b9edbe3aefea691b0
-    sha256: 957be00fcff45d338024a7623f4016de3e59265f005e1216c5b2d178f82a1ace
-  build: py311h7145743_0
+    md5: 2e2cb56137053970a885157905d6e9cf
+    sha256: b775431fbb2da9dcf3c4de070738565c3dda0d0cb84bb4e5d7892c81eaa4924b
+  build: py312h9118e91_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 4837715
-  timestamp: 1699507498365
+  size: 4832209
+  timestamp: 1699507697400
 - platform: osx-64
   name: ruff
   version: 0.1.5
@@ -28125,20 +28305,20 @@ package:
   dependencies:
   - __osx >=10.9
   - libcxx >=16.0.6
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.1.5-py311hec6fdf1_0.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.1.5-py312hde94f14_0.conda
   hash:
-    md5: ff29608b152cbd76c422ad3f97004876
-    sha256: ec15e79d5131afdd4592f7c1a878df0b7a8e022d5b644ab9fcb8d431915b4082
-  build: py311hec6fdf1_0
+    md5: 2b74e5920fd7a4a9cee52f930a5d46b1
+    sha256: ac50dea60681c922487a57c2991c0c27222c7464c2abd6894915c278bcc2dbe4
+  build: py312hde94f14_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 4589293
-  timestamp: 1699508029856
+  size: 4587294
+  timestamp: 1699508051210
 - platform: osx-arm64
   name: ruff
   version: 0.1.5
@@ -28147,44 +28327,44 @@ package:
   dependencies:
   - __osx >=10.9
   - libcxx >=16.0.6
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.1.5-py311h6fc163c_0.conda
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.1.5-py312h6267552_0.conda
   hash:
-    md5: 24659c389d8601c8076fb9401f3c59ed
-    sha256: a496efea6c4723c7a0e9ef11f38c8237c913ff3b6911085f1793885d102101a5
-  build: py311h6fc163c_0
+    md5: 2cdcc0e70bac01459ea476f601f88973
+    sha256: 0eb116cc02b720ebd128c921086255a21709a9c702892ebbfa0a9216539bdf2b
+  build: py312h6267552_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 4352507
-  timestamp: 1699508211540
+  size: 4352351
+  timestamp: 1699508088217
 - platform: win-64
   name: ruff
   version: 0.1.5
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.1.5-py311hc14472d_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.1.5-py312h60fbdae_0.conda
   hash:
-    md5: d76d37dff16a88d763749ecbbe01b53d
-    sha256: fe3d7b09bb772e45e4a4a31274f4feca0ec4b165560b49f64ac1ff7f143c35be
-  build: py311hc14472d_0
+    md5: 0c9a42fcc3a43981469e40943c54cf61
+    sha256: 3f71f687e38c4c03a656afbe81e009aa69b7a86678ba05d7f5bb54e9536bd699
+  build: py312h60fbdae_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 4748020
-  timestamp: 1699508487043
+  size: 4746907
+  timestamp: 1699508620199
 - platform: linux-64
   name: s2n
   version: 1.3.56
@@ -28215,23 +28395,23 @@ package:
   - joblib >=1.1.1
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - scipy
   - threadpoolctl >=2.0.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.3.2-py311hc009520_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.3.2-py312h394d371_1.conda
   hash:
-    md5: 6b92d3d0680eae9d1d9860a721f7fb51
-    sha256: 638253cba17e44081674b2dd7bee2025c202e91b653182da511ca57de942689d
-  build: py311hc009520_1
+    md5: 2eefaf33e0b88b81c470ef13e8846b12
+    sha256: d322f190ee65842c36b7d67f14bc1bd5e96a6bbbc9ad98fd4185127b5dcb9db8
+  build: py312h394d371_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 9575097
-  timestamp: 1698225284583
+  size: 9472762
+  timestamp: 1698225320408
 - platform: osx-64
   name: scikit-learn
   version: 1.3.2
@@ -28242,23 +28422,23 @@ package:
   - joblib >=1.1.1
   - libcxx >=16.0.6
   - llvm-openmp >=16.0.6
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - scipy
   - threadpoolctl >=2.0.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.3.2-py311h66081b9_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.3.2-py312h5e37b4f_1.conda
   hash:
-    md5: a7053f3e86b6b9139593a027c54e3097
-    sha256: 0b4aee092d4689d07aa95ed1d1071eeb74a5e011d34bc9ebd9b27e9b2166db7e
-  build: py311h66081b9_1
+    md5: db81a28a7ac776fcad4ba25ea70330a0
+    sha256: 529f7f0d93ea23b378f7e3732ae3488a428ea0fbb49452a88ab791eb30559f9e
+  build: py312h5e37b4f_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 8805008
-  timestamp: 1698226061893
+  size: 8548276
+  timestamp: 1698225745377
 - platform: osx-arm64
   name: scikit-learn
   version: 1.3.2
@@ -28269,24 +28449,24 @@ package:
   - joblib >=1.1.1
   - libcxx >=16.0.6
   - llvm-openmp >=16.0.6
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
   - scipy
   - threadpoolctl >=2.0.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.3.2-py311ha25ca4d_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.3.2-py312h6f466fd_1.conda
   hash:
-    md5: dea73952c589de24ec577c41fac181c5
-    sha256: 589bca23648b8969b16a36f87d7114a12fbe88d665cde32427c7126e5b34e63c
-  build: py311ha25ca4d_1
+    md5: 782e2eb59822c1a18d43fd19b1f54d6a
+    sha256: e8a985ee3482db446a9f7403a0c39e113ef7396b1eb92e0812923b38ab5715e4
+  build: py312h6f466fd_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 8840075
-  timestamp: 1698225663288
+  size: 8613837
+  timestamp: 1698226181627
 - platform: win-64
   name: scikit-learn
   version: 1.3.2
@@ -28294,26 +28474,26 @@ package:
   manager: conda
   dependencies:
   - joblib >=1.1.1
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - scipy
   - threadpoolctl >=2.0.0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.3.2-py311h142b183_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.3.2-py312hcacafb1_1.conda
   hash:
-    md5: a24599e0d80cf658b7d942c82907caef
-    sha256: 55893f59edf4bc55c6911b82207dc3d0052e28ebbef94ed0643f887a2c231fd7
-  build: py311h142b183_1
+    md5: 163f0f1d3cd69264f15d827135cdc0f9
+    sha256: d04023630f6fd5e6910a073a938f1d589936637782fd244f003d9088cf953259
+  build: py312hcacafb1_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 8328461
-  timestamp: 1698225997015
+  size: 8151994
+  timestamp: 1698225934981
 - platform: linux-64
   name: scipy
   version: 1.11.3
@@ -28327,22 +28507,22 @@ package:
   - libgfortran5 >=12.3.0
   - liblapack >=3.9.0,<4.0a0
   - libstdcxx-ng >=12
-  - numpy >=1.23.5,<1.28
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.11.3-py311h64a7726_1.conda
+  - numpy >=1.26.0,<1.28
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.11.3-py312heda63a1_1.conda
   hash:
-    md5: e4b4d3b764e2d029477d0db88248a8b5
-    sha256: 13ea70afe49a3c92fb9b82a6efcfa23a05ca8f24ec2dff22597d651e0e2b4767
-  build: py311h64a7726_1
+    md5: c89108be4deb842ced096623aa932fd0
+    sha256: f913f07ce861be04e05097fe962682d43fdc891f069f24fc2a2d7f916d849225
+  build: py312heda63a1_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 16002963
-  timestamp: 1696468652023
+  size: 15961550
+  timestamp: 1696468446611
 - platform: osx-64
   name: scipy
   version: 1.11.3
@@ -28356,22 +28536,22 @@ package:
   - libgfortran5 >=12.3.0
   - libgfortran5 >=13.2.0
   - liblapack >=3.9.0,<4.0a0
-  - numpy >=1.23.5,<1.28
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.11.3-py311h16c3c4d_1.conda
+  - numpy >=1.26.0,<1.28
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.11.3-py312h2c2f0bb_1.conda
   hash:
-    md5: 77164acef9bc09545bd3324a8f986be5
-    sha256: 78270d60ea00482b4f64a4b2d5d4e432f48125f6b76780e2094c8363ad48b611
-  build: py311h16c3c4d_1
+    md5: 0671c0db4a12dd2c176db00022a223fb
+    sha256: 58ed25d047733f2cdce791f75a8652bf4830d9e9421ff3cf35fc30924c5ab2e0
+  build: py312h2c2f0bb_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 16243071
-  timestamp: 1696469112175
+  size: 15646530
+  timestamp: 1696469066773
 - platform: osx-arm64
   name: scipy
   version: 1.11.3
@@ -28385,23 +28565,23 @@ package:
   - libgfortran5 >=12.3.0
   - libgfortran5 >=13.2.0
   - liblapack >=3.9.0,<4.0a0
-  - numpy >=1.23.5,<1.28
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.11.3-py311h93d07a4_1.conda
+  - numpy >=1.26.0,<1.28
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.11.3-py312h44883eb_1.conda
   hash:
-    md5: 1c687552b288a801a7851166f2494768
-    sha256: 6347f47c02eef02afe1e5534c88269f73b2da28cdff8c826b210e529b8bd1f07
-  build: py311h93d07a4_1
+    md5: 09dc8bfd193d4f0cdf2f5ce619e6ba66
+    sha256: a1de458f94a9aecb79620ada349c7530135b4616a378684b1bd423d46170eb10
+  build: py312h44883eb_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 15110473
-  timestamp: 1696469388055
+  size: 14831141
+  timestamp: 1696469685812
 - platform: win-64
   name: scipy
   version: 1.11.3
@@ -28411,25 +28591,25 @@ package:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
-  - numpy >=1.23.5,<1.28
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.0,<1.28
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.11.3-py311h0b4df5a_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.11.3-py312h8753938_1.conda
   hash:
-    md5: 67910f5db4ee7b8bbf39250c167d3a34
-    sha256: 1fc5493e5c6706c3e1a925090478f1c8306f493602cb8a4d935de8aa361be36c
-  build: py311h0b4df5a_1
+    md5: b70c6ed21d69694aac4316e77ed67f3b
+    sha256: 54a3d553d791fe63bed3ed2c3b68f5ba5dc7559f11185eac1af0c3b8439a117c
+  build: py312h8753938_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   license: BSD-3-Clause
   license_family: BSD
-  size: 14873188
-  timestamp: 1696469599650
+  size: 14655959
+  timestamp: 1696469803046
 - platform: linux-64
   name: secretstorage
   version: 3.3.3
@@ -28439,20 +28619,20 @@ package:
   - cryptography
   - dbus
   - jeepney >=0.6
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.3.3-py311h38be061_2.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.3.3-py312h7900ff3_2.conda
   hash:
-    md5: 30a57eaa8e72cb0c2c84d6d7db32010c
-    sha256: 45e7d85a3663993e8bffdb7c6040561923c848e3262228b163042663caa4485e
-  build: py311h38be061_2
+    md5: 39067833cbb620066d492f8bd6f11dbf
+    sha256: 0479e3f8c8e90049a6d92d4c7e67916c6d6cdafd11a1a31c54c785cce44aeb20
+  build: py312h7900ff3_2
   arch: x86_64
   subdir: linux-64
   build_number: 2
   license: BSD-3-Clause
   license_family: BSD
-  size: 32421
-  timestamp: 1695551942931
+  size: 31766
+  timestamp: 1695551875966
 - platform: linux-64
   name: semver
   version: 2.13.0
@@ -28708,21 +28888,21 @@ package:
   dependencies:
   - geos >=3.12.0,<3.12.1.0a0
   - libgcc-ng >=12
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.2-py311he06c224_0.conda
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.2-py312h1cd15a4_0.conda
   hash:
-    md5: c90e2469d7512f3bba893533a82d7a02
-    sha256: 2a02e516c57a2122cf9acaec54b75a821ad5f959a7702b17cb8df2c3fe31ef20
-  build: py311he06c224_0
+    md5: 30c8f6b56ed67287c18ce608113602bc
+    sha256: 33bc9471da3e7cdd7f2cbd8954486866495136b53a45915b7797e6b9bef26c55
+  build: py312h1cd15a4_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 574587
-  timestamp: 1697191790758
+  size: 564253
+  timestamp: 1697191786076
 - platform: osx-64
   name: shapely
   version: 2.0.2
@@ -28730,21 +28910,21 @@ package:
   manager: conda
   dependencies:
   - geos >=3.12.0,<3.12.1.0a0
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.2-py311h359915d_0.conda
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.2-py312hbe61eff_0.conda
   hash:
-    md5: 5569c5122a7938835a8a7c498aaded67
-    sha256: 240cca365e75d5f5aa09ee62c95813288d3652f666a1ab227015195316b8f9fe
-  build: py311h359915d_0
+    md5: 00dec9e62c5a7c43a29506edb6048689
+    sha256: 83078c15984a67a5901f24aab84ebc3a4848d27ea30b8a4084880c3c4acd1cb2
+  build: py312hbe61eff_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 543102
-  timestamp: 1697191795638
+  size: 533274
+  timestamp: 1697191765372
 - platform: osx-arm64
   name: shapely
   version: 2.0.2
@@ -28752,22 +28932,22 @@ package:
   manager: conda
   dependencies:
   - geos >=3.12.0,<3.12.1.0a0
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.2-py311h4826c84_0.conda
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.2-py312hf679d78_0.conda
   hash:
-    md5: a9de7ff7899a7067646aa7053eb5737c
-    sha256: 3d08d9553565704fef53d0c9cb901bb2f40337f0a590b3ea714d363a34ee2250
-  build: py311h4826c84_0
+    md5: f0074bdb7085b1f1626a986496fc5af6
+    sha256: b32a86631919a3c7cd5c17b74e3f70ad4913efd4aab648519f512f63b62c9229
+  build: py312hf679d78_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 541397
-  timestamp: 1697191908684
+  size: 527635
+  timestamp: 1697191764696
 - platform: win-64
   name: shapely
   version: 2.0.2
@@ -28775,24 +28955,24 @@ package:
   manager: conda
   dependencies:
   - geos >=3.12.0,<3.12.1.0a0
-  - numpy >=1.23.5,<2.0a0
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - numpy >=1.26.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.2-py311h72efec2_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.2-py312h92c3dd1_0.conda
   hash:
-    md5: 617eaf53ee620cdb0f3b5928c054e6af
-    sha256: 23adfdb0f4911fd58845485d318e647161b8c2b316c5c0f40ca40295d09e96e3
-  build: py311h72efec2_0
+    md5: 1daded226f8faf6053dde92c192b7ab5
+    sha256: 9f527a8507cd9425c64776775a79e584f27c59c38216260b34695ce31db640f2
+  build: py312h92c3dd1_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 543280
-  timestamp: 1697191896614
+  size: 532148
+  timestamp: 1697191979002
 - platform: linux-64
   name: sip
   version: 6.7.12
@@ -28803,21 +28983,21 @@ package:
   - libstdcxx-ng >=12
   - packaging
   - ply
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - tomli
-  url: https://conda.anaconda.org/conda-forge/linux-64/sip-6.7.12-py311hb755f60_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/sip-6.7.12-py312h30efb56_0.conda
   hash:
-    md5: 02336abab4cb5dd794010ef53c54bd09
-    sha256: 71a0ee22522b232bf50d4d03d012e53cd5d1251d09dffc1c72d7c33a1086fe6f
-  build: py311hb755f60_0
+    md5: 32633871002ee9902f747d2236e0d122
+    sha256: baf6e63e213bb11e369a51e511b44217546a11f8470242bbaa8fac45cb4a39c3
+  build: py312h30efb56_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: GPL-3.0-only
   license_family: GPL
-  size: 585197
-  timestamp: 1697300605264
+  size: 576283
+  timestamp: 1697300599736
 - platform: win-64
   name: sip
   version: 6.7.12
@@ -28826,24 +29006,24 @@ package:
   dependencies:
   - packaging
   - ply
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - tomli
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/sip-6.7.12-py311h12c1d0e_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/sip-6.7.12-py312h53d5487_0.conda
   hash:
-    md5: c29f20b2860d1824535135d76d022394
-    sha256: 1129ac093d0c04ca07603fab9dfd2ee1e9a760eb94b31450e2cef1ffffa6a31a
-  build: py311h12c1d0e_0
+    md5: a5d3d1363d6d0b4827d6b940414a5b76
+    sha256: 2347c2e7d5e7282b991d5d4f7448d9e6fe8c26e5d6df0d09f0e60b11b7d19586
+  build: py312h53d5487_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: GPL-3.0-only
   license_family: GPL
-  size: 595071
-  timestamp: 1697300986959
+  size: 589657
+  timestamp: 1697301028797
 - platform: linux-64
   name: six
   version: 1.16.0
@@ -29536,96 +29716,96 @@ package:
   timestamp: 1697713986066
 - platform: linux-64
   name: terminado
-  version: 0.17.1
+  version: 0.18.0
   category: main
   manager: conda
   dependencies:
   - __linux
   - ptyprocess
-  - python >=3.7
+  - python >=3.8
   - tornado >=6.1.0
-  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyh41d4057_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.0-pyh0d859eb_0.conda
   hash:
-    md5: 3788984d535770cad699efaeb6cb3037
-    sha256: bce252eb53330a8ba9617caa7a1dc75ce602c8808cf547a8f4d48285901f47c3
-  build: pyh41d4057_0
+    md5: e463f348b8b0eb62c9f7c6fbc780286c
+    sha256: e90139ef15ea9d75a69cd6b6302c29ed5b01c03ddfa717b71acb32b60af74269
+  build: pyh0d859eb_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: BSD-2-Clause
   license_family: BSD
   noarch: python
-  size: 20787
-  timestamp: 1670253786972
+  size: 22369
+  timestamp: 1699810283724
 - platform: osx-64
   name: terminado
-  version: 0.17.1
+  version: 0.18.0
   category: main
   manager: conda
   dependencies:
   - __osx
   - ptyprocess
-  - python >=3.7
+  - python >=3.8
   - tornado >=6.1.0
-  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyhd1c38e8_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.0-pyh31c8845_0.conda
   hash:
-    md5: 046120b71d8896cb7faef78bfdbfee1e
-    sha256: a2f8382ab390c74af592cc3566dc22e2ed81e5ac69c5b6417d1b7c22e63927bc
-  build: pyhd1c38e8_0
+    md5: 14759b57f5b9d97033e633fff0a2d27e
+    sha256: 8e8741c688ade9be8f86c0b209780c7fbe4a97e4265311ca9d8dda5fcedc6a28
+  build: pyh31c8845_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: BSD-2-Clause
   license_family: BSD
   noarch: python
-  size: 20347
-  timestamp: 1670254383751
+  size: 22631
+  timestamp: 1699810378589
 - platform: osx-arm64
   name: terminado
-  version: 0.17.1
+  version: 0.18.0
   category: main
   manager: conda
   dependencies:
   - __osx
   - ptyprocess
-  - python >=3.7
+  - python >=3.8
   - tornado >=6.1.0
-  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyhd1c38e8_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.0-pyh31c8845_0.conda
   hash:
-    md5: 046120b71d8896cb7faef78bfdbfee1e
-    sha256: a2f8382ab390c74af592cc3566dc22e2ed81e5ac69c5b6417d1b7c22e63927bc
-  build: pyhd1c38e8_0
+    md5: 14759b57f5b9d97033e633fff0a2d27e
+    sha256: 8e8741c688ade9be8f86c0b209780c7fbe4a97e4265311ca9d8dda5fcedc6a28
+  build: pyh31c8845_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: BSD-2-Clause
   license_family: BSD
   noarch: python
-  size: 20347
-  timestamp: 1670254383751
+  size: 22631
+  timestamp: 1699810378589
 - platform: win-64
   name: terminado
-  version: 0.17.0
+  version: 0.18.0
   category: main
   manager: conda
   dependencies:
   - __win
-  - python >=3.7
+  - python >=3.8
   - pywinpty >=1.1.0
   - tornado >=6.1.0
-  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.0-pyh08f2357_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.0-pyh5737063_0.conda
   hash:
-    md5: 0152a609d5748ed9887d195b1e61a6c9
-    sha256: 5c8fcf31430e0f312bc65ab5aa5b893fcc250820c023b02ff3fd188ae13199a5
-  build: pyh08f2357_0
+    md5: f2fc93bc1e08e04612c4d19361bb0011
+    sha256: 4353d8d2372ad050cbdab05890c057356ea8693ecfb959396ebb8ffdfc1948bf
+  build: pyh5737063_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: BSD-2-Clause
   license_family: BSD
   noarch: python
-  size: 19530
-  timestamp: 1666708102607
+  size: 22855
+  timestamp: 1699810439015
 - platform: linux-64
   name: threadpoolctl
   version: 3.2.0
@@ -30234,84 +30414,84 @@ package:
   manager: conda
   dependencies:
   - libgcc-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.3.3-py311h459d7ec_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.3.3-py312h98912ed_1.conda
   hash:
-    md5: a700fcb5cedd3e72d0c75d095c7a6eda
-    sha256: 3f0640415c6f50c6b31b5ce41a870ac48c130fda8921aae11afea84c54a6ba84
-  build: py311h459d7ec_1
+    md5: 5bd63a3bf512694536cee3e48463a47c
+    sha256: 970d4e3e0b9b34dc8383055a956d4a9158a9f527264bc7ece769ba284d2395ff
+  build: py312h98912ed_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 843714
-  timestamp: 1695373626426
+  size: 829585
+  timestamp: 1695373731705
 - platform: osx-64
   name: tornado
   version: 6.3.3
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.3.3-py311h2725bcf_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.3.3-py312h104f124_1.conda
   hash:
-    md5: daf5f053a40c2b0b8f86b605e302b7a4
-    sha256: e3e4c12236b0a59e6568a9dc839116776eda408ca12bc0ad4e7a9dba4d66912f
-  build: py311h2725bcf_1
+    md5: 6835d4940d6fbd41e1a32d58dfae8f06
+    sha256: 7f4f2a3a43c0bf62025b46f28366598aa04e0d4a32c87bfe4a275b4df562eba3
+  build: py312h104f124_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 843855
-  timestamp: 1695373925218
+  size: 827934
+  timestamp: 1695373724352
 - platform: osx-arm64
   name: tornado
   version: 6.3.3
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.3.3-py311heffc1b2_1.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.3.3-py312h02f2b3b_1.conda
   hash:
-    md5: a3a94203d225faec0d6bd000ea30b0a1
-    sha256: 65e96fcaa2fad8013fdfd1c7cbdc4684b253541c10091fa7acd55b4a3daa87e6
-  build: py311heffc1b2_1
+    md5: 3ec18cacdeb6f7a87fee073b28bc7118
+    sha256: f59281be797e9cfa2f1cfd5bff89a8268823e98fe49aaa6bede9a91b27e887ab
+  build: py312h02f2b3b_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 843751
-  timestamp: 1695373818353
+  size: 826881
+  timestamp: 1695374110756
 - platform: win-64
   name: tornado
   version: 6.3.3
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/tornado-6.3.3-py311ha68e1ae_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/tornado-6.3.3-py312he70551f_1.conda
   hash:
-    md5: ec581b55f82fd6a4a96770c74d48e456
-    sha256: 669091a38b2cb226198a6018a2784d4a4b55eb6416b14a4521a84882e02f47be
-  build: py311ha68e1ae_1
+    md5: a3bebd12ad9b94a4b9c46f8fd197e883
+    sha256: 196ceac8b914e71706c2a45907c20ef10ae097e0c2775950ad232065659026d6
+  build: py312he70551f_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 845683
-  timestamp: 1695374005077
+  size: 829792
+  timestamp: 1695373970360
 - platform: linux-64
   name: traitlets
   version: 5.13.0
@@ -31265,20 +31445,20 @@ package:
   - cffi
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py311h9547e67_4.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py312h8572e83_4.conda
   hash:
-    md5: 586da7df03b68640de14dc3e8bcbf76f
-    sha256: c2d33e998f637b594632eba3727529171a06eb09896e36aa42f1ebcb03779472
-  build: py311h9547e67_4
+    md5: 52c9e25ee0a32485a102eeecdb7eef52
+    sha256: f9a4384d466f4d8b5b497d951329dd4407ebe02f8f93456434e9ab789d6e23ce
+  build: py312h8572e83_4
   arch: x86_64
   subdir: linux-64
   build_number: 4
   license: MIT
   license_family: MIT
-  size: 13961
-  timestamp: 1695549513130
+  size: 14050
+  timestamp: 1695549556745
 - platform: osx-64
   name: ukkonen
   version: 1.0.1
@@ -31287,20 +31467,20 @@ package:
   dependencies:
   - cffi
   - libcxx >=15.0.7
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.0.1-py311h5fe6e05_4.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/ukkonen-1.0.1-py312h49ebfd2_4.conda
   hash:
-    md5: 8f750b84128d48dc8376572c5eace61e
-    sha256: b273782a1277042a54e12411beebd378d2a2a69e503bcf147766e98628e91c91
-  build: py311h5fe6e05_4
+    md5: 4e6b5a8025cd8fd97b3cfe103ffce6b1
+    sha256: efca19a5e73e4aacfc5e90a5389272b2508e41dc4adab9eb5353c5200ba37041
+  build: py312h49ebfd2_4
   arch: x86_64
   subdir: osx-64
   build_number: 4
   license: MIT
   license_family: MIT
-  size: 13193
-  timestamp: 1695549883822
+  size: 13246
+  timestamp: 1695549689363
 - platform: osx-arm64
   name: ukkonen
   version: 1.0.1
@@ -31309,21 +31489,21 @@ package:
   dependencies:
   - cffi
   - libcxx >=15.0.7
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.0.1-py311he4fd1f5_4.conda
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ukkonen-1.0.1-py312h389731b_4.conda
   hash:
-    md5: 5d5ab5c5af32931e03608034f4a5fd75
-    sha256: 384fc81a34e248019d43a115386f77859ab63e0e6f12dade486d76359703743f
-  build: py311he4fd1f5_4
+    md5: 6407429e0969b58b8717dbb4c6c15513
+    sha256: 7336cf66feba973207f4903c20b05c3c82e351246df4b6113f72d92b9ee55b81
+  build: py312h389731b_4
   arch: aarch64
   subdir: osx-arm64
   build_number: 4
   license: MIT
   license_family: MIT
-  size: 13958
-  timestamp: 1695549884615
+  size: 13948
+  timestamp: 1695549890285
 - platform: win-64
   name: ukkonen
   version: 1.0.1
@@ -31331,23 +31511,23 @@ package:
   manager: conda
   dependencies:
   - cffi
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/ukkonen-1.0.1-py311h005e61a_4.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/ukkonen-1.0.1-py312h0d7def4_4.conda
   hash:
-    md5: d9988836cc20c90e05901ab05962f496
-    sha256: ef774047df25201a6425fe1ec194505a3cac9ba02e96953360442f59364d12b3
-  build: py311h005e61a_4
+    md5: 57cfbb8ce3a1800bd343bf6afba6f878
+    sha256: f5f7550991ca647f69b67b9188c7104a3456122611dd6a6e753cff555e45dfd9
+  build: py312h0d7def4_4
   arch: x86_64
   subdir: win-64
   build_number: 4
   license: MIT
   license_family: MIT
-  size: 17225
-  timestamp: 1695549858085
+  size: 17235
+  timestamp: 1695549871621
 - platform: linux-64
   name: uri-template
   version: 1.3.0
@@ -31509,17 +31689,17 @@ package:
   timestamp: 1677713151746
 - platform: linux-64
   name: urllib3
-  version: 2.0.7
+  version: 2.1.0
   category: main
   manager: conda
   dependencies:
   - brotli-python >=1.0.9
   - pysocks >=1.5.6,<2.0,!=1.5.7
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 270e71c14d37074b1d066ee21cf0c4a6
-    sha256: 9fe14735dde74278c6f1710cbe883d5710fc98501a96031dec6849a8d8a1bb11
+    md5: f8ced8ee63830dec7ecc1be048d1470a
+    sha256: eff5029820b4eaeab3a291a39854a6cd8fc8c4216264087f68c2d8d59822c869
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -31527,21 +31707,21 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 98507
-  timestamp: 1697720586316
+  size: 85324
+  timestamp: 1699933655057
 - platform: osx-64
   name: urllib3
-  version: 2.0.7
+  version: 2.1.0
   category: main
   manager: conda
   dependencies:
   - brotli-python >=1.0.9
   - pysocks >=1.5.6,<2.0,!=1.5.7
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 270e71c14d37074b1d066ee21cf0c4a6
-    sha256: 9fe14735dde74278c6f1710cbe883d5710fc98501a96031dec6849a8d8a1bb11
+    md5: f8ced8ee63830dec7ecc1be048d1470a
+    sha256: eff5029820b4eaeab3a291a39854a6cd8fc8c4216264087f68c2d8d59822c869
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -31549,21 +31729,21 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 98507
-  timestamp: 1697720586316
+  size: 85324
+  timestamp: 1699933655057
 - platform: osx-arm64
   name: urllib3
-  version: 2.0.7
+  version: 2.1.0
   category: main
   manager: conda
   dependencies:
   - brotli-python >=1.0.9
   - pysocks >=1.5.6,<2.0,!=1.5.7
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 270e71c14d37074b1d066ee21cf0c4a6
-    sha256: 9fe14735dde74278c6f1710cbe883d5710fc98501a96031dec6849a8d8a1bb11
+    md5: f8ced8ee63830dec7ecc1be048d1470a
+    sha256: eff5029820b4eaeab3a291a39854a6cd8fc8c4216264087f68c2d8d59822c869
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -31571,21 +31751,21 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 98507
-  timestamp: 1697720586316
+  size: 85324
+  timestamp: 1699933655057
 - platform: win-64
   name: urllib3
-  version: 2.0.7
+  version: 2.1.0
   category: main
   manager: conda
   dependencies:
   - brotli-python >=1.0.9
   - pysocks >=1.5.6,<2.0,!=1.5.7
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 270e71c14d37074b1d066ee21cf0c4a6
-    sha256: 9fe14735dde74278c6f1710cbe883d5710fc98501a96031dec6849a8d8a1bb11
+    md5: f8ced8ee63830dec7ecc1be048d1470a
+    sha256: eff5029820b4eaeab3a291a39854a6cd8fc8c4216264087f68c2d8d59822c869
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -31593,8 +31773,8 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 98507
-  timestamp: 1697720586316
+  size: 85324
+  timestamp: 1699933655057
 - platform: win-64
   name: vc
   version: '14.3'
@@ -31753,169 +31933,165 @@ package:
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - pyyaml >=3.10
-  url: https://conda.anaconda.org/conda-forge/linux-64/watchdog-3.0.0-py311h38be061_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/watchdog-3.0.0-py312h7900ff3_1.conda
   hash:
-    md5: 1901b9f3ca3782f31450fd7158d2fe8a
-    sha256: c1fd4f6bd6f3c4009fe2f97d3ed8edd2f2a46058293e0176b06fa181eb66558f
-  build: py311h38be061_1
+    md5: 6efb26e8a58a6a56f4fee7f21f892532
+    sha256: 4cdaa1b5553412f9c2b9ecfe580154ede063f8b9b103e6d39c5a407741d75cc4
+  build: py312h7900ff3_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   license: Apache-2.0
   license_family: APACHE
-  size: 138066
-  timestamp: 1695395380738
+  size: 134413
+  timestamp: 1695395379159
 - platform: osx-64
   name: watchdog
   version: 3.0.0
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - pyyaml >=3.10
-  url: https://conda.anaconda.org/conda-forge/osx-64/watchdog-3.0.0-py311h5ef12f2_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/watchdog-3.0.0-py312h388f535_1.conda
   hash:
-    md5: 32c15f3306fd2e9a9c2876f2fc33d5ed
-    sha256: e3c40135edb9399277f8afc7b5344b507e40a46cef2ade2d3185f951c884c72b
-  build: py311h5ef12f2_1
+    md5: fba613e83c36e18f5501647800d3ed3b
+    sha256: 779601fbda1dc19b7d391e4102389add38da595b8e0f9e59c04c913dbf24e0a1
+  build: py312h388f535_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   license: Apache-2.0
   license_family: APACHE
-  size: 145907
-  timestamp: 1695395842364
+  size: 142946
+  timestamp: 1695395691197
 - platform: osx-arm64
   name: watchdog
   version: 3.0.0
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
   - pyyaml >=3.10
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/watchdog-3.0.0-py311heffc1b2_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/watchdog-3.0.0-py312h02f2b3b_1.conda
   hash:
-    md5: 67202ddda794d7ff7ca6b6e45337073d
-    sha256: 3fd810c89bb56b70518f1e60b7d3769ca13ab8a55e572cc90bba61f7a2a3e8b5
-  build: py311heffc1b2_1
+    md5: b46d14ac225275964abb4b58d94d47c7
+    sha256: 545e660efb86da41d31ead3038c2e9f25a67c082ad3109246de2d649c3d036c7
+  build: py312h02f2b3b_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   license: Apache-2.0
   license_family: APACHE
-  size: 147013
-  timestamp: 1695395641979
+  size: 144329
+  timestamp: 1695395632282
 - platform: win-64
   name: watchdog
   version: 3.0.0
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12.0rc3,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - pyyaml >=3.10
-  url: https://conda.anaconda.org/conda-forge/win-64/watchdog-3.0.0-py311h1ea47a8_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/watchdog-3.0.0-py312h2e8e312_1.conda
   hash:
-    md5: dc9bf2e5cbb5288f126606e67b2b410a
-    sha256: c05b8ee23e7b2992901688cfbb00a18706b2269d2518c87f72e1147209e27faf
-  build: py311h1ea47a8_1
+    md5: a56e5763430a9f6d78da401c831e629d
+    sha256: ea8ec6802b91338ec1f24d46742e7f50da0533004f080f0c5646209c0a82070e
+  build: py312h2e8e312_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   license: Apache-2.0
   license_family: APACHE
-  size: 154457
-  timestamp: 1695395884217
+  size: 151305
+  timestamp: 1695395846556
 - platform: linux-64
   name: wcwidth
-  version: 0.2.9
+  version: 0.2.10
   category: main
   manager: conda
   dependencies:
   - backports.functools_lru_cache
   - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.10-pyhd8ed1ab_0.conda
   hash:
-    md5: 8e8280dec091763dfdc29e066de52270
-    sha256: 7552f6545ed212b9ae5d023870481fc377c7f18b4854b63160699b95a420c42e
+    md5: 48978e4e99db7d1ee0d277f6dee20684
+    sha256: e988673c05416073d0e776bac223b6c79fb5cc1207291c6c6f9e238624a135c0
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
-  license_family: MIT
   noarch: python
-  size: 30316
-  timestamp: 1698744892384
+  size: 32557
+  timestamp: 1699959343164
 - platform: osx-64
   name: wcwidth
-  version: 0.2.9
+  version: 0.2.10
   category: main
   manager: conda
   dependencies:
   - backports.functools_lru_cache
   - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.10-pyhd8ed1ab_0.conda
   hash:
-    md5: 8e8280dec091763dfdc29e066de52270
-    sha256: 7552f6545ed212b9ae5d023870481fc377c7f18b4854b63160699b95a420c42e
+    md5: 48978e4e99db7d1ee0d277f6dee20684
+    sha256: e988673c05416073d0e776bac223b6c79fb5cc1207291c6c6f9e238624a135c0
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
-  license_family: MIT
   noarch: python
-  size: 30316
-  timestamp: 1698744892384
+  size: 32557
+  timestamp: 1699959343164
 - platform: osx-arm64
   name: wcwidth
-  version: 0.2.9
+  version: 0.2.10
   category: main
   manager: conda
   dependencies:
   - backports.functools_lru_cache
   - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.10-pyhd8ed1ab_0.conda
   hash:
-    md5: 8e8280dec091763dfdc29e066de52270
-    sha256: 7552f6545ed212b9ae5d023870481fc377c7f18b4854b63160699b95a420c42e
+    md5: 48978e4e99db7d1ee0d277f6dee20684
+    sha256: e988673c05416073d0e776bac223b6c79fb5cc1207291c6c6f9e238624a135c0
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
-  license_family: MIT
   noarch: python
-  size: 30316
-  timestamp: 1698744892384
+  size: 32557
+  timestamp: 1699959343164
 - platform: win-64
   name: wcwidth
-  version: 0.2.9
+  version: 0.2.10
   category: main
   manager: conda
   dependencies:
   - backports.functools_lru_cache
   - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.10-pyhd8ed1ab_0.conda
   hash:
-    md5: 8e8280dec091763dfdc29e066de52270
-    sha256: 7552f6545ed212b9ae5d023870481fc377c7f18b4854b63160699b95a420c42e
+    md5: 48978e4e99db7d1ee0d277f6dee20684
+    sha256: e988673c05416073d0e776bac223b6c79fb5cc1207291c6c6f9e238624a135c0
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: MIT
-  license_family: MIT
   noarch: python
-  size: 30316
-  timestamp: 1698744892384
+  size: 32557
+  timestamp: 1699959343164
 - platform: linux-64
   name: webcolors
   version: '1.13'
@@ -32280,80 +32456,84 @@ package:
   manager: conda
   dependencies:
   - libgcc-ng >=12
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py311h459d7ec_0.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py312h98912ed_0.conda
   hash:
-    md5: 6669b5529d206c1f880b642cdd17ae05
-    sha256: 6587e0b7d42368f767172b239a755fcf6363d91348faf9b7ab5743585369fc58
-  build: py311h459d7ec_0
+    md5: fa957a1c7bee7e47ad44633caf7be8bc
+    sha256: dc8431b343961347ad93b33d2d8270e8c15d8825382f4f2540835c94aba2de05
+  build: py312h98912ed_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: BSD-2-Clause
-  size: 63465
-  timestamp: 1699532930817
+  license_family: BSD
+  size: 62482
+  timestamp: 1699532968076
 - platform: osx-64
   name: wrapt
   version: 1.16.0
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.16.0-py311he705e18_0.conda
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.16.0-py312h41838bb_0.conda
   hash:
-    md5: 5ef2eefe4fca7c786bbbdd4f1de464ed
-    sha256: e5546a52c0c0ed8a78dbac1cfec9a639f37fb3a86ea8ade8ff44aa7459dc6796
-  build: py311he705e18_0
+    md5: d87798aa7210da2c5eaf96c0346dca00
+    sha256: 9ed208c4c844c50f161764df7ed7a226c42822917c892ab7c8f67eec6ca96dff
+  build: py312h41838bb_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: BSD-2-Clause
-  size: 59558
-  timestamp: 1699533106157
+  license_family: BSD
+  size: 59057
+  timestamp: 1699533259706
 - platform: osx-arm64
   name: wrapt
   version: 1.16.0
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.16.0-py311h05b510d_0.conda
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.16.0-py312he37b823_0.conda
   hash:
-    md5: 35f87feb986222d2ada633b45df0bbc9
-    sha256: c071b132b8415ccd1452e0b8002aa79ea59a4fd0b0ac0d3b2fd0ab6b19b3390c
-  build: py311h05b510d_0
+    md5: 86726ebb1f6da39c68f306ae624ee4ed
+    sha256: 25824dd9a22f2c1e8f205eb55c906b28b2f4748a68cb8e3d95ffdf73f08cbac9
+  build: py312he37b823_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: BSD-2-Clause
-  size: 60998
-  timestamp: 1699533434768
+  license_family: BSD
+  size: 59676
+  timestamp: 1699533197501
 - platform: win-64
   name: wrapt
   version: 1.16.0
   category: main
   manager: conda
   dependencies:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.16.0-py311ha68e1ae_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.16.0-py312he70551f_0.conda
   hash:
-    md5: b96598823313b647148417455f2fa659
-    sha256: e8209b3ebdde15834b59101fd14a7f293d868d2fbad2dcd634357cc3406f1052
-  build: py311ha68e1ae_0
+    md5: cea7b1aa961de6a8ac90584b5968a01d
+    sha256: e4b5ac6c897e68a798dfe13a1499dc9b555c48b468aa477d456807f2a7366c30
+  build: py312he70551f_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: BSD-2-Clause
-  size: 62017
-  timestamp: 1699533574835
+  license_family: BSD
+  size: 61358
+  timestamp: 1699533495284
 - platform: linux-64
   name: xarray
   version: 2023.10.1
@@ -33724,4 +33904,3 @@ package:
   license_family: BSD
   size: 343428
   timestamp: 1693151615801
-version: 1


### PR DESCRIPTION
I noticed with #731 we went back from Python 3.12 to 3.11. This updates all dependencies, including Python back to 3.12.

I did this using pixi 0.7.0 which just came out: https://github.com/prefix-dev/pixi/releases/tag/v0.7.0

The lockfile format seems the same, so I'm hoping this works on TeamCity with pixi 0.6.0, but I triggered tests to make sure. There is a new top level `version: 2` entry on top of the lockfile, so it looks like they started versioning it.
