### PR TITLE
More informative repr's

### DIFF
--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -316,6 +316,17 @@ class TableModel(FileModel, Generic[TableT]):
         else:
             return []
 
+    def __repr__(self) -> str:
+        # Make sure not to return just "None", because it gets extremely confusing
+        # when debugging.
+        return f"<{self.tablename()}>\n{self.df.__repr__()}"
+
+    def _repr_html_(self):
+        if self.df is None:
+            return self.__repr__()
+        else:
+            return f"<div>{self.tablename()}</div>" + self.df._repr_html_()
+
 
 class SpatialTableModel(TableModel[TableT], Generic[TableT]):
     @classmethod
@@ -394,3 +405,23 @@ class NodeModel(BaseModel):
                 input_dir,
                 sort_keys=self._sort_keys.get("field", ["node_id"]),
             )
+
+    def _repr_content(self) -> str:
+        """Generate a succinct overview of the content.
+
+        Skip "empty" attributes: when the dataframe of a TableModel is None.
+        """
+        content = []
+        for field in self.fields():
+            attr = getattr(self, field)
+            if isinstance(attr, TableModel):
+                if attr.df is not None:
+                    content.append(field)
+            else:
+                content.append(field)
+        return ", ".join(content)
+
+    def __repr__(self) -> str:
+        content = self._repr_content()
+        typename = type(self).__name__
+        return f"{typename}({content})"

--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -319,7 +319,7 @@ class TableModel(FileModel, Generic[TableT]):
     def __repr__(self) -> str:
         # Make sure not to return just "None", because it gets extremely confusing
         # when debugging.
-        return f"<{self.tablename()}>\n{self.df.__repr__()}"
+        return f"{self.tablename()}\n{self.df.__repr__()}"
 
     def _repr_html_(self):
         if self.df is None:

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -210,17 +210,19 @@ class Model(FileModel):
 
         Skip "empty" NodeModel instances: when all dataframes are None.
         """
-        content = ["<ribasim.Model>"]
+        content = ["ribasim.Model("]
+        INDENT = "    "
         for field in self.fields():
             attr = getattr(self, field)
             if isinstance(attr, NodeModel):
                 attr_content = attr._repr_content()
                 typename = type(attr).__name__
                 if attr_content:
-                    content.append(f"{field}={typename}({attr_content})")
+                    content.append(f"{INDENT}{field}={typename}({attr_content}),")
             else:
-                content.append(f"{field}={repr(attr)}")
+                content.append(f"{INDENT}{field}={repr(attr)},")
 
+        content.append(")")
         return "\n".join(content)
 
     def _repr_html(self):

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -225,10 +225,6 @@ class Model(FileModel):
         content.append(")")
         return "\n".join(content)
 
-    def _repr_html(self):
-        # Default to standard repr for now
-        return self.__repr__()
-
     def _write_toml(self, directory: FilePath):
         directory = Path(directory)
 

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -38,7 +38,7 @@ from ribasim.config import (
 )
 from ribasim.geometry.edge import Edge
 from ribasim.geometry.node import Node
-from ribasim.input_base import FileModel, NodeModel, TableModel, context_file_loading
+from ribasim.input_base import FileModel, NodeModel, context_file_loading
 from ribasim.types import FilePath
 
 
@@ -206,15 +206,21 @@ class Model(FileModel):
         return str(path)
 
     def __repr__(self) -> str:
-        first = []
-        second = []
+        """Generate a succinct overview of the Model content.
+
+        Skip "empty" NodeModel instances: when all dataframes are None.
+        """
+        content = ["<ribasim.Model>"]
         for field in self.fields():
             attr = getattr(self, field)
-            if isinstance(attr, TableModel):
-                second.append(f"{field}: {repr(attr)}")
+            if isinstance(attr, NodeModel):
+                attr_content = attr._repr_content()
+                typename = type(attr).__name__
+                if attr_content:
+                    content.append(f"{field}={typename}({attr_content})")
             else:
-                first.append(f"{field}={repr(attr)}")
-        content = ["<ribasim.Model>"] + first + second
+                content.append(f"{field}={repr(attr)}")
+
         return "\n".join(content)
 
     def _repr_html(self):

--- a/python/ribasim/tests/test_io.py
+++ b/python/ribasim/tests/test_io.py
@@ -72,8 +72,13 @@ def test_repr():
     )
 
     pump_1 = Pump(static=static_data)
+    pump_2 = Pump()
 
-    assert repr(pump_1) == "Pump(static=TableModel[PumpStaticSchema]())"
+    assert repr(pump_1) == "Pump(static)"
+    assert repr(pump_2) == "Pump()"
+    # Ensure _repr_html doesn't error
+    assert isinstance(pump_1.static._repr_html_(), str)
+    assert isinstance(pump_2.static._repr_html_(), str)
 
 
 def test_extra_columns():

--- a/python/ribasim/tests/test_model.py
+++ b/python/ribasim/tests/test_model.py
@@ -9,7 +9,7 @@ from shapely import Point
 
 def test_repr(basic):
     representation = repr(basic).split("\n")
-    assert representation[0] == "<ribasim.Model>"
+    assert representation[0] == "ribasim.Model("
 
 
 def test_solver():


### PR DESCRIPTION
* Show dataframe for TableModel
* For NodeModel: only show not-None entries
* For Model: show only NodeModel with any data

Fixes #809

This seems better, model shows only stuff with data:

```python
ribasim.Model(
    filepath=WindowsPath('harm/ribasim.toml'),
    starttime=datetime.datetime(2020, 1, 1, 0, 0),
    endtime=datetime.datetime(2020, 2, 1, 0, 0),
    update_timestep=datetime.timedelta(days=1),
    relative_dir=WindowsPath('.'),
    input_dir=WindowsPath('.'),
    results_dir=WindowsPath('results'),
    network=Network(filepath, node, edge),
    results=Results(basin=WindowsPath('results/basin.arrow'), flow=WindowsPath('results/flow.arrow'), control=WindowsPath('results/control.arrow'), outstate=None, compression='zstd', compression_level=6),
    solver=Solver(algorithm='QNDF', saveat=[], adaptive=True, dt=None, dtmin=None, dtmax=None, force_dtmin=False, abstol=1e-06, reltol=1e-05, maxiters=1000000000, sparse=True, autodiff=True),
    logging=Logging(verbosity='info', timing=False),
    allocation=Allocation(timestep=None, use_allocation=False, objective_type='quadratic_relative'),
    basin=Basin(profile, state, time),
    level_boundary=LevelBoundary(static),
    manning_resistance=ManningResistance(static),
    tabulated_rating_curve=TabulatedRatingCurve(static),
)
```

It's also closer to the Python code representation, with the parentheses and the commas.

NodeModel instances show the members with data, e.g. `model.basin`:

```
Basin(profile, state, time)
```

Empty NodeModel instances are omitted from the Model overview, but can be seen, e.g. `model.pump` shows:

```
Pump()
```

 -- which nicely matches the instantiation.

TableModel repr's show the dataframe (but with the tablename prepended for clarity):

```
LevelBoundary / static
   node_id active  level remarks
0        1   None   7.15     
```

Also for the HTML repr:

![image](https://github.com/Deltares/Ribasim/assets/13662783/3d81aaa6-8c99-49ad-ae5e-4f110d624ad5)

I've removed the `< >` around the types. They weren't very consistent to begin with. I originally took inspiration from xarray, but xarray doesn't use the brackets very consistently either in their repr's.