### PR TITLE
Pin number of processes used in Python tests to 4

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -75,9 +75,9 @@ build = { "cmd" = "julia --project build.jl --app --lib", cwd = "build/create_bi
 remove-artifacts = "julia --eval 'rm(joinpath(Base.DEPOT_PATH[1], \"artifacts\"), force=true, recursive=true)'"
 
 # Test
-test-ribasim-python = "pytest --numprocesses=auto python/ribasim/tests"
+test-ribasim-python = "pytest --numprocesses=4 python/ribasim/tests"
 test-ribasim-api = "pytest --basetemp=python/ribasim_api/tests/temp --junitxml=report.xml python/ribasim_api/tests"
-test-ribasim-cli = "pytest --numprocesses=auto --basetemp=build/ribasim_cli/tests/temp --junitxml=report.xml build/ribasim_cli/tests"
+test-ribasim-cli = "pytest --numprocesses=4 --basetemp=build/ribasim_cli/tests/temp --junitxml=report.xml build/ribasim_cli/tests"
 test-ribasim-core = { cmd = "julia --project=core --eval 'using Pkg; Pkg.test()'", depends_on = [
     "generate-testmodels",
 ] }


### PR DESCRIPTION
Otherwise, some machines get stack overflow errors when running Python tests