### PR TITLE
Unit tests for qgis/core/model.py

### DIFF
--- a/ribasim_qgis/tests/core/test_model.py
+++ b/ribasim_qgis/tests/core/test_model.py
@@ -13,9 +13,7 @@ class TestModel(unittest.TestCase):
     data_folder_path = tests_folder_path / "data"
 
     def test_get_directory_path_from_model_file(self):
-        """_summary
-        Tests that get_directory_path_from_model_file() can resolve paths from a toml file.
-        """
+        """Tests that get_directory_path_from_model_file() can resolve paths from a toml file."""
         for test_case in [("input_dir", "."), ("results_dir", "results")]:
             with self.subTest(property=test_case[0], value=test_case[1]):
                 path = get_directory_path_from_model_file(
@@ -30,9 +28,7 @@ class TestModel(unittest.TestCase):
                 self.assertEqual(path, self.data_folder_path / test_case[1])
 
     def test_get_database_path_from_model_file(self):
-        """_summary
-        Tests that get_database_path_from_model_file() can find the input directory and appends the database.gpkg to it.
-        """
+        """Tests that get_database_path_from_model_file() can find the input directory and appends the database.gpkg to it."""
         path = get_database_path_from_model_file(
             self.data_folder_path / "simple_valid.toml"
         )

--- a/ribasim_qgis/tests/core/test_model.py
+++ b/ribasim_qgis/tests/core/test_model.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from qgis.testing import unittest
+
+from ribasim_qgis.core.model import (
+    get_database_path_from_model_file,
+    get_directory_path_from_model_file,
+)
+
+
+class TestModel(unittest.TestCase):
+    tests_folder_path = Path(__file__).parent.parent.resolve()
+    data_folder_path = tests_folder_path / "data"
+
+    def test_get_directory_path_from_model_file(self):
+        """_summary
+        Tests that get_directory_path_from_model_file() can resolve paths from a toml file.
+        """
+        for test_case in [("input_dir", "."), ("results_dir", "results")]:
+            with self.subTest(property=test_case[0], value=test_case[1]):
+                path = get_directory_path_from_model_file(
+                    self.data_folder_path / "simple_valid.toml",
+                    property=test_case[0],
+                )
+                self.assertTrue(path.is_absolute(), msg=f"{path} is not absolute")
+                self.assertTrue(
+                    path.is_relative_to(self.tests_folder_path),
+                    msg=f"Path '{path}' is not relative to {self.tests_folder_path}",
+                )
+                self.assertEqual(path, self.data_folder_path / test_case[1])
+
+    def test_get_database_path_from_model_file(self):
+        """_summary
+        Tests that get_database_path_from_model_file() can find the input directory and appends the database.gpkg to it.
+        """
+        path = get_database_path_from_model_file(
+            self.data_folder_path / "simple_valid.toml"
+        )
+        self.assertTrue(path.is_absolute(), msg=f"{path} is not absolute")
+        self.assertTrue(
+            path.is_relative_to(self.tests_folder_path),
+            msg=f"Path '{path}' is not relative to {self.tests_folder_path}",
+        )
+        self.assertEqual(path, self.data_folder_path / "database.gpkg")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ribasim_qgis/tests/data/simple_valid.toml
+++ b/ribasim_qgis/tests/data/simple_valid.toml
@@ -1,0 +1,4 @@
+starttime = 2020-01-01 00:00:00
+endtime = 2021-01-01 00:00:00
+input_dir = "."
+results_dir = "results"


### PR DESCRIPTION
Can be run by calling `pixi run code.` to ensure the environment is set correctly, then simply run it by pressing F5 to debug the local file. The tests also run over `pixi run test-ribasim-qgis` in docker.

The tests cannot be found by VS code, since we are mixing `unittests` and `pytest` and VS Code can only handle one type. Also, it seems to try to activate a conda environment that is not present.

Fixes #813 