### PR TITLE
Don't require consecutive Node IDs

### DIFF
--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -248,7 +248,7 @@ function create_callbacks(
             save_subgrid_level,
             saved_subgrid_level;
             saveat,
-            save_start = false,
+            save_start = true,
         )
         push!(callbacks, export_cb)
     end

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -273,14 +273,13 @@ class Model(FileModel):
             all_node_ids.update(node.node_ids())
 
         unique, counts = np.unique(list(all_node_ids), return_counts=True)
-
-        node_ids_non_negative_integers = np.greater(unique, -1) & np.equal(
-            unique.astype(int), unique
+        node_ids_negative_integers = np.less(unique, 0) | np.not_equal(
+            unique.astype(np.int64), unique
         )
 
-        if not node_ids_non_negative_integers.all():
+        if node_ids_negative_integers.any():
             raise ValueError(
-                f"Node IDs must be non-negative integers, got {unique[~node_ids_non_negative_integers]}."
+                f"Node IDs must be non-negative integers, got {unique[node_ids_negative_integers]}."
             )
 
         if (counts > 1).any():

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -267,8 +267,6 @@ class Model(FileModel):
     def validate_model_node_field_ids(self):
         """Check whether the node IDs of the node_type fields are valid."""
 
-        n_nodes = self.network.n_nodes()
-
         # Check node IDs of node fields
         all_node_ids = set[int]()
         for node in self.nodes().values():
@@ -276,33 +274,19 @@ class Model(FileModel):
 
         unique, counts = np.unique(list(all_node_ids), return_counts=True)
 
-        node_ids_positive_integers = np.greater(unique, 0) & np.equal(
+        node_ids_non_negative_integers = np.greater(unique, -1) & np.equal(
             unique.astype(int), unique
         )
 
-        if not node_ids_positive_integers.all():
+        if not node_ids_non_negative_integers.all():
             raise ValueError(
-                f"Node IDs must be positive integers, got {unique[~node_ids_positive_integers]}."
+                f"Node IDs must be non-negative integers, got {unique[~node_ids_non_negative_integers]}."
             )
 
         if (counts > 1).any():
             raise ValueError(
                 f"These node IDs were assigned to multiple node types: {unique[(counts > 1)]}."
             )
-
-        if not np.array_equal(unique, np.arange(n_nodes) + 1):
-            node_ids_missing = set(np.arange(n_nodes) + 1) - set(unique)
-            node_ids_over = set(unique) - set(np.arange(n_nodes) + 1)
-            msg = [
-                f"Expected node IDs from 1 to {n_nodes} (the number of rows in self.network.node.df)."
-            ]
-            if len(node_ids_missing) > 0:
-                msg.append(f"These node IDs are missing: {node_ids_missing}.")
-
-            if len(node_ids_over) > 0:
-                msg.append(f"These node IDs are unexpected: {node_ids_over}.")
-
-            raise ValueError(" ".join(msg))
 
     def validate_model_node_ids(self):
         """Check whether the node IDs in the data tables correspond to the node IDs in the network."""

--- a/python/ribasim/tests/test_model.py
+++ b/python/ribasim/tests/test_model.py
@@ -112,7 +112,6 @@ def test_node_ids_unsequential(basic):
     model = basic
 
     basin = model.basin
-
     basin.profile = pd.DataFrame(
         data={
             "node_id": [1, 1, 3, 3, 6, 6, 1000, 1000],
@@ -120,16 +119,9 @@ def test_node_ids_unsequential(basic):
             "level": [0.0, 1.0] * 4,
         }
     )
-
     basin.static.df["node_id"] = [1, 3, 6, 1000]
 
-    with pytest.raises(ValueError) as excinfo:
-        model.validate_model_node_field_ids()
-
-    assert (
-        "Expected node IDs from 1 to 17 (the number of rows in self.network.node.df). These node IDs are missing: {9}. These node IDs are unexpected: {1000}."
-        in str(excinfo.value)
-    )
+    model.validate_model_node_field_ids()
 
 
 def test_tabulated_rating_curve_model(tabulated_rating_curve, tmp_path):

--- a/python/ribasim/tests/test_model.py
+++ b/python/ribasim/tests/test_model.py
@@ -71,7 +71,7 @@ def test_invalid_node_id(basic):
 
     with pytest.raises(
         ValueError,
-        match=re.escape("Node IDs must be positive integers, got [-1]."),
+        match=re.escape("Node IDs must be non-negative integers, got [-1]."),
     ):
         model.validate_model_node_field_ids()
 

--- a/python/ribasim_testmodels/ribasim_testmodels/trivial.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/trivial.py
@@ -10,9 +10,9 @@ def trivial_model() -> ribasim.Model:
     # Set up the nodes:
     xy = np.array(
         [
-            (400.0, 200.0),  # 1: Basin
-            (450.0, 200.0),  # 2: TabulatedRatingCurve
-            (500.0, 200.0),  # 3: Terminal
+            (400.0, 200.0),  # 6: Basin
+            (450.0, 200.0),  # 4: TabulatedRatingCurve
+            (500.0, 200.0),  # 8: Terminal
         ]
     )
     node_xy = gpd.points_from_xy(x=xy[:, 0], y=xy[:, 1])
@@ -25,15 +25,15 @@ def trivial_model() -> ribasim.Model:
     node = ribasim.Node(
         df=gpd.GeoDataFrame(
             data={"type": node_type},
-            index=pd.Index(np.arange(len(xy)) + 1, name="fid"),
+            index=pd.Index([6, 4, 8], name="fid"),
             geometry=node_xy,
             crs="EPSG:28992",
         )
     )
 
     # Setup the edges:
-    from_id = np.array([1, 2], dtype=np.int64)
-    to_id = np.array([2, 3], dtype=np.int64)
+    from_id = np.array([6, 4], dtype=np.int64)
+    to_id = np.array([4, 8], dtype=np.int64)
     lines = node.geometry_from_connectivity(from_id, to_id)
     edge = ribasim.Edge(
         df=gpd.GeoDataFrame(
@@ -42,6 +42,7 @@ def trivial_model() -> ribasim.Model:
                 "to_node_id": to_id,
                 "edge_type": len(from_id) * ["flow"],
             },
+            index=pd.Index([11, 9], name="fid"),
             geometry=lines,
             crs="EPSG:28992",
         )
@@ -50,7 +51,7 @@ def trivial_model() -> ribasim.Model:
     # Setup the basins:
     profile = pd.DataFrame(
         data={
-            "node_id": [1, 1],
+            "node_id": [6, 6],
             "area": [0.01, 1000.0],
             "level": [0.0, 1.0],
         }
@@ -64,7 +65,7 @@ def trivial_model() -> ribasim.Model:
 
     static = pd.DataFrame(
         data={
-            "node_id": [1],
+            "node_id": [6],
             "drainage": [0.0],
             "potential_evaporation": [evaporation],
             "infiltration": [0.0],
@@ -81,8 +82,8 @@ def trivial_model() -> ribasim.Model:
     #
     subgrid = pd.DataFrame(
         data={
-            "subgrid_id": [1, 1, 2, 2, 3, 3],
-            "node_id": [1, 1, 1, 1, 1, 1],
+            "subgrid_id": [11, 11, 22, 22, 33, 33],
+            "node_id": [6, 6, 6, 6, 6, 6],
             "basin_level": [0.0, 1.0, 0.0, 1.0, 0.0, 1.0],
             "subgrid_level": [-1.0, 0.0, 0.0, 1.0, 1.0, 2.0],
         }
@@ -96,7 +97,7 @@ def trivial_model() -> ribasim.Model:
     rating_curve = ribasim.TabulatedRatingCurve(
         static=pd.DataFrame(
             data={
-                "node_id": [2, 2],
+                "node_id": [4, 4],
                 "level": [0.0, 1.0],
                 "discharge": [0.0, q1000],
             }
@@ -106,7 +107,7 @@ def trivial_model() -> ribasim.Model:
     terminal = ribasim.Terminal(
         static=pd.DataFrame(
             data={
-                "node_id": [3],
+                "node_id": [8],
             }
         )
     )


### PR DESCRIPTION
Fixes #694

It basically was already fixed in the metagraphs refactor, I just had to remove the validation check from Python.

This also adds support for 0, but not negative IDs, as I feel those could be confusing.

I used the trivial model to add some ID variations, and directly added some tests of the Arrow file results that we didn't really have yet.
