### PR TITLE
Allow compiled binaries to get version

### DIFF
--- a/build/libribasim/src/libribasim.jl
+++ b/build/libribasim/src/libribasim.jl
@@ -175,7 +175,7 @@ end
 
 Base.@ccallable function get_version(version::Cstring)::Cint
     @try_c_uninitialized begin
-        ribasim_version = pkgversion(Ribasim)
+        ribasim_version = Ribasim.pkgversion(Ribasim)
         unsafe_write_to_cstring!(version, string(ribasim_version))
     end
 end

--- a/core/src/utils.jl
+++ b/core/src/utils.jl
@@ -1,3 +1,11 @@
+"Get the package version of a given module"
+function pkgversion(m::Module)::VersionNumber
+    rootmodule = Base.moduleroot(m)
+    pkg = Base.PkgId(rootmodule)
+    pkgorigin = get(Base.pkgorigins, pkg, nothing)
+    return pkgorigin.version
+end
+
 "Check that only supported edge types are declared."
 function valid_edge_types(db::DB)::Bool
     edge_rows = execute(

--- a/python/ribasim_api/tests/test_bmi.py
+++ b/python/ribasim_api/tests/test_bmi.py
@@ -126,7 +126,6 @@ def test_get_component_name(libribasim):
     assert libribasim.get_component_name() == "Ribasim"
 
 
-@pytest.mark.skip("https://github.com/Deltares/Ribasim/issues/364")
 def test_get_version(libribasim):
     toml_path = Path(__file__).parents[3] / "core" / "Project.toml"
     with open(toml_path, mode="rb") as fp:


### PR DESCRIPTION
We started using the function that Julia provides, but it doesn't seem to work with compiled binaries

Fixes #364
