### PR TITLE
replace setuptools with hatchling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,9 +14,6 @@
             "source.fixAll": "explicit"
         }
     },
-    "python.analysis.extraPaths": [
-        ".pixi/env/Library/python"
-    ],
     "mypy-type-checker.importStrategy": "fromEnvironment",
     "python.testing.pytestArgs": [
         "."

--- a/pixi.lock
+++ b/pixi.lock
@@ -6036,6 +6036,86 @@ package:
   size: 2339094
   timestamp: 1676076991561
 - platform: linux-64
+  name: editables
+  version: '0.3'
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.5
+  url: https://conda.anaconda.org/conda-forge/noarch/editables-0.3-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: ce5a846b6282ad352022dac9510e8fd6
+    sha256: 6d46237b3feafc1617705c9cf243b1dc79968842eec46e8ded6bb72bd60f5a00
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 8431
+  timestamp: 1649618340031
+- platform: osx-64
+  name: editables
+  version: '0.3'
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.5
+  url: https://conda.anaconda.org/conda-forge/noarch/editables-0.3-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: ce5a846b6282ad352022dac9510e8fd6
+    sha256: 6d46237b3feafc1617705c9cf243b1dc79968842eec46e8ded6bb72bd60f5a00
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 8431
+  timestamp: 1649618340031
+- platform: osx-arm64
+  name: editables
+  version: '0.3'
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.5
+  url: https://conda.anaconda.org/conda-forge/noarch/editables-0.3-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: ce5a846b6282ad352022dac9510e8fd6
+    sha256: 6d46237b3feafc1617705c9cf243b1dc79968842eec46e8ded6bb72bd60f5a00
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 8431
+  timestamp: 1649618340031
+- platform: win-64
+  name: editables
+  version: '0.3'
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.5
+  url: https://conda.anaconda.org/conda-forge/noarch/editables-0.3-pyhd8ed1ab_0.tar.bz2
+  hash:
+    md5: ce5a846b6282ad352022dac9510e8fd6
+    sha256: 6d46237b3feafc1617705c9cf243b1dc79968842eec46e8ded6bb72bd60f5a00
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 8431
+  timestamp: 1649618340031
+- platform: linux-64
   name: eigen
   version: 3.4.0
   category: main
@@ -9481,6 +9561,114 @@ package:
   license_family: MIT
   size: 1438931
   timestamp: 1683684067694
+- platform: linux-64
+  name: hatchling
+  version: 1.21.0
+  category: main
+  manager: conda
+  dependencies:
+  - editables >=0.3
+  - importlib-metadata
+  - packaging >=21.3
+  - pathspec >=0.10.1
+  - pluggy >=1.0.0
+  - python >=3.7
+  - tomli >=1.2.2
+  - trove-classifiers
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.21.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3a7957d6f4c1bff9a055eba725a6550b
+    sha256: c445953db5ab087a4cd378c149db48ee4a886b0e6ce0ce469d779458ac251bc8
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 58703
+  timestamp: 1702967711898
+- platform: osx-64
+  name: hatchling
+  version: 1.21.0
+  category: main
+  manager: conda
+  dependencies:
+  - editables >=0.3
+  - importlib-metadata
+  - packaging >=21.3
+  - pathspec >=0.10.1
+  - pluggy >=1.0.0
+  - python >=3.7
+  - tomli >=1.2.2
+  - trove-classifiers
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.21.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3a7957d6f4c1bff9a055eba725a6550b
+    sha256: c445953db5ab087a4cd378c149db48ee4a886b0e6ce0ce469d779458ac251bc8
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 58703
+  timestamp: 1702967711898
+- platform: osx-arm64
+  name: hatchling
+  version: 1.21.0
+  category: main
+  manager: conda
+  dependencies:
+  - editables >=0.3
+  - importlib-metadata
+  - packaging >=21.3
+  - pathspec >=0.10.1
+  - pluggy >=1.0.0
+  - python >=3.7
+  - tomli >=1.2.2
+  - trove-classifiers
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.21.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3a7957d6f4c1bff9a055eba725a6550b
+    sha256: c445953db5ab087a4cd378c149db48ee4a886b0e6ce0ce469d779458ac251bc8
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 58703
+  timestamp: 1702967711898
+- platform: win-64
+  name: hatchling
+  version: 1.21.0
+  category: main
+  manager: conda
+  dependencies:
+  - editables >=0.3
+  - importlib-metadata
+  - packaging >=21.3
+  - pathspec >=0.10.1
+  - pluggy >=1.0.0
+  - python >=3.7
+  - tomli >=1.2.2
+  - trove-classifiers
+  url: https://conda.anaconda.org/conda-forge/noarch/hatchling-1.21.0-pyhd8ed1ab_0.conda
+  hash:
+    md5: 3a7957d6f4c1bff9a055eba725a6550b
+    sha256: c445953db5ab087a4cd378c149db48ee4a886b0e6ce0ce469d779458ac251bc8
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 58703
+  timestamp: 1702967711898
 - platform: linux-64
   name: hdf4
   version: 4.2.15
@@ -34421,6 +34609,86 @@ package:
   noarch: python
   size: 109927
   timestamp: 1701095799725
+- platform: linux-64
+  name: trove-classifiers
+  version: 2024.1.8
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.1.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: b120d43603f9b021d252fb7754b35557
+    sha256: ce42c9fc7a07a1586467e4e637f4ddc9e1082f1daacb31c98dc5f4c9f56e4601
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  noarch: python
+  size: 18404
+  timestamp: 1704733002526
+- platform: osx-64
+  name: trove-classifiers
+  version: 2024.1.8
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.1.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: b120d43603f9b021d252fb7754b35557
+    sha256: ce42c9fc7a07a1586467e4e637f4ddc9e1082f1daacb31c98dc5f4c9f56e4601
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  noarch: python
+  size: 18404
+  timestamp: 1704733002526
+- platform: osx-arm64
+  name: trove-classifiers
+  version: 2024.1.8
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.1.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: b120d43603f9b021d252fb7754b35557
+    sha256: ce42c9fc7a07a1586467e4e637f4ddc9e1082f1daacb31c98dc5f4c9f56e4601
+  build: pyhd8ed1ab_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  noarch: python
+  size: 18404
+  timestamp: 1704733002526
+- platform: win-64
+  name: trove-classifiers
+  version: 2024.1.8
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2024.1.8-pyhd8ed1ab_0.conda
+  hash:
+    md5: b120d43603f9b021d252fb7754b35557
+    sha256: ce42c9fc7a07a1586467e4e637f4ddc9e1082f1daacb31c98dc5f4c9f56e4601
+  build: pyhd8ed1ab_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  noarch: python
+  size: 18404
+  timestamp: 1704733002526
 - platform: linux-64
   name: twine
   version: 4.0.2

--- a/pixi.toml
+++ b/pixi.toml
@@ -149,6 +149,7 @@ types-requests = "*"
 typing-extensions = ">=4.6"
 xarray = "*"
 xmipy = "*"
+hatchling = "1.21.0.*"
 
 [target.win-64.dependencies]
 quarto = "*"

--- a/pixi.toml
+++ b/pixi.toml
@@ -149,7 +149,7 @@ types-requests = "*"
 typing-extensions = ">=4.6"
 xarray = "*"
 xmipy = "*"
-hatchling = "1.21.0.*"
+hatchling = "*"
 
 [target.win-64.dependencies]
 quarto = "*"

--- a/python/ribasim/pyproject.toml
+++ b/python/ribasim/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=61"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "ribasim"
@@ -31,18 +31,9 @@ dynamic = ["version"]
 [project.optional-dependencies]
 tests = ["pytest", "pytest-xdist", "pytest-cov", "ribasim_testmodels"]
 
-[tool.setuptools]
-zip-safe = true
-
-[tool.setuptools.dynamic]
-version = { attr = "ribasim.__version__" }
-
-[tool.setuptools.packages.find]
-include = ["ribasim", "ribasim.*"]
-
-[tool.setuptools.package-data]
-"ribasim" = ["py.typed"]
-
 [project.urls]
 Documentation = "https://deltares.github.io/Ribasim"
 Source = "https://github.com/Deltares/Ribasim"
+
+[tool.hatch.version]
+path = "ribasim/__init__.py"

--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -411,7 +411,7 @@ class NodeModel(ChildModel):
             if isinstance(attr, TableModel):
                 yield attr
 
-    def node_ids(self):
+    def node_ids(self) -> set[int]:
         node_ids: set[int] = set()
         for table in self.tables():
             node_ids.update(table.node_ids())

--- a/python/ribasim_api/pyproject.toml
+++ b/python/ribasim_api/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=61"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "ribasim_api"
@@ -21,18 +21,9 @@ dynamic = ["version"]
 [project.optional-dependencies]
 tests = ["pytest", "ribasim", "ribasim_testmodels"]
 
-[tool.setuptools]
-zip-safe = true
-
-[tool.setuptools.dynamic]
-version = { attr = "ribasim_api.__version__" }
-
-[tool.setuptools.packages.find]
-include = ["ribasim_api", "ribasim_api.*"]
-
-[tool.setuptools.package-data]
-"ribasim_api" = ["py.typed"]
-
 [project.urls]
 Documentation = "https://deltares.github.io/Ribasim"
 Source = "https://github.com/Deltares/Ribasim"
+
+[tool.hatch.version]
+path = "ribasim_api/__init__.py"

--- a/python/ribasim_testmodels/README.md
+++ b/python/ribasim_testmodels/README.md
@@ -1,0 +1,8 @@
+# Ribasim Testmodels
+
+`ribasim_testmodels` can generate model files with data that can be run by Ribasim.
+The test models are used for internal testing of Ribasim.
+
+# Contributing
+
+For the developer docs please have a look at https://deltares.github.io/Ribasim/python/developer.html

--- a/python/ribasim_testmodels/pyproject.toml
+++ b/python/ribasim_testmodels/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=61"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
 [project]
 name = "ribasim_testmodels"
@@ -19,18 +19,9 @@ dynamic = ["version"]
 [project.optional-dependencies]
 tests = ["pytest"]
 
-[tool.setuptools]
-zip-safe = true
-
-[tool.setuptools.dynamic]
-version.attr = "ribasim_testmodels.__version__"
-
-[tool.setuptools.packages.find]
-include = ["ribasim_testmodels", "ribasim_testmodels.*"]
-
-[tool.setuptools.package-data]
-"ribasim_testmodels" = ["py.typed"]
-
 [project.urls]
 Documentation = "https://deltares.github.io/Ribasim"
 Source = "https://github.com/Deltares/Ribasim"
+
+[tool.hatch.version]
+path = "ribasim_testmodels/__init__.py"

--- a/python/ribasim_testmodels/ribasim_testmodels/basic.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/basic.py
@@ -175,7 +175,7 @@ def basic_model() -> ribasim.Model:
     to_id = np.array(
         [2, 3, 4, 5, 8, 6, 7, 9, 9, 10, 12, 3, 13, 14, 6, 1, 17], dtype=np.int64
     )
-    lines = node.geometry_from_connectivity(from_id, to_id)
+    lines = node.geometry_from_connectivity(from_id.tolist(), to_id.tolist())
     edge = ribasim.Edge(
         df=gpd.GeoDataFrame(
             data={
@@ -248,7 +248,9 @@ def basic_transient_model() -> ribasim.Model:
             "urban_runoff": 0.0,
         }
     )
-    basin_ids = model.basin.static.df["node_id"].to_numpy()
+    df = model.basin.static.df
+    assert df is not None
+    basin_ids = df["node_id"].to_numpy()
     forcing = (
         pd.concat(
             [timeseries.assign(node_id=id) for id in basin_ids], ignore_index=True
@@ -263,9 +265,8 @@ def basic_transient_model() -> ribasim.Model:
             "level": 1.4,
         }
     )
-
-    model.basin.time = forcing
-    model.basin.state = state
+    model.basin.time = forcing  # type: ignore # TODO: Fix implicit typing from pydantic. See TableModel.check_dataframe
+    model.basin.state = state  # type: ignore # TODO: Fix implicit typing from pydantic. See TableModel.check_dataframe
 
     return model
 
@@ -361,7 +362,7 @@ def tabulated_rating_curve_model() -> ribasim.Model:
     # Setup the edges:
     from_id = np.array([1, 1, 2, 3], dtype=np.int64)
     to_id = np.array([2, 3, 4, 4], dtype=np.int64)
-    lines = node.geometry_from_connectivity(from_id, to_id)
+    lines = node.geometry_from_connectivity(from_id.tolist(), to_id.tolist())
     edge = ribasim.Edge(
         df=gpd.GeoDataFrame(
             data={

--- a/python/ribasim_testmodels/ribasim_testmodels/bucket.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/bucket.py
@@ -28,7 +28,7 @@ def bucket_model() -> ribasim.Model:
     # Setup the dummy edges:
     from_id = np.array([], dtype=np.int64)
     to_id = np.array([], dtype=np.int64)
-    lines = node.geometry_from_connectivity(from_id, to_id)
+    lines = node.geometry_from_connectivity(from_id.tolist(), to_id.tolist())
     edge = ribasim.Edge(
         df=gpd.GeoDataFrame(
             data={

--- a/python/ribasim_testmodels/ribasim_testmodels/discrete_control.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/discrete_control.py
@@ -49,7 +49,7 @@ def pump_discrete_control_model() -> ribasim.Model:
 
     edge_type = 4 * ["flow"] + 2 * ["control"]
 
-    lines = node.geometry_from_connectivity(from_id, to_id)
+    lines = node.geometry_from_connectivity(from_id.tolist(), to_id.tolist())
     edge = ribasim.Edge(
         df=gpd.GeoDataFrame(
             data={"from_node_id": from_id, "to_node_id": to_id, "edge_type": edge_type},
@@ -473,7 +473,7 @@ def tabulated_rating_curve_control_model() -> ribasim.Model:
     # Setup the edges:
     from_id = np.array([1, 2, 4], dtype=np.int64)
     to_id = np.array([2, 3, 2], dtype=np.int64)
-    lines = node.geometry_from_connectivity(from_id, to_id)
+    lines = node.geometry_from_connectivity(from_id.tolist(), to_id.tolist())
     edge = ribasim.Edge(
         df=gpd.GeoDataFrame(
             data={

--- a/python/ribasim_testmodels/ribasim_testmodels/trivial.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/trivial.py
@@ -34,7 +34,7 @@ def trivial_model() -> ribasim.Model:
     # Setup the edges:
     from_id = np.array([6, 0], dtype=np.int64)
     to_id = np.array([0, terminal_id], dtype=np.int64)
-    lines = node.geometry_from_connectivity(from_id, to_id)
+    lines = node.geometry_from_connectivity(from_id.tolist(), to_id.tolist())
     edge = ribasim.Edge(
         df=gpd.GeoDataFrame(
             data={


### PR DESCRIPTION
Fixes #925 
Fixes #797 

Use hatchling as build backend to create wheels.

Makes editable installs better accessible for development. Can be tested by looking into e.g. `backwater.py`, and see that `import ribasim` is colored and that `ribasim.Model` contains documentation when you hover over it in VS Code.