### PR TITLE
Make QGIS tables editable

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,10 @@
     "python.analysis.extraPaths": [
         ".pixi/env/Library/python"
     ],
-    "mypy-type-checker.importStrategy": "fromEnvironment"
+    "mypy-type-checker.importStrategy": "fromEnvironment",
+    "python.testing.pytestArgs": [
+        "."
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
 }

--- a/open-vscode.bat
+++ b/open-vscode.bat
@@ -1,0 +1,1 @@
+pixi run code . | exit

--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Generator
 from contextlib import closing
 from contextvars import ContextVar
 from pathlib import Path
-from sqlite3 import Connection, connect
+from sqlite3 import Connection, Cursor, connect
 from typing import (
     Any,
     Generic,
@@ -244,11 +244,30 @@ class TableModel(FileModel, Generic[TableT]):
         with closing(connect(temp_path)) as connection:
             self.df.to_sql(table, connection, index=False, if_exists="replace")
 
-            # Set geopackage attribute table
             with closing(connection.cursor()) as cursor:
+                # QGIS requires an fid column for each table, otherwise it is not possible to edit data.
+                cursor.execute(f'PRAGMA table_info("{table}")')
+                table_info = cursor.fetchall()
+                has_primary_key = any(row[5] == 1 for row in table_info)
+                column_names = [result[1] for result in table_info]
+                if not has_primary_key:
+                    self.__add_fid_column(table, cursor, column_names)
+
+                # Set geopackage attribute table
                 sql = "INSERT INTO gpkg_contents (table_name, data_type, identifier) VALUES (?, ?, ?)"
                 cursor.execute(sql, (table, "attributes", table))
+
             connection.commit()
+
+    @staticmethod
+    def __add_fid_column(table: str, cursor: Cursor, column_names: list[str]) -> None:
+        column_list = ", ".join(column_names)
+        sql = f'CREATE TABLE "{table}_temp" (fid INTEGER PRIMARY KEY AUTOINCREMENT, {column_list})'
+        cursor.execute(sql)
+        sql = f'INSERT INTO "{table}_temp" ({column_list}) SELECT {column_list} FROM "{table}"'
+        cursor.execute(sql)
+        cursor.execute(f'DROP TABLE "{table}"')
+        cursor.execute(f'ALTER TABLE "{table}_temp" RENAME TO "{table}"')
 
     def _write_arrow(self, filepath: Path, directory: Path, input_dir: Path) -> None:
         """Write the contents of the input to a an arrow file."""

--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -256,11 +256,10 @@ class TableModel(FileModel, Generic[TableT]):
                 dtype={"fid": "INTEGER PRIMARY KEY AUTOINCREMENT"},
             )
 
+            # Set geopackage attribute table
             with closing(connection.cursor()) as cursor:
-                # Set geopackage attribute table
                 sql = "INSERT INTO gpkg_contents (table_name, data_type, identifier) VALUES (?, ?, ?)"
                 cursor.execute(sql, (table, "attributes", table))
-
             connection.commit()
 
     def _write_arrow(self, filepath: Path, directory: Path, input_dir: Path) -> None:

--- a/python/ribasim/tests/test_model.py
+++ b/python/ribasim/tests/test_model.py
@@ -1,10 +1,13 @@
 import re
+from sqlite3 import connect
 
 import pandas as pd
 import pytest
 from pydantic import ValidationError
 from ribasim import Model, Solver
 from shapely import Point
+
+from python.ribasim.ribasim.input_base import esc_id
 
 
 def test_repr(basic):
@@ -135,3 +138,14 @@ def test_tabulated_rating_curve_model(tabulated_rating_curve, tmp_path):
 
 def test_plot(discrete_control_of_pid_control):
     discrete_control_of_pid_control.plot()
+
+
+def test_write_adds_fid_in_tables(basic, tmp_path):
+    model_orig = basic
+    model_orig.write(tmp_path / "basic/ribasim.toml")
+    with connect(tmp_path / "basic/database.gpkg") as connection:
+        query = f"select * from {esc_id('Basin / profile')}"
+        df = pd.read_sql_query(query, connection, parse_dates=["time"])
+        assert "fid" in df.columns
+        fids = df.get("fid")
+        assert fids.equals(pd.Series(range(1, len(fids) + 1)))


### PR DESCRIPTION
Add an fid column to all tables and make them a PRIMARY KEY AUTOINCREMENT.
From now on, QGIS understands that they are editable.

Fixes #841 