### PR TITLE
Fix plotting PID listen edges

### DIFF
--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -404,26 +404,23 @@ class Model(FileModel):
                     x_end.append(point_end.x)
                     y_end.append(point_end.y)
 
-        if self.pid_control.static.df is not None:
-            static = self.pid_control.static.df
-            time = self.pid_control.time.df
-            node_static = self.network.node.static.df
+        for table in [self.pid_control.static.df, self.pid_control.time.df]:
+            if table is None:
+                continue
 
-            for table in [static, time]:
-                if table is None:
-                    continue
+            node = self.network.node.df
 
-                for node_id in table.node_id.unique():
-                    for listen_node_id in table.loc[
-                        table.node_id == node_id, "listen_node_id"
-                    ].unique():
-                        point_start = node_static.iloc[listen_node_id - 1].geometry
-                        x_start.append(point_start.x)
-                        y_start.append(point_start.y)
+            for node_id in table.node_id.unique():
+                for listen_node_id in table.loc[
+                    table.node_id == node_id, "listen_node_id"
+                ].unique():
+                    point_start = node.iloc[listen_node_id - 1].geometry
+                    x_start.append(point_start.x)
+                    y_start.append(point_start.y)
 
-                        point_end = node_static.iloc[node_id - 1].geometry
-                        x_end.append(point_end.x)
-                        y_end.append(point_end.y)
+                    point_end = node.iloc[node_id - 1].geometry
+                    x_end.append(point_end.x)
+                    y_end.append(point_end.y)
 
         if len(x_start) == 0:
             return

--- a/python/ribasim/tests/conftest.py
+++ b/python/ribasim/tests/conftest.py
@@ -27,3 +27,8 @@ def tabulated_rating_curve() -> ribasim.Model:
 @pytest.fixture()
 def backwater() -> ribasim.Model:
     return ribasim_testmodels.backwater_model()
+
+
+@pytest.fixture()
+def discrete_control_of_pid_control() -> ribasim.Model:
+    return ribasim_testmodels.discrete_control_of_pid_control_model()

--- a/python/ribasim/tests/test_model.py
+++ b/python/ribasim/tests/test_model.py
@@ -131,3 +131,7 @@ def test_tabulated_rating_curve_model(tabulated_rating_curve, tmp_path):
     model_orig = tabulated_rating_curve
     model_orig.write(tmp_path / "tabulated_rating_curve/ribasim.toml")
     Model.read(tmp_path / "tabulated_rating_curve/ribasim.toml")
+
+
+def test_plot(discrete_control_of_pid_control):
+    discrete_control_of_pid_control.plot()


### PR DESCRIPTION
This was broken in the Python overhaul, `self.network.node.static.df` needed to be updated to `self.network.node.df`.
I added a test to make sure the plotting code at least doesn't error, using a model that has both discrete as well as PID control.

The rest of the diff is to fix printing PID listen edges if there is only time dependent PID control, like in https://deltares.github.io/Ribasim/python/examples.html#model-with-pid-control, since we only checked if `if self.pid_control.static.df is not None`.

This now looks good, `discrete_control_of_pid_control`:
![image](https://github.com/Deltares/Ribasim/assets/4471859/ff20473b-83db-4d63-a6d9-4f2d400c12da)