### PR TITLE
Fix problems emerging from DSD demo model

### DIFF
--- a/core/src/allocation.jl
+++ b/core/src/allocation.jl
@@ -195,6 +195,10 @@ function process_allocation_graph_edges!(
             continue
         end
 
+        if node_id_1 == node_id_2
+            continue
+        end
+
         # Find capacity of this composite allocation graph edge
         positive_flow = true
         negative_flow = true

--- a/core/src/utils.jl
+++ b/core/src/utils.jl
@@ -940,10 +940,10 @@ function update_jac_prototype!(
         if has_index_in
             jac_prototype[idx_in, idx_in] = 1.0
 
-            _, idxs_out =
+            _, basin_idxs_out, has_fractional_flow_outneighbors =
                 get_fractional_flow_connected_basins(id, basin, fractional_flow, graph)
 
-            if isempty(idxs_out)
+            if !has_fractional_flow_outneighbors
                 id_out = outflow_id(graph, id)
                 has_index_out, idx_out = id_index(basin.node_id, id_out)
 
@@ -951,7 +951,7 @@ function update_jac_prototype!(
                     jac_prototype[idx_in, idx_out] = 1.0
                 end
             else
-                for idx_out in idxs_out
+                for idx_out in basin_idxs_out
                     jac_prototype[idx_in, idx_out] = 1.0
                 end
             end
@@ -1033,12 +1033,15 @@ function get_fractional_flow_connected_basins(
     basin::Basin,
     fractional_flow::FractionalFlow,
     graph::MetaGraph,
-)::Tuple{Vector{Int}, Vector{Int}}
+)::Tuple{Vector{Int}, Vector{Int}, Bool}
     fractional_flow_idxs = Int[]
     basin_idxs = Int[]
 
+    has_fractional_flow_outneighbors = false
+
     for first_outneighbor_id in outflow_ids(graph, node_id)
         if first_outneighbor_id in fractional_flow.node_id
+            has_fractional_flow_outneighbors = true
             second_outneighbor_id = outflow_id(graph, first_outneighbor_id)
             has_index, basin_idx = id_index(basin.node_id, second_outneighbor_id)
             if has_index
@@ -1050,7 +1053,7 @@ function get_fractional_flow_connected_basins(
             end
         end
     end
-    return fractional_flow_idxs, basin_idxs
+    return fractional_flow_idxs, basin_idxs, has_fractional_flow_outneighbors
 end
 
 """

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -85,7 +85,7 @@ neighbortypes(::Val{:discrete_control}) = Set((
     :tabulated_rating_curve,
     :linear_resistance,
     :manning_resistance,
-    :fractioal_flow,
+    :fractional_flow,
     :pid_control,
 ))
 neighbortypes(::Val{:pid_control}) = Set((:pump, :outlet))
@@ -446,7 +446,7 @@ function valid_edges(graph::MetaGraph)::Bool
 
         if !(type_dst in neighbortypes(type_src))
             errors = true
-            edge_id = graph[id_src, id_dst].id.value
+            edge_id = graph[id_src, id_dst].id
             @error "Cannot connect a $type_src to a $type_dst (edge #$edge_id from node $id_src to $id_dst)."
         end
     end

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -577,15 +577,15 @@ function valid_fractional_flow(
     src_ids = Set{NodeID}()
 
     for id in node_id
-        union!(src_ids, inneighbor_labels(graph, id))
+        union!(src_ids, inflow_ids(graph, id))
     end
 
     node_id_set = Set{NodeID}(node_id)
     control_states = Set{String}([key[2] for key in keys(control_mapping)])
 
     for src_id in src_ids
-        src_outneighbor_ids = Set(outneighbor_labels(graph, src_id))
-        if src_outneighbor_ids ⊈ node_id
+        src_outneighbor_ids = Set(outflow_ids(graph, src_id))
+        if src_outneighbor_ids ⊈ node_id_set
             errors = true
             @error(
                 "Node $src_id combines fractional flow outneighbors with other outneigbor types."


### PR DESCRIPTION
Fixes the issue mentioned [here](https://github.com/Deltares/Ribasim/pull/842#issuecomment-1830045720). This error occurs due to the wrong assumption in the code that fractional flow nodes only have basin outneighbors.

Also fixes the issue mentioned [here](https://github.com/Deltares/Ribasim/pull/845). Here the problem is dat allocation pre-processing created (allocation only) self-edges, which triggered the error for fractional flow connectivity which should only look at flow edges.
