### PR TITLE
Declare numpy dependency of ribasim-python

### DIFF
--- a/python/ribasim/pyproject.toml
+++ b/python/ribasim/pyproject.toml
@@ -16,6 +16,7 @@ requires-python = ">=3.10"
 dependencies = [
     "geopandas",
     "matplotlib",
+    "numpy",
     "pandas",
     "pandera != 0.16.0",
     "pyarrow",


### PR DESCRIPTION
Found in https://github.com/conda-forge/ribasim-feedstock/pull/4

It is already mentioned as a dependency in ribasim_testmodels and ribasim_api.