### PR TITLE
Fix QGIS plugin now that database entry is not in TOML

### DIFF
--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -260,8 +260,11 @@ class DatasetWidget(QWidget):
 
     def _get_database_path_from_model_file(self) -> str:
         with open(self.path, "rb") as f:
-            input_dir = tomllib.load(f)["input_dir"]
-        return str((Path(self.path).parent / input_dir / "database.gpkg").resolve())
+            input_dir = Path(tomllib.load(f)["input_dir"])
+        if input_dir.is_absolute():
+            return str(input_dir / "database.gpkg")
+        else:
+            return str((Path(self.path).parent / input_dir / "database.gpkg").resolve())
 
     def new_model(self) -> None:
         """Create a new Ribasim model file, and set it as the active dataset."""

--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -261,10 +261,9 @@ class DatasetWidget(QWidget):
     def _get_database_path_from_model_file(self) -> str:
         with open(self.path, "rb") as f:
             input_dir = Path(tomllib.load(f)["input_dir"])
-        if input_dir.is_absolute():
-            return str(input_dir / "database.gpkg")
-        else:
-            return str((Path(self.path).parent / input_dir / "database.gpkg").resolve())
+        # The .joinpath method (/) of pathlib.Path will take care of an absolute input_dir.
+        # No need to check it ourselves!
+        return str((Path(self.path).parent / input_dir / "database.gpkg").resolve())
 
     def new_model(self) -> None:
         """Create a new Ribasim model file, and set it as the active dataset."""

--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -260,8 +260,8 @@ class DatasetWidget(QWidget):
 
     def _get_database_path_from_model_file(self) -> str:
         with open(self.path, "rb") as f:
-            model_filename = tomllib.load(f)["database"]
-            return str(Path(self.path).parent.joinpath(model_filename))
+            input_dir = tomllib.load(f)["input_dir"]
+        return str((Path(self.path).parent / input_dir / "database.gpkg").resolve())
 
     def new_model(self) -> None:
         """Create a new Ribasim model file, and set it as the active dataset."""


### PR DESCRIPTION
This code gives an error in the QGIS plugin:

```python
    def _get_database_path_from_model_file(self) -> str:
        with open(self.path, "rb") as f:
            model_filename = tomllib.load(f)["database"]
            return str(Path(self.path).parent.joinpath(model_filename))
```

Because the database entry is no longer present in the TOML because of #815.