### PR TITLE
[fix] Apply meta renaming to spatial tables.

### DIFF
--- a/python/ribasim/ribasim/geometry/edge.py
+++ b/python/ribasim/ribasim/geometry/edge.py
@@ -19,6 +19,7 @@ class EdgeSchema(pa.SchemaModel):
     name: Series[str] = pa.Field(default="")
     from_node_id: Series[int] = pa.Field(default=0, coerce=True)
     to_node_id: Series[int] = pa.Field(default=0, coerce=True)
+    edge_type: Series[str] = pa.Field(default="flow", coerce=True)
     allocation_network_id: Series[pd.Int64Dtype] = pa.Field(
         default=pd.NA, nullable=True, coerce=True
     )

--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -163,7 +163,7 @@ class TableModel(FileModel, Generic[TableT]):
     @classmethod
     def prefix_extra_columns(cls, v: DataFrame[TableT]):
         """Prefix extra columns with meta_."""
-        if isinstance(v, pd.DataFrame):
+        if isinstance(v, (pd.DataFrame, gpd.GeoDataFrame)):
             v.rename(
                 lambda x: prefix_column(x, cls.columns()), axis="columns", inplace=True
             )
@@ -351,6 +351,15 @@ class SpatialTableModel(TableModel[TableT], Generic[TableT]):
                 df = None
 
             return df
+
+    @classmethod
+    def columns(cls) -> list[str]:
+        """Retrieve column names"""
+        T = cls.tableschema()
+        if T is not None:
+            return list(T.to_schema().columns.keys())
+        else:
+            return []
 
     def _write_table(self, path: FilePath) -> None:
         """

--- a/python/ribasim/tests/test_io.py
+++ b/python/ribasim/tests/test_io.py
@@ -5,7 +5,7 @@ from numpy.testing import assert_array_equal
 from pandas import DataFrame
 from pandas.testing import assert_frame_equal
 from pydantic import ValidationError
-from ribasim import Pump
+from ribasim import Node, Pump
 
 
 def __assert_equal(a: DataFrame, b: DataFrame) -> None:
@@ -87,7 +87,7 @@ def test_repr():
     assert isinstance(pump_2.static._repr_html_(), str)
 
 
-def test_extra_columns():
+def test_extra_columns(basic_transient):
     static_data = pd.DataFrame(
         data={"node_id": [1, 2, 3], "flow_rate": [1.0, -1.0, 0.0], "id": [-1, -2, -3]}
     )
@@ -95,3 +95,10 @@ def test_extra_columns():
     pump_1 = Pump(static=static_data)
 
     assert "meta_id" in pump_1.static.df.columns
+
+    model_orig = basic_transient
+    df = model_orig.network.node.df.copy()
+    df["node_id"] = df.index
+    node = Node(df=df)
+
+    assert "meta_node_id" in node.df.columns


### PR DESCRIPTION
Fixes #934

We now always apply the meta prefix to unknown columns in the Node and Edge spatial tables as well.
