### PR TITLE
Add pixi task to update registry

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -21,16 +21,22 @@ install-ribasim-testmodels = "pip install --no-deps --editable python/ribasim_te
 install-pre-commit = "pre-commit install"
 install-without-pre-commit = { depends_on = [
     "install-julia",
+    "update-registry-julia",
     "install-ribasim-python",
     "install-ribasim-api",
     "install-ribasim-testmodels",
 ] }
 install = { depends_on = ["install-without-pre-commit", "install-pre-commit"] }
 # Instantiate
+update-registry-julia = "julia --project --eval='using Pkg; Registry.update()'"
 instantiate-julia = "julia --project --eval='using Pkg; Pkg.instantiate()'"
+initialize-julia = { depends_on = [
+    "update-registry-julia",
+    "instantiate-julia",
+] }
 # Docs
 build-julia-docs = { cmd = "julia --project=docs docs/make.jl", depends_on = [
-    "instantiate-julia",
+    "initialize-julia",
 ] }
 quartodoc-build = { cmd = "quartodoc build && rm objects.json", cwd = "docs" }
 quarto-preview = { cmd = "quarto preview docs", depends_on = [
@@ -56,15 +62,15 @@ lint = { depends_on = [
 # Build
 build-ribasim-cli = { cmd = "julia --project build.jl --app", cwd = "build/create_binaries", depends_on = [
     "generate-testmodels",
-    "instantiate-julia",
+    "initialize-julia",
 ] }
 build-libribasim = { cmd = "julia --project build.jl --lib", cwd = "build/create_binaries", depends_on = [
     "generate-testmodels",
-    "instantiate-julia",
+    "initialize-julia",
 ] }
 build = { "cmd" = "julia --project build.jl --app --lib", cwd = "build/create_binaries", depends_on = [
     "generate-testmodels",
-    "instantiate-julia",
+    "initialize-julia",
 ] }
 remove-artifacts = "julia --eval 'rm(joinpath(Base.DEPOT_PATH[1], \"artifacts\"), force=true, recursive=true)'"
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -28,7 +28,7 @@ install-without-pre-commit = { depends_on = [
 ] }
 install = { depends_on = ["install-without-pre-commit", "install-pre-commit"] }
 # Instantiate
-update-registry-julia = "julia --project --eval='using Pkg; Registry.update()'"
+update-registry-julia = "julia --eval='using Pkg; Registry.update()'"
 instantiate-julia = "julia --project --eval='using Pkg; Pkg.instantiate()'"
 initialize-julia = { depends_on = [
     "update-registry-julia",


### PR DESCRIPTION
With our current workflow, it can happen that dev A updates the packages in Manifest.toml, and dev B gets the error:

```
ERROR: Unsatisfiable requirements detected for package X
```

The problem is that dev B's local registry is outdated, so it is not aware of the new versions of X that are being used. This adds a task to update the registry, and runs it by default when building or installing. That should make this error more rare, and perhaps easier to resolve.

Note that this is an issue that may get resolved in Pkg in the future; https://github.com/JuliaLang/Pkg.jl/issues/3713