### PR TITLE
Set initial level after parameter creation

### DIFF
--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -83,6 +83,9 @@ function BMI.initialize(T::Type{Model}, config::Config)::Model
         end
         storages
     end
+    # Synchronize level with storage
+    set_current_basin_properties!(parameters.basin, storage)
+
     @assert length(storage) == n "Basin / state length differs from number of Basins"
     # Integrals for PID control
     integral = zeros(length(parameters.pid_control.node_id))

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -77,11 +77,13 @@
         @test basin.level[1] ≈ 0.044711584
 
         # The exporter interpolates 1:1 for three subgrid elements, but shifted by 1.0 meter.
+        basin_level = basin.level[1]
         @test length(p.subgrid.level) == 3
         @test diff(p.subgrid.level) ≈ [-1.0, 2.0]
         # TODO The original subgrid IDs are lost and mapped to 1, 2, 3
         @test subgrid.subgrid_id[1:3] == [11, 22, 33] broken = true
-        @test subgrid.subgrid_level[1:3] == [0.0, -1.0, 1.0]
+        @test subgrid.subgrid_level[1:3] ≈
+              [basin_level, basin_level - 1.0, basin_level + 1.0]
         @test subgrid.subgrid_level[(end - 2):end] == p.subgrid.level
     end
 end


### PR DESCRIPTION
Fixes #952 

The basin level would remain at 0.0 otherwise.
Then the callback is called at t=0.0, and the resulting interpolated subgrid levels are nonsense.