### PR TITLE
Opt out of Aqua 0.8 persistent_tasks test

### DIFF
--- a/core/Project.toml
+++ b/core/Project.toml
@@ -39,7 +39,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
-Aqua = "0.8"
+Aqua = "0.7"
 Arrow = "2.3"
 BasicModelInterface = "0.1"
 CSV = "0.10"

--- a/core/Project.toml
+++ b/core/Project.toml
@@ -39,7 +39,7 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
-Aqua = "0.7"
+Aqua = "0.8"
 Arrow = "2.3"
 BasicModelInterface = "0.1"
 CSV = "0.10"

--- a/core/test/runtests.jl
+++ b/core/test/runtests.jl
@@ -17,5 +17,5 @@ using SafeTestsets: @safetestset
     @safetestset "Docs" include("docs.jl")
     @safetestset "Command Line Interface" include("cli.jl")
     @safetestset "libribasim" include("libribasim.jl")
-    Aqua.test_all(Ribasim; ambiguities = false)
+    Aqua.test_all(Ribasim; ambiguities = false, persistent_tasks = false)
 end


### PR DESCRIPTION
The release of Aqua 0.8 broke CI. That won't happen again since on main now we declare the compat. It seems that we don't work with Aqua 0.8 yet, so we stick to 0.7 for now. The error is:

```
┌ Error: Unexpected error: /tmp/jl_LSHYf656FI/done.log was not created, but precompilation exited
└ @ Aqua ~/.julia/packages/Aqua/rTj6Y/src/persistent_tasks.jl:159
  Activating project at `/tmp/jl_b4guN0`
Persistent tasks: Test Failed at /home/runner/.julia/packages/Aqua/rTj6Y/src/persistent_tasks.jl:80
  Expression: !(has_persistent_tasks(package; kwargs...))
```

from https://github.com/Deltares/Ribasim/actions/runs/6890693118/job/18744259890

We can opt-out of this test with `persistent_tasks=false`, see also https://juliatesting.github.io/Aqua.jl/dev/#Aqua.test_persistent_tasks-Tuple%7BBase.PkgId%7D and https://juliatesting.github.io/Aqua.jl/dev/#Aqua.find_persistent_tasks_deps-Tuple%7BBase.PkgId%7D.

Created #792 to track enabling this.