### PR TITLE
fix pixi to v0.7.0 in GitHub Actions

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: "latest"
+          pixi-version: v0.7.0
       - name: Prepare pixi
         run: pixi run install-without-pre-commit
       - name: Prepare model input

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: "latest"
+          pixi-version: v0.7.0
       - name: Prepare pixi
         run: pixi run install-without-pre-commit
 

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.4.1
         with:
-          pixi-version: "latest"
+          pixi-version: v0.7.0
       - name: Prepare pixi
         run: pixi run install-without-pre-commit
       - name: Run mypy on python/ribasim


### PR DESCRIPTION
V0.8.0 just came out and now our CI is broken. Let's try if this fixes it so we can upgrade at a better time.

https://github.com/prefix-dev/pixi/releases/tag/v0.8.0