### PR TITLE
Disable randomly failing MacOS core tests

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -20,7 +20,8 @@ jobs:
           - "~1.10.0-0"
         os:
           - ubuntu-latest
-          - macOS-latest
+          # https://github.com/Deltares/Ribasim/issues/825
+          # - macOS-latest
           - windows-latest
         arch:
           - x64


### PR DESCRIPTION
Until we have time to look into #825, I feel like it is better to just disable MacOS for core CI. With Linux and Windows we still have decent OS coverage.