### PR TITLE
Update pixi lock file and fix mypy issues

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -931,100 +931,100 @@ package:
   timestamp: 1704011393776
 - platform: linux-64
   name: aws-c-auth
-  version: 0.7.11
+  version: 0.7.14
   category: main
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
-  - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
+  - aws-c-io >=0.14.3,<0.14.4.0a0
+  - aws-c-sdkutils >=0.1.14,<0.1.15.0a0
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.11-h0b4cabd_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.14-h70caa3e_3.conda
   hash:
-    md5: e9a6562446d81183d1483bb23bfc478c
-    sha256: ef98131dbff55f482b0af10d17aa6c478e59987661cf3c22dddb30a441986aa5
-  build: h0b4cabd_1
+    md5: bcf273598ba3626de3a2a33dfcc1498d
+    sha256: 687099ea218e0ddf49a402974b2610e0f0cf3d63fda0400c1471df965ec84820
+  build: h70caa3e_3
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 103197
-  timestamp: 1704837011679
+  size: 103663
+  timestamp: 1706630624620
 - platform: osx-64
   name: aws-c-auth
-  version: 0.7.11
+  version: 0.7.14
   category: main
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
-  - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.11-h94c8779_1.conda
+  - aws-c-io >=0.14.3,<0.14.4.0a0
+  - aws-c-sdkutils >=0.1.14,<0.1.15.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.14-hfc9c217_3.conda
   hash:
-    md5: 0c504fbf22cf8560e4cbe1a68d71bace
-    sha256: 2aa423f5c64c4df7a8a2d9b4f7fa915c4a7d6e01a018f04fbf4c4bd9b699ea50
-  build: h94c8779_1
+    md5: 9418b43aff594d953c0bbbc63e02a058
+    sha256: f5abad09e09043a9474a8e70b07765c8d8ca76dca448b278987fe70ff1ae33f3
+  build: hfc9c217_3
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 90008
-  timestamp: 1704837466758
+  size: 90547
+  timestamp: 1706630782905
 - platform: osx-arm64
   name: aws-c-auth
-  version: 0.7.11
+  version: 0.7.14
   category: main
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
-  - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.11-ha4ce7b8_1.conda
+  - aws-c-io >=0.14.3,<0.14.4.0a0
+  - aws-c-sdkutils >=0.1.14,<0.1.15.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.14-h8117f06_3.conda
   hash:
-    md5: ed467f71fac4eca9454ca1ff99be7f84
-    sha256: 4b4318d4ad5cb9d3f3e141e43528e3c7f161e8f167195ff2627e6ec778bd890f
-  build: ha4ce7b8_1
+    md5: 8974f0b358debe2bf47c474708073b86
+    sha256: 6c42ae3a872aa105910d569d6780b20e1483aab32dd9beaccac0f6679d885f57
+  build: h8117f06_3
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 89277
-  timestamp: 1704837158697
+  size: 89310
+  timestamp: 1706630880950
 - platform: win-64
   name: aws-c-auth
-  version: 0.7.11
+  version: 0.7.14
   category: main
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
-  - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
+  - aws-c-io >=0.14.3,<0.14.4.0a0
+  - aws-c-sdkutils >=0.1.14,<0.1.15.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.11-hcf9e330_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.14-ha04060b_3.conda
   hash:
-    md5: b3c4233e6a4ef5537e05002398a734e6
-    sha256: 3416485aea072b49e9ed52d0c5ece6fef7aeaa214a6fa83b480be9d17ba96fa5
-  build: hcf9e330_1
+    md5: 357ff5d1c1a85022d7a808f7f052be05
+    sha256: 0470f17b9407fdaa32f1b3c75dc39af5b9004e8a9a7aa493c37d1dcecb8e8b4e
+  build: ha04060b_3
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 98788
-  timestamp: 1704837661732
+  size: 98984
+  timestamp: 1706631273541
 - platform: linux-64
   name: aws-c-cal
   version: 0.6.9
@@ -1269,22 +1269,22 @@ package:
   manager: conda
   dependencies:
   - aws-c-common >=0.9.12,<0.9.13.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.14.3,<0.14.4.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.1-h97bb272_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.1-h17cd1f3_5.conda
   hash:
-    md5: 5a16088be732d54b50c134203f712d24
-    sha256: a7cb50ccb2779d2934cae3a4fcc3d032a4525b63a464d6bd23957650381d633e
-  build: h97bb272_2
+    md5: 65d1aabc7656d7c08585efd584332235
+    sha256: 4cecf7af18d757fa36872a2ed8fc12b24555b87ca47844dd11669199b062b91d
+  build: h17cd1f3_5
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
   license_family: Apache
-  size: 54060
-  timestamp: 1704831731839
+  size: 53822
+  timestamp: 1706620093952
 - platform: osx-64
   name: aws-c-event-stream
   version: 0.4.1
@@ -1292,21 +1292,21 @@ package:
   manager: conda
   dependencies:
   - aws-c-common >=0.9.12,<0.9.13.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.14.3,<0.14.4.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
   - libcxx >=15
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.1-h3600a39_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.1-h725fa68_5.conda
   hash:
-    md5: d15584e342a31e978262627e6fd4063b
-    sha256: ef306832c033c46ab4b434ebf6e0a53a0f1a5023d6dbd6d31b90c2deea997a6c
-  build: h3600a39_2
+    md5: 3a419a70c578b45e85905bbc543626d7
+    sha256: 6f031ec29e205d9f1e4787a7e23d48093121daafe45645c9fabd49803998fa86
+  build: h725fa68_5
   arch: x86_64
   subdir: osx-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
   license_family: Apache
-  size: 46597
-  timestamp: 1704832159311
+  size: 46744
+  timestamp: 1706620260478
 - platform: osx-arm64
   name: aws-c-event-stream
   version: 0.4.1
@@ -1314,21 +1314,21 @@ package:
   manager: conda
   dependencies:
   - aws-c-common >=0.9.12,<0.9.13.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.14.3,<0.14.4.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
   - libcxx >=15
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.4.1-he66824e_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.4.1-hf6cc7c5_5.conda
   hash:
-    md5: 64e84b88c3e9ff59fbd63816877a23d5
-    sha256: 7ba075401a7963fd50d9f364053806c4a86e4f51cd8d2f063be875a78306e689
-  build: he66824e_2
+    md5: f7961cf04fa30ab72834dcef2bcdc72e
+    sha256: a63b54574d0a73b657ff7337d1f89bc0e5aed295d523f35c61ab193307f63df3
+  build: hf6cc7c5_5
   arch: aarch64
   subdir: osx-arm64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
   license_family: Apache
-  size: 47412
-  timestamp: 1704832224840
+  size: 46992
+  timestamp: 1706620322284
 - platform: win-64
   name: aws-c-event-stream
   version: 0.4.1
@@ -1336,23 +1336,23 @@ package:
   manager: conda
   dependencies:
   - aws-c-common >=0.9.12,<0.9.13.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.14.3,<0.14.4.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.1-h875930a_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.1-hf127292_5.conda
   hash:
-    md5: a52a52512331e06ec6496b8d5a92230b
-    sha256: 867f701a927b5d4711eed0ae68149fc45854b1ca9f20df87a1a8a3e8deab4c5a
-  build: h875930a_2
+    md5: 9462bb7fbe1721f6c0c3341281c3158c
+    sha256: e92109308e2f7558304f1fed31de3767efa3a7e174ba32583ae99aa7f45032fc
+  build: hf127292_5
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
   license_family: Apache
-  size: 55105
-  timestamp: 1704832205361
+  size: 54389
+  timestamp: 1706620560929
 - platform: linux-64
   name: aws-c-http
   version: 0.8.0
@@ -1362,20 +1362,20 @@ package:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-compression >=0.2.17,<0.2.18.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.14.3,<0.14.4.0a0
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.0-h9129f04_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.0-hc6da83f_5.conda
   hash:
-    md5: ec632590307b47ac47d22ebcf91f4043
-    sha256: 5929ac8e3118146f9d23a5fdff54e2025501ee20a2cd9d8dd2b0115a60442dce
-  build: h9129f04_2
+    md5: a257c3335609a22036947f99a87ca024
+    sha256: 0524523bec0bef2b367064c7069f88eaf4dc4945d353cdf1ef84e152d1e5e19a
+  build: hc6da83f_5
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
   license_family: Apache
-  size: 194710
-  timestamp: 1704831283922
+  size: 195203
+  timestamp: 1706619867410
 - platform: osx-64
   name: aws-c-http
   version: 0.8.0
@@ -1385,19 +1385,19 @@ package:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-compression >=0.2.17,<0.2.18.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.0-h19e0e28_2.conda
+  - aws-c-io >=0.14.3,<0.14.4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.0-heddac68_5.conda
   hash:
-    md5: 0714dff2eee274db27ad65d82b61374d
-    sha256: f6de21c9ade6ac83b418a5277025b9a0ec55fdcb9c34f8cf3a595122b9b5e43f
-  build: h19e0e28_2
+    md5: 479f58d5d7914e2652855a2c62dac07d
+    sha256: 165e0c38633f2044536b8779065760df5cce8cfe1efa5bb5bf115abb031d0039
+  build: heddac68_5
   arch: x86_64
   subdir: osx-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
   license_family: Apache
-  size: 162332
-  timestamp: 1704831551750
+  size: 163001
+  timestamp: 1706620086692
 - platform: osx-arm64
   name: aws-c-http
   version: 0.8.0
@@ -1407,19 +1407,19 @@ package:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-compression >=0.2.17,<0.2.18.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.8.0-hd3d28cd_2.conda
+  - aws-c-io >=0.14.3,<0.14.4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.8.0-hf1748bb_5.conda
   hash:
-    md5: bf12b06426420df2055eaa104889bc07
-    sha256: 8e80c37e5f2cc84f92634c9c60a4eaa062c2b57dcc1001c5faf711b77318abb8
-  build: hd3d28cd_2
+    md5: f82039f5c0a3a384dbbaeb64474a5c55
+    sha256: 4a88c61c6c5326828a6144b994e7c0b0ec7d58f51452b348f0dcecfae77421d2
+  build: hf1748bb_5
   arch: aarch64
   subdir: osx-arm64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
   license_family: Apache
-  size: 151638
-  timestamp: 1704832516933
+  size: 151098
+  timestamp: 1706620269704
 - platform: win-64
   name: aws-c-http
   version: 0.8.0
@@ -1429,87 +1429,87 @@ package:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-compression >=0.2.17,<0.2.18.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.14.3,<0.14.4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.0-ha1a3518_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.0-h0cc4be6_5.conda
   hash:
-    md5: ebae76e0c9ff7b3faa0227eae7e061e5
-    sha256: 920362d41e78885a4aca7484b3f2c7ee5c2aa1d35549c3e6348249a359e04208
-  build: ha1a3518_2
+    md5: 9cde958dea36567da2872c39a2669b76
+    sha256: 39444a642f1ed2a0098b92cac4593d8ab33819183744d6af5d56e7451803375f
+  build: h0cc4be6_5
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
   license_family: Apache
-  size: 180154
-  timestamp: 1704831834094
+  size: 180230
+  timestamp: 1706620666360
 - platform: linux-64
   name: aws-c-io
-  version: 0.14.0
+  version: 0.14.3
   category: main
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - libgcc-ng >=12
-  - s2n >=1.4.1,<1.4.2.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.0-hf8f278a_1.conda
+  - s2n >=1.4.2,<1.4.3.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.3-hbde70e5_0.conda
   hash:
-    md5: 30ebacf5b5fd61294851301887dc7518
-    sha256: dd52e17a5be987b384c62574d90ddafbba68fa65b1f1344236b90c50ffed304d
-  build: hf8f278a_1
+    md5: 5f2096c8888ab7278ab54ab55ede51bd
+    sha256: f6f60085fd787d2def12fb7213e7490166168faa2365c4bde6575992cd2b422a
+  build: hbde70e5_0
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 156922
-  timestamp: 1704324380777
+  size: 157496
+  timestamp: 1706572894883
 - platform: osx-64
   name: aws-c-io
-  version: 0.14.0
+  version: 0.14.3
   category: main
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.0-h49ca7b5_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.3-h49ca7b5_0.conda
   hash:
-    md5: f276e1df52ac6d261e5fa7e85d8cb02f
-    sha256: 27d102f01cc662f703ecc7cff9350526587e6fc57347ddc6d3df8db569b2e19b
-  build: h49ca7b5_1
+    md5: 6666aa6edb8c31e28b6e1c71892212b9
+    sha256: f010f99a051c8a77d70c22f82b36281283c7192a92b88ebbd323ca6a3f8e96a5
+  build: h49ca7b5_0
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 138089
-  timestamp: 1704324660243
+  size: 137806
+  timestamp: 1706573069078
 - platform: osx-arm64
   name: aws-c-io
-  version: 0.14.0
+  version: 0.14.3
   category: main
   manager: conda
   dependencies:
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.14.0-h8daa835_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.14.3-h8daa835_0.conda
   hash:
-    md5: c15089f0a5df47a3278232235a6c2d3a
-    sha256: 026567637cd89f840fdb70550aa2fe5d325ca3cf52b8d66b48e588d3f0cfc2ea
-  build: h8daa835_1
+    md5: 2ee44b55ec8a85726704bc536e3ffaed
+    sha256: 6c87dcf7155342097590e49a08b8f6f8bbe0cc6a6a271d6055aa2ddeb57d84ce
+  build: h8daa835_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 136440
-  timestamp: 1704324776900
+  size: 136866
+  timestamp: 1706573244678
 - platform: win-64
   name: aws-c-io
-  version: 0.14.0
+  version: 0.14.3
   category: main
   manager: conda
   dependencies:
@@ -1518,18 +1518,18 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.0-hf372335_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.3-hf372335_0.conda
   hash:
-    md5: c66b7cd0d3b75e2b16aaa6f248da035a
-    sha256: 97faea92d53733ed2fe488bc0800250844a5d4228ed61eb53080f008cb0c2e29
-  build: hf372335_1
+    md5: 5ff29bf53c0c6020ccaa692b68f09736
+    sha256: 26db1deaa776df1581cc5e34b284422adefc1e07c02415ef2c73285e2d108b58
+  build: hf372335_0
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 159305
-  timestamp: 1704324752355
+  size: 160084
+  timestamp: 1706573532382
 - platform: linux-64
   name: aws-c-mqtt
   version: 0.10.1
@@ -1538,20 +1538,20 @@ package:
   dependencies:
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.14.3,<0.14.4.0a0
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.1-h2b97f5f_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.1-h0ef3971_3.conda
   hash:
-    md5: 4cba7afc0f74a7cce3159c0bceb607c3
-    sha256: 8edcb09a2d93c24320f517f837a0e46e98749b72dc7c9d55ce1fa0c4fa5db116
-  build: h2b97f5f_0
+    md5: 5f80f11865fad4cc684f1007170df6ec
+    sha256: 3ef6d24924308ed8ea9c0d3201cde18aa36fb2f8c5a79b09cdc31944424bb6f8
+  build: h0ef3971_3
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 164163
-  timestamp: 1704952035148
+  size: 165105
+  timestamp: 1706631391183
 - platform: osx-64
   name: aws-c-mqtt
   version: 0.10.1
@@ -1560,19 +1560,19 @@ package:
   dependencies:
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.1-h947eb33_0.conda
+  - aws-c-io >=0.14.3,<0.14.4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.1-hcdc93dc_3.conda
   hash:
-    md5: 572658337a20c3a1e6ecf59f610be930
-    sha256: 0f9a6de491c1c61ed1635a2814d6be52f041f2bf393c04a85a1da13ee862c90b
-  build: h947eb33_0
+    md5: 1dc5c6a6c28f28c17d98a2db850eaecb
+    sha256: ffc9f373fc5482259e6b616c0814edecd74c7f4c008495b74a7a2bd7619d8b4d
+  build: hcdc93dc_3
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 138205
-  timestamp: 1704952213032
+  size: 139306
+  timestamp: 1706631769862
 - platform: osx-arm64
   name: aws-c-mqtt
   version: 0.10.1
@@ -1581,19 +1581,19 @@ package:
   dependencies:
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.1-h59ff425_0.conda
+  - aws-c-io >=0.14.3,<0.14.4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.1-h7f0f801_3.conda
   hash:
-    md5: aef14e17e37ef7ff95c1deb57cee8a23
-    sha256: 2e88ba1370be78b0532870bd1a5cffbc464e31b5d64f5763d2517b5c53753af4
-  build: h59ff425_0
+    md5: 97436e96a3ab245df1c2610672ea8db5
+    sha256: 0865312673162e2c44a7d2f42e68b145bf83c33d7cfd3b73a7b8d39c0402f6ba
+  build: h7f0f801_3
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 117799
-  timestamp: 1704951841008
+  size: 118044
+  timestamp: 1706631187820
 - platform: win-64
   name: aws-c-mqtt
   version: 0.10.1
@@ -1602,184 +1602,184 @@ package:
   dependencies:
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.14.3,<0.14.4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.1-hda1dad8_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.1-h189e261_3.conda
   hash:
-    md5: 74a86d9501c064c275340ce934a8b94e
-    sha256: bf1cd835d1ac774c16b22980099562baa55fdaa0b805f054f07bc484e3ca7316
-  build: hda1dad8_0
+    md5: ad334269c08c41575be9dda1956f7a06
+    sha256: 5c963b0f806235ee661149ac3a516a43a4c83fc0f48674c6cfe3da58dec5e2c7
+  build: h189e261_3
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 158491
-  timestamp: 1704952481137
+  size: 158027
+  timestamp: 1706631859339
 - platform: linux-64
   name: aws-c-s3
-  version: 0.4.9
+  version: 0.5.0
   category: main
   manager: conda
   dependencies:
-  - aws-c-auth >=0.7.11,<0.7.12.0a0
+  - aws-c-auth >=0.7.14,<0.7.15.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.14.3,<0.14.4.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
   - libgcc-ng >=12
-  - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.4.9-hca09fc5_0.conda
+  - openssl >=3.2.1,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.5.0-hb337f33_1.conda
   hash:
-    md5: 44f261ca46a671789f59dc305d51afeb
-    sha256: b10ad88a1b1f7bf8bb999e06b4bb92e87fa9ede81a10492a373d354f4276a77b
-  build: hca09fc5_0
+    md5: 5a79a179185e87891d43530a49fea2c6
+    sha256: 5bada2c121adffcb803a1b1d830051f092203f7de5470e0e42dfb56d799db509
+  build: hb337f33_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 105530
-  timestamp: 1704951008173
+  size: 105221
+  timestamp: 1706649667322
 - platform: osx-64
   name: aws-c-s3
-  version: 0.4.9
+  version: 0.5.0
   category: main
   manager: conda
   dependencies:
-  - aws-c-auth >=0.7.11,<0.7.12.0a0
+  - aws-c-auth >=0.7.14,<0.7.15.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.14.3,<0.14.4.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.4.9-hee0ca28_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.5.0-h4b43a42_1.conda
   hash:
-    md5: b3d80d5c3ff89a4e04799caf71e8ec41
-    sha256: 4d85b122da9250ad318922e09e63f2ed9efb2c394c9c5e38bcdc38a534f6db1a
-  build: hee0ca28_0
+    md5: b6d5c85e50f7d6a0856d3430b80cb7ea
+    sha256: aa488082a7d23d9a09bbccbec589c32d589bacb5023dfe9af9800e072d9b9e78
+  build: h4b43a42_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 91824
-  timestamp: 1704952536433
+  size: 90931
+  timestamp: 1706649936371
 - platform: osx-arm64
   name: aws-c-s3
-  version: 0.4.9
+  version: 0.5.0
   category: main
   manager: conda
   dependencies:
-  - aws-c-auth >=0.7.11,<0.7.12.0a0
+  - aws-c-auth >=0.7.14,<0.7.15.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.14.3,<0.14.4.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.4.9-h7f99a2c_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.5.0-h82332b0_1.conda
   hash:
-    md5: 912d57a741e590a1f568345088409393
-    sha256: 9ce65a457cc2a02e12badb0110615bbb8498c6a33c8b96d98bec9f9aea520172
-  build: h7f99a2c_0
+    md5: 7757e3031af32d53c663604db6427a8d
+    sha256: e301a3e3b5d59cee03fe1153a52c913b938eac1b950dc52354214984e053d2f8
+  build: h82332b0_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 90889
-  timestamp: 1704951269051
+  size: 90326
+  timestamp: 1706650071920
 - platform: win-64
   name: aws-c-s3
-  version: 0.4.9
+  version: 0.5.0
   category: main
   manager: conda
   dependencies:
-  - aws-c-auth >=0.7.11,<0.7.12.0a0
+  - aws-c-auth >=0.7.14,<0.7.15.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.14.3,<0.14.4.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.4.9-hef93162_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.5.0-h623a383_1.conda
   hash:
-    md5: 823d4901a83a0c573dff98f1ca12a13b
-    sha256: 509d16210f4b5532c68e64403cc01e2ec0742203d4c878e98dbb03238a5f335e
-  build: hef93162_0
+    md5: 87f4635a522cec07e29de42ac7616f0b
+    sha256: f2a50d5a6bb4e5f8358a022b93886a32af2e02db1677964991d9d4bd00d8b6a3
+  build: h623a383_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 101440
-  timestamp: 1704951633740
+  size: 101331
+  timestamp: 1706650187019
 - platform: linux-64
   name: aws-c-sdkutils
-  version: 0.1.13
+  version: 0.1.14
   category: main
   manager: conda
   dependencies:
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.13-h572eabf_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.14-h572eabf_0.conda
   hash:
-    md5: 7c56e8a2c4e8729443217e62e0bf65ba
-    sha256: eb54d7573f9bbd1d01458203dd83e9c0c94c73be91af9142dd78e1a928be5b7e
-  build: h572eabf_1
+    md5: 42db61eee93a2c0f918d18bd4422d331
+    sha256: 5e9ee515fc99105a92938cd28f9229c1abb38d8afb6ec223cfbeee0f9082ebd8
+  build: h572eabf_0
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 53329
-  timestamp: 1704305432266
+  size: 55544
+  timestamp: 1706176816594
 - platform: osx-64
   name: aws-c-sdkutils
-  version: 0.1.13
+  version: 0.1.14
   category: main
   manager: conda
   dependencies:
   - aws-c-common >=0.9.12,<0.9.13.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.13-h45babc2_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.14-h45babc2_0.conda
   hash:
-    md5: 4fd7f6b8225feb707d401eb18bfc0b2a
-    sha256: f780e3d3de1a4111b63ee7fad24046e2618c4086fcbdebca5cb75469fc7abfda
-  build: h45babc2_1
+    md5: 7605efd7c37ce3b6c0eaae86878a495c
+    sha256: 6873854003b70b79be2945ab5e6ffed9a8d40e955ce1c8479e1e907fd66eaade
+  build: h45babc2_0
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 47618
-  timestamp: 1704305657024
+  size: 49901
+  timestamp: 1706176988341
 - platform: osx-arm64
   name: aws-c-sdkutils
-  version: 0.1.13
+  version: 0.1.14
   category: main
   manager: conda
   dependencies:
   - aws-c-common >=0.9.12,<0.9.13.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.13-h4fd42c2_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.14-h4fd42c2_0.conda
   hash:
-    md5: d45de4f4fd881f65d794f86a4471e370
-    sha256: da5567016574499b732dbf276c0840751dafe7efbd61159917ea527c079a8c01
-  build: h4fd42c2_1
+    md5: 92386b4cb3bee39dc69236593c2b8acb
+    sha256: 1684522b3d3459b459f5e9b3e54e702b428d28a9450a962f0f0fc90d4ccb749b
+  build: h4fd42c2_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 46876
-  timestamp: 1704305885624
+  size: 49337
+  timestamp: 1706176998959
 - platform: win-64
   name: aws-c-sdkutils
-  version: 0.1.13
+  version: 0.1.14
   category: main
   manager: conda
   dependencies:
@@ -1787,18 +1787,18 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.13-hd33547d_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.14-hd33547d_0.conda
   hash:
-    md5: cbb18754a7d5a850cd08f58a65acabc9
-    sha256: 61a1bcc39090d2702f24c0220cfd1e4ff5ce195f3ba6fa2c36cdce3246b2ff9b
-  build: hd33547d_1
+    md5: 74ba3b20e2efe19d303c8fee39d0845a
+    sha256: 2b15548397cb5d523a2423805efbaa06b8c45478dd6e9685ba0e7be49b4335da
+  build: hd33547d_0
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 51953
-  timestamp: 1704305964425
+  size: 54171
+  timestamp: 1706177132190
 - platform: linux-64
   name: aws-checksums
   version: 0.1.17
@@ -1881,246 +1881,246 @@ package:
   timestamp: 1704306216290
 - platform: linux-64
   name: aws-crt-cpp
-  version: 0.26.0
+  version: 0.26.1
   category: main
   manager: conda
   dependencies:
-  - aws-c-auth >=0.7.11,<0.7.12.0a0
+  - aws-c-auth >=0.7.14,<0.7.15.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-event-stream >=0.4.1,<0.4.2.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.14.3,<0.14.4.0a0
   - aws-c-mqtt >=0.10.1,<0.10.2.0a0
-  - aws-c-s3 >=0.4.9,<0.4.10.0a0
-  - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
+  - aws-c-s3 >=0.5.0,<0.5.1.0a0
+  - aws-c-sdkutils >=0.1.14,<0.1.15.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.26.0-h04327c0_8.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.26.1-h0637f07_8.conda
   hash:
-    md5: 8d2aeb8c24b47ad3ff87166957b216fd
-    sha256: 4bdef70ff6362d8a3350b4c4181d078e7b1f654a249d63294e9ab1c5a9ca72c7
-  build: h04327c0_8
+    md5: dcf0d0d5d3522dd8ed1081d6fca9cca8
+    sha256: 1eaf4b607f0fddd9917881e15db5e2530cd4a4bcb9619c9109672dcc96487b08
+  build: h0637f07_8
   arch: x86_64
   subdir: linux-64
   build_number: 8
   license: Apache-2.0
   license_family: Apache
-  size: 334064
-  timestamp: 1704982186302
+  size: 334957
+  timestamp: 1706660520009
 - platform: osx-64
   name: aws-crt-cpp
-  version: 0.26.0
+  version: 0.26.1
   category: main
   manager: conda
   dependencies:
-  - aws-c-auth >=0.7.11,<0.7.12.0a0
+  - aws-c-auth >=0.7.14,<0.7.15.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-event-stream >=0.4.1,<0.4.2.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.14.3,<0.14.4.0a0
   - aws-c-mqtt >=0.10.1,<0.10.2.0a0
-  - aws-c-s3 >=0.4.9,<0.4.10.0a0
-  - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
+  - aws-c-s3 >=0.5.0,<0.5.1.0a0
+  - aws-c-sdkutils >=0.1.14,<0.1.15.0a0
   - libcxx >=15
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.26.0-he4637c3_8.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.26.1-had021ca_8.conda
   hash:
-    md5: 47d83636ee8f3876199ad1c3bf32a5b3
-    sha256: 1eaea1b9e4ce6e39ffbdc9533e5f738d01b88b3219cb6a583d8a270a923abaec
-  build: he4637c3_8
+    md5: 7bf17521e118fffdecce4b645a0fb6fc
+    sha256: 427d623ae15280d7e14b6ed3b285ccbf678dc3166e1c495884e86b12c2701c1b
+  build: had021ca_8
   arch: x86_64
   subdir: osx-64
   build_number: 8
   license: Apache-2.0
   license_family: Apache
-  size: 280566
-  timestamp: 1704982613343
+  size: 281131
+  timestamp: 1706660740208
 - platform: osx-arm64
   name: aws-crt-cpp
-  version: 0.26.0
+  version: 0.26.1
   category: main
   manager: conda
   dependencies:
-  - aws-c-auth >=0.7.11,<0.7.12.0a0
+  - aws-c-auth >=0.7.14,<0.7.15.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-event-stream >=0.4.1,<0.4.2.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.14.3,<0.14.4.0a0
   - aws-c-mqtt >=0.10.1,<0.10.2.0a0
-  - aws-c-s3 >=0.4.9,<0.4.10.0a0
-  - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
+  - aws-c-s3 >=0.5.0,<0.5.1.0a0
+  - aws-c-sdkutils >=0.1.14,<0.1.15.0a0
   - libcxx >=15
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.26.0-hfff802b_8.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.26.1-h84a144a_8.conda
   hash:
-    md5: 9f4ebd51ab78bed865f2cea217cc2800
-    sha256: a88854f232025c297d3161a43795909d8a00a936cb782780fa2e3fc83ea6d489
-  build: hfff802b_8
+    md5: cd8c59043fcc4aad4be99aa0ea24346c
+    sha256: 7472b0878063b85521773341a363c314b0570e9bf161acdecdc3272cd6395162
+  build: h84a144a_8
   arch: aarch64
   subdir: osx-arm64
   build_number: 8
   license: Apache-2.0
   license_family: Apache
-  size: 217993
-  timestamp: 1704982595239
+  size: 217751
+  timestamp: 1706660689339
 - platform: win-64
   name: aws-crt-cpp
-  version: 0.26.0
+  version: 0.26.1
   category: main
   manager: conda
   dependencies:
-  - aws-c-auth >=0.7.11,<0.7.12.0a0
+  - aws-c-auth >=0.7.14,<0.7.15.0a0
   - aws-c-cal >=0.6.9,<0.6.10.0a0
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-event-stream >=0.4.1,<0.4.2.0a0
   - aws-c-http >=0.8.0,<0.8.1.0a0
-  - aws-c-io >=0.14.0,<0.14.1.0a0
+  - aws-c-io >=0.14.3,<0.14.4.0a0
   - aws-c-mqtt >=0.10.1,<0.10.2.0a0
-  - aws-c-s3 >=0.4.9,<0.4.10.0a0
-  - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
+  - aws-c-s3 >=0.5.0,<0.5.1.0a0
+  - aws-c-sdkutils >=0.1.14,<0.1.15.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.26.0-hed7b20b_8.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.26.1-hb490d84_8.conda
   hash:
-    md5: 31e92428a809c11c1b58b50021052091
-    sha256: 5cd3b124744ffbec6280a8db786b88ee6066151624a2c2e2867f5bc6c2d7a617
-  build: hed7b20b_8
+    md5: cad6081fdee7a0849adfc05554567242
+    sha256: 328a1a1127bbb4b684e12282268366a9f230c5cbbbd481888565aa56b6138cbb
+  build: hb490d84_8
   arch: x86_64
   subdir: win-64
   build_number: 8
   license: Apache-2.0
   license_family: Apache
-  size: 242431
-  timestamp: 1704982881743
+  size: 241749
+  timestamp: 1706660909443
 - platform: linux-64
   name: aws-sdk-cpp
-  version: 1.11.210
+  version: 1.11.242
   category: main
   manager: conda
   dependencies:
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-event-stream >=0.4.1,<0.4.2.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
-  - aws-crt-cpp >=0.26.0,<0.26.1.0a0
+  - aws-crt-cpp >=0.26.1,<0.26.2.0a0
   - libcurl >=8.5.0,<9.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.210-hba3e011_10.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.242-h65f022c_0.conda
   hash:
-    md5: a4f975a959587b0e75df8e0f9f2d4347
-    sha256: 97b50927c4312ad80f3729669fa8b55195c066710e0af73c818c244df01b7604
-  build: hba3e011_10
+    md5: 09b53fbd76044de441d25261840821ac
+    sha256: 0cc1cd1007879d43051284f84d98cf46491edbae5d0beed945b7823624fd5b69
+  build: h65f022c_0
   arch: x86_64
   subdir: linux-64
-  build_number: 10
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 3537491
-  timestamp: 1704953801860
+  size: 3609138
+  timestamp: 1705178620056
 - platform: osx-64
   name: aws-sdk-cpp
-  version: 1.11.210
+  version: 1.11.242
   category: main
   manager: conda
   dependencies:
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-event-stream >=0.4.1,<0.4.2.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
-  - aws-crt-cpp >=0.26.0,<0.26.1.0a0
+  - aws-crt-cpp >=0.26.1,<0.26.2.0a0
   - libcurl >=8.5.0,<9.0a0
   - libcxx >=15
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.210-hf51409f_10.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.242-h2d1bcde_0.conda
   hash:
-    md5: 10d6bd28caf5b216b9042d3fd891fab4
-    sha256: fd4ff9b0422d104bde364fb0dc27f85eb64adce03fc866315120493e9409a64a
-  build: hf51409f_10
+    md5: b5c1c2951a7f5e6fca66553d80fe61c8
+    sha256: 2fc27f8fddc6ce9c72a1633ddf503df57173fe079c3759d561b159bfe072a53b
+  build: h2d1bcde_0
   arch: x86_64
   subdir: osx-64
-  build_number: 10
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 3257844
-  timestamp: 1704954438819
+  size: 3391066
+  timestamp: 1705179304517
 - platform: osx-arm64
   name: aws-sdk-cpp
-  version: 1.11.210
+  version: 1.11.242
   category: main
   manager: conda
   dependencies:
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-event-stream >=0.4.1,<0.4.2.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
-  - aws-crt-cpp >=0.26.0,<0.26.1.0a0
+  - aws-crt-cpp >=0.26.1,<0.26.2.0a0
   - libcurl >=8.5.0,<9.0a0
   - libcxx >=15
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.210-he93ac2d_10.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.242-h26e3666_0.conda
   hash:
-    md5: 7b36897c51a1a12db6b3a79a3c6e0a80
-    sha256: 861ef77ea13a8ca24f115bf7aea446b38ad491977188350cb74df1423a8b7841
-  build: he93ac2d_10
+    md5: 440b5c6602144a54c1d838ea62880d6d
+    sha256: c9f40e8bc2d36d6827725ce6aaba580c8af67c6e61d19cbd4235bbb009313552
+  build: h26e3666_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 10
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 3278036
-  timestamp: 1704954424076
+  size: 3427884
+  timestamp: 1705179393736
 - platform: win-64
   name: aws-sdk-cpp
-  version: 1.11.210
+  version: 1.11.242
   category: main
   manager: conda
   dependencies:
   - aws-c-common >=0.9.12,<0.9.13.0a0
   - aws-c-event-stream >=0.4.1,<0.4.2.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
-  - aws-crt-cpp >=0.26.0,<0.26.1.0a0
+  - aws-crt-cpp >=0.26.1,<0.26.2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.210-h20b5662_10.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.242-hf72cfbd_0.conda
   hash:
-    md5: 7ddadc695cfea67f809439aeacd99d67
-    sha256: 9812a530a4ca263140714bc7b96246aac8825e083e7978971d842c8753e1950d
-  build: h20b5662_10
+    md5: c8b41cf62f007671504cb89a92ff2676
+    sha256: 8685e99ac1a8bf0f77df6d8d564e9f195bfd61b5098e01d723c9b044f04c3007
+  build: hf72cfbd_0
   arch: x86_64
   subdir: win-64
-  build_number: 10
+  build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 3361937
-  timestamp: 1704954844029
+  size: 3426959
+  timestamp: 1705179921641
 - platform: linux-64
   name: azure-core-cpp
-  version: 1.10.3
+  version: 1.11.0
   category: main
   manager: conda
   dependencies:
-  - libcurl >=8.3.0,<9.0a0
+  - libcurl >=8.5.0,<9.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - openssl >=3.1.3,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.10.3-h91d86a7_0.conda
+  - openssl >=3.2.1,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.11.0-h91d86a7_1.conda
   hash:
-    md5: db7a05c674efad9c19f8a2ff76e4976c
-    sha256: e2965b736f80cc66f4a90314592569dd7d87039e791b0e6b88870d32ab3e2901
-  build: h91d86a7_0
+    md5: 0babb92c299af923d2cc98f88bbc6539
+    sha256: d92e9aa5c8069bd3c934c8bbe8563d5e20f6cb7d688b493929d3d69d3e24934c
+  build: h91d86a7_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 341714
-  timestamp: 1696577398675
+  size: 342443
+  timestamp: 1706647994902
 - platform: osx-64
   name: azure-core-cpp
   version: 1.11.0
@@ -2129,19 +2129,19 @@ package:
   dependencies:
   - libcurl >=8.5.0,<9.0a0
   - libcxx >=15
-  - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.11.0-hbb1e571_0.conda
+  - openssl >=3.2.1,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.11.0-hbb1e571_1.conda
   hash:
-    md5: 9589ec84a80f16f763d14d0e9be7af15
-    sha256: b3fbb6438ab609ada643a3b1d30e7c0cd394ec5864036b33695b9565ee6e97f8
-  build: hbb1e571_0
+    md5: c3e0ac365475fcc6c2cd5c44bf22ebc9
+    sha256: fbe2a686c14f04c18ef6b2311603430d9dbd3bdd50e1b2daa71e2678e4386280
+  build: hbb1e571_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 300692
-  timestamp: 1705027275317
+  size: 299783
+  timestamp: 1706648107244
 - platform: osx-arm64
   name: azure-core-cpp
   version: 1.11.0
@@ -2150,19 +2150,19 @@ package:
   dependencies:
   - libcurl >=8.5.0,<9.0a0
   - libcxx >=15
-  - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.11.0-he231e37_0.conda
+  - openssl >=3.2.1,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.11.0-he231e37_1.conda
   hash:
-    md5: 331d81c4fe103355442a51b1e381a45b
-    sha256: e016272a05b81da26eb633643c1c9601528771820ebe132eac20029239461168
-  build: he231e37_0
+    md5: c2f26fc5c955973b823b5c6c514d9cea
+    sha256: a73be81148ad13abbd28c2fd9cf3d122016d14e1d14df66c106d5f0e387d4122
+  build: he231e37_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 291790
-  timestamp: 1705027401731
+  size: 291465
+  timestamp: 1706648381199
 - platform: win-64
   name: azure-core-cpp
   version: 1.11.0
@@ -2173,18 +2173,18 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/azure-core-cpp-1.11.0-h249a519_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/azure-core-cpp-1.11.0-h249a519_1.conda
   hash:
-    md5: faab1e6febc48ce9e8a1ca5f34b6225b
-    sha256: 38b58e5e9e746f58d6c33ec43e9aa3cd5ffce72835c21f1a7fbff7613db2241e
-  build: h249a519_0
+    md5: 8a8dd442b112c18e34c6d4a60b1724e3
+    sha256: 693399cea6440acbfed00e0ab5f556d236a27e6ef58d5611329dbda7ad1a0a9e
+  build: h249a519_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: MIT
   license_family: MIT
-  size: 482115
-  timestamp: 1705027396062
+  size: 482609
+  timestamp: 1706648411406
 - platform: linux-64
   name: azure-storage-blobs-cpp
   version: 12.10.0
@@ -2280,91 +2280,89 @@ package:
   category: main
   manager: conda
   dependencies:
-  - azure-core-cpp >=1.10.3,<2.0a0
+  - azure-core-cpp >=1.11.0,<1.12.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libxml2 >=2.12.1,<2.13.0a0
-  - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.5.0-hb858b4b_2.conda
+  - libxml2 >=2.12.4,<3.0a0
+  - openssl >=3.2.1,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.5.0-h94269e2_3.conda
   hash:
-    md5: 19f23b45d1925a9a8f701a3f6f9cce4f
-    sha256: 68e177ae983d63323b9bd1c1528776bb0e03d5d5aef0addba97aed4537e649a6
-  build: hb858b4b_2
+    md5: 2862966bef50f0f91f528f23b1270e52
+    sha256: 839f9ea01ad1a6acbe9c55073ca7ef677809f8d366a8500dae50e0a91da71a0e
+  build: h94269e2_3
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 3
   license: MIT
   license_family: MIT
-  size: 131317
-  timestamp: 1701393274447
+  size: 132329
+  timestamp: 1706719947421
 - platform: osx-64
   name: azure-storage-common-cpp
   version: 12.5.0
   category: main
   manager: conda
   dependencies:
-  - __osx >=10.9
-  - azure-core-cpp >=1.10.3,<2.0a0
-  - libcxx >=16.0.6
-  - libxml2 >=2.12.1,<3.0.0a0
-  - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.5.0-hf4badfb_2.conda
+  - azure-core-cpp >=1.11.0,<1.12.0a0
+  - libcxx >=15
+  - libxml2 >=2.12.4,<3.0a0
+  - openssl >=3.2.1,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.5.0-h0e82ce4_3.conda
   hash:
-    md5: 277020b2f0245d1d5a0a3bb0e921c069
-    sha256: b9336e9cbbf7a26f5cfab7dca2aec8037549efe8c8d6022e07b38f8840bbc608
-  build: hf4badfb_2
+    md5: bfcac27cf768fe12a5eaa818a4e4f140
+    sha256: e3cdbade1f8f198c4e50fbbcc268addc3b717a15bc5e89b6d7210267cf6fa036
+  build: h0e82ce4_3
   arch: x86_64
   subdir: osx-64
-  build_number: 2
+  build_number: 3
   license: MIT
   license_family: MIT
-  size: 110038
-  timestamp: 1701393612263
+  size: 110135
+  timestamp: 1706720200909
 - platform: osx-arm64
   name: azure-storage-common-cpp
   version: 12.5.0
   category: main
   manager: conda
   dependencies:
-  - __osx >=10.9
-  - azure-core-cpp >=1.10.3,<2.0a0
-  - libcxx >=16.0.6
-  - libxml2 >=2.12.1,<3.0.0a0
-  - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.5.0-h607ffeb_2.conda
+  - azure-core-cpp >=1.11.0,<1.12.0a0
+  - libcxx >=15
+  - libxml2 >=2.12.4,<3.0a0
+  - openssl >=3.2.1,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.5.0-h09a5875_3.conda
   hash:
-    md5: 457b5b7cfda7d6bec46e95cbe6554bc5
-    sha256: 1c020b792916289eec5b203e6cb301e80d434dc74de3ad9269ffa5b3fb9fa8c3
-  build: h607ffeb_2
+    md5: 6f2341a820fab6c06cf0bd5ff086246c
+    sha256: e90f836807f253d448dfe59270ed1ed426ebbb9cde32db796d19698bd84baf68
+  build: h09a5875_3
   arch: aarch64
   subdir: osx-arm64
-  build_number: 2
+  build_number: 3
   license: MIT
   license_family: MIT
-  size: 106495
-  timestamp: 1701393783292
+  size: 106579
+  timestamp: 1706720372285
 - platform: win-64
   name: azure-storage-common-cpp
   version: 12.5.0
   category: main
   manager: conda
   dependencies:
-  - azure-core-cpp >=1.10.3,<2.0a0
+  - azure-core-cpp >=1.11.0,<1.12.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/azure-storage-common-cpp-12.5.0-h91493d7_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/azure-storage-common-cpp-12.5.0-h91493d7_3.conda
   hash:
-    md5: b90cc625e300c18cbd75a8f7cd880a1b
-    sha256: cd3550f2181f3b62853af292d4f2639c2d1dee139f3949621173c4699aeb30da
-  build: h91493d7_2
+    md5: cbc9c2b5554ab768713144b22196956b
+    sha256: 96bc651c68f461de7042c7ab7d95e9c52d6cae8dbb610a3805be66b1157da89f
+  build: h91493d7_3
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 3
   license: MIT
   license_family: MIT
-  size: 224838
-  timestamp: 1701393883816
+  size: 224641
+  timestamp: 1706720304130
 - platform: linux-64
   name: babel
   version: 2.14.0
@@ -2619,7 +2617,7 @@ package:
   timestamp: 1705564819537
 - platform: linux-64
   name: black
-  version: 23.12.1
+  version: 24.1.1
   category: main
   manager: conda
   dependencies:
@@ -2630,21 +2628,21 @@ package:
   - platformdirs >=2
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/black-23.12.1-py311h38be061_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/black-24.1.1-py311h38be061_0.conda
   hash:
-    md5: cb563ab54c59917f004d4faf7a29c610
-    sha256: 90c29112da654aa4f713b03220b884aa4d11a74e642a72bf9d56e872700c7423
+    md5: bdc14831b477b49c278a470b67f4be01
+    sha256: 35abd0bd83ddc79f23b1405a85f84b3c60073e23a5e849d2f63314ed0aeb3324
   build: py311h38be061_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 378436
-  timestamp: 1703317664029
+  size: 380346
+  timestamp: 1706510528620
 - platform: osx-64
   name: black
-  version: 23.12.1
+  version: 24.1.1
   category: main
   manager: conda
   dependencies:
@@ -2655,21 +2653,21 @@ package:
   - platformdirs >=2
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/black-23.12.1-py311h6eed73b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/black-24.1.1-py311h6eed73b_0.conda
   hash:
-    md5: df285ee5615270aa4172c322dbecac3f
-    sha256: 6f82c6dbb55421163945bc4d03cc23734903e93c0ffd724d67530ce7c6d5a010
+    md5: bc1382c5e3854341d392c98e32e76a1c
+    sha256: 822bc9f5c883479d6d0bbe619fee795e7806c17f0eacfafd5c4cc989146179e7
   build: py311h6eed73b_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 379701
-  timestamp: 1703317853109
+  size: 381899
+  timestamp: 1706510683853
 - platform: osx-arm64
   name: black
-  version: 23.12.1
+  version: 24.1.1
   category: main
   manager: conda
   dependencies:
@@ -2681,21 +2679,21 @@ package:
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/black-23.12.1-py311h267d04e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/black-24.1.1-py311h267d04e_0.conda
   hash:
-    md5: c4cfd1e85e013c9a0995166897d06b73
-    sha256: b4ebb13643a6d77429f24b3fb3985d8e7eebd4804ea59b0834273ba0de451220
+    md5: c71bacdfb8e3bcd118d7e3ac3765d3b7
+    sha256: 44cd0f9fc497003fcfa0fa0c7ca37e1cd15e3e7d935c1e0a5a16adeae217c66a
   build: py311h267d04e_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 379989
-  timestamp: 1703317897071
+  size: 380590
+  timestamp: 1706510833691
 - platform: win-64
   name: black
-  version: 23.12.1
+  version: 24.1.1
   category: main
   manager: conda
   dependencies:
@@ -2706,67 +2704,66 @@ package:
   - platformdirs >=2
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/win-64/black-23.12.1-py311h1ea47a8_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/black-24.1.1-py311h1ea47a8_0.conda
   hash:
-    md5: aa307be056896f2da4ac4fcf2f348b08
-    sha256: 79f6f11a0057c6c648e72a976b88f3bc5d14b6f0fdb4f66eafefb643c063e692
+    md5: 8ba10f0196415499899a2dc611d843e1
+    sha256: 7f14e2abbdd045aeac848c82df8c8963587acf6c9f6dba3bbdd1e5c02cd74713
   build: py311h1ea47a8_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 395159
-  timestamp: 1703318197279
+  size: 398002
+  timestamp: 1706511072280
 - platform: win-64
   name: blas
   version: '2.121'
   category: main
   manager: conda
   dependencies:
-  - blas-devel 3.9.0 21_win64_mkl
-  - libblas 3.9.0 21_win64_mkl
-  - libcblas 3.9.0 21_win64_mkl
-  - liblapack 3.9.0 21_win64_mkl
-  - liblapacke 3.9.0 21_win64_mkl
+  - blas-devel 3.9.0 21_win64_openblas
+  - libblas 3.9.0 21_win64_openblas
+  - libcblas 3.9.0 21_win64_openblas
+  - liblapack 3.9.0 21_win64_openblas
+  - liblapacke 3.9.0 21_win64_openblas
   - m2w64-gcc-libs
   - m2w64-gcc-libs-core
-  url: https://conda.anaconda.org/conda-forge/win-64/blas-2.121-mkl.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/blas-2.121-openblas.conda
   hash:
-    md5: 87ae78b8197b890e5a429f91769dfac7
-    sha256: b44ac779599779a81528348fab050e9b7676f1944281e9ac586609a15df0838a
-  build: mkl
+    md5: d5e9a2e2e56fce4e49844e13210b9d10
+    sha256: 157f32227335579017e96798bf7f74a69bcf134d33e893a9a87f33b73be3c3cc
+  build: openblas
   arch: x86_64
   subdir: win-64
   build_number: 21
   license: BSD-3-Clause
   license_family: BSD
-  size: 17016
-  timestamp: 1705980772111
+  size: 15958
+  timestamp: 1705980301701
 - platform: win-64
   name: blas-devel
   version: 3.9.0
   category: main
   manager: conda
   dependencies:
-  - libblas 3.9.0 21_win64_mkl
-  - libcblas 3.9.0 21_win64_mkl
-  - liblapack 3.9.0 21_win64_mkl
-  - liblapacke 3.9.0 21_win64_mkl
-  - mkl >=2024.0.0,<2025.0a0
-  - mkl-devel 2024.0.*
-  url: https://conda.anaconda.org/conda-forge/win-64/blas-devel-3.9.0-21_win64_mkl.conda
+  - libblas 3.9.0 21_win64_openblas
+  - libcblas 3.9.0 21_win64_openblas
+  - liblapack 3.9.0 21_win64_openblas
+  - liblapacke 3.9.0 21_win64_openblas
+  - openblas 0.3.26.*
+  url: https://conda.anaconda.org/conda-forge/win-64/blas-devel-3.9.0-21_win64_openblas.conda
   hash:
-    md5: dfb57411138b9548b9d6c65f7fe6af32
-    sha256: b9346a22ad49510e6dd548077324087f058415074dbd78371b63e4db189079b0
-  build: 21_win64_mkl
+    md5: dda86746ca0dd83e8fd7ef866d0621b7
+    sha256: cbf824738b716667bbb39a7b7806166f35b0cb38f3cfb3f310f79f477d1ee11c
+  build: 21_win64_openblas
   arch: x86_64
   subdir: win-64
   build_number: 21
   license: BSD-3-Clause
   license_family: BSD
-  size: 16459
-  timestamp: 1705980621558
+  size: 15354
+  timestamp: 1705980122238
 - platform: linux-64
   name: bleach
   version: 6.1.0
@@ -3056,7 +3053,7 @@ package:
   timestamp: 1698243713437
 - platform: linux-64
   name: bokeh
-  version: 3.3.3
+  version: 3.3.4
   category: main
   manager: conda
   dependencies:
@@ -3070,10 +3067,10 @@ package:
   - pyyaml >=3.10
   - tornado >=5.1
   - xyzservices >=2021.09.1
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.3.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.3.4-pyhd8ed1ab_0.conda
   hash:
-    md5: e6b7ca7e29811c2f72f93e8188171caa
-    sha256: 68a7e59b98235cef7fecced56a76056e54392d6961129c2b3b135fc5ec92a6c3
+    md5: 6cc92bba68b7bb5a3b180e96508f9480
+    sha256: b9cf3b2d136ecdd32dfb97776c97ea92915caab759179ee94c6c1abbab806a62
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -3081,11 +3078,11 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 4941170
-  timestamp: 1704748161694
+  size: 4553167
+  timestamp: 1706215976186
 - platform: osx-64
   name: bokeh
-  version: 3.3.3
+  version: 3.3.4
   category: main
   manager: conda
   dependencies:
@@ -3099,10 +3096,10 @@ package:
   - pyyaml >=3.10
   - tornado >=5.1
   - xyzservices >=2021.09.1
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.3.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.3.4-pyhd8ed1ab_0.conda
   hash:
-    md5: e6b7ca7e29811c2f72f93e8188171caa
-    sha256: 68a7e59b98235cef7fecced56a76056e54392d6961129c2b3b135fc5ec92a6c3
+    md5: 6cc92bba68b7bb5a3b180e96508f9480
+    sha256: b9cf3b2d136ecdd32dfb97776c97ea92915caab759179ee94c6c1abbab806a62
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -3110,11 +3107,11 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 4941170
-  timestamp: 1704748161694
+  size: 4553167
+  timestamp: 1706215976186
 - platform: osx-arm64
   name: bokeh
-  version: 3.3.3
+  version: 3.3.4
   category: main
   manager: conda
   dependencies:
@@ -3128,10 +3125,10 @@ package:
   - pyyaml >=3.10
   - tornado >=5.1
   - xyzservices >=2021.09.1
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.3.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.3.4-pyhd8ed1ab_0.conda
   hash:
-    md5: e6b7ca7e29811c2f72f93e8188171caa
-    sha256: 68a7e59b98235cef7fecced56a76056e54392d6961129c2b3b135fc5ec92a6c3
+    md5: 6cc92bba68b7bb5a3b180e96508f9480
+    sha256: b9cf3b2d136ecdd32dfb97776c97ea92915caab759179ee94c6c1abbab806a62
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -3139,11 +3136,11 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 4941170
-  timestamp: 1704748161694
+  size: 4553167
+  timestamp: 1706215976186
 - platform: win-64
   name: bokeh
-  version: 3.3.3
+  version: 3.3.4
   category: main
   manager: conda
   dependencies:
@@ -3157,10 +3154,10 @@ package:
   - pyyaml >=3.10
   - tornado >=5.1
   - xyzservices >=2021.09.1
-  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.3.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/bokeh-3.3.4-pyhd8ed1ab_0.conda
   hash:
-    md5: e6b7ca7e29811c2f72f93e8188171caa
-    sha256: 68a7e59b98235cef7fecced56a76056e54392d6961129c2b3b135fc5ec92a6c3
+    md5: 6cc92bba68b7bb5a3b180e96508f9480
+    sha256: b9cf3b2d136ecdd32dfb97776c97ea92915caab759179ee94c6c1abbab806a62
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -3168,92 +3165,88 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 4941170
-  timestamp: 1704748161694
+  size: 4553167
+  timestamp: 1706215976186
 - platform: linux-64
   name: branca
-  version: 0.7.0
+  version: 0.7.1
   category: main
   manager: conda
   dependencies:
-  - jinja2
+  - jinja2 >=3
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 980ae382aec2ebb7c20e8848f4d695d7
-    sha256: 9013b381e6745a7f717b7f742d3fe366ba619f1670da0d849ae589c4e88b0dbc
-  build: pyhd8ed1ab_1
+    md5: 35fa1bfd27c4d4c3cd46501a9ca7bd78
+    sha256: 4053ce4389a524e226eea020e2e507335e908a45d324b4f48d4b4407b17c88e3
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 0
   license: MIT
-  license_family: MIT
   noarch: python
-  size: 29178
-  timestamp: 1699296133785
+  size: 29211
+  timestamp: 1706711216173
 - platform: osx-64
   name: branca
-  version: 0.7.0
+  version: 0.7.1
   category: main
   manager: conda
   dependencies:
-  - jinja2
+  - jinja2 >=3
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 980ae382aec2ebb7c20e8848f4d695d7
-    sha256: 9013b381e6745a7f717b7f742d3fe366ba619f1670da0d849ae589c4e88b0dbc
-  build: pyhd8ed1ab_1
+    md5: 35fa1bfd27c4d4c3cd46501a9ca7bd78
+    sha256: 4053ce4389a524e226eea020e2e507335e908a45d324b4f48d4b4407b17c88e3
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 0
   license: MIT
-  license_family: MIT
   noarch: python
-  size: 29178
-  timestamp: 1699296133785
+  size: 29211
+  timestamp: 1706711216173
 - platform: osx-arm64
   name: branca
-  version: 0.7.0
+  version: 0.7.1
   category: main
   manager: conda
   dependencies:
-  - jinja2
+  - jinja2 >=3
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 980ae382aec2ebb7c20e8848f4d695d7
-    sha256: 9013b381e6745a7f717b7f742d3fe366ba619f1670da0d849ae589c4e88b0dbc
-  build: pyhd8ed1ab_1
+    md5: 35fa1bfd27c4d4c3cd46501a9ca7bd78
+    sha256: 4053ce4389a524e226eea020e2e507335e908a45d324b4f48d4b4407b17c88e3
+  build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 0
   license: MIT
-  license_family: MIT
   noarch: python
-  size: 29178
-  timestamp: 1699296133785
+  size: 29211
+  timestamp: 1706711216173
 - platform: win-64
   name: branca
-  version: 0.7.0
+  version: 0.7.1
   category: main
   manager: conda
   dependencies:
-  - jinja2
+  - jinja2 >=3
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.0-pyhd8ed1ab_1.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/branca-0.7.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 980ae382aec2ebb7c20e8848f4d695d7
-    sha256: 9013b381e6745a7f717b7f742d3fe366ba619f1670da0d849ae589c4e88b0dbc
-  build: pyhd8ed1ab_1
+    md5: 35fa1bfd27c4d4c3cd46501a9ca7bd78
+    sha256: 4053ce4389a524e226eea020e2e507335e908a45d324b4f48d4b4407b17c88e3
+  build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 0
   license: MIT
-  license_family: MIT
   noarch: python
-  size: 29178
-  timestamp: 1699296133785
+  size: 29211
+  timestamp: 1706711216173
 - platform: linux-64
   name: brotli
   version: 1.1.0
@@ -3696,80 +3689,80 @@ package:
   timestamp: 1699280668742
 - platform: linux-64
   name: c-ares
-  version: 1.25.0
+  version: 1.26.0
   category: main
   manager: conda
   dependencies:
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.25.0-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.26.0-hd590300_0.conda
   hash:
-    md5: 89e40af02dd3a0846c0c1131c5126706
-    sha256: c4bbdafd6791583e3c77e8ed0e1df9e0021d542249c3543de3d72788f5c8a0c4
+    md5: a86d90025198fd411845fc245ebc06c8
+    sha256: 3771589a91303710a59d1d40bbcdca43743969fe993ea576538ba375ac8ab0fa
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 156989
-  timestamp: 1704784109506
+  size: 162725
+  timestamp: 1706299899438
 - platform: osx-64
   name: c-ares
-  version: 1.25.0
+  version: 1.26.0
   category: main
   manager: conda
   dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.25.0-h10d778d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.26.0-h10d778d_0.conda
   hash:
-    md5: 80e97c8f21c33a3b9256504858cf49b6
-    sha256: 0456f70b14a3bc2e2b14610f03e00681626039e89d13ba5868fbc54795697a82
+    md5: 04a8ab3d4f9a9446b286c4a90f665148
+    sha256: 4b01708ed02f3e2cf9e8919a6fc1d3116cdf84c1a771294031e880f54235f47c
   build: h10d778d_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 142849
-  timestamp: 1704784338685
+  size: 147816
+  timestamp: 1706300301840
 - platform: osx-arm64
   name: c-ares
-  version: 1.25.0
+  version: 1.26.0
   category: main
   manager: conda
   dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.25.0-h93a5062_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.26.0-h93a5062_0.conda
   hash:
-    md5: 0a40466cb14b485738f1910340775f71
-    sha256: 2a3df1920cfc493592c311db87138442475849ff11a14eb1dbf12caa80d8077b
+    md5: 58b9187431de0a2ffebc907f4590e2e5
+    sha256: 1dfdbac985a74a905f2bcf62f13ce758a8356e50d4b28ddbc2027df8580717d8
   build: h93a5062_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 140452
-  timestamp: 1704784426235
+  size: 145325
+  timestamp: 1706300196534
 - platform: win-64
   name: c-ares
-  version: 1.25.0
+  version: 1.26.0
   category: main
   manager: conda
   dependencies:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.25.0-hcfcfb64_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.26.0-hcfcfb64_0.conda
   hash:
-    md5: 11d1d8216b19c47bb54e5941c92c1285
-    sha256: ac695c2c6b34a5434aec7eeff89625a44ea88975d2b79799bd6eb9606c49161b
+    md5: db4a1d40f8ac823f51450eb9da44dff0
+    sha256: 8b5a70412d441a43686f1f580d7db5886e0bc0840ccc4d3a6d3bb8c355847a3f
   build: hcfcfb64_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 148939
-  timestamp: 1704784681275
+  size: 153934
+  timestamp: 1706300577110
 - platform: linux-64
   name: ca-certificates
   version: 2023.11.17
@@ -5501,7 +5494,7 @@ package:
   timestamp: 1699042419820
 - platform: linux-64
   name: coverage
-  version: 7.4.0
+  version: 7.4.1
   category: main
   manager: conda
   dependencies:
@@ -5509,42 +5502,42 @@ package:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - tomli
-  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.4.0-py311h459d7ec_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.4.1-py311h459d7ec_0.conda
   hash:
-    md5: bbaf0376ed2f153a90f167ad908da3d0
-    sha256: 3d1a0ae99477d91f2c7e4f5a7554e6de2eaa9bc4450a2db307005c65e394e7f2
+    md5: 9caf3270065a2d40fd9a443ba1568e96
+    sha256: 021009626f10f8f477ebc1aa5f7fccdf08561cbea605e00272752b256a2c5476
   build: py311h459d7ec_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  size: 364870
-  timestamp: 1703727330547
+  size: 365671
+  timestamp: 1706301885733
 - platform: osx-64
   name: coverage
-  version: 7.4.0
+  version: 7.4.1
   category: main
   manager: conda
   dependencies:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - tomli
-  url: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.4.0-py311he705e18_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.4.1-py311he705e18_0.conda
   hash:
-    md5: 26c6acf173e93e71cb28339544abc377
-    sha256: eb603b678fa508acade2a96899c8d235095c9b6c915fb64e9a82d77bc33665c3
+    md5: 7a4416832638b8a69d792571a276af63
+    sha256: ca52e9bd135dcf0c68a69c22ad141917e6d1e45164b622bf7268c2eefab1f796
   build: py311he705e18_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  size: 363494
-  timestamp: 1703727528872
+  size: 365714
+  timestamp: 1706302080179
 - platform: osx-arm64
   name: coverage
-  version: 7.4.0
+  version: 7.4.1
   category: main
   manager: conda
   dependencies:
@@ -5552,21 +5545,21 @@ package:
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
   - tomli
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.4.0-py311h05b510d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.4.1-py311h05b510d_0.conda
   hash:
-    md5: 7a801e12fd286ee7d3be2bf7fb1e029f
-    sha256: 78c909fcedf2aa360b95e4ea395706557df4adde27ce3b9086f7e2934c26a2b2
+    md5: 2b18cf475176db56ef176a66a151f125
+    sha256: 01190cd3017a7c2f88000bbd1f4e4b64903e45f0a531c5517067d68e13c92b1c
   build: py311h05b510d_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  size: 365440
-  timestamp: 1703727575915
+  size: 365101
+  timestamp: 1706302205809
 - platform: win-64
   name: coverage
-  version: 7.4.0
+  version: 7.4.1
   category: main
   manager: conda
   dependencies:
@@ -5576,41 +5569,41 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/coverage-7.4.0-py311ha68e1ae_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/coverage-7.4.1-py311ha68e1ae_0.conda
   hash:
-    md5: 4e57a4f9db2ff69d14204ae3863686e2
-    sha256: 138dcbfb37bee8b22ba8e577933843a4da5713d68e2562de92a2e63dadd78ddb
+    md5: 2369d87013e4b1e53befef72e127f78a
+    sha256: 4842f5e3d86a700f8db8051f4d94a91ececca9a558254f126e2db895ad067aa2
   build: py311ha68e1ae_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: Apache-2.0
   license_family: APACHE
-  size: 382380
-  timestamp: 1703727762345
+  size: 384354
+  timestamp: 1706302331862
 - platform: linux-64
   name: cryptography
-  version: 42.0.0
+  version: 42.0.2
   category: main
   manager: conda
   dependencies:
   - cffi >=1.12
   - libgcc-ng >=12
-  - openssl >=3.1.4,<4.0a0
+  - openssl >=3.1.5,<4.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-42.0.0-py311hcb13ee4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-42.0.2-py311hcb13ee4_0.conda
   hash:
-    md5: fbe3e1fe48bc9137f71ff2c1cb95d14b
-    sha256: f63afd05c1230f47212eb35e92dfd3300fb6c94c0e1d75e432a27b3267d21dd9
+    md5: c61fd9e9fcfa599ea5a8b1de42b147a8
+    sha256: 165591f6dd5db602255ff170569e41508fea47cfa5bce51e79cfe251493a54f0
   build: py311hcb13ee4_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
   license_family: BSD
-  size: 2044499
-  timestamp: 1706068357584
+  size: 2044751
+  timestamp: 1706658911349
 - platform: linux-64
   name: curl
   version: 8.5.0
@@ -5934,14 +5927,14 @@ package:
   timestamp: 1683598954152
 - platform: linux-64
   name: dask
-  version: 2024.1.0
+  version: 2024.1.1
   category: main
   manager: conda
   dependencies:
   - bokeh >=2.4.2,!=3.0.*
   - cytoolz >=0.11.0
-  - dask-core >=2024.1.0,<2024.1.1.0a0
-  - distributed >=2024.1.0,<2024.1.1.0a0
+  - dask-core >=2024.1.1,<2024.1.2.0a0
+  - distributed >=2024.1.1,<2024.1.2.0a0
   - jinja2 >=2.10.3
   - lz4 >=4.3.2
   - numpy >=1.21
@@ -5949,10 +5942,10 @@ package:
   - pyarrow >=7.0
   - pyarrow-hotfix
   - python >=3.9
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 972955a551de85754e66bb61bd628232
-    sha256: b6f6cfbd68026633b3b65ce817ac7f92f1defc2fa6aed9d4a2d70f2224d06d0a
+    md5: c319bdbcfa9952e246f9d35e7c13a927
+    sha256: 8f3d605b2d89eb0a9792576b385098ce7f9bdb827b88c6d5e2c9517914895bd0
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -5962,18 +5955,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 7515
-  timestamp: 1705107766795
+  size: 7547
+  timestamp: 1706319568780
 - platform: osx-64
   name: dask
-  version: 2024.1.0
+  version: 2024.1.1
   category: main
   manager: conda
   dependencies:
   - bokeh >=2.4.2,!=3.0.*
   - cytoolz >=0.11.0
-  - dask-core >=2024.1.0,<2024.1.1.0a0
-  - distributed >=2024.1.0,<2024.1.1.0a0
+  - dask-core >=2024.1.1,<2024.1.2.0a0
+  - distributed >=2024.1.1,<2024.1.2.0a0
   - jinja2 >=2.10.3
   - lz4 >=4.3.2
   - numpy >=1.21
@@ -5981,10 +5974,10 @@ package:
   - pyarrow >=7.0
   - pyarrow-hotfix
   - python >=3.9
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 972955a551de85754e66bb61bd628232
-    sha256: b6f6cfbd68026633b3b65ce817ac7f92f1defc2fa6aed9d4a2d70f2224d06d0a
+    md5: c319bdbcfa9952e246f9d35e7c13a927
+    sha256: 8f3d605b2d89eb0a9792576b385098ce7f9bdb827b88c6d5e2c9517914895bd0
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -5994,18 +5987,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 7515
-  timestamp: 1705107766795
+  size: 7547
+  timestamp: 1706319568780
 - platform: osx-arm64
   name: dask
-  version: 2024.1.0
+  version: 2024.1.1
   category: main
   manager: conda
   dependencies:
   - bokeh >=2.4.2,!=3.0.*
   - cytoolz >=0.11.0
-  - dask-core >=2024.1.0,<2024.1.1.0a0
-  - distributed >=2024.1.0,<2024.1.1.0a0
+  - dask-core >=2024.1.1,<2024.1.2.0a0
+  - distributed >=2024.1.1,<2024.1.2.0a0
   - jinja2 >=2.10.3
   - lz4 >=4.3.2
   - numpy >=1.21
@@ -6013,10 +6006,10 @@ package:
   - pyarrow >=7.0
   - pyarrow-hotfix
   - python >=3.9
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 972955a551de85754e66bb61bd628232
-    sha256: b6f6cfbd68026633b3b65ce817ac7f92f1defc2fa6aed9d4a2d70f2224d06d0a
+    md5: c319bdbcfa9952e246f9d35e7c13a927
+    sha256: 8f3d605b2d89eb0a9792576b385098ce7f9bdb827b88c6d5e2c9517914895bd0
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -6026,18 +6019,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 7515
-  timestamp: 1705107766795
+  size: 7547
+  timestamp: 1706319568780
 - platform: win-64
   name: dask
-  version: 2024.1.0
+  version: 2024.1.1
   category: main
   manager: conda
   dependencies:
   - bokeh >=2.4.2,!=3.0.*
   - cytoolz >=0.11.0
-  - dask-core >=2024.1.0,<2024.1.1.0a0
-  - distributed >=2024.1.0,<2024.1.1.0a0
+  - dask-core >=2024.1.1,<2024.1.2.0a0
+  - distributed >=2024.1.1,<2024.1.2.0a0
   - jinja2 >=2.10.3
   - lz4 >=4.3.2
   - numpy >=1.21
@@ -6045,10 +6038,10 @@ package:
   - pyarrow >=7.0
   - pyarrow-hotfix
   - python >=3.9
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-2024.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 972955a551de85754e66bb61bd628232
-    sha256: b6f6cfbd68026633b3b65ce817ac7f92f1defc2fa6aed9d4a2d70f2224d06d0a
+    md5: c319bdbcfa9952e246f9d35e7c13a927
+    sha256: 8f3d605b2d89eb0a9792576b385098ce7f9bdb827b88c6d5e2c9517914895bd0
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -6058,11 +6051,11 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 7515
-  timestamp: 1705107766795
+  size: 7547
+  timestamp: 1706319568780
 - platform: linux-64
   name: dask-core
-  version: 2024.1.0
+  version: 2024.1.1
   category: main
   manager: conda
   dependencies:
@@ -6075,10 +6068,10 @@ package:
   - python >=3.9
   - pyyaml >=5.3.1
   - toolz >=0.10.0
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: cab4cec272dc1e30086f7d32faa4f130
-    sha256: a5d2dd0ed941e2c0067b3b6c4d594838f70c59ed4450e7344049bde9a3c2b654
+    md5: 1a92a5bd77b2430796696e25c3d8dbcb
+    sha256: b9521f5fe75ec73b2be9227abd6d27e51d7d2698c614f46d4977e7135b003bef
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -6086,11 +6079,11 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 870822
-  timestamp: 1705098230606
+  size: 874193
+  timestamp: 1706311523993
 - platform: osx-64
   name: dask-core
-  version: 2024.1.0
+  version: 2024.1.1
   category: main
   manager: conda
   dependencies:
@@ -6103,10 +6096,10 @@ package:
   - python >=3.9
   - pyyaml >=5.3.1
   - toolz >=0.10.0
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: cab4cec272dc1e30086f7d32faa4f130
-    sha256: a5d2dd0ed941e2c0067b3b6c4d594838f70c59ed4450e7344049bde9a3c2b654
+    md5: 1a92a5bd77b2430796696e25c3d8dbcb
+    sha256: b9521f5fe75ec73b2be9227abd6d27e51d7d2698c614f46d4977e7135b003bef
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -6114,11 +6107,11 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 870822
-  timestamp: 1705098230606
+  size: 874193
+  timestamp: 1706311523993
 - platform: osx-arm64
   name: dask-core
-  version: 2024.1.0
+  version: 2024.1.1
   category: main
   manager: conda
   dependencies:
@@ -6131,10 +6124,10 @@ package:
   - python >=3.9
   - pyyaml >=5.3.1
   - toolz >=0.10.0
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: cab4cec272dc1e30086f7d32faa4f130
-    sha256: a5d2dd0ed941e2c0067b3b6c4d594838f70c59ed4450e7344049bde9a3c2b654
+    md5: 1a92a5bd77b2430796696e25c3d8dbcb
+    sha256: b9521f5fe75ec73b2be9227abd6d27e51d7d2698c614f46d4977e7135b003bef
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -6142,11 +6135,11 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 870822
-  timestamp: 1705098230606
+  size: 874193
+  timestamp: 1706311523993
 - platform: win-64
   name: dask-core
-  version: 2024.1.0
+  version: 2024.1.1
   category: main
   manager: conda
   dependencies:
@@ -6159,10 +6152,10 @@ package:
   - python >=3.9
   - pyyaml >=5.3.1
   - toolz >=0.10.0
-  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/dask-core-2024.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: cab4cec272dc1e30086f7d32faa4f130
-    sha256: a5d2dd0ed941e2c0067b3b6c4d594838f70c59ed4450e7344049bde9a3c2b654
+    md5: 1a92a5bd77b2430796696e25c3d8dbcb
+    sha256: b9521f5fe75ec73b2be9227abd6d27e51d7d2698c614f46d4977e7135b003bef
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -6170,8 +6163,8 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 870822
-  timestamp: 1705098230606
+  size: 874193
+  timestamp: 1706311523993
 - platform: linux-64
   name: datamodel-code-generator
   version: 0.24.2
@@ -6767,14 +6760,14 @@ package:
   timestamp: 1702383349284
 - platform: linux-64
   name: distributed
-  version: 2024.1.0
+  version: 2024.1.1
   category: main
   manager: conda
   dependencies:
   - click >=8.0
   - cloudpickle >=1.5.0
   - cytoolz >=0.10.1
-  - dask-core >=2024.1.0,<2024.1.1.0a0
+  - dask-core >=2024.1.1,<2024.1.2.0a0
   - jinja2 >=2.10.3
   - locket >=1.0.0
   - msgpack-python >=1.0.0
@@ -6788,10 +6781,10 @@ package:
   - tornado >=6.0.4
   - urllib3 >=1.24.3
   - zict >=3.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 6c7822204c9e438b2f298e82127f05ec
-    sha256: 3a376ff500035e602c8fcfb1624aee75ccf12ec89409e620576d97194ff87590
+    md5: 81039f39690f341dcb0a68bf62e812be
+    sha256: 097b27d3a2d79ef437711203d872da2cbb0b52610213c6f1dfa69c6142bab061
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -6801,18 +6794,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 789739
-  timestamp: 1705103952389
+  size: 792729
+  timestamp: 1706315510287
 - platform: osx-64
   name: distributed
-  version: 2024.1.0
+  version: 2024.1.1
   category: main
   manager: conda
   dependencies:
   - click >=8.0
   - cloudpickle >=1.5.0
   - cytoolz >=0.10.1
-  - dask-core >=2024.1.0,<2024.1.1.0a0
+  - dask-core >=2024.1.1,<2024.1.2.0a0
   - jinja2 >=2.10.3
   - locket >=1.0.0
   - msgpack-python >=1.0.0
@@ -6826,10 +6819,10 @@ package:
   - tornado >=6.0.4
   - urllib3 >=1.24.3
   - zict >=3.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 6c7822204c9e438b2f298e82127f05ec
-    sha256: 3a376ff500035e602c8fcfb1624aee75ccf12ec89409e620576d97194ff87590
+    md5: 81039f39690f341dcb0a68bf62e812be
+    sha256: 097b27d3a2d79ef437711203d872da2cbb0b52610213c6f1dfa69c6142bab061
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -6839,18 +6832,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 789739
-  timestamp: 1705103952389
+  size: 792729
+  timestamp: 1706315510287
 - platform: osx-arm64
   name: distributed
-  version: 2024.1.0
+  version: 2024.1.1
   category: main
   manager: conda
   dependencies:
   - click >=8.0
   - cloudpickle >=1.5.0
   - cytoolz >=0.10.1
-  - dask-core >=2024.1.0,<2024.1.1.0a0
+  - dask-core >=2024.1.1,<2024.1.2.0a0
   - jinja2 >=2.10.3
   - locket >=1.0.0
   - msgpack-python >=1.0.0
@@ -6864,10 +6857,10 @@ package:
   - tornado >=6.0.4
   - urllib3 >=1.24.3
   - zict >=3.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 6c7822204c9e438b2f298e82127f05ec
-    sha256: 3a376ff500035e602c8fcfb1624aee75ccf12ec89409e620576d97194ff87590
+    md5: 81039f39690f341dcb0a68bf62e812be
+    sha256: 097b27d3a2d79ef437711203d872da2cbb0b52610213c6f1dfa69c6142bab061
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -6877,18 +6870,18 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 789739
-  timestamp: 1705103952389
+  size: 792729
+  timestamp: 1706315510287
 - platform: win-64
   name: distributed
-  version: 2024.1.0
+  version: 2024.1.1
   category: main
   manager: conda
   dependencies:
   - click >=8.0
   - cloudpickle >=1.5.0
   - cytoolz >=0.10.1
-  - dask-core >=2024.1.0,<2024.1.1.0a0
+  - dask-core >=2024.1.1,<2024.1.2.0a0
   - jinja2 >=2.10.3
   - locket >=1.0.0
   - msgpack-python >=1.0.0
@@ -6902,10 +6895,10 @@ package:
   - tornado >=6.0.4
   - urllib3 >=1.24.3
   - zict >=3.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/distributed-2024.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 6c7822204c9e438b2f298e82127f05ec
-    sha256: 3a376ff500035e602c8fcfb1624aee75ccf12ec89409e620576d97194ff87590
+    md5: 81039f39690f341dcb0a68bf62e812be
+    sha256: 097b27d3a2d79ef437711203d872da2cbb0b52610213c6f1dfa69c6142bab061
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -6915,8 +6908,8 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 789739
-  timestamp: 1705103952389
+  size: 792729
+  timestamp: 1706315510287
 - platform: linux-64
   name: docutils
   version: 0.20.1
@@ -9159,7 +9152,7 @@ package:
   - libgcc-ng >=12
   - libgdal 3.8.3 hcd1fc54_0
   - libstdcxx-ng >=12
-  - libxml2 >=2.12.3,<2.13.0a0
+  - libxml2 >=2.12.3,<3.0.0a0
   - numpy >=1.23.5,<2.0a0
   - openssl >=3.2.0,<4.0a0
   - python >=3.11,<3.12.0a0
@@ -9339,115 +9332,111 @@ package:
   timestamp: 1601490140447
 - platform: linux-64
   name: geopandas
-  version: 0.14.2
+  version: 0.14.3
   category: main
   manager: conda
   dependencies:
   - fiona >=1.8.21
   - folium
-  - geopandas-base 0.14.2 pyha770c72_0
+  - geopandas-base 0.14.3 pyha770c72_0
   - mapclassify >=2.4.0
   - matplotlib-base
   - python >=3.9
   - rtree
   - xyzservices
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 4f873f6e48ae63d573c3e4937185027e
-    sha256: 5d0e42a7dbc4bec7fa716c55d5ece0f9a90fccc905bae7d619f46a83aa7efccc
+    md5: d8e208e375441bf1404e9693f13f3c25
+    sha256: 15bdc3d85ffa9c6601f57dd5e2780dbcbe52ca5da70164fb5bb1bb4c72b92010
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 7673
-  timestamp: 1704439143094
+  size: 7619
+  timestamp: 1706734846170
 - platform: osx-64
   name: geopandas
-  version: 0.14.2
+  version: 0.14.3
   category: main
   manager: conda
   dependencies:
   - fiona >=1.8.21
   - folium
-  - geopandas-base 0.14.2 pyha770c72_0
+  - geopandas-base 0.14.3 pyha770c72_0
   - mapclassify >=2.4.0
   - matplotlib-base
   - python >=3.9
   - rtree
   - xyzservices
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 4f873f6e48ae63d573c3e4937185027e
-    sha256: 5d0e42a7dbc4bec7fa716c55d5ece0f9a90fccc905bae7d619f46a83aa7efccc
+    md5: d8e208e375441bf1404e9693f13f3c25
+    sha256: 15bdc3d85ffa9c6601f57dd5e2780dbcbe52ca5da70164fb5bb1bb4c72b92010
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 7673
-  timestamp: 1704439143094
+  size: 7619
+  timestamp: 1706734846170
 - platform: osx-arm64
   name: geopandas
-  version: 0.14.2
+  version: 0.14.3
   category: main
   manager: conda
   dependencies:
   - fiona >=1.8.21
   - folium
-  - geopandas-base 0.14.2 pyha770c72_0
+  - geopandas-base 0.14.3 pyha770c72_0
   - mapclassify >=2.4.0
   - matplotlib-base
   - python >=3.9
   - rtree
   - xyzservices
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 4f873f6e48ae63d573c3e4937185027e
-    sha256: 5d0e42a7dbc4bec7fa716c55d5ece0f9a90fccc905bae7d619f46a83aa7efccc
+    md5: d8e208e375441bf1404e9693f13f3c25
+    sha256: 15bdc3d85ffa9c6601f57dd5e2780dbcbe52ca5da70164fb5bb1bb4c72b92010
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 7673
-  timestamp: 1704439143094
+  size: 7619
+  timestamp: 1706734846170
 - platform: win-64
   name: geopandas
-  version: 0.14.2
+  version: 0.14.3
   category: main
   manager: conda
   dependencies:
   - fiona >=1.8.21
   - folium
-  - geopandas-base 0.14.2 pyha770c72_0
+  - geopandas-base 0.14.3 pyha770c72_0
   - mapclassify >=2.4.0
   - matplotlib-base
   - python >=3.9
   - rtree
   - xyzservices
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.2-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-0.14.3-pyhd8ed1ab_0.conda
   hash:
-    md5: 4f873f6e48ae63d573c3e4937185027e
-    sha256: 5d0e42a7dbc4bec7fa716c55d5ece0f9a90fccc905bae7d619f46a83aa7efccc
+    md5: d8e208e375441bf1404e9693f13f3c25
+    sha256: 15bdc3d85ffa9c6601f57dd5e2780dbcbe52ca5da70164fb5bb1bb4c72b92010
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 7673
-  timestamp: 1704439143094
+  size: 7619
+  timestamp: 1706734846170
 - platform: linux-64
   name: geopandas-base
-  version: 0.14.2
+  version: 0.14.3
   category: main
   manager: conda
   dependencies:
@@ -9456,22 +9445,21 @@ package:
   - pyproj >=3.3.0
   - python >=3.9
   - shapely >=1.8.0
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.2-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.3-pyha770c72_0.conda
   hash:
-    md5: e825cfead1f4223911d9538f6c575c90
-    sha256: d896b02d8107a3c61cacd8e2a56a11b931710aba59cf3baa748837ef48404252
+    md5: fbac4b2194c962b97324a3f5dd7d2696
+    sha256: 0a8fb5a368d19fd08f7f65dfcff563322cb34e47947cabab8fc7f187d9bc9269
   build: pyha770c72_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 1017954
-  timestamp: 1704439132721
+  size: 1020461
+  timestamp: 1706734838573
 - platform: osx-64
   name: geopandas-base
-  version: 0.14.2
+  version: 0.14.3
   category: main
   manager: conda
   dependencies:
@@ -9480,22 +9468,21 @@ package:
   - pyproj >=3.3.0
   - python >=3.9
   - shapely >=1.8.0
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.2-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.3-pyha770c72_0.conda
   hash:
-    md5: e825cfead1f4223911d9538f6c575c90
-    sha256: d896b02d8107a3c61cacd8e2a56a11b931710aba59cf3baa748837ef48404252
+    md5: fbac4b2194c962b97324a3f5dd7d2696
+    sha256: 0a8fb5a368d19fd08f7f65dfcff563322cb34e47947cabab8fc7f187d9bc9269
   build: pyha770c72_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 1017954
-  timestamp: 1704439132721
+  size: 1020461
+  timestamp: 1706734838573
 - platform: osx-arm64
   name: geopandas-base
-  version: 0.14.2
+  version: 0.14.3
   category: main
   manager: conda
   dependencies:
@@ -9504,22 +9491,21 @@ package:
   - pyproj >=3.3.0
   - python >=3.9
   - shapely >=1.8.0
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.2-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.3-pyha770c72_0.conda
   hash:
-    md5: e825cfead1f4223911d9538f6c575c90
-    sha256: d896b02d8107a3c61cacd8e2a56a11b931710aba59cf3baa748837ef48404252
+    md5: fbac4b2194c962b97324a3f5dd7d2696
+    sha256: 0a8fb5a368d19fd08f7f65dfcff563322cb34e47947cabab8fc7f187d9bc9269
   build: pyha770c72_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 1017954
-  timestamp: 1704439132721
+  size: 1020461
+  timestamp: 1706734838573
 - platform: win-64
   name: geopandas-base
-  version: 0.14.2
+  version: 0.14.3
   category: main
   manager: conda
   dependencies:
@@ -9528,19 +9514,18 @@ package:
   - pyproj >=3.3.0
   - python >=3.9
   - shapely >=1.8.0
-  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.2-pyha770c72_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-0.14.3-pyha770c72_0.conda
   hash:
-    md5: e825cfead1f4223911d9538f6c575c90
-    sha256: d896b02d8107a3c61cacd8e2a56a11b931710aba59cf3baa748837ef48404252
+    md5: fbac4b2194c962b97324a3f5dd7d2696
+    sha256: 0a8fb5a368d19fd08f7f65dfcff563322cb34e47947cabab8fc7f187d9bc9269
   build: pyha770c72_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: BSD-3-Clause
-  license_family: BSD
   noarch: python
-  size: 1017954
-  timestamp: 1704439132721
+  size: 1020461
+  timestamp: 1706734838573
 - platform: linux-64
   name: geos
   version: 3.12.1
@@ -10340,16 +10325,16 @@ package:
   timestamp: 1604365484436
 - platform: linux-64
   name: griffe
-  version: 0.39.1
+  version: 0.40.0
   category: main
   manager: conda
   dependencies:
   - colorama >=0.4
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/griffe-0.39.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/griffe-0.40.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 749f8001c996e588bcf46a46df2d16f3
-    sha256: 761d6586a06abc95536fa6924093e452fa374c47e7826428f377d07387bf23e4
+    md5: b8d137dfae8e983be1d7dad909d055a9
+    sha256: e6cddd65b322c43d450bd1f6e9181d5442e5a87d9be1cda7e0cb6d0d332bdaab
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -10357,20 +10342,20 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 369460
-  timestamp: 1705637974962
+  size: 390294
+  timestamp: 1706636538153
 - platform: osx-64
   name: griffe
-  version: 0.39.1
+  version: 0.40.0
   category: main
   manager: conda
   dependencies:
   - colorama >=0.4
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/griffe-0.39.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/griffe-0.40.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 749f8001c996e588bcf46a46df2d16f3
-    sha256: 761d6586a06abc95536fa6924093e452fa374c47e7826428f377d07387bf23e4
+    md5: b8d137dfae8e983be1d7dad909d055a9
+    sha256: e6cddd65b322c43d450bd1f6e9181d5442e5a87d9be1cda7e0cb6d0d332bdaab
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -10378,20 +10363,20 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 369460
-  timestamp: 1705637974962
+  size: 390294
+  timestamp: 1706636538153
 - platform: osx-arm64
   name: griffe
-  version: 0.39.1
+  version: 0.40.0
   category: main
   manager: conda
   dependencies:
   - colorama >=0.4
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/griffe-0.39.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/griffe-0.40.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 749f8001c996e588bcf46a46df2d16f3
-    sha256: 761d6586a06abc95536fa6924093e452fa374c47e7826428f377d07387bf23e4
+    md5: b8d137dfae8e983be1d7dad909d055a9
+    sha256: e6cddd65b322c43d450bd1f6e9181d5442e5a87d9be1cda7e0cb6d0d332bdaab
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -10399,20 +10384,20 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 369460
-  timestamp: 1705637974962
+  size: 390294
+  timestamp: 1706636538153
 - platform: win-64
   name: griffe
-  version: 0.39.1
+  version: 0.40.0
   category: main
   manager: conda
   dependencies:
   - colorama >=0.4
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/griffe-0.39.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/griffe-0.40.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 749f8001c996e588bcf46a46df2d16f3
-    sha256: 761d6586a06abc95536fa6924093e452fa374c47e7826428f377d07387bf23e4
+    md5: b8d137dfae8e983be1d7dad909d055a9
+    sha256: e6cddd65b322c43d450bd1f6e9181d5442e5a87d9be1cda7e0cb6d0d332bdaab
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -10420,8 +10405,8 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 369460
-  timestamp: 1705637974962
+  size: 390294
+  timestamp: 1706636538153
 - platform: linux-64
   name: gsl
   version: '2.7'
@@ -10538,6 +10523,7 @@ package:
   subdir: linux-64
   build_number: 0
   license: LGPL-2.0-or-later
+  license_family: LGPL
   size: 2709696
   timestamp: 1706154948546
 - platform: osx-64
@@ -10564,6 +10550,7 @@ package:
   subdir: osx-64
   build_number: 0
   license: LGPL-2.0-or-later
+  license_family: LGPL
   size: 2344738
   timestamp: 1706155251056
 - platform: osx-arm64
@@ -10590,6 +10577,7 @@ package:
   subdir: osx-arm64
   build_number: 0
   license: LGPL-2.0-or-later
+  license_family: LGPL
   size: 1917386
   timestamp: 1706155193009
 - platform: win-64
@@ -10616,6 +10604,7 @@ package:
   subdir: win-64
   build_number: 0
   license: LGPL-2.0-or-later
+  license_family: LGPL
   size: 2034401
   timestamp: 1706155374324
 - platform: linux-64
@@ -10640,6 +10629,7 @@ package:
   subdir: linux-64
   build_number: 0
   license: LGPL-2.0-or-later
+  license_family: LGPL
   size: 1981554
   timestamp: 1706154826325
 - platform: osx-64
@@ -10662,6 +10652,7 @@ package:
   subdir: osx-64
   build_number: 0
   license: LGPL-2.0-or-later
+  license_family: LGPL
   size: 1781693
   timestamp: 1706154946526
 - platform: osx-arm64
@@ -10684,6 +10675,7 @@ package:
   subdir: osx-arm64
   build_number: 0
   license: LGPL-2.0-or-later
+  license_family: LGPL
   size: 1344295
   timestamp: 1706154905073
 - platform: win-64
@@ -10708,6 +10700,7 @@ package:
   subdir: win-64
   build_number: 0
   license: LGPL-2.0-or-later
+  license_family: LGPL
   size: 1930741
   timestamp: 1706155201555
 - platform: linux-64
@@ -10758,6 +10751,7 @@ package:
   subdir: linux-64
   build_number: 0
   license: MIT
+  license_family: MIT
   noarch: python
   size: 58374
   timestamp: 1706161223269
@@ -10784,6 +10778,7 @@ package:
   subdir: osx-64
   build_number: 0
   license: MIT
+  license_family: MIT
   noarch: python
   size: 58374
   timestamp: 1706161223269
@@ -10810,6 +10805,7 @@ package:
   subdir: osx-arm64
   build_number: 0
   license: MIT
+  license_family: MIT
   noarch: python
   size: 58374
   timestamp: 1706161223269
@@ -10836,6 +10832,7 @@ package:
   subdir: win-64
   build_number: 0
   license: MIT
+  license_family: MIT
   noarch: python
   size: 58374
   timestamp: 1706161223269
@@ -11866,18 +11863,18 @@ package:
   category: main
   manager: conda
   dependencies: []
-  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.0.0-h57928b3_49840.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.0.0-h57928b3_49841.conda
   hash:
-    md5: 17969ee589e13b49e36f39549d42cd33
-    sha256: bef0d8633ba85adee523efe08582793bcbf84c889bc47cd1025f912980a1d01b
-  build: h57928b3_49840
+    md5: e3255c8cdaf1d52f15816d1970f9c77a
+    sha256: 6ee8eb9080bb3268654e015dd17ad79d0c1ea98b2eee6b928ecd27f01d6b38e8
+  build: h57928b3_49841
   arch: x86_64
   subdir: win-64
-  build_number: 49840
+  build_number: 49841
   license: LicenseRef-ProprietaryIntel
   license_family: Proprietary
-  size: 2324884
-  timestamp: 1701972722357
+  size: 2325424
+  timestamp: 1706182537883
 - platform: linux-64
   name: ipykernel
   version: 6.29.0
@@ -13190,80 +13187,86 @@ package:
   timestamp: 1705707742938
 - platform: linux-64
   name: juliaup
-  version: 1.12.5
+  version: 1.13.0
   category: main
   manager: conda
   dependencies:
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/juliaup-1.12.5-he8a937b_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/juliaup-1.13.0-he8a937b_0.conda
   hash:
-    md5: c4870df046513a30e44d7dc2be63a139
-    sha256: b13d8275f7e9e33e3e1a67682ce2db855fcf7a0b7d8e8d34c51b2614aba7e95e
+    md5: 36f632298719dd4b37d57cca4ebd2ead
+    sha256: 7eec8c76b948ff51cfdb03e4d0d5303dba913b929de8173dc2df1ad5f8900cee
   build: he8a937b_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 3921032
-  timestamp: 1700708476678
+  size: 3859930
+  timestamp: 1706564340550
 - platform: osx-64
   name: juliaup
-  version: 1.12.5
+  version: 1.13.0
   category: main
   manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-64/juliaup-1.12.5-h63b85fc_0.conda
+  dependencies:
+  - __osx >=10.15
+  url: https://conda.anaconda.org/conda-forge/osx-64/juliaup-1.13.0-hf4330d5_0.conda
   hash:
-    md5: 1481b0db0973837e46fcc4f40481b6bb
-    sha256: 9822289f6dc61870a47c970779f086c1bb4120a1806bbeda09be839e27e28834
-  build: h63b85fc_0
+    md5: 1bc86f6ebb96981962e52b6d42a09616
+    sha256: 81b1271be7f7c22b47d8b3dbfc959434087be1ff357cd4c9bf4a0bbf90fa60e1
+  build: hf4330d5_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
+  constrains:
+  - __osx >=10.12
   license: MIT
   license_family: MIT
-  size: 2175398
-  timestamp: 1700708939422
+  size: 2183774
+  timestamp: 1706564964770
 - platform: osx-arm64
   name: juliaup
-  version: 1.12.5
+  version: 1.13.0
   category: main
   manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/juliaup-1.12.5-h5ef7bb8_0.conda
+  dependencies:
+  - __osx >=11.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/juliaup-1.13.0-h67a62a2_0.conda
   hash:
-    md5: 7f3b83e3160b3590cf42db7a77f5cea1
-    sha256: 22af850735662d8314813fd91046962a721b489c6276c1be1a87631431a468f7
-  build: h5ef7bb8_0
+    md5: 7625255395624b0c93f77266d1dbd18e
+    sha256: d38262639d9c40fd3078cd263ac4b592451f27405a31d67df058f4d6e34d0b19
+  build: h67a62a2_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
+  constrains:
+  - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 2132572
-  timestamp: 1700709172349
+  size: 2127788
+  timestamp: 1706564824739
 - platform: win-64
   name: juliaup
-  version: 1.12.5
+  version: 1.13.0
   category: main
   manager: conda
   dependencies:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/juliaup-1.12.5-h975169c_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/juliaup-1.13.0-h975169c_0.conda
   hash:
-    md5: 6cdac6a328bdcc0ca6888f698839f1c7
-    sha256: c07bc6cb6990170bd7b6636464ce5a556d0919ca0a8150ada7bb49f8faa142c5
+    md5: 78c45d1f9c8f0f4e563802d46db11ec0
+    sha256: a14b9856b9c2f6ffd40d1b538dc1539b5e3058710df7c3c8fd8d837d2d43b1eb
   build: h975169c_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 1389695
-  timestamp: 1700709334996
+  size: 1391312
+  timestamp: 1706565757417
 - platform: linux-64
   name: jupyter-lsp
   version: 2.2.2
@@ -13892,7 +13895,7 @@ package:
   timestamp: 1706006876397
 - platform: linux-64
   name: jupyterlab
-  version: 4.0.11
+  version: 4.0.12
   category: main
   manager: conda
   dependencies:
@@ -13911,10 +13914,10 @@ package:
   - tomli
   - tornado >=6.2.0
   - traitlets
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.11-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.12-pyhd8ed1ab_0.conda
   hash:
-    md5: 42370604825af7396ef4317b67b22e2c
-    sha256: a6193a5160b9d3760a6b898858c69e9cfafddb126db45782429fc6b898011eee
+    md5: be2dcb121242a2f045ef8e8240e2b29d
+    sha256: b94fac375d239da7f56a7bcc48bfef9dff54033e272ec60946998950ea8ad1a0
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -13922,11 +13925,11 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 5861540
-  timestamp: 1705683961171
+  size: 5620459
+  timestamp: 1706634583806
 - platform: osx-64
   name: jupyterlab
-  version: 4.0.11
+  version: 4.0.12
   category: main
   manager: conda
   dependencies:
@@ -13945,10 +13948,10 @@ package:
   - tomli
   - tornado >=6.2.0
   - traitlets
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.11-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.12-pyhd8ed1ab_0.conda
   hash:
-    md5: 42370604825af7396ef4317b67b22e2c
-    sha256: a6193a5160b9d3760a6b898858c69e9cfafddb126db45782429fc6b898011eee
+    md5: be2dcb121242a2f045ef8e8240e2b29d
+    sha256: b94fac375d239da7f56a7bcc48bfef9dff54033e272ec60946998950ea8ad1a0
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -13956,11 +13959,11 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 5861540
-  timestamp: 1705683961171
+  size: 5620459
+  timestamp: 1706634583806
 - platform: osx-arm64
   name: jupyterlab
-  version: 4.0.11
+  version: 4.0.12
   category: main
   manager: conda
   dependencies:
@@ -13979,10 +13982,10 @@ package:
   - tomli
   - tornado >=6.2.0
   - traitlets
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.11-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.12-pyhd8ed1ab_0.conda
   hash:
-    md5: 42370604825af7396ef4317b67b22e2c
-    sha256: a6193a5160b9d3760a6b898858c69e9cfafddb126db45782429fc6b898011eee
+    md5: be2dcb121242a2f045ef8e8240e2b29d
+    sha256: b94fac375d239da7f56a7bcc48bfef9dff54033e272ec60946998950ea8ad1a0
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -13990,11 +13993,11 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 5861540
-  timestamp: 1705683961171
+  size: 5620459
+  timestamp: 1706634583806
 - platform: win-64
   name: jupyterlab
-  version: 4.0.11
+  version: 4.0.12
   category: main
   manager: conda
   dependencies:
@@ -14013,10 +14016,10 @@ package:
   - tomli
   - tornado >=6.2.0
   - traitlets
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.11-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.0.12-pyhd8ed1ab_0.conda
   hash:
-    md5: 42370604825af7396ef4317b67b22e2c
-    sha256: a6193a5160b9d3760a6b898858c69e9cfafddb126db45782429fc6b898011eee
+    md5: be2dcb121242a2f045ef8e8240e2b29d
+    sha256: b94fac375d239da7f56a7bcc48bfef9dff54033e272ec60946998950ea8ad1a0
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -14024,8 +14027,8 @@ package:
   license: BSD-3-Clause
   license_family: BSD
   noarch: python
-  size: 5861540
-  timestamp: 1705683961171
+  size: 5620459
+  timestamp: 1706634583806
 - platform: linux-64
   name: jupyterlab_pygments
   version: 0.3.0
@@ -15117,7 +15120,7 @@ package:
   dependencies:
   - bzip2 >=1.0.8,<2.0a0
   - libgcc-ng >=12
-  - libxml2 >=2.12.2,<2.13.0a0
+  - libxml2 >=2.12.2,<3.0.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - lzo >=2.10,<3.0a0
@@ -15225,8 +15228,8 @@ package:
   category: main
   manager: conda
   dependencies:
-  - aws-crt-cpp >=0.26.0,<0.26.1.0a0
-  - aws-sdk-cpp >=1.11.210,<1.11.211.0a0
+  - aws-crt-cpp >=0.26.1,<0.26.2.0a0
+  - aws-sdk-cpp >=1.11.242,<1.11.243.0a0
   - bzip2 >=1.0.8,<2.0a0
   - glog >=0.6.0,<0.7.0a0
   - libabseil * cxx17*
@@ -15244,22 +15247,21 @@ package:
   - re2
   - snappy >=1.1.10,<2.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.2-h84dd17c_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.2-he2c5238_5_cpu.conda
   hash:
-    md5: 571e88947e7cadb42bfacb517c346662
-    sha256: 3490212354a8dc8960eeaa8de43cb85356c5318fd49a243a7108818e09aca982
-  build: h84dd17c_2_cpu
+    md5: 6b2813827cd6ee60f8428cfc3aa59542
+    sha256: 032de52743f5e507cb7c9763baf6d41ea1bdf7ee2e4622d9638da7bad47e0cb4
+  build: he2c5238_5_cpu
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 5
   constrains:
-  - parquet-cpp <0.0a0
-  - arrow-cpp <0.0a0
   - apache-arrow-proc =*=cpu
+  - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
   license: Apache-2.0
-  license_family: APACHE
-  size: 22721490
-  timestamp: 1704354970709
+  size: 22723017
+  timestamp: 1706713363414
 - platform: osx-64
   name: libarrow
   version: 14.0.2
@@ -15267,8 +15269,8 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.13
-  - aws-crt-cpp >=0.26.0,<0.26.1.0a0
-  - aws-sdk-cpp >=1.11.210,<1.11.211.0a0
+  - aws-crt-cpp >=0.26.1,<0.26.2.0a0
+  - aws-sdk-cpp >=1.11.242,<1.11.243.0a0
   - bzip2 >=1.0.8,<2.0a0
   - glog >=0.6.0,<0.7.0a0
   - libabseil * cxx17*
@@ -15285,30 +15287,29 @@ package:
   - re2
   - snappy >=1.1.10,<2.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-14.0.2-h1aaacd4_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-14.0.2-h9a9dd9d_5_cpu.conda
   hash:
-    md5: ab5d6d9fc2f3304d99bbe6e50059a4f0
-    sha256: 13fde6b9ca0357272c9710a438a769a18921490051e2dbcc815853d0c17a2a1c
-  build: h1aaacd4_2_cpu
+    md5: c5c100502a2fc30178bafa10b47f3ed9
+    sha256: 5612d429b9d5f9145090a1774310856ed4021779827a77322c9507baecc7a62e
+  build: h9a9dd9d_5_cpu
   arch: x86_64
   subdir: osx-64
-  build_number: 2
+  build_number: 5
   constrains:
   - parquet-cpp <0.0a0
   - apache-arrow-proc =*=cpu
   - arrow-cpp <0.0a0
   license: Apache-2.0
-  license_family: APACHE
-  size: 15783377
-  timestamp: 1704355600914
+  size: 15793670
+  timestamp: 1706714043483
 - platform: osx-arm64
   name: libarrow
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - aws-crt-cpp >=0.26.0,<0.26.1.0a0
-  - aws-sdk-cpp >=1.11.210,<1.11.211.0a0
+  - aws-crt-cpp >=0.26.1,<0.26.2.0a0
+  - aws-sdk-cpp >=1.11.242,<1.11.243.0a0
   - bzip2 >=1.0.8,<2.0a0
   - glog >=0.6.0,<0.7.0a0
   - libabseil * cxx17*
@@ -15325,30 +15326,29 @@ package:
   - re2
   - snappy >=1.1.10,<2.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-14.0.2-h4ce3932_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-14.0.2-h906e67b_5_cpu.conda
   hash:
-    md5: d61d4cee3c195a5f574b3ade7a85ef94
-    sha256: 6c176a5ece3c72c0c1b7d7be5cc0f0a8dc637e634c936730a6d744e564fb75cb
-  build: h4ce3932_2_cpu
+    md5: e866ce3b43afd20f3e71439dfd8333ed
+    sha256: 55dedf62323e5524e2d4346a34d18c6f688c1ba47ef872fb8e9a67c8e1814fe5
+  build: h906e67b_5_cpu
   arch: aarch64
   subdir: osx-arm64
-  build_number: 2
+  build_number: 5
   constrains:
   - apache-arrow-proc =*=cpu
-  - arrow-cpp <0.0a0
   - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
   license: Apache-2.0
-  license_family: APACHE
-  size: 14634457
-  timestamp: 1704355766916
+  size: 14631754
+  timestamp: 1706714650865
 - platform: win-64
   name: libarrow
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - aws-crt-cpp >=0.26.0,<0.26.1.0a0
-  - aws-sdk-cpp >=1.11.210,<1.11.211.0a0
+  - aws-crt-cpp >=0.26.1,<0.26.2.0a0
+  - aws-sdk-cpp >=1.11.242,<1.11.243.0a0
   - bzip2 >=1.0.8,<2.0a0
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
@@ -15361,7 +15361,7 @@ package:
   - libutf8proc >=2.8.0,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - orc >=1.9.2,<1.9.3.0a0
   - re2
   - snappy >=1.1.10,<2.0a0
@@ -15369,196 +15369,187 @@ package:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-14.0.2-he5f67d5_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-14.0.2-h33d03ac_5_cpu.conda
   hash:
-    md5: 4deff1889c1047ab2920e63ce527e840
-    sha256: 12f7d520b023579cf9229ed4e20206254212f6faead301077c1204e4a2ccf879
-  build: he5f67d5_2_cpu
+    md5: 46f6ec75d406b033ef4470a781971f17
+    sha256: a67277503e411282c0b069d938bce1e0eec6571c194663fd815377cf959fedf4
+  build: h33d03ac_5_cpu
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 5
   constrains:
+  - arrow-cpp <0.0a0
   - parquet-cpp <0.0a0
   - apache-arrow-proc =*=cpu
-  - arrow-cpp <0.0a0
   license: Apache-2.0
-  license_family: APACHE
-  size: 5000205
-  timestamp: 1704355416005
+  size: 4947734
+  timestamp: 1706714295264
 - platform: linux-64
   name: libarrow-acero
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h84dd17c_2_cpu
+  - libarrow 14.0.2 he2c5238_5_cpu
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.2-h59595ed_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.2-h59595ed_5_cpu.conda
   hash:
-    md5: 4b00f12f1f3c7350a0345aa9c18798d6
-    sha256: 4b847de73614a65edd892250ccd6e617d44fe88c2f56f10dfa0370b5c84120a7
-  build: h59595ed_2_cpu
+    md5: e2e73384e6b86bc504fdaa67154d75fc
+    sha256: 3d9b08742cad394a095d5da2e8d55b735071026ca6746a37f0d10ef0786429ac
+  build: h59595ed_5_cpu
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 576913
-  timestamp: 1704355059610
+  size: 576662
+  timestamp: 1706713442087
 - platform: osx-64
   name: libarrow-acero
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h1aaacd4_2_cpu
+  - libarrow 14.0.2 h9a9dd9d_5_cpu
   - libcxx >=14
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-14.0.2-h000cb23_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-14.0.2-h000cb23_5_cpu.conda
   hash:
-    md5: 4e2fc03720088ab54db18aa84fbb75fe
-    sha256: dea3527b02eaf5eede8c94d3eb10d16c08f413aa61c574a941579e1a9b0a5a59
-  build: h000cb23_2_cpu
+    md5: 460a329b9c7beaadfae75a801b748260
+    sha256: 7bf4065b2b298cbcce41ba13d3e2e7229b1c4f73aacab936f942a3f116cbb5bc
+  build: h000cb23_5_cpu
   arch: x86_64
   subdir: osx-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 511952
-  timestamp: 1704355744885
+  size: 512288
+  timestamp: 1706714181985
 - platform: osx-arm64
   name: libarrow-acero
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h4ce3932_2_cpu
+  - libarrow 14.0.2 h906e67b_5_cpu
   - libcxx >=14
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-14.0.2-h13dd4ca_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-14.0.2-h13dd4ca_5_cpu.conda
   hash:
-    md5: b4b1760597af9889cd2f5311b0c34e7f
-    sha256: 93784ab7aec5fe72a96bb028868037fc95ee0f72a43c5cdcdc98b31b3f6b3ef6
-  build: h13dd4ca_2_cpu
+    md5: bb71aae303216eab37f6410a5917b12d
+    sha256: 83ff047e9d6797a8de47c88e5183d4b3289fed8118bcda87cc1f15de8ab4f02b
+  build: h13dd4ca_5_cpu
   arch: aarch64
   subdir: osx-arm64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 494126
-  timestamp: 1704355933680
+  size: 494986
+  timestamp: 1706714799212
 - platform: win-64
   name: libarrow-acero
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 he5f67d5_2_cpu
+  - libarrow 14.0.2 h33d03ac_5_cpu
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-14.0.2-h63175ca_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-14.0.2-h63175ca_5_cpu.conda
   hash:
-    md5: e3425ace09ee0422e654638f21fb2a9e
-    sha256: 46e4fda9f254981875138e4dd42624806081886b62b15216c7977a5edeff79bf
-  build: h63175ca_2_cpu
+    md5: ece7595c84584f9845a46af8022256e4
+    sha256: 3de7234584dc3931893a870ebc6c1323db34865927b62e883a0d6dd10506706a
+  build: h63175ca_5_cpu
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 430004
-  timestamp: 1704355525077
+  size: 429118
+  timestamp: 1706714418349
 - platform: linux-64
   name: libarrow-dataset
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h84dd17c_2_cpu
-  - libarrow-acero 14.0.2 h59595ed_2_cpu
+  - libarrow 14.0.2 he2c5238_5_cpu
+  - libarrow-acero 14.0.2 h59595ed_5_cpu
   - libgcc-ng >=12
-  - libparquet 14.0.2 h352af49_2_cpu
+  - libparquet 14.0.2 h352af49_5_cpu
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.2-h59595ed_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.2-h59595ed_5_cpu.conda
   hash:
-    md5: 5561fbdff1a630b3768fcbcd1307bcc2
-    sha256: edd010a1edcd73dc0b1e9b0fed1bd42f2e4252e0390a7f5432ae796fc39f2144
-  build: h59595ed_2_cpu
+    md5: be0e9f734715e37830a1c6a8d95bed9a
+    sha256: e36d6623643e26725aa6d53968185921a44a1e0ead96b9f3478a78b83b9a79b7
+  build: h59595ed_5_cpu
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 582023
-  timestamp: 1704355222590
+  size: 580515
+  timestamp: 1706713557769
 - platform: osx-64
   name: libarrow-dataset
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h1aaacd4_2_cpu
-  - libarrow-acero 14.0.2 h000cb23_2_cpu
+  - libarrow 14.0.2 h9a9dd9d_5_cpu
+  - libarrow-acero 14.0.2 h000cb23_5_cpu
   - libcxx >=14
-  - libparquet 14.0.2 h381d950_2_cpu
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-14.0.2-h000cb23_2_cpu.conda
+  - libparquet 14.0.2 h381d950_5_cpu
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-14.0.2-h000cb23_5_cpu.conda
   hash:
-    md5: 912e66fb84d6979da1d37535691b0a1b
-    sha256: 9c7773e8068d8230bc1a7af3bca60fd23ab69b0ee58bd1327e5ea7a4349f9b5c
-  build: h000cb23_2_cpu
+    md5: 492e11a5de873884aaf141b26d06b7e3
+    sha256: b9cccc76bd8cb803eb081d4fb1dabe6cf4107cf494158e33234213a85e70a0c4
+  build: h000cb23_5_cpu
   arch: x86_64
   subdir: osx-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 511562
-  timestamp: 1704356220922
+  size: 511597
+  timestamp: 1706714440344
 - platform: osx-arm64
   name: libarrow-dataset
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h4ce3932_2_cpu
-  - libarrow-acero 14.0.2 h13dd4ca_2_cpu
+  - libarrow 14.0.2 h906e67b_5_cpu
+  - libarrow-acero 14.0.2 h13dd4ca_5_cpu
   - libcxx >=14
-  - libparquet 14.0.2 hf6ce1d5_2_cpu
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-14.0.2-h13dd4ca_2_cpu.conda
+  - libparquet 14.0.2 hf6ce1d5_5_cpu
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-14.0.2-h13dd4ca_5_cpu.conda
   hash:
-    md5: bec70ec592be6a282cb06250fa5e71a4
-    sha256: 4a72d1476f49b5c234a2ef798ef33c473f8d6307aaceec65341a4f11db5ba23c
-  build: h13dd4ca_2_cpu
+    md5: 68fbadf6a1664396810e2f379cc34c58
+    sha256: 99dbb5f5e9d34ae8ce011945b2cfd9d82847483bdee2e5e4cc6235707af4b76d
+  build: h13dd4ca_5_cpu
   arch: aarch64
   subdir: osx-arm64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 526384
-  timestamp: 1704356487597
+  size: 527891
+  timestamp: 1706715134677
 - platform: win-64
   name: libarrow-dataset
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 he5f67d5_2_cpu
-  - libarrow-acero 14.0.2 h63175ca_2_cpu
-  - libparquet 14.0.2 h7ec3a38_2_cpu
+  - libarrow 14.0.2 h33d03ac_5_cpu
+  - libarrow-acero 14.0.2 h63175ca_5_cpu
+  - libparquet 14.0.2 h7ec3a38_5_cpu
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-14.0.2-h63175ca_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-14.0.2-h63175ca_5_cpu.conda
   hash:
-    md5: de680262729b7a718ee3427b7af68416
-    sha256: 53ae88b6b05f80309fa1789885b8b13a435d1c0cef71d2eb635da45417db8327
-  build: h63175ca_2_cpu
+    md5: ff81464a2f483b9086ca076d2b6ca0f7
+    sha256: fc0bdfab23c48148acf6c489c98e5149003cecfb54b8ff22495beae37cfed566
+  build: h63175ca_5_cpu
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 428399
-  timestamp: 1704355889001
+  size: 427741
+  timestamp: 1706714739876
 - platform: linux-64
   name: libarrow-flight
   version: 14.0.2
@@ -15567,24 +15558,23 @@ package:
   dependencies:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libarrow 14.0.2 h84dd17c_2_cpu
+  - libarrow 14.0.2 he2c5238_5_cpu
   - libgcc-ng >=12
-  - libgrpc >=1.59.3,<1.60.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libgrpc >=1.60.0,<1.61.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - libstdcxx-ng >=12
   - ucx >=1.15.0,<1.16.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.2-h120cb0d_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.2-hdc44a87_5_cpu.conda
   hash:
-    md5: e03930dbf4508a5153cd0fc237756a75
-    sha256: aa6ca307db6fb91cff2712a6c6091a3f9277ce054550fbe26c7bb93d65e395fb
-  build: h120cb0d_2_cpu
+    md5: 38affb2f29ad46c41c6d256618590e2e
+    sha256: 3cb3383cef62960a3fe9884554c4c523c8e066168f038deebd439d311de4f86b
+  build: hdc44a87_5_cpu
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 500908
-  timestamp: 1704355109389
+  size: 498301
+  timestamp: 1706713472204
 - platform: osx-64
   name: libarrow-flight
   version: 14.0.2
@@ -15594,22 +15584,21 @@ package:
   - __osx >=10.13
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libarrow 14.0.2 h1aaacd4_2_cpu
+  - libarrow 14.0.2 h9a9dd9d_5_cpu
   - libcxx >=14
-  - libgrpc >=1.59.3,<1.60.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-14.0.2-ha1803ca_2_cpu.conda
+  - libgrpc >=1.60.0,<1.61.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-14.0.2-h949774c_5_cpu.conda
   hash:
-    md5: ea3430af75e5aad9d123eeae096e7413
-    sha256: 2c41f0edfa2ec26ede42d17211bac938a862252cc9ffb47a1e65d88ab53bf00e
-  build: ha1803ca_2_cpu
+    md5: e356b5c5236065be138c19698518adae
+    sha256: a527397415e231693d367f65004dd3dfde3dfb3a1fe8fee0bb411d5a97e3bbe4
+  build: h949774c_5_cpu
   arch: x86_64
   subdir: osx-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 319741
-  timestamp: 1704355863264
+  size: 320266
+  timestamp: 1706714242991
 - platform: osx-arm64
   name: libarrow-flight
   version: 14.0.2
@@ -15618,22 +15607,21 @@ package:
   dependencies:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libarrow 14.0.2 h4ce3932_2_cpu
+  - libarrow 14.0.2 h906e67b_5_cpu
   - libcxx >=14
-  - libgrpc >=1.59.3,<1.60.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-14.0.2-ha94d253_2_cpu.conda
+  - libgrpc >=1.60.0,<1.61.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-14.0.2-h7c660a6_5_cpu.conda
   hash:
-    md5: 9acf1572e3db073db00e67d21cfb7477
-    sha256: 6e18f49f8c6b58958882d9735529ebfec402ce3443e0934b9fd89ac1d7d22c57
-  build: ha94d253_2_cpu
+    md5: 310a35766159074118121a903b5aeb29
+    sha256: 43966e1a6066073f80d5b13382ae0fa06c3713a99e4bb97fbed34f14429dcdd6
+  build: h7c660a6_5_cpu
   arch: aarch64
   subdir: osx-arm64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 331157
-  timestamp: 1704356092185
+  size: 332086
+  timestamp: 1706714888759
 - platform: win-64
   name: libarrow-flight
   version: 14.0.2
@@ -15642,47 +15630,45 @@ package:
   dependencies:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libarrow 14.0.2 he5f67d5_2_cpu
-  - libgrpc >=1.59.3,<1.60.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libarrow 14.0.2 h33d03ac_5_cpu
+  - libgrpc >=1.60.0,<1.61.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-14.0.2-h53b1db0_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-14.0.2-he112ba8_5_cpu.conda
   hash:
-    md5: 65b3299f58b837ec5dd5de3ea9a9ac73
-    sha256: d1abcb363232ab848fd556f9861af14d846d5ad8ecbd3225af36d1a9bd45f5eb
-  build: h53b1db0_2_cpu
+    md5: fab0a52dac608aa04e0d2831a2df07a4
+    sha256: 5cddf25d75b340d2cc276f066633d3819fca471e403adc1a229085caaef7cf18
+  build: he112ba8_5_cpu
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 285319
-  timestamp: 1704355615110
+  size: 285158
+  timestamp: 1706714501376
 - platform: linux-64
   name: libarrow-flight-sql
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h84dd17c_2_cpu
-  - libarrow-flight 14.0.2 h120cb0d_2_cpu
+  - libarrow 14.0.2 he2c5238_5_cpu
+  - libarrow-flight 14.0.2 hdc44a87_5_cpu
   - libgcc-ng >=12
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.2-h61ff412_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.2-hfbc7f12_5_cpu.conda
   hash:
-    md5: 1afaafe003abec8aec34f46ec418980a
-    sha256: 839f7e2682e9b1b004df3c2c28ac4c0c04e1e9bd8f1942d48a3abe24700f1437
-  build: h61ff412_2_cpu
+    md5: 433fb0e9bc65684f0d51b71d7b13008b
+    sha256: 2042f824865e1dcfdc9a709103accd01f06d11119a3273c49e1df7ebbc1efa82
+  build: hfbc7f12_5_cpu
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 193226
-  timestamp: 1704355263191
+  size: 192823
+  timestamp: 1706713586827
 - platform: osx-64
   name: libarrow-flight-sql
   version: 14.0.2
@@ -15690,195 +15676,187 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.13
-  - libarrow 14.0.2 h1aaacd4_2_cpu
-  - libarrow-flight 14.0.2 ha1803ca_2_cpu
+  - libarrow 14.0.2 h9a9dd9d_5_cpu
+  - libarrow-flight 14.0.2 h949774c_5_cpu
   - libcxx >=14
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-14.0.2-h8ec153b_2_cpu.conda
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-14.0.2-he85462c_5_cpu.conda
   hash:
-    md5: 67d65eb4d9921ab25a440db879138d09
-    sha256: a961db70a5256049e8cd6f08fcfbec1f397a33e79e8ad103e57e801b4fc3675f
-  build: h8ec153b_2_cpu
+    md5: ddc7c7292c3a0f2f64a1fcd2e89af2e3
+    sha256: 734100d5d944801a5b44ffed11689c8ed6f585009071dde2d61ec51d62d65004
+  build: he85462c_5_cpu
   arch: x86_64
   subdir: osx-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 154235
-  timestamp: 1704356322848
+  size: 153715
+  timestamp: 1706714504589
 - platform: osx-arm64
   name: libarrow-flight-sql
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h4ce3932_2_cpu
-  - libarrow-flight 14.0.2 ha94d253_2_cpu
+  - libarrow 14.0.2 h906e67b_5_cpu
+  - libarrow-flight 14.0.2 h7c660a6_5_cpu
   - libcxx >=14
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-14.0.2-h39a9b85_2_cpu.conda
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-14.0.2-h6dff610_5_cpu.conda
   hash:
-    md5: c6e0c75f69f3c31b0a4f02d415e0739d
-    sha256: 3621589405facf900779210f9f49556290cee0861a9797585eb6af7933017d65
-  build: h39a9b85_2_cpu
+    md5: 0e76ecf86bd5226a00f8bcc8f529f34b
+    sha256: c65b7752a182aba74cc424aa195acec1dcb565c92c05f83a6f796219550f4b09
+  build: h6dff610_5_cpu
   arch: aarch64
   subdir: osx-arm64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 161406
-  timestamp: 1704356624291
+  size: 161327
+  timestamp: 1706715219772
 - platform: win-64
   name: libarrow-flight-sql
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 he5f67d5_2_cpu
-  - libarrow-flight 14.0.2 h53b1db0_2_cpu
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libarrow 14.0.2 h33d03ac_5_cpu
+  - libarrow-flight 14.0.2 he112ba8_5_cpu
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-sql-14.0.2-h78eab7c_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-sql-14.0.2-h8f0bfdc_5_cpu.conda
   hash:
-    md5: 27731c55915b881c92112baac7fd4f04
-    sha256: 6dd037f69f153308f6c16009d76bc75ba12adf8c7f69b3006e57b2e07528f84f
-  build: h78eab7c_2_cpu
+    md5: 11aed107d74a2afd8616d062ba35b72e
+    sha256: 8d49e3abd8722075e81199797a0cc618eb79e2fd9ba87cd996d342afaa7df3d5
+  build: h8f0bfdc_5_cpu
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 222701
-  timestamp: 1704355966327
+  size: 233426
+  timestamp: 1706714809245
 - platform: linux-64
   name: libarrow-gandiva
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h84dd17c_2_cpu
+  - libarrow 14.0.2 he2c5238_5_cpu
   - libgcc-ng >=12
   - libllvm15 >=15.0.7,<15.1.0a0
   - libre2-11 >=2023.6.2,<2024.0a0
   - libstdcxx-ng >=12
   - libutf8proc >=2.8.0,<3.0a0
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - re2
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.2-hacb8726_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.2-hacb8726_5_cpu.conda
   hash:
-    md5: db1a164476c3b26f4425542ab9ce11df
-    sha256: bc3c180af8e842877455d1d429c28a3207da4f3f243390b0ba8e06051525ff48
-  build: hacb8726_2_cpu
+    md5: d2372c0313f9e837e7021b43802e424a
+    sha256: 0e094983c26d6128cac3fc4ff8d8f4686ecc10737b0e2fd1aa9e0d3f4bb08acf
+  build: hacb8726_5_cpu
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 893895
-  timestamp: 1704355148995
+  size: 894357
+  timestamp: 1706713501918
 - platform: osx-64
   name: libarrow-gandiva
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h1aaacd4_2_cpu
+  - libarrow 14.0.2 h9a9dd9d_5_cpu
   - libcxx >=14
   - libllvm15 >=15.0.7,<15.1.0a0
   - libre2-11 >=2023.6.2,<2024.0a0
   - libutf8proc >=2.8.0,<3.0a0
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - re2
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-14.0.2-h01dce7f_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-14.0.2-h01dce7f_5_cpu.conda
   hash:
-    md5: 3903071e62de031ce169187cdb2e32af
-    sha256: d17c1474d202bac57c590b9f2cf062c837a69991c59135b422a520bff4bbae57
-  build: h01dce7f_2_cpu
+    md5: 76a3ee0ab9871dc91053def50d422e03
+    sha256: bdf6dc7c0c406b056a5e9bdb3ccc565e37658b404cedbe811e0ae1acd08c9c4b
+  build: h01dce7f_5_cpu
   arch: x86_64
   subdir: osx-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 699571
-  timestamp: 1704355988767
+  size: 698530
+  timestamp: 1706714307945
 - platform: osx-arm64
   name: libarrow-gandiva
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h4ce3932_2_cpu
+  - libarrow 14.0.2 h906e67b_5_cpu
   - libcxx >=14
   - libllvm15 >=15.0.7,<15.1.0a0
   - libre2-11 >=2023.6.2,<2024.0a0
   - libutf8proc >=2.8.0,<3.0a0
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - re2
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-14.0.2-hf757142_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-14.0.2-hf757142_5_cpu.conda
   hash:
-    md5: f4285d86a247a339bf7bf43fda4ded17
-    sha256: 237007a5c35c612823762327ae355f396ba34b66b40317e87de41f36a2f839bc
-  build: hf757142_2_cpu
+    md5: 146e9ba5c3d1ce83f75f38d326462010
+    sha256: f932269ccacf9d5f4b7fd64f89cda886a24b0813474a0cb91dd9385f15a704ff
+  build: hf757142_5_cpu
   arch: aarch64
   subdir: osx-arm64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 689008
-  timestamp: 1704356234671
+  size: 688566
+  timestamp: 1706714975422
 - platform: win-64
   name: libarrow-gandiva
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 he5f67d5_2_cpu
+  - libarrow 14.0.2 h33d03ac_5_cpu
   - libre2-11 >=2023.6.2,<2024.0a0
   - libutf8proc >=2.8.0,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - re2
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-14.0.2-hb2eaab1_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-14.0.2-hb2eaab1_5_cpu.conda
   hash:
-    md5: dfaa10cd86363d7509cd4dbe8f13f031
-    sha256: c5681de79ecc4e054f32814927d918103f1a72a762990f8745c154a36a955fc7
-  build: hb2eaab1_2_cpu
+    md5: b6663085cbaf4b20a316a07740725f8e
+    sha256: 09ddb923f05b51b1203d76754f0899e9cbfff9ea86ee5ee636bd8041f86ce1fd
+  build: hb2eaab1_5_cpu
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 10173801
-  timestamp: 1704355710068
+  size: 10160690
+  timestamp: 1706714578316
 - platform: linux-64
   name: libarrow-substrait
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h84dd17c_2_cpu
-  - libarrow-acero 14.0.2 h59595ed_2_cpu
-  - libarrow-dataset 14.0.2 h59595ed_2_cpu
+  - libarrow 14.0.2 he2c5238_5_cpu
+  - libarrow-acero 14.0.2 h59595ed_5_cpu
+  - libarrow-dataset 14.0.2 h59595ed_5_cpu
   - libgcc-ng >=12
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.2-h61ff412_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.2-hfbc7f12_5_cpu.conda
   hash:
-    md5: 838d3d33c458225578f64e59c4410a9f
-    sha256: 675d616f8454d38f41b1833e8deffc51dbb2c2b4b48c54e8adba4795ff606bec
-  build: h61ff412_2_cpu
+    md5: 152e456b028cd0e946ec44634a878265
+    sha256: 334a3303f5e88fd0d1b7235611f4a744d201bb451f8f801adb94ad2ee108cfcd
+  build: hfbc7f12_5_cpu
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 508750
-  timestamp: 1704355298174
+  size: 517238
+  timestamp: 1706713612887
 - platform: osx-64
   name: libarrow-substrait
   version: 14.0.2
@@ -15886,46 +15864,44 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.13
-  - libarrow 14.0.2 h1aaacd4_2_cpu
-  - libarrow-acero 14.0.2 h000cb23_2_cpu
-  - libarrow-dataset 14.0.2 h000cb23_2_cpu
+  - libarrow 14.0.2 h9a9dd9d_5_cpu
+  - libarrow-acero 14.0.2 h000cb23_5_cpu
+  - libarrow-dataset 14.0.2 h000cb23_5_cpu
   - libcxx >=14
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-14.0.2-h8ec153b_2_cpu.conda
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-14.0.2-he85462c_5_cpu.conda
   hash:
-    md5: 3e279309bd00e8115283665bdbe257b8
-    sha256: eabb1705fbd324b55a2f6cc7b7451b7a15882bab25cfd05113f3f1f05f2a787e
-  build: h8ec153b_2_cpu
+    md5: 6e1c4753930281dea851944e13f625c8
+    sha256: a5170e5043e82cb0c52985eb80d8e0f81bfb328d8e0816b2aaf3eeec134f1e7f
+  build: he85462c_5_cpu
   arch: x86_64
   subdir: osx-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 453318
-  timestamp: 1704356431617
+  size: 452788
+  timestamp: 1706714567589
 - platform: osx-arm64
   name: libarrow-substrait
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h4ce3932_2_cpu
-  - libarrow-acero 14.0.2 h13dd4ca_2_cpu
-  - libarrow-dataset 14.0.2 h13dd4ca_2_cpu
+  - libarrow 14.0.2 h906e67b_5_cpu
+  - libarrow-acero 14.0.2 h13dd4ca_5_cpu
+  - libarrow-dataset 14.0.2 h13dd4ca_5_cpu
   - libcxx >=14
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-14.0.2-h7fd9903_2_cpu.conda
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-14.0.2-h3c8a37a_5_cpu.conda
   hash:
-    md5: 98b3c3e9288e0d451d9329fa784fe256
-    sha256: f7712ad3916fb83171c82ba5031f4356df7cb96cff2a6fa9ef17e44fe9940270
-  build: h7fd9903_2_cpu
+    md5: 5884b3094299b6ed9144497955bc2339
+    sha256: 9ac4c1d9a25f921fc02790921a254fc4737970e5d8b89a08318711aa17fab179
+  build: h3c8a37a_5_cpu
   arch: aarch64
   subdir: osx-arm64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 474175
-  timestamp: 1704356753787
+  size: 471704
+  timestamp: 1706715304129
 - platform: win-64
   name: libarrow-substrait
   version: 14.0.2
@@ -15934,25 +15910,24 @@ package:
   dependencies:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libarrow 14.0.2 he5f67d5_2_cpu
-  - libarrow-acero 14.0.2 h63175ca_2_cpu
-  - libarrow-dataset 14.0.2 h63175ca_2_cpu
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libarrow 14.0.2 h33d03ac_5_cpu
+  - libarrow-acero 14.0.2 h63175ca_5_cpu
+  - libarrow-dataset 14.0.2 h63175ca_5_cpu
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-14.0.2-hd4c9904_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-14.0.2-h7aa34db_5_cpu.conda
   hash:
-    md5: 3d267143a5827a81b607619a12e3f7cd
-    sha256: cec14db792abd05497b40bfcc4c41ec3ad463cfcceeec5bd1422da5c297b4228
-  build: hd4c9904_2_cpu
+    md5: fcc11bea4a8f0dc4e53579f27c2413f1
+    sha256: 1eb8ba09f4f957cb513164a68134c365e451cb1358b7645ebebe200bb200d2ba
+  build: h7aa34db_5_cpu
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 346667
-  timestamp: 1704356049987
+  size: 358984
+  timestamp: 1706714879260
 - platform: linux-64
   name: libblas
   version: 3.9.0
@@ -16034,24 +16009,25 @@ package:
   category: main
   manager: conda
   dependencies:
-  - mkl 2024.0.0 h66d3029_49657
-  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-21_win64_mkl.conda
+  - libopenblas 0.3.26 pthreads_hc140b1d_0
+  url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-21_win64_openblas.conda
   hash:
-    md5: ebba3846d11201fe54277e4965ba5250
-    sha256: ad47053cee17802df875203aba191b04d97a50d820dbf75a114a50972c517334
-  build: 21_win64_mkl
+    md5: 62ce74acc92bdb5824c6a86a096709de
+    sha256: f3efad3b893086c8883c6e00f58d9687eace24e1e780ed39967680f434bad2da
+  build: 21_win64_openblas
   arch: x86_64
   subdir: win-64
   build_number: 21
   constrains:
-  - liblapack 3.9.0 21_win64_mkl
-  - blas * mkl
-  - libcblas 3.9.0 21_win64_mkl
-  - liblapacke 3.9.0 21_win64_mkl
+  - liblapack 3.9.0 21_win64_openblas
+  - blas * openblas
+  - libcblas 3.9.0 21_win64_openblas
+  - liblapacke 3.9.0 21_win64_openblas
+  track_features: blas_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 5017135
-  timestamp: 1705980415163
+  size: 3973197
+  timestamp: 1705979993813
 - platform: linux-64
   name: libboost-headers
   version: 1.84.0
@@ -16459,23 +16435,24 @@ package:
   category: main
   manager: conda
   dependencies:
-  - libblas 3.9.0 21_win64_mkl
-  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-21_win64_mkl.conda
+  - libblas 3.9.0 21_win64_openblas
+  url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-21_win64_openblas.conda
   hash:
-    md5: 38e5ec23bc2b62f9dd971143aa9dddb7
-    sha256: 886505d0a4a5b508b2255991395aadecdad140719ba0d413411fec86491a9283
-  build: 21_win64_mkl
+    md5: bd3b35e4825f64dbf9f2c14b7e5f3624
+    sha256: e44786130a4feea9557c180c42235ddc87b68616215b1e17145d98db7b6a5aa9
+  build: 21_win64_openblas
   arch: x86_64
   subdir: win-64
   build_number: 21
   constrains:
-  - liblapack 3.9.0 21_win64_mkl
-  - blas * mkl
-  - liblapacke 3.9.0 21_win64_mkl
+  - blas * openblas
+  - liblapack 3.9.0 21_win64_openblas
+  - liblapacke 3.9.0 21_win64_openblas
+  track_features: blas_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 5017024
-  timestamp: 1705980469944
+  size: 3973158
+  timestamp: 1705980029383
 - platform: linux-64
   name: libclang
   version: 15.0.7
@@ -17330,6 +17307,26 @@ package:
   license_family: BSD
   size: 394383
   timestamp: 1687765514062
+- platform: win-64
+  name: libflang
+  version: 5.0.0
+  category: main
+  manager: conda
+  dependencies:
+  - openmp 5.0.0
+  - vc >=14,<15.0a0
+  url: https://conda.anaconda.org/conda-forge/win-64/libflang-5.0.0-h6538335_20180525.tar.bz2
+  hash:
+    md5: 9f473a344e18668e99a93f7e21a54b69
+    sha256: 0b893b511190332320f4a3e3d6424fbd350271ffbca34eb25b5cd8bc451f1a05
+  build: h6538335_20180525
+  arch: x86_64
+  subdir: win-64
+  build_number: 20180525
+  track_features: flang
+  license: Apache 2.0
+  size: 531143
+  timestamp: 1527899216421
 - platform: linux-64
   name: libgcc-ng
   version: 13.2.0
@@ -17338,20 +17335,20 @@ package:
   dependencies:
   - _libgcc_mutex 0.1 conda_forge
   - _openmp_mutex >=4.5
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_4.conda
   hash:
-    md5: 23fdf1fef05baeb7eadc2aed5fb0011f
-    sha256: 5e88f658e07a30ab41b154b42c59f079b168acfa9551a75bdc972099453f4105
-  build: h807b86a_3
+    md5: e0dee4121cc9d961b3740e3759b02d13
+    sha256: 827c0326a88a042a4b50399c60971a882663c769afcbdfcf64850a9d3f48aaff
+  build: h807b86a_4
   arch: x86_64
   subdir: linux-64
-  build_number: 3
+  build_number: 4
   constrains:
-  - libgomp 13.2.0 h807b86a_3
+  - libgomp 13.2.0 h807b86a_4
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 773629
-  timestamp: 1699753612541
+  size: 773838
+  timestamp: 1706339399229
 - platform: linux-64
   name: libgcrypt
   version: 1.10.3
@@ -17408,7 +17405,7 @@ package:
   - libtiff >=4.6.0,<4.7.0a0
   - libuuid >=2.38.1,<3.0a0
   - libwebp-base >=1.3.2,<2.0a0
-  - libxml2 >=2.12.3,<2.13.0a0
+  - libxml2 >=2.12.3,<3.0.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - openjpeg >=2.5.0,<3.0a0
@@ -17642,7 +17639,7 @@ package:
   - libtiff >=4.6.0,<4.7.0a0
   - libuuid >=2.38.1,<3.0a0
   - libwebp-base >=1.3.2,<2.0a0
-  - libxml2 >=2.12.3,<2.13.0a0
+  - libxml2 >=2.12.3,<3.0.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - openjpeg >=2.5.0,<3.0a0
   - openssl >=3.2.0,<4.0a0
@@ -17882,19 +17879,19 @@ package:
   category: main
   manager: conda
   dependencies:
-  - libgfortran5 13.2.0 ha4646dd_3
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_3.conda
+  - libgfortran5 13.2.0 ha4646dd_4
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_4.conda
   hash:
-    md5: 73031c79546ad06f1fe62e57fdd021bc
-    sha256: 5b918950b84605b6865de438757f507b1eff73c96fd562f7022c80028b088c14
-  build: h69a702a_3
+    md5: 4956aae564e90a1fc96f3bc58152c2b2
+    sha256: 751dccc714cc6a444e1be1474da2aab19e1a64c73ba3f133165f3d7d71eacc19
+  build: h69a702a_4
   arch: x86_64
   subdir: linux-64
-  build_number: 3
+  build_number: 4
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 23837
-  timestamp: 1699753845201
+  size: 23954
+  timestamp: 1706339630379
 - platform: linux-64
   name: libgfortran5
   version: 13.2.0
@@ -17902,20 +17899,20 @@ package:
   manager: conda
   dependencies:
   - libgcc-ng >=13.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_4.conda
   hash:
-    md5: c714d905cdfa0e70200f68b80cc04764
-    sha256: 0084a1d29a4f8ee3b8edad80eb6c42e5f0480f054f28cf713fb314bebb347a50
-  build: ha4646dd_3
+    md5: e661d5238ba69d8fe2e488bbde6f9cc4
+    sha256: d3cd28683be2129665bf93eac011476b9903e0d7000bff8e224f857e06d750ee
+  build: ha4646dd_4
   arch: x86_64
   subdir: linux-64
-  build_number: 3
+  build_number: 4
   constrains:
   - libgfortran-ng 13.2.0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 1436929
-  timestamp: 1699753630186
+  size: 1442387
+  timestamp: 1706339417357
 - platform: osx-64
   name: libgfortran5
   version: 13.2.0
@@ -18070,18 +18067,18 @@ package:
   manager: conda
   dependencies:
   - _libgcc_mutex 0.1 conda_forge
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_4.conda
   hash:
-    md5: 7124cbb46b13d395bdde68f2d215c989
-    sha256: 6ebedee39b6bbbc969715d0d7fa4b381cce67e1139862604ffa393f821c08e81
-  build: h807b86a_3
+    md5: cd6ae9659d3cd53207efa8e0ed3ab15d
+    sha256: f0c29623b471dfe97f7d77addad6bcbfcd6407e2e0041a5f474c5b3891ef04d5
+  build: h807b86a_4
   arch: x86_64
   subdir: linux-64
-  build_number: 3
+  build_number: 4
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 421834
-  timestamp: 1699753531479
+  size: 422115
+  timestamp: 1706339311614
 - platform: linux-64
   name: libgoogle-cloud
   version: 2.12.0
@@ -18091,26 +18088,26 @@ package:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
   - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl >=8.4.0,<9.0a0
+  - libcurl >=8.5.0,<9.0a0
   - libgcc-ng >=12
-  - libgrpc >=1.59.2,<1.60.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libgrpc >=1.60.0,<1.61.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - libstdcxx-ng >=12
-  - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.12.0-h5206363_4.conda
+  - openssl >=3.2.0,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.12.0-hef10d8f_5.conda
   hash:
-    md5: b5eb63d2683102be45d17c55021282f6
-    sha256: 82a7d211d0df165b073f9e8ba6d789c4b1c7c4882d546ca12d40f201fc3496fc
-  build: h5206363_4
+    md5: 055e2266d27f0e2290cf0a6ad668a225
+    sha256: 3c80f8da632c01b5beb50bdc4c7c488501793cd7c138427f61e93f98719e8342
+  build: hef10d8f_5
   arch: x86_64
   subdir: linux-64
-  build_number: 4
+  build_number: 5
   constrains:
-  - google-cloud-cpp 2.12.0 *_4
+  - google-cloud-cpp 2.12.0 *_5
   license: Apache-2.0
   license_family: Apache
-  size: 43491878
-  timestamp: 1698886698923
+  size: 42970307
+  timestamp: 1706084513579
 - platform: osx-64
   name: libgoogle-cloud
   version: 2.12.0
@@ -18118,58 +18115,56 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.13
-  - __osx >=10.9
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
   - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl >=8.4.0,<9.0a0
-  - libcxx >=16.0.6
-  - libgrpc >=1.59.2,<1.60.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.12.0-hc0857f6_4.conda
+  - libcurl >=8.5.0,<9.0a0
+  - libcxx >=15
+  - libgrpc >=1.60.0,<1.61.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - openssl >=3.2.0,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.12.0-he77a663_5.conda
   hash:
-    md5: 976555c39f83093265491c9c081a801c
-    sha256: 1bf47f43796369ec85a27221ab9a84ecc848f93a88049d046cd8521c25b129f6
-  build: hc0857f6_4
+    md5: dac48d8fadf9e28c7010f49b56804862
+    sha256: 4cae7eefaeba18daf87f046c1e26026f741d1c3f0f0740bf082e3dbd8454ac67
+  build: he77a663_5
   arch: x86_64
   subdir: osx-64
-  build_number: 4
+  build_number: 5
   constrains:
-  - google-cloud-cpp 2.12.0 *_4
+  - google-cloud-cpp 2.12.0 *_5
   license: Apache-2.0
   license_family: Apache
-  size: 30883666
-  timestamp: 1698889432429
+  size: 30561341
+  timestamp: 1706087235514
 - platform: osx-arm64
   name: libgoogle-cloud
   version: 2.12.0
   category: main
   manager: conda
   dependencies:
-  - __osx >=10.9
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
   - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl >=8.4.0,<9.0a0
-  - libcxx >=16.0.6
-  - libgrpc >=1.59.2,<1.60.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  - openssl >=3.1.4,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.12.0-hfb399a7_4.conda
+  - libcurl >=8.5.0,<9.0a0
+  - libcxx >=15
+  - libgrpc >=1.60.0,<1.61.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - openssl >=3.2.0,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.12.0-h49bbb43_5.conda
   hash:
-    md5: d62901188ab756c841cbb9a80c6c3f3c
-    sha256: 22122939a462f64a82ca2f305c43e5e5cf5a55f1ae12979c2445f9dc196b7047
-  build: hfb399a7_4
+    md5: d692ffaa8a4c54936205b7f794596c2c
+    sha256: bedf55e777aafb89a371bf0322f15bff952a620278920c100177d61e37aecca9
+  build: h49bbb43_5
   arch: aarch64
   subdir: osx-arm64
-  build_number: 4
+  build_number: 5
   constrains:
-  - google-cloud-cpp 2.12.0 *_4
+  - google-cloud-cpp 2.12.0 *_5
   license: Apache-2.0
   license_family: Apache
-  size: 31440327
-  timestamp: 1698982048456
+  size: 31306190
+  timestamp: 1706379740264
 - platform: win-64
   name: libgoogle-cloud
   version: 2.12.0
@@ -18179,27 +18174,27 @@ package:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
   - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl >=8.4.0,<9.0a0
-  - libgrpc >=1.59.2,<1.60.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
-  - openssl >=3.1.4,<4.0a0
+  - libcurl >=8.5.0,<9.0a0
+  - libgrpc >=1.60.0,<1.61.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
+  - openssl >=3.2.0,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.12.0-h39f2fc6_4.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.12.0-hc7cbac0_5.conda
   hash:
-    md5: f79cf72abe2235de65fb50b386f323a0
-    sha256: 9621cb3e90aa22123cc7120bc1228df31453a390b7760773a0e5453a2718f7ef
-  build: h39f2fc6_4
+    md5: 1f219361b6f83f8e7ab4d2c67ff06ce4
+    sha256: 03f360345841ecb6cdc6a3a3a75a04e29d2f53e5fc180822d9ebef5d131a9007
+  build: hc7cbac0_5
   arch: x86_64
   subdir: win-64
-  build_number: 4
+  build_number: 5
   constrains:
-  - google-cloud-cpp 2.12.0 *_4
+  - google-cloud-cpp 2.12.0 *_5
   license: Apache-2.0
   license_family: Apache
-  size: 13270
-  timestamp: 1698887885269
+  size: 13304
+  timestamp: 1706080367432
 - platform: linux-64
   name: libgpg-error
   version: '1.47'
@@ -18223,126 +18218,145 @@ package:
   timestamp: 1686979818648
 - platform: linux-64
   name: libgrpc
-  version: 1.59.3
+  version: 1.60.0
   category: main
   manager: conda
   dependencies:
-  - c-ares >=1.21.0,<2.0a0
+  - c-ares >=1.26.0,<2.0a0
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
   - libgcc-ng >=12
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - libre2-11 >=2023.6.2,<2024.0a0
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.4,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - re2
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.59.3-hd6c4280_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.60.0-h74775cd_1.conda
   hash:
-    md5: 896c137eaf0c22f2fef58332eb4a4b83
-    sha256: 3f95a2792e565b628cb284de92017a37a1cddc4a3f83453b8f75d9adc9f8cfdd
-  build: hd6c4280_0
+    md5: e5dac7b919ed16dbcf9dc0f512cb68c0
+    sha256: 905958d0aa94a7f8344d72f0079c52d7629bcec0d98680dff7f258b7a2061d46
+  build: h74775cd_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   constrains:
-  - grpc-cpp =1.59.3
+  - grpc-cpp =1.60.0
   license: Apache-2.0
   license_family: APACHE
-  size: 6600132
-  timestamp: 1700259627150
+  size: 7287004
+  timestamp: 1706706833141
 - platform: osx-64
   name: libgrpc
-  version: 1.59.3
+  version: 1.60.0
   category: main
   manager: conda
   dependencies:
   - __osx >=10.13
-  - __osx >=10.9
-  - c-ares >=1.21.0,<2.0a0
+  - c-ares >=1.26.0,<2.0a0
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libcxx >=16.0.6
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libcxx >=15
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - libre2-11 >=2023.6.2,<2024.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.4,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - re2
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.59.3-ha7f534c_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.60.0-h038e8f1_1.conda
   hash:
-    md5: a557d871e80f2dd22efd78e00f9a1597
-    sha256: 1b7330bb2aa16ca0dd319e97a829d5494fb2459a841b54f7631932b144e38624
-  build: ha7f534c_0
+    md5: c590aec9c56b58e8f67ca6ea8cac3d68
+    sha256: 46d07bab8cbaf225ad7716d799b8a957e3fc271fab14130452ac90d678d2ac5b
+  build: h038e8f1_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   constrains:
-  - grpc-cpp =1.59.3
+  - grpc-cpp =1.60.0
   license: Apache-2.0
   license_family: APACHE
-  size: 4111631
-  timestamp: 1700261027372
+  size: 4717536
+  timestamp: 1706708079190
 - platform: osx-arm64
   name: libgrpc
-  version: 1.59.3
+  version: 1.60.0
   category: main
   manager: conda
   dependencies:
-  - __osx >=10.9
-  - c-ares >=1.21.0,<2.0a0
+  - c-ares >=1.26.0,<2.0a0
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libcxx >=16.0.6
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libcxx >=15
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - libre2-11 >=2023.6.2,<2024.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.4,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - re2
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.59.3-hbcf6334_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.60.0-hfc68871_1.conda
   hash:
-    md5: e9c7cbc84af929dd47501629a5e19713
-    sha256: 54cacd1fc7503d48c135301a775568f15089b537b3c56804767c627a89a20c30
-  build: hbcf6334_0
+    md5: 6375b46e5fd2088b44c2c15c52314d76
+    sha256: 9ebfbef426381d8a5e4f6996538bb6f326918d805414f84f3d310b3cefa6703e
+  build: hfc68871_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   constrains:
-  - grpc-cpp =1.59.3
+  - grpc-cpp =1.60.0
   license: Apache-2.0
   license_family: APACHE
-  size: 3950361
-  timestamp: 1700260902499
+  size: 4185859
+  timestamp: 1706708855643
 - platform: win-64
   name: libgrpc
-  version: 1.59.3
+  version: 1.60.0
   category: main
   manager: conda
   dependencies:
-  - c-ares >=1.21.0,<2.0a0
+  - c-ares >=1.26.0,<2.0a0
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - libre2-11 >=2023.6.2,<2024.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.4,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - re2
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.59.3-h5bbd4a7_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.60.0-h0bf0bfa_1.conda
   hash:
-    md5: 70a20bdb4a01daea0e8c12050267294f
-    sha256: 77f29a3d26e87b176416ddf4dbbb076ff95ad09837ea9f100b788d0379700014
-  build: h5bbd4a7_0
+    md5: 0217eebf6ce883ff6bf5b925eff45ba5
+    sha256: a72e1fd2d43514486118c21e5e507917ab08c2169d62a52d71d5cbea936befa4
+  build: h0bf0bfa_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   constrains:
-  - grpc-cpp =1.59.3
+  - grpc-cpp =1.60.0
   license: Apache-2.0
   license_family: APACHE
-  size: 14228484
-  timestamp: 1700260902057
+  size: 14699240
+  timestamp: 1706708232199
+- platform: linux-64
+  name: libhwloc
+  version: 2.9.3
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.11.5,<3.0.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.9.3-default_h554bfaf_1009.conda
+  hash:
+    md5: f36ddc11ca46958197a45effdd286e45
+    sha256: 6950fee24766d03406e0f6f965262a5d98829c71eed8d1004f313892423b559b
+  build: default_h554bfaf_1009
+  arch: x86_64
+  subdir: linux-64
+  build_number: 1009
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2615665
+  timestamp: 1694532603730
 - platform: osx-64
   name: libhwloc
   version: 2.9.3
@@ -18730,46 +18744,48 @@ package:
   category: main
   manager: conda
   dependencies:
-  - libblas 3.9.0 21_win64_mkl
-  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-21_win64_mkl.conda
+  - libblas 3.9.0 21_win64_openblas
+  url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-21_win64_openblas.conda
   hash:
-    md5: c4740f091cb75987390087934354a621
-    sha256: 3fa7c08dd4edf59cb0907d2e5b74e6be890e0671f845e1bae892d212d118a7e9
-  build: 21_win64_mkl
+    md5: 505d2b51f16f4c309a110bc665c157a6
+    sha256: 9a00ab203a34ebf46e5963a653e5fc8baf14b13a0fd2090140032395df852ffe
+  build: 21_win64_openblas
   arch: x86_64
   subdir: win-64
   build_number: 21
   constrains:
-  - blas * mkl
-  - libcblas 3.9.0 21_win64_mkl
-  - liblapacke 3.9.0 21_win64_mkl
+  - blas * openblas
+  - libcblas 3.9.0 21_win64_openblas
+  - liblapacke 3.9.0 21_win64_openblas
+  track_features: blas_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 5017043
-  timestamp: 1705980523462
+  size: 3973581
+  timestamp: 1705980063912
 - platform: win-64
   name: liblapacke
   version: 3.9.0
   category: main
   manager: conda
   dependencies:
-  - libblas 3.9.0 21_win64_mkl
-  - libcblas 3.9.0 21_win64_mkl
-  - liblapack 3.9.0 21_win64_mkl
-  url: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-21_win64_mkl.conda
+  - libblas 3.9.0 21_win64_openblas
+  - libcblas 3.9.0 21_win64_openblas
+  - liblapack 3.9.0 21_win64_openblas
+  url: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-21_win64_openblas.conda
   hash:
-    md5: a4844669ed07bb5b7f182e9ca4de2a70
-    sha256: 965820dbb7f0da76487b4682e045343543b78d63568007f1d66fa555d0011f0e
-  build: 21_win64_mkl
+    md5: 4db28310990fd98f139224780f5c64ae
+    sha256: 4adc77776eb0519d86adb61917289f68497e2db9acf5f17576d4b38be037cf1b
+  build: 21_win64_openblas
   arch: x86_64
   subdir: win-64
   build_number: 21
   constrains:
-  - blas * mkl
+  - blas * openblas
+  track_features: blas_openblas
   license: BSD-3-Clause
   license_family: BSD
-  size: 5040017
-  timestamp: 1705980578057
+  size: 3973187
+  timestamp: 1705980098952
 - platform: linux-64
   name: libllvm14
   version: 14.0.6
@@ -18839,7 +18855,7 @@ package:
   dependencies:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libxml2 >=2.12.1,<2.13.0a0
+  - libxml2 >=2.12.1,<3.0.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-hb3ce162_4.conda
@@ -18911,7 +18927,7 @@ package:
   - libcurl >=8.5.0,<9.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libxml2 >=2.12.2,<2.13.0a0
+  - libxml2 >=2.12.2,<3.0.0a0
   - libzip >=1.10.1,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.2.0,<4.0a0
@@ -19300,6 +19316,30 @@ package:
   license_family: BSD
   size: 2917606
   timestamp: 1704950245195
+- platform: win-64
+  name: libopenblas
+  version: 0.3.26
+  category: main
+  manager: conda
+  dependencies:
+  - libflang >=5.0.0,<6.0.0.a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/libopenblas-0.3.26-pthreads_hc140b1d_0.conda
+  hash:
+    md5: 961a6872e97cdeba131645e987179443
+    sha256: 40443fa1fa6015ca64f50ea75407ffe3c5d951b6879fc8a345d13603766ef845
+  build: pthreads_hc140b1d_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  constrains:
+  - openblas >=0.3.26,<0.3.27.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3970611
+  timestamp: 1704955151478
 - platform: linux-64
   name: libopus
   version: 1.3.1
@@ -19361,91 +19401,87 @@ package:
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h84dd17c_2_cpu
+  - libarrow 14.0.2 he2c5238_5_cpu
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libthrift >=0.19.0,<0.19.1.0a0
-  - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.2-h352af49_2_cpu.conda
+  - openssl >=3.2.1,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.2-h352af49_5_cpu.conda
   hash:
-    md5: b265698e6c69269fe78a8cc972269c35
-    sha256: 4d0113cb62bb15c7fde3da36b4bb1862182ec5f89e0165ebcf5ae0bce155097f
-  build: h352af49_2_cpu
+    md5: acfeeddce03334b228f05bde2a6d5e1b
+    sha256: 34d9dc28bb8e5a1369f1a019ca6eddf51f7b0853210316a18d72eb853e9ce38f
+  build: h352af49_5_cpu
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 1163710
-  timestamp: 1704355184404
+  size: 1164848
+  timestamp: 1706713529608
 - platform: osx-64
   name: libparquet
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h1aaacd4_2_cpu
+  - libarrow 14.0.2 h9a9dd9d_5_cpu
   - libcxx >=14
   - libthrift >=0.19.0,<0.19.1.0a0
-  - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-14.0.2-h381d950_2_cpu.conda
+  - openssl >=3.2.1,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-14.0.2-h381d950_5_cpu.conda
   hash:
-    md5: c9b769d78c837821bfabc4fbd3cf3936
-    sha256: 8f58f4a46ae7eb500fff04a26e6f15de111999df4017bd4c4aac8f7245c95016
-  build: h381d950_2_cpu
+    md5: de66119377db0c895c44f40402a9be6c
+    sha256: ccbfa5f9b336c4294de467f9f09aedbdecca9339bba31f2c4bfdc8d0d6030da6
+  build: h381d950_5_cpu
   arch: x86_64
   subdir: osx-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 928914
-  timestamp: 1704356105480
+  size: 928057
+  timestamp: 1706714373186
 - platform: osx-arm64
   name: libparquet
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h4ce3932_2_cpu
+  - libarrow 14.0.2 h906e67b_5_cpu
   - libcxx >=14
   - libthrift >=0.19.0,<0.19.1.0a0
-  - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-14.0.2-hf6ce1d5_2_cpu.conda
+  - openssl >=3.2.1,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-14.0.2-hf6ce1d5_5_cpu.conda
   hash:
-    md5: 3ec6dde23ee1ecea255c788e5ce16c82
-    sha256: e1deb2b68a0a24c85f75831e44a59d582168b5b9481ab7138683226e702416c2
-  build: hf6ce1d5_2_cpu
+    md5: 628667c6d2d2f8498e0ef0bf18adb88d
+    sha256: cb052026870572653a7a8867a671910ca4182915436ea1c524c8c80b00e5c632
+  build: hf6ce1d5_5_cpu
   arch: aarch64
   subdir: osx-arm64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 911760
-  timestamp: 1704356359375
+  size: 913509
+  timestamp: 1706715052870
 - platform: win-64
   name: libparquet
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 he5f67d5_2_cpu
+  - libarrow 14.0.2 h33d03ac_5_cpu
   - libthrift >=0.19.0,<0.19.1.0a0
-  - openssl >=3.2.0,<4.0a0
+  - openssl >=3.2.1,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-14.0.2-h7ec3a38_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-14.0.2-h7ec3a38_5_cpu.conda
   hash:
-    md5: 4de7b992bc7bc1a71b07fa893c80fcfb
-    sha256: 929bb7e2a0903d9442aac788969b8626017e97193929bceae991a4ddcdde3875
-  build: h7ec3a38_2_cpu
+    md5: a220554c4ca459a5512027f3a45369ac
+    sha256: a9303fa3ebc84ec8f2b2922cf3e37c18f2e17086a4929366417f0eafa1c49713
+  build: h7ec3a38_5_cpu
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 5
   license: Apache-2.0
-  license_family: APACHE
-  size: 780687
-  timestamp: 1704355806769
+  size: 781014
+  timestamp: 1706714668631
 - platform: linux-64
   name: libpng
   version: 1.6.39
@@ -19604,7 +19640,7 @@ package:
   timestamp: 1702130694327
 - platform: linux-64
   name: libprotobuf
-  version: 4.24.4
+  version: 4.25.1
   category: main
   manager: conda
   dependencies:
@@ -19613,21 +19649,21 @@ package:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.24.4-hf27288f_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.1-hf27288f_0.conda
   hash:
-    md5: 1a0287ab734591ad63603734f923016b
-    sha256: 3e0f6454190abb27edd2aeb724688ee440de133edb02cbb17d5609ba36aa8be0
+    md5: fa5eb01e989d7484fed5ca88997e892b
+    sha256: 97ef9c6ce2b710aadc9a4520c1e354ce476286691623439f2a28b3f50906242b
   build: hf27288f_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 2568098
-  timestamp: 1696556878001
+  size: 2717560
+  timestamp: 1705834183873
 - platform: osx-64
   name: libprotobuf
-  version: 4.24.4
+  version: 4.25.1
   category: main
   manager: conda
   dependencies:
@@ -19636,44 +19672,43 @@ package:
   - libabseil >=20230802.1,<20230803.0a0
   - libcxx >=15
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.24.4-hc4f2305_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.1-hc4f2305_0.conda
   hash:
-    md5: b0f4b64fca855d81e9cde1ceecbcb333
-    sha256: 6516b3a430ae3678190a1ece9a8cb38a3ddd9c3acedc3955b76c1e668eeb2eb1
+    md5: c56993259c1876b30466251c054dad17
+    sha256: 1aa1db8e42840466bd5c350ac12c7a899288c6a8c32ea650f9f20764623fd0e2
   build: hc4f2305_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 2121595
-  timestamp: 1705835096979
+  size: 2302858
+  timestamp: 1705834549037
 - platform: osx-arm64
   name: libprotobuf
-  version: 4.24.4
+  version: 4.25.1
   category: main
   manager: conda
   dependencies:
-  - __osx >=10.9
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libcxx >=16.0.6
+  - libcxx >=15
   - libzlib >=1.2.13,<1.3.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.24.4-hc9861d8_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.1-h810fc01_0.conda
   hash:
-    md5: ac5438d981e105e053b341eb30c44273
-    sha256: 2e81e023f463ef239e2fb7f56a4e8eed61a1d8e9ca3f2f07bec1668cc369b2ce
-  build: hc9861d8_0
+    md5: 92b341be84cc25716aa4f86c1762333c
+    sha256: c55124c4166679a0162b05b886a205c0b31a6cf37ea9a22d7908b84b5e39a280
+  build: h810fc01_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 2060711
-  timestamp: 1696556460522
+  size: 2234169
+  timestamp: 1705834134457
 - platform: win-64
   name: libprotobuf
-  version: 4.24.4
+  version: 4.25.1
   category: main
   manager: conda
   dependencies:
@@ -19683,18 +19718,18 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.24.4-hb8276f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.1-hb8276f3_0.conda
   hash:
-    md5: db95f0bafffb9a5b6b9f398d35d693ad
-    sha256: 2c2b9c1f65458c2f2a4b57d49bf8113781b933b63f8fc976f050627bddcf983d
+    md5: 57af335450788e34a95bbb78a29dced1
+    sha256: 1bbffda6dba3f6fd12c79673d8c99f8ed358104baa8075a6e6040b1996eddafc
   build: hb8276f3_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: BSD-3-Clause
   license_family: BSD
-  size: 5281089
-  timestamp: 1696556929616
+  size: 5592047
+  timestamp: 1705835144318
 - platform: linux-64
   name: libre2-11
   version: 2023.06.02
@@ -20087,7 +20122,7 @@ package:
   - librttopo >=1.1.0,<1.2.0a0
   - libsqlite >=3.44.2,<4.0a0
   - libstdcxx-ng >=12
-  - libxml2 >=2.12.2,<2.13.0a0
+  - libxml2 >=2.12.2,<3.0.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - proj >=9.3.1,<9.3.2.0a0
   - sqlite
@@ -20362,18 +20397,18 @@ package:
   category: main
   manager: conda
   dependencies: []
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_4.conda
   hash:
-    md5: 937eaed008f6bf2191c5fe76f87755e9
-    sha256: 6c6c49efedcc5709a66f19fb6b26b69c6a5245310fd1d9a901fd5e38aaf7f882
-  build: h7e041cc_3
+    md5: f6a3a9c67eb8030555d04066bcd65320
+    sha256: a93f6e0ccffadea286ba8fd0cac04708b9389425ae39c760dd5e501ac8bf8f76
+  build: h7e041cc_4
   arch: x86_64
   subdir: linux-64
-  build_number: 3
+  build_number: 4
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 3842940
-  timestamp: 1699753676253
+  size: 3838135
+  timestamp: 1706339462090
 - platform: linux-64
   name: libsystemd0
   version: '255'
@@ -21098,7 +21133,7 @@ package:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libxcb >=1.15,<1.16.0a0
-  - libxml2 >=2.12.1,<2.13.0a0
+  - libxml2 >=2.12.1,<3.0.0a0
   - xkeyboard-config
   - xorg-libxau >=1.0.11,<2.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.6.0-hd429924_1.conda
@@ -21210,7 +21245,7 @@ package:
   manager: conda
   dependencies:
   - libgcc-ng >=12
-  - libxml2 >=2.12.1,<2.13.0a0
+  - libxml2 >=2.12.1,<3.0.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libxslt-1.1.39-h76b75d6_0.conda
   hash:
     md5: e71f31f8cfb0a91439f2086fc8aa0461
@@ -21455,6 +21490,24 @@ package:
   license_family: Other
   size: 55800
   timestamp: 1686575452215
+- platform: win-64
+  name: llvm-meta
+  version: 5.0.0
+  category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/noarch/llvm-meta-5.0.0-0.tar.bz2
+  hash:
+    md5: 213b5b5ad34008147a824460e50a691c
+    sha256: 090bbeacc3297ff579b53f55ad184f05c30e316fe9d5d7df63df1d2ad4578b79
+  build: '0'
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  noarch: generic
+  size: 2667
 - platform: osx-64
   name: llvm-openmp
   version: 17.0.6
@@ -21676,7 +21729,7 @@ package:
   manager: conda
   dependencies:
   - libgcc-ng >=12
-  - libxml2 >=2.12.3,<2.13.0a0
+  - libxml2 >=2.12.3,<3.0.0a0
   - libxslt >=1.1.39,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - python >=3.11,<3.12.0a0
@@ -23017,56 +23070,18 @@ package:
   dependencies:
   - intel-openmp 2024.*
   - tbb 2021.*
-  url: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.0.0-h66d3029_49657.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/mkl-2024.0.0-h66d3029_49658.conda
   hash:
-    md5: 006b65d9cd436247dfe053df772e041d
-    sha256: 928bed978827e4c891d0879d79ecda6c9104ed7df1f1d4e2e392c9c80b471be7
-  build: h66d3029_49657
+    md5: 9782703dbc6e14cbc32bc89ec76922c2
+    sha256: 7df43df56b68908c266232d025b4734d12de41f636b8158283c43e40611165e4
+  build: h66d3029_49658
   arch: x86_64
   subdir: win-64
-  build_number: 49657
+  build_number: 49658
   license: LicenseRef-ProprietaryIntel
   license_family: Proprietary
-  size: 108505947
-  timestamp: 1701973497498
-- platform: win-64
-  name: mkl-devel
-  version: 2024.0.0
-  category: main
-  manager: conda
-  dependencies:
-  - mkl 2024.0.0 h66d3029_49657
-  - mkl-include 2024.0.0 h66d3029_49657
-  url: https://conda.anaconda.org/conda-forge/win-64/mkl-devel-2024.0.0-h57928b3_49657.conda
-  hash:
-    md5: 385b9dcf11c859acc506dcb40451f904
-    sha256: f680af5df0788b6383336d55429014e2329cca2e2bcf6adc2acec0a686a6586d
-  build: h57928b3_49657
-  arch: x86_64
-  subdir: win-64
-  build_number: 49657
-  license: LicenseRef-ProprietaryIntel
-  license_family: Proprietary
-  size: 5259841
-  timestamp: 1701973856091
-- platform: win-64
-  name: mkl-include
-  version: 2024.0.0
-  category: main
-  manager: conda
-  dependencies: []
-  url: https://conda.anaconda.org/conda-forge/win-64/mkl-include-2024.0.0-h66d3029_49657.conda
-  hash:
-    md5: 4477b53b9f7edc041962c92a5d5e9caa
-    sha256: 9e6e0a2a32eb798a0f0571430dc6f4c31ad4446579c36dd42ec45e8bf0c40533
-  build: h66d3029_49657
-  arch: x86_64
-  subdir: win-64
-  build_number: 49657
-  license: LicenseRef-ProprietaryIntel
-  license_family: Proprietary
-  size: 698431
-  timestamp: 1701972737138
+  size: 108374598
+  timestamp: 1706183251746
 - platform: linux-64
   name: mock
   version: 5.1.0
@@ -25637,6 +25652,29 @@ package:
   noarch: python
   size: 29115
   timestamp: 1656021470538
+- platform: win-64
+  name: openblas
+  version: 0.3.26
+  category: main
+  manager: conda
+  dependencies:
+  - libflang >=5.0.0,<6.0.0.a0
+  - libopenblas 0.3.26 pthreads_hc140b1d_0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/openblas-0.3.26-pthreads_h3721920_0.conda
+  hash:
+    md5: c4803747929997cb8aac395d55059859
+    sha256: 27e5b02f367eea261ce58c484e5effba3e9ceb2f3cf487e331167e8c8ae6cd19
+  build: pthreads_h3721920_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 169776
+  timestamp: 1704955176460
 - platform: linux-64
   name: openjpeg
   version: 2.5.0
@@ -25728,73 +25766,91 @@ package:
   license_family: BSD
   size: 236847
   timestamp: 1694708878963
+- platform: win-64
+  name: openmp
+  version: 5.0.0
+  category: main
+  manager: conda
+  dependencies:
+  - llvm-meta 5.0.0|5.0.0.*
+  - vc 14.*
+  url: https://conda.anaconda.org/conda-forge/win-64/openmp-5.0.0-vc14_1.tar.bz2
+  hash:
+    md5: 8284c925330fa53668ade00db3c9e787
+    sha256: 05c19170938b589f59049679d4e0679c98160fecc6fd1bf721b0f4980bd235dd
+  build: vc14_1
+  arch: x86_64
+  subdir: win-64
+  build_number: 1
+  license: NCSA
+  size: 590466
 - platform: linux-64
   name: openssl
-  version: 3.2.0
+  version: 3.2.1
   category: main
   manager: conda
   dependencies:
   - ca-certificates
   - libgcc-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.0-hd590300_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_0.conda
   hash:
-    md5: 603827b39ea2b835268adb8c821b8570
-    sha256: 80efc6f429bd8e622d999652e5cba2ca56fcdb9c16a439d2ce9b4313116e4a87
-  build: hd590300_1
+    md5: 51a753e64a3027bd7e23a189b1f6e91e
+    sha256: c02c12bdb898daacf7eb3d09859f93ea8f285fd1a6132ff6ff0493ab52c7fe57
+  build: hd590300_0
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 0
   constrains:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 2854103
-  timestamp: 1701162437033
+  size: 2863069
+  timestamp: 1706635653339
 - platform: osx-64
   name: openssl
-  version: 3.2.0
+  version: 3.2.1
   category: main
   manager: conda
   dependencies:
   - ca-certificates
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.0-hd75f5a5_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_0.conda
   hash:
-    md5: 06cb561619487c88891839b9beb5244c
-    sha256: 99161bf349f5dc80322f2a2c188588d11efa662566e4e19f2ac0a36d9fa3de25
-  build: hd75f5a5_1
+    md5: 3033be9a59fd744172b03971b9ccd081
+    sha256: 20c1b1a34a1831c24d37ed1500ca07300171184af0c66598f3c5ca901634d713
+  build: hd75f5a5_0
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 0
   constrains:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 2508164
-  timestamp: 1701163123673
+  size: 2509168
+  timestamp: 1706636810736
 - platform: osx-arm64
   name: openssl
-  version: 3.2.0
+  version: 3.2.1
   category: main
   manager: conda
   dependencies:
   - ca-certificates
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.0-h0d3ecfb_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_0.conda
   hash:
-    md5: 47d16d26100f19ca495882882b7bc93b
-    sha256: a53e1c6c058b621fd1d13cca6f9cccd534d2b3f4b4ac789fe26f7902031d6c41
-  build: h0d3ecfb_1
+    md5: 421cc6e8715447b73c2c57dcf78cb9d2
+    sha256: 13663fcd4abc8681b31ccbad39800fee2127cb6159b51a989ed48a816af36cf5
+  build: h0d3ecfb_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 0
   constrains:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 2856233
-  timestamp: 1701162541844
+  size: 2862719
+  timestamp: 1706635779319
 - platform: win-64
   name: openssl
-  version: 3.2.0
+  version: 3.2.1
   category: main
   manager: conda
   dependencies:
@@ -25802,20 +25858,20 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.0-hcfcfb64_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.1-hcfcfb64_0.conda
   hash:
-    md5: d10167022f99bad12ee07dea022d5830
-    sha256: 373b9671173ef3413d2a95f3781176b818db904ba82298f8447b9658d71e2cc9
-  build: hcfcfb64_1
+    md5: 158df8eead8092cf0e27167c8761a8dd
+    sha256: 1df1c43136f863d5e9ba20b703001caf9a4d0ea56bdc3eeb948c977e3d4f91d3
+  build: hcfcfb64_0
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 0
   constrains:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 8248125
-  timestamp: 1701164404616
+  size: 8229619
+  timestamp: 1706638014697
 - platform: linux-64
   name: orc
   version: 1.9.2
@@ -25823,24 +25879,24 @@ package:
   manager: conda
   dependencies:
   - libgcc-ng >=12
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - snappy >=1.1.10,<2.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-1.9.2-h4b38347_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/orc-1.9.2-h7829240_1.conda
   hash:
-    md5: 6e6f990b097d3e237e18a8e321d08484
-    sha256: a06dd76bc0f2f99f5db5e348298c906007c3aa9e31b963f71d16e63f770b900b
-  build: h4b38347_0
+    md5: 306ffb76ce3cdfc539d29fa5b8dd716c
+    sha256: 051d28565da5899b46897f4811d9ee4d2ff1d9c618c092eef73bc13badb704c0
+  build: h7829240_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 1018308
-  timestamp: 1700372809593
+  size: 1020588
+  timestamp: 1705934665593
 - platform: osx-64
   name: orc
   version: 1.9.2
@@ -25848,57 +25904,55 @@ package:
   manager: conda
   dependencies:
   - __osx >=10.13
-  - __osx >=10.9
-  - libcxx >=16.0.6
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libcxx >=15
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - snappy >=1.1.10,<2.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/orc-1.9.2-h9ab30d4_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/orc-1.9.2-ha277160_1.conda
   hash:
-    md5: 8fb76f7b135aec885cfe47c52b2eb4b5
-    sha256: a948db80c0b756db07abce1972d6b8d1a08a7ced5a687b02435348c81443de08
-  build: h9ab30d4_0
+    md5: 5abf98a78ed66f1164e56e7cb852660e
+    sha256: a4ad062d21bd4dcca20048cf22eff203f34b28514b19d114b2ac547510c14f85
+  build: ha277160_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 423917
-  timestamp: 1700373043647
+  size: 426003
+  timestamp: 1705935160603
 - platform: osx-arm64
   name: orc
   version: 1.9.2
   category: main
   manager: conda
   dependencies:
-  - __osx >=10.9
-  - libcxx >=16.0.6
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libcxx >=15
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - snappy >=1.1.10,<2.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-1.9.2-h7c018df_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-1.9.2-hb41d57e_1.conda
   hash:
-    md5: 1ef4159e9686d95ce8ea9f1d4d999f29
-    sha256: b1ad0f09dc69a8956079371d9853534f991f8311352e4e21503e6e5d20e4017b
-  build: h7c018df_0
+    md5: 2b7e8bb8c22c8e73bd8307d0e4fb3d15
+    sha256: 5930ff00fdae4b0e640023ba8c72ad77dc9018c63c36326f91efae2bf22b459f
+  build: hb41d57e_1
   arch: aarch64
   subdir: osx-arm64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 405599
-  timestamp: 1700373052638
+  size: 406699
+  timestamp: 1705935083911
 - platform: win-64
   name: orc
   version: 1.9.2
   category: main
   manager: conda
   dependencies:
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - snappy >=1.1.10,<2.0a0
@@ -25906,30 +25960,30 @@ package:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/win-64/orc-1.9.2-hf0b6bd4_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/orc-1.9.2-hf6f83f4_1.conda
   hash:
-    md5: 29af097d73ea38cf72e666ec90e0044e
-    sha256: 14d81cf427dec751709b86b4d501388f2a51ea8851f73d82116865bf4cca2667
-  build: hf0b6bd4_0
+    md5: 07b32e66750eed8e7a15ff0ee1187df8
+    sha256: d66c24024b652b6509a3ba5bc25d8b9cb6f6d46cd79ebacf7def1d758831d4b1
+  build: hf6f83f4_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: Apache
-  size: 884906
-  timestamp: 1700373245961
+  size: 892053
+  timestamp: 1705935126565
 - platform: linux-64
   name: overrides
-  version: 7.6.0
+  version: 7.7.0
   category: main
   manager: conda
   dependencies:
   - python >=3.6
   - typing_utils
-  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3ed0205566229c23c70fd9e6318e0568
-    sha256: caa3afb0e2ae034cf71a14532646e7fde10ee3c070d20ea906fcf57b62e8c744
+    md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
+    sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -25937,20 +25991,20 @@ package:
   license: Apache-2.0
   license_family: APACHE
   noarch: python
-  size: 30196
-  timestamp: 1705794347236
+  size: 30232
+  timestamp: 1706394723472
 - platform: osx-64
   name: overrides
-  version: 7.6.0
+  version: 7.7.0
   category: main
   manager: conda
   dependencies:
   - python >=3.6
   - typing_utils
-  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3ed0205566229c23c70fd9e6318e0568
-    sha256: caa3afb0e2ae034cf71a14532646e7fde10ee3c070d20ea906fcf57b62e8c744
+    md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
+    sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -25958,20 +26012,20 @@ package:
   license: Apache-2.0
   license_family: APACHE
   noarch: python
-  size: 30196
-  timestamp: 1705794347236
+  size: 30232
+  timestamp: 1706394723472
 - platform: osx-arm64
   name: overrides
-  version: 7.6.0
+  version: 7.7.0
   category: main
   manager: conda
   dependencies:
   - python >=3.6
   - typing_utils
-  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3ed0205566229c23c70fd9e6318e0568
-    sha256: caa3afb0e2ae034cf71a14532646e7fde10ee3c070d20ea906fcf57b62e8c744
+    md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
+    sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -25979,20 +26033,20 @@ package:
   license: Apache-2.0
   license_family: APACHE
   noarch: python
-  size: 30196
-  timestamp: 1705794347236
+  size: 30232
+  timestamp: 1706394723472
 - platform: win-64
   name: overrides
-  version: 7.6.0
+  version: 7.7.0
   category: main
   manager: conda
   dependencies:
   - python >=3.6
   - typing_utils
-  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.6.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3ed0205566229c23c70fd9e6318e0568
-    sha256: caa3afb0e2ae034cf71a14532646e7fde10ee3c070d20ea906fcf57b62e8c744
+    md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
+    sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -26000,8 +26054,8 @@ package:
   license: Apache-2.0
   license_family: APACHE
   noarch: python
-  size: 30196
-  timestamp: 1705794347236
+  size: 30232
+  timestamp: 1706394723472
 - platform: linux-64
   name: owslib
   version: 0.29.3
@@ -27069,6 +27123,7 @@ package:
   subdir: linux-64
   build_number: 3
   license: BSD-3-Clause
+  license_family: BSD
   size: 4383987
   timestamp: 1706167189439
 - platform: osx-64
@@ -27105,6 +27160,7 @@ package:
   constrains:
   - __osx >=10.15
   license: BSD-3-Clause
+  license_family: BSD
   size: 3054242
   timestamp: 1706168535936
 - platform: osx-arm64
@@ -27139,6 +27195,7 @@ package:
   subdir: osx-arm64
   build_number: 3
   license: BSD-3-Clause
+  license_family: BSD
   size: 2739508
   timestamp: 1706168142545
 - platform: win-64
@@ -27177,6 +27234,7 @@ package:
   subdir: win-64
   build_number: 3
   license: BSD-3-Clause
+  license_family: BSD
   size: 2949237
   timestamp: 1706168779252
 - platform: linux-64
@@ -27610,83 +27668,83 @@ package:
   timestamp: 1702822023465
 - platform: linux-64
   name: pixman
-  version: 0.43.0
+  version: 0.43.2
   category: main
   manager: conda
   dependencies:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.0-h59595ed_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
   hash:
-    md5: 6b4b43013628634b6cfdee6b74fd696b
-    sha256: 07a5ffcd34e241f900433af4c6d4904518aab76add4e1e40a2c4bad93ae43f2b
+    md5: 71004cbf7924e19c02746ccde9fd7123
+    sha256: 366d28e2a0a191d6c535e234741e0cd1d94d713f76073d8af4a5ccb2a266121e
   build: h59595ed_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 387320
-  timestamp: 1704646964705
+  size: 386826
+  timestamp: 1706549500138
 - platform: osx-64
   name: pixman
-  version: 0.43.0
+  version: 0.43.2
   category: main
   manager: conda
   dependencies:
   - libcxx >=15
-  url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.0-h73e2aa4_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.2-h73e2aa4_0.conda
   hash:
-    md5: e7b41ef9fef108d52355c9d603e5a6a8
-    sha256: e1c1d69c7297496bcbd2969feaeb725a35cf04ffe419688f6067e94bc4dee686
+    md5: 26cf3be47886ded561d3d2cd8654893f
+    sha256: 26b16d9a6aed8f3d96a7dbad5d63b6ab1bcce13d77c050bcbaf7378bada2d225
   build: h73e2aa4_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 326301
-  timestamp: 1704647133185
+  size: 324294
+  timestamp: 1706549556213
 - platform: osx-arm64
   name: pixman
-  version: 0.43.0
+  version: 0.43.2
   category: main
   manager: conda
   dependencies:
   - libcxx >=15
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.0-hebf3989_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.2-hebf3989_0.conda
   hash:
-    md5: 6becbd8db3b0aa168259018c3806b814
-    sha256: 4587c34eb9ada1ba82c3e9f8ffe7354dff6c385f0e8c94fe1bbc775f4ddba5c9
+    md5: aaf3f4397959b8900c7c2f90304ccb29
+    sha256: dc3ec60e769f80c1d5124ba2788e3c9122443743989ad5f92addf416c7a4e58b
   build: hebf3989_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 201507
-  timestamp: 1704647221719
+  size: 198606
+  timestamp: 1706549867392
 - platform: win-64
   name: pixman
-  version: 0.43.0
+  version: 0.43.2
   category: main
   manager: conda
   dependencies:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.0-h63175ca_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.2-h63175ca_0.conda
   hash:
-    md5: b481afd4e3d086adce96302751de233c
-    sha256: d1b164e230b16b236855853fda2d4aceb5d92fdfc53f67d942c5edc26dc5f617
+    md5: 1060b0e26af2192e80b1d04cae0b029f
+    sha256: 659db230ba8121395b23fa6fce5f16532f54e4e7397ff9e7c19d9c7e436d29f8
   build: h63175ca_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 463334
-  timestamp: 1704647571150
+  size: 460196
+  timestamp: 1706549794397
 - platform: linux-64
   name: pkginfo
   version: 1.9.6
@@ -27845,84 +27903,80 @@ package:
   timestamp: 1694617398467
 - platform: linux-64
   name: platformdirs
-  version: 4.1.0
+  version: 4.2.0
   category: main
   manager: conda
   dependencies:
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 45a5065664da0d1dfa8f8cd2eaf05ab9
-    sha256: 9e4ff17ce802159ed31344eb913eaa877688226765b77947b102b42255a53853
+    md5: a0bc3eec34b0fab84be6b2da94e98e20
+    sha256: 2ebfb971236ab825dd79dd6086ea742a9901008ffb9c6222c1f2b5172a8039d3
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
-  license_family: MIT
   noarch: python
-  size: 20058
-  timestamp: 1701708396900
+  size: 20210
+  timestamp: 1706713564353
 - platform: osx-64
   name: platformdirs
-  version: 4.1.0
+  version: 4.2.0
   category: main
   manager: conda
   dependencies:
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 45a5065664da0d1dfa8f8cd2eaf05ab9
-    sha256: 9e4ff17ce802159ed31344eb913eaa877688226765b77947b102b42255a53853
+    md5: a0bc3eec34b0fab84be6b2da94e98e20
+    sha256: 2ebfb971236ab825dd79dd6086ea742a9901008ffb9c6222c1f2b5172a8039d3
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
-  license_family: MIT
   noarch: python
-  size: 20058
-  timestamp: 1701708396900
+  size: 20210
+  timestamp: 1706713564353
 - platform: osx-arm64
   name: platformdirs
-  version: 4.1.0
+  version: 4.2.0
   category: main
   manager: conda
   dependencies:
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 45a5065664da0d1dfa8f8cd2eaf05ab9
-    sha256: 9e4ff17ce802159ed31344eb913eaa877688226765b77947b102b42255a53853
+    md5: a0bc3eec34b0fab84be6b2da94e98e20
+    sha256: 2ebfb971236ab825dd79dd6086ea742a9901008ffb9c6222c1f2b5172a8039d3
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
-  license_family: MIT
   noarch: python
-  size: 20058
-  timestamp: 1701708396900
+  size: 20210
+  timestamp: 1706713564353
 - platform: win-64
   name: platformdirs
-  version: 4.1.0
+  version: 4.2.0
   category: main
   manager: conda
   dependencies:
   - python >=3.8
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 45a5065664da0d1dfa8f8cd2eaf05ab9
-    sha256: 9e4ff17ce802159ed31344eb913eaa877688226765b77947b102b42255a53853
+    md5: a0bc3eec34b0fab84be6b2da94e98e20
+    sha256: 2ebfb971236ab825dd79dd6086ea742a9901008ffb9c6222c1f2b5172a8039d3
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: MIT
-  license_family: MIT
   noarch: python
-  size: 20058
-  timestamp: 1701708396900
+  size: 20210
+  timestamp: 1706713564353
 - platform: linux-64
   name: plotly
   version: 5.18.0
@@ -28587,7 +28641,7 @@ package:
   - krb5 >=1.21.2,<1.22.0a0
   - libgcc-ng >=12
   - libpq 16.1 h33b98f1_7
-  - libxml2 >=2.12.2,<2.13.0a0
+  - libxml2 >=2.12.2,<3.0.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.2.0,<4.0a0
   - readline >=8.2,<9.0a0
@@ -29661,132 +29715,128 @@ package:
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h84dd17c_2_cpu
-  - libarrow-acero 14.0.2 h59595ed_2_cpu
-  - libarrow-dataset 14.0.2 h59595ed_2_cpu
-  - libarrow-flight 14.0.2 h120cb0d_2_cpu
-  - libarrow-flight-sql 14.0.2 h61ff412_2_cpu
-  - libarrow-gandiva 14.0.2 hacb8726_2_cpu
-  - libarrow-substrait 14.0.2 h61ff412_2_cpu
+  - libarrow 14.0.2 he2c5238_5_cpu
+  - libarrow-acero 14.0.2 h59595ed_5_cpu
+  - libarrow-dataset 14.0.2 h59595ed_5_cpu
+  - libarrow-flight 14.0.2 hdc44a87_5_cpu
+  - libarrow-flight-sql 14.0.2 hfbc7f12_5_cpu
+  - libarrow-gandiva 14.0.2 hacb8726_5_cpu
+  - libarrow-substrait 14.0.2 hfbc7f12_5_cpu
   - libgcc-ng >=12
-  - libparquet 14.0.2 h352af49_2_cpu
+  - libparquet 14.0.2 h352af49_5_cpu
   - libstdcxx-ng >=12
   - numpy >=1.23.5,<2.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.2-py311h39c9aba_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.2-py311h39c9aba_5_cpu.conda
   hash:
-    md5: 07fb7193fa96aab8e61c4483b9e61e51
-    sha256: 9117ea0cf236f9bb43cc05ec2d0744c9f789132dbc255d82f1fd2b6fd9e0b3ba
-  build: py311h39c9aba_2_cpu
+    md5: 8fca9b0bb9361a6a4bf14637c47eec8f
+    sha256: c16cfca880150d7bbc4bece9f84704f1c16d828e9521214534d1aae33b86c7b9
+  build: py311h39c9aba_5_cpu
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 5
   constrains:
   - apache-arrow-proc =*=cpu
   license: Apache-2.0
-  license_family: APACHE
-  size: 4515359
-  timestamp: 1704356601353
+  size: 4535384
+  timestamp: 1706714806034
 - platform: osx-64
   name: pyarrow
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h1aaacd4_2_cpu
-  - libarrow-acero 14.0.2 h000cb23_2_cpu
-  - libarrow-dataset 14.0.2 h000cb23_2_cpu
-  - libarrow-flight 14.0.2 ha1803ca_2_cpu
-  - libarrow-flight-sql 14.0.2 h8ec153b_2_cpu
-  - libarrow-gandiva 14.0.2 h01dce7f_2_cpu
-  - libarrow-substrait 14.0.2 h8ec153b_2_cpu
+  - libarrow 14.0.2 h9a9dd9d_5_cpu
+  - libarrow-acero 14.0.2 h000cb23_5_cpu
+  - libarrow-dataset 14.0.2 h000cb23_5_cpu
+  - libarrow-flight 14.0.2 h949774c_5_cpu
+  - libarrow-flight-sql 14.0.2 he85462c_5_cpu
+  - libarrow-gandiva 14.0.2 h01dce7f_5_cpu
+  - libarrow-substrait 14.0.2 he85462c_5_cpu
   - libcxx >=14
-  - libparquet 14.0.2 h381d950_2_cpu
+  - libparquet 14.0.2 h381d950_5_cpu
   - numpy >=1.23.5,<2.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-14.0.2-py311h54e7ce8_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-14.0.2-py311h54e7ce8_5_cpu.conda
   hash:
-    md5: a4c277c33b47c06b3c3fd2939fdb9c9a
-    sha256: fb631eb88510f59c2a5dc21764ce554e961e7970ea952e17bfb5742b54b322ba
-  build: py311h54e7ce8_2_cpu
+    md5: 06d6c48f218af972946cd587e34e18d1
+    sha256: 84f1fde751ba460f93507e3a8db554e8ae63abcc81cd512c0a8cdeea14d489c3
+  build: py311h54e7ce8_5_cpu
   arch: x86_64
   subdir: osx-64
-  build_number: 2
+  build_number: 5
   constrains:
   - apache-arrow-proc =*=cpu
   license: Apache-2.0
-  license_family: APACHE
-  size: 4029309
-  timestamp: 1704362351224
+  size: 4012425
+  timestamp: 1706716961217
 - platform: osx-arm64
   name: pyarrow
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 h4ce3932_2_cpu
-  - libarrow-acero 14.0.2 h13dd4ca_2_cpu
-  - libarrow-dataset 14.0.2 h13dd4ca_2_cpu
-  - libarrow-flight 14.0.2 ha94d253_2_cpu
-  - libarrow-flight-sql 14.0.2 h39a9b85_2_cpu
-  - libarrow-gandiva 14.0.2 hf757142_2_cpu
-  - libarrow-substrait 14.0.2 h7fd9903_2_cpu
+  - libarrow 14.0.2 h906e67b_5_cpu
+  - libarrow-acero 14.0.2 h13dd4ca_5_cpu
+  - libarrow-dataset 14.0.2 h13dd4ca_5_cpu
+  - libarrow-flight 14.0.2 h7c660a6_5_cpu
+  - libarrow-flight-sql 14.0.2 h6dff610_5_cpu
+  - libarrow-gandiva 14.0.2 hf757142_5_cpu
+  - libarrow-substrait 14.0.2 h3c8a37a_5_cpu
   - libcxx >=14
-  - libparquet 14.0.2 hf6ce1d5_2_cpu
+  - libparquet 14.0.2 hf6ce1d5_5_cpu
   - numpy >=1.23.5,<2.0a0
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-14.0.2-py311hd7bc329_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-14.0.2-py311hd7bc329_5_cpu.conda
   hash:
-    md5: 6a599e9f9b2ab76b1006cf60fe1730a1
-    sha256: 382cae1613f740afac2bedf7b4b3d7d19775ab7c31b419553351806d0ac9bc29
-  build: py311hd7bc329_2_cpu
+    md5: 372e694e227022e4d7f984f5bbf46132
+    sha256: 6957a55846e49c10e65bc98acd70315c68391ea584d6a9547dd2fca7ad14116e
+  build: py311hd7bc329_5_cpu
   arch: aarch64
   subdir: osx-arm64
-  build_number: 2
+  build_number: 5
   constrains:
   - apache-arrow-proc =*=cpu
   license: Apache-2.0
-  license_family: APACHE
-  size: 4090895
-  timestamp: 1704361615592
+  size: 4061164
+  timestamp: 1706718666243
 - platform: win-64
   name: pyarrow
   version: 14.0.2
   category: main
   manager: conda
   dependencies:
-  - libarrow 14.0.2 he5f67d5_2_cpu
-  - libarrow-acero 14.0.2 h63175ca_2_cpu
-  - libarrow-dataset 14.0.2 h63175ca_2_cpu
-  - libarrow-flight 14.0.2 h53b1db0_2_cpu
-  - libarrow-flight-sql 14.0.2 h78eab7c_2_cpu
-  - libarrow-gandiva 14.0.2 hb2eaab1_2_cpu
-  - libarrow-substrait 14.0.2 hd4c9904_2_cpu
-  - libparquet 14.0.2 h7ec3a38_2_cpu
+  - libarrow 14.0.2 h33d03ac_5_cpu
+  - libarrow-acero 14.0.2 h63175ca_5_cpu
+  - libarrow-dataset 14.0.2 h63175ca_5_cpu
+  - libarrow-flight 14.0.2 he112ba8_5_cpu
+  - libarrow-flight-sql 14.0.2 h8f0bfdc_5_cpu
+  - libarrow-gandiva 14.0.2 hb2eaab1_5_cpu
+  - libarrow-substrait 14.0.2 h7aa34db_5_cpu
+  - libparquet 14.0.2 h7ec3a38_5_cpu
   - numpy >=1.23.5,<2.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-14.0.2-py311h6a6099b_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-14.0.2-py311h6a6099b_5_cpu.conda
   hash:
-    md5: 3e9caae94be752658cbe9449440681ee
-    sha256: cd32ac9c0b740933f5c47eb3b9e731b7ff171cc648fe72434de3c95585d7af5e
-  build: py311h6a6099b_2_cpu
+    md5: 6b898704b8bb05a11f6181be354b858f
+    sha256: 131c4573f0356b50823788b11be969ed1d39dd444720e9f3752569ca7f8938ab
+  build: py311h6a6099b_5_cpu
   arch: x86_64
   subdir: win-64
-  build_number: 2
+  build_number: 5
   constrains:
   - apache-arrow-proc =*=cpu
   license: Apache-2.0
-  license_family: APACHE
-  size: 3486905
-  timestamp: 1704357865002
+  size: 3460464
+  timestamp: 1706717915822
 - platform: linux-64
   name: pyarrow-hotfix
   version: '0.6'
@@ -29953,18 +30003,18 @@ package:
   timestamp: 1636257201998
 - platform: linux-64
   name: pydantic
-  version: 2.5.3
+  version: 2.6.0
   category: main
   manager: conda
   dependencies:
   - annotated-types >=0.4.0
-  - pydantic-core 2.14.6
+  - pydantic-core 2.16.1
   - python >=3.7
   - typing-extensions >=4.6.1
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.5.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3569001fd8b37e542aaefdf5de124e19
-    sha256: 07ec778cbf17737b740f0547fb5cba91a7bff52945fe637287458e4119c58ffe
+    md5: aeba5c2230ecff6cb6d8e413b53f0fcc
+    sha256: 6107b51a1114cb2490215526030ff54636866a2a55d6794e7cb5717e618a06f0
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -29972,22 +30022,22 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 262369
-  timestamp: 1703248592754
+  size: 271498
+  timestamp: 1706544163939
 - platform: osx-64
   name: pydantic
-  version: 2.5.3
+  version: 2.6.0
   category: main
   manager: conda
   dependencies:
   - annotated-types >=0.4.0
-  - pydantic-core 2.14.6
+  - pydantic-core 2.16.1
   - python >=3.7
   - typing-extensions >=4.6.1
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.5.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3569001fd8b37e542aaefdf5de124e19
-    sha256: 07ec778cbf17737b740f0547fb5cba91a7bff52945fe637287458e4119c58ffe
+    md5: aeba5c2230ecff6cb6d8e413b53f0fcc
+    sha256: 6107b51a1114cb2490215526030ff54636866a2a55d6794e7cb5717e618a06f0
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -29995,22 +30045,22 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 262369
-  timestamp: 1703248592754
+  size: 271498
+  timestamp: 1706544163939
 - platform: osx-arm64
   name: pydantic
-  version: 2.5.3
+  version: 2.6.0
   category: main
   manager: conda
   dependencies:
   - annotated-types >=0.4.0
-  - pydantic-core 2.14.6
+  - pydantic-core 2.16.1
   - python >=3.7
   - typing-extensions >=4.6.1
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.5.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3569001fd8b37e542aaefdf5de124e19
-    sha256: 07ec778cbf17737b740f0547fb5cba91a7bff52945fe637287458e4119c58ffe
+    md5: aeba5c2230ecff6cb6d8e413b53f0fcc
+    sha256: 6107b51a1114cb2490215526030ff54636866a2a55d6794e7cb5717e618a06f0
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -30018,22 +30068,22 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 262369
-  timestamp: 1703248592754
+  size: 271498
+  timestamp: 1706544163939
 - platform: win-64
   name: pydantic
-  version: 2.5.3
+  version: 2.6.0
   category: main
   manager: conda
   dependencies:
   - annotated-types >=0.4.0
-  - pydantic-core 2.14.6
+  - pydantic-core 2.16.1
   - python >=3.7
   - typing-extensions >=4.6.1
-  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.5.3-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.6.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 3569001fd8b37e542aaefdf5de124e19
-    sha256: 07ec778cbf17737b740f0547fb5cba91a7bff52945fe637287458e4119c58ffe
+    md5: aeba5c2230ecff6cb6d8e413b53f0fcc
+    sha256: 6107b51a1114cb2490215526030ff54636866a2a55d6794e7cb5717e618a06f0
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -30041,11 +30091,11 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 262369
-  timestamp: 1703248592754
+  size: 271498
+  timestamp: 1706544163939
 - platform: linux-64
   name: pydantic-core
-  version: 2.14.6
+  version: 2.16.1
   category: main
   manager: conda
   dependencies:
@@ -30053,42 +30103,44 @@ package:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - typing-extensions >=4.6.0,!=4.7.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.14.6-py311h46250e7_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.16.1-py311h46250e7_0.conda
   hash:
-    md5: 410930043285723aeb06ac81ce0032ef
-    sha256: 5e50e2fd3f46a6602a01172874818b4a618a0f78d8c8de7157833190b28c3058
-  build: py311h46250e7_1
+    md5: 3d67570812117e0857423ee791b5ab73
+    sha256: e2f4a6bde4b289f82b798018d2189bb37730732f54adb6fa5936bd86ed79106c
+  build: py311h46250e7_0
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 0
   license: MIT
   license_family: MIT
-  size: 1601053
-  timestamp: 1703318953188
+  size: 1667886
+  timestamp: 1705675277919
 - platform: osx-64
   name: pydantic-core
-  version: 2.14.6
+  version: 2.16.1
   category: main
   manager: conda
   dependencies:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - typing-extensions >=4.6.0,!=4.7.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.14.6-py311h5e0f0e4_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pydantic-core-2.16.1-py311hd64b9fd_0.conda
   hash:
-    md5: 63affb07fbaba131554d011c24c0a25e
-    sha256: e8faa50d36d1d4e30e60cdc59f8e737a028ddb03c0573db0fbe62bf35365635b
-  build: py311h5e0f0e4_1
+    md5: 8a0b7119713bd8215ce23e38757d1b66
+    sha256: 8433fbb27845dc119614a312bf0a7ccbb0a44bd6cc3c487acf3894e5cae405b2
+  build: py311hd64b9fd_0
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 0
+  constrains:
+  - __osx >=10.12
   license: MIT
   license_family: MIT
-  size: 1513354
-  timestamp: 1703319292290
+  size: 1596717
+  timestamp: 1705675497273
 - platform: osx-arm64
   name: pydantic-core
-  version: 2.14.6
+  version: 2.16.1
   category: main
   manager: conda
   dependencies:
@@ -30096,21 +30148,23 @@ package:
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
   - typing-extensions >=4.6.0,!=4.7.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.14.6-py311h94f323b_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.16.1-py311h94f323b_0.conda
   hash:
-    md5: c682a26c8b23389b70182e895bf779a5
-    sha256: 9caccc7d9cfda2c2f9e9ba7867501d3149cd465e7587e1e668fd464de2ffe50a
-  build: py311h94f323b_1
+    md5: e6198e56685da1a7e912ee9443882aef
+    sha256: 2adb7152cc0caad01d760aa65c4fe07d4e4ec454c0f9d33e8e644ec12465dad7
+  build: py311h94f323b_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 0
+  constrains:
+  - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 1418339
-  timestamp: 1703319504236
+  size: 1482240
+  timestamp: 1705675444174
 - platform: win-64
   name: pydantic-core
-  version: 2.14.6
+  version: 2.16.1
   category: main
   manager: conda
   dependencies:
@@ -30120,18 +30174,18 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.14.6-py311hc37eb10_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.16.1-py311hc37eb10_0.conda
   hash:
-    md5: 46b5cae8b19da565e34b8b6c58ccba86
-    sha256: 0d36653be6d0dd69afe08c8ebf20ddde00ab56d508e11bc0f0f3467f2e7b1aad
-  build: py311hc37eb10_1
+    md5: bd6338a79db799112841949350e2cf96
+    sha256: bb313a6aeadd4912f916bfa8b9a04d63d02ccceb4edd4651dec503e2cdf294a1
+  build: py311hc37eb10_0
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 0
   license: MIT
   license_family: MIT
-  size: 1585088
-  timestamp: 1703319667858
+  size: 1617478
+  timestamp: 1705675912728
 - platform: linux-64
   name: pygments
   version: 2.17.2
@@ -31138,7 +31192,7 @@ package:
   timestamp: 1661605138291
 - platform: linux-64
   name: pytest
-  version: 7.4.4
+  version: 8.0.0
   category: main
   manager: conda
   dependencies:
@@ -31146,13 +31200,13 @@ package:
   - exceptiongroup >=1.0.0rc8
   - iniconfig
   - packaging
-  - pluggy >=0.12,<2.0
-  - python >=3.7
+  - pluggy <2.0,>=1.4.0
+  - python >=3.8
   - tomli >=1.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a9d145de8c5f064b5fa68fb34725d9f4
-    sha256: 8979721b7f86b183d21103f3ec2734783847d317c1b754f462f407efc7c60886
+    md5: 5ba1cc5b924226349d4a49fb547b7579
+    sha256: 42717ca3e48c08b3098db01cbb3c04afd5fa67e67bad4691f2b88781269580a7
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -31162,11 +31216,11 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 244564
-  timestamp: 1704035308916
+  size: 251713
+  timestamp: 1706448088334
 - platform: osx-64
   name: pytest
-  version: 7.4.4
+  version: 8.0.0
   category: main
   manager: conda
   dependencies:
@@ -31174,13 +31228,13 @@ package:
   - exceptiongroup >=1.0.0rc8
   - iniconfig
   - packaging
-  - pluggy >=0.12,<2.0
-  - python >=3.7
+  - pluggy <2.0,>=1.4.0
+  - python >=3.8
   - tomli >=1.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a9d145de8c5f064b5fa68fb34725d9f4
-    sha256: 8979721b7f86b183d21103f3ec2734783847d317c1b754f462f407efc7c60886
+    md5: 5ba1cc5b924226349d4a49fb547b7579
+    sha256: 42717ca3e48c08b3098db01cbb3c04afd5fa67e67bad4691f2b88781269580a7
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -31190,11 +31244,11 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 244564
-  timestamp: 1704035308916
+  size: 251713
+  timestamp: 1706448088334
 - platform: osx-arm64
   name: pytest
-  version: 7.4.4
+  version: 8.0.0
   category: main
   manager: conda
   dependencies:
@@ -31202,13 +31256,13 @@ package:
   - exceptiongroup >=1.0.0rc8
   - iniconfig
   - packaging
-  - pluggy >=0.12,<2.0
-  - python >=3.7
+  - pluggy <2.0,>=1.4.0
+  - python >=3.8
   - tomli >=1.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a9d145de8c5f064b5fa68fb34725d9f4
-    sha256: 8979721b7f86b183d21103f3ec2734783847d317c1b754f462f407efc7c60886
+    md5: 5ba1cc5b924226349d4a49fb547b7579
+    sha256: 42717ca3e48c08b3098db01cbb3c04afd5fa67e67bad4691f2b88781269580a7
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -31218,11 +31272,11 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 244564
-  timestamp: 1704035308916
+  size: 251713
+  timestamp: 1706448088334
 - platform: win-64
   name: pytest
-  version: 7.4.4
+  version: 8.0.0
   category: main
   manager: conda
   dependencies:
@@ -31230,13 +31284,13 @@ package:
   - exceptiongroup >=1.0.0rc8
   - iniconfig
   - packaging
-  - pluggy >=0.12,<2.0
-  - python >=3.7
+  - pluggy <2.0,>=1.4.0
+  - python >=3.8
   - tomli >=1.0.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.4-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.0.0-pyhd8ed1ab_0.conda
   hash:
-    md5: a9d145de8c5f064b5fa68fb34725d9f4
-    sha256: 8979721b7f86b183d21103f3ec2734783847d317c1b754f462f407efc7c60886
+    md5: 5ba1cc5b924226349d4a49fb547b7579
+    sha256: 42717ca3e48c08b3098db01cbb3c04afd5fa67e67bad4691f2b88781269580a7
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -31246,8 +31300,8 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 244564
-  timestamp: 1704035308916
+  size: 251713
+  timestamp: 1706448088334
 - platform: linux-64
   name: pytest-cov
   version: 4.1.0
@@ -31968,15 +32022,15 @@ package:
   timestamp: 1695147711935
 - platform: linux-64
   name: pytz
-  version: 2023.3.post1
+  version: '2023.4'
   category: main
   manager: conda
   dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.4-pyhd8ed1ab_0.conda
   hash:
-    md5: c93346b446cd08c169d843ae5fc0da97
-    sha256: 6b680e63d69aaf087cd43ca765a23838723ef59b0a328799e6363eb13f52c49e
+    md5: 89445e229eb2d6605be88e0908afc912
+    sha256: c988e6b9032ac2f917540a1d5a2268f45c01892c392fd7eee9d5c60270337835
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -31984,19 +32038,19 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 187454
-  timestamp: 1693930444432
+  size: 189221
+  timestamp: 1706549525585
 - platform: osx-64
   name: pytz
-  version: 2023.3.post1
+  version: '2023.4'
   category: main
   manager: conda
   dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.4-pyhd8ed1ab_0.conda
   hash:
-    md5: c93346b446cd08c169d843ae5fc0da97
-    sha256: 6b680e63d69aaf087cd43ca765a23838723ef59b0a328799e6363eb13f52c49e
+    md5: 89445e229eb2d6605be88e0908afc912
+    sha256: c988e6b9032ac2f917540a1d5a2268f45c01892c392fd7eee9d5c60270337835
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -32004,19 +32058,19 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 187454
-  timestamp: 1693930444432
+  size: 189221
+  timestamp: 1706549525585
 - platform: osx-arm64
   name: pytz
-  version: 2023.3.post1
+  version: '2023.4'
   category: main
   manager: conda
   dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.4-pyhd8ed1ab_0.conda
   hash:
-    md5: c93346b446cd08c169d843ae5fc0da97
-    sha256: 6b680e63d69aaf087cd43ca765a23838723ef59b0a328799e6363eb13f52c49e
+    md5: 89445e229eb2d6605be88e0908afc912
+    sha256: c988e6b9032ac2f917540a1d5a2268f45c01892c392fd7eee9d5c60270337835
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -32024,19 +32078,19 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 187454
-  timestamp: 1693930444432
+  size: 189221
+  timestamp: 1706549525585
 - platform: win-64
   name: pytz
-  version: 2023.3.post1
+  version: '2023.4'
   category: main
   manager: conda
   dependencies:
-  - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.4-pyhd8ed1ab_0.conda
   hash:
-    md5: c93346b446cd08c169d843ae5fc0da97
-    sha256: 6b680e63d69aaf087cd43ca765a23838723ef59b0a328799e6363eb13f52c49e
+    md5: 89445e229eb2d6605be88e0908afc912
+    sha256: c988e6b9032ac2f917540a1d5a2268f45c01892c392fd7eee9d5c60270337835
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -32044,8 +32098,8 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 187454
-  timestamp: 1693930444432
+  size: 189221
+  timestamp: 1706549525585
 - platform: win-64
   name: pywin32
   version: '306'
@@ -32396,9 +32450,9 @@ package:
   - laz-perf
   - libexpat >=2.5.0,<3.0a0
   - libgcc-ng >=12
-  - libgdal >=3.8.3,<3.9.0a0
+  - libgdal >=3.8.1,<3.9.0a0
   - libpq >=16.1,<17.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - libspatialindex >=1.9.3,<1.9.4.0a0
   - libspatialite >=5.1.0,<5.2.0a0
   - libsqlite >=3.44.2,<4.0a0
@@ -32436,18 +32490,18 @@ package:
   - six
   - sqlite
   - yaml
-  url: https://conda.anaconda.org/conda-forge/linux-64/qgis-3.34.3-py311ha16602e_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/qgis-3.34.3-py311h8bd7567_1.conda
   hash:
-    md5: 51cae087c4e6cdb5c905075b42a2dbcf
-    sha256: c865da5e924c7eebeb8ec0f33e0ac3bca118cdb1452e0e7840022cf3d10d5826
-  build: py311ha16602e_0
+    md5: 5242c7d5681405d4ebcc0aae667f5d31
+    sha256: df634767c647f7e6a51dda83a19e06d48f08de9b3893c4f611d0e7ddd8039b45
+  build: py311h8bd7567_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: GPL-2.0-only
   license_family: GPL
-  size: 92054419
-  timestamp: 1705742316909
+  size: 92812807
+  timestamp: 1706015902473
 - platform: osx-64
   name: qgis
   version: 3.34.3
@@ -32467,9 +32521,9 @@ package:
   - laz-perf
   - libcxx >=15
   - libexpat >=2.5.0,<3.0a0
-  - libgdal >=3.8.3,<3.9.0a0
+  - libgdal >=3.8.1,<3.9.0a0
   - libpq >=16.1,<17.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - libspatialindex >=1.9.3,<1.9.4.0a0
   - libspatialite >=5.1.0,<5.2.0a0
   - libsqlite >=3.44.2,<4.0a0
@@ -32506,23 +32560,23 @@ package:
   - six
   - sqlite
   - yaml
-  url: https://conda.anaconda.org/conda-forge/osx-64/qgis-3.34.3-py311hfb4095b_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/qgis-3.34.3-py311hf1c53af_1.conda
   hash:
-    md5: c8861fbad8b7557929871164596cb79e
-    sha256: 1fe27bb6b31887a8392f4a2e7ff6e9023c69ba8e500160e2f28d7ad16f66954e
-  build: py311hfb4095b_0
+    md5: 1fd010f461334d5a22fd39c8e22dde23
+    sha256: 363afc5ae4f4ff0af1a1251ec91de2cb6d18bc2cecfdc2345578c4f66e913e50
+  build: py311hf1c53af_1
   arch: x86_64
   subdir: osx-64
-  build_number: 0
+  build_number: 1
   constrains:
   - __osx >=10.15
   license: GPL-2.0-only
   license_family: GPL
-  size: 74685455
-  timestamp: 1705742799318
+  size: 74493278
+  timestamp: 1706019955144
 - platform: osx-arm64
   name: qgis
-  version: 3.34.2
+  version: 3.34.3
   category: main
   manager: conda
   dependencies:
@@ -32538,9 +32592,9 @@ package:
   - laz-perf
   - libcxx >=15
   - libexpat >=2.5.0,<3.0a0
-  - libgdal >=3.8.3,<3.9.0a0
+  - libgdal >=3.8.1,<3.9.0a0
   - libpq >=16.1,<17.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - libspatialindex >=1.9.3,<1.9.4.0a0
   - libspatialite >=5.1.0,<5.2.0a0
   - libsqlite >=3.44.2,<4.0a0
@@ -32578,11 +32632,11 @@ package:
   - six
   - sqlite
   - yaml
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/qgis-3.34.2-py311hca233d7_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/qgis-3.34.3-py311hfd5c3c4_1.conda
   hash:
-    md5: 322e93b0ff4f255f85d3610b23581bc9
-    sha256: d94460a2d9cc4c4a7012a8c7a015962e7a619491fbcda04aeff281df38f8359b
-  build: py311hca233d7_1
+    md5: 1bd90ad7ac10cb6495e369a94051afb9
+    sha256: 976486bb64d3f5e4a1fd4f9dfe4f3ff853be733b127cc9652ae5c4fe16889fb9
+  build: py311hfd5c3c4_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
@@ -32590,8 +32644,8 @@ package:
   - __osx >=11.0
   license: GPL-2.0-only
   license_family: GPL
-  size: 71540900
-  timestamp: 1705368086927
+  size: 72104344
+  timestamp: 1706020117473
 - platform: win-64
   name: qgis
   version: 3.34.3
@@ -32609,9 +32663,9 @@ package:
   - khronos-opencl-icd-loader >=2023.4.17
   - laz-perf
   - libexpat >=2.5.0,<3.0a0
-  - libgdal >=3.8.3,<3.9.0a0
+  - libgdal >=3.8.1,<3.9.0a0
   - libpq >=16.1,<17.0a0
-  - libprotobuf >=4.24.4,<4.24.5.0a0
+  - libprotobuf >=4.25.1,<4.25.2.0a0
   - libspatialindex >=1.9.3,<1.9.4.0a0
   - libspatialite >=5.1.0,<5.2.0a0
   - libsqlite >=3.44.2,<4.0a0
@@ -32650,18 +32704,18 @@ package:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - yaml
-  url: https://conda.anaconda.org/conda-forge/win-64/qgis-3.34.3-py311h1d565df_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/qgis-3.34.3-py311heb9a00c_1.conda
   hash:
-    md5: e94c099f0e344a9c04857d8c5184cad6
-    sha256: 7ba97ac9a5f99ddaceb45a3bb7d4a68ffd5eee80fe42f40afa1b7b218526de93
-  build: py311h1d565df_0
+    md5: 75310ba737e86f6f41c842f91d5958e6
+    sha256: 550a92857adcfa7ea494e592ffcf3851e4973cf3a429ecd068faaedaee86f7c1
+  build: py311heb9a00c_1
   arch: x86_64
   subdir: win-64
-  build_number: 0
+  build_number: 1
   license: GPL-2.0-only
   license_family: GPL
-  size: 71614889
-  timestamp: 1705744847837
+  size: 72651690
+  timestamp: 1706021117547
 - platform: linux-64
   name: qgis-plugin-manager
   version: 1.6.1
@@ -33027,7 +33081,7 @@ package:
   - libstdcxx-ng >=12
   - libxcb >=1.15,<1.16.0a0
   - libxkbcommon >=1.6.0,<2.0a0
-  - libxml2 >=2.12.2,<2.13.0a0
+  - libxml2 >=2.12.2,<3.0.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - mysql-libs >=8.0.33,<8.1.0a0
   - nspr >=4.35,<5.0a0
@@ -33276,7 +33330,7 @@ package:
   - libstdcxx-ng >=12
   - libwebp
   - libwebp-base >=1.3.2,<2.0a0
-  - libxml2 >=2.12.3,<2.13.0a0
+  - libxml2 >=2.12.3,<3.0.0a0
   - libxslt >=1.1.39,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - qt-main >=5.15.8,<5.16.0a0
@@ -33664,7 +33718,7 @@ package:
   timestamp: 1685706684958
 - platform: linux-64
   name: rdma-core
-  version: '49.0'
+  version: '50.0'
   category: main
   manager: conda
   dependencies:
@@ -33672,18 +33726,18 @@ package:
   - libgcc-ng >=12
   - libnl >=3.9.0,<4.0a0
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-49.0-hd3aeb46_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-50.0-hd3aeb46_0.conda
   hash:
-    md5: 855579013120ad3078e7d5dcadb643e1
-    sha256: 3f541042f7b51484a996eab53493b9242969bc406614eba76ceecfa4f4a0822a
-  build: hd3aeb46_2
+    md5: 4594b391274e38f07c668acb45285a1f
+    sha256: 7cc75473895aa7d4fa1824ef94bd451768fa4a36a5046b3281ed2b1a6787853d
+  build: hd3aeb46_0
   arch: x86_64
   subdir: linux-64
-  build_number: 2
+  build_number: 0
   license: Linux-OpenIB
   license_family: BSD
-  size: 4708814
-  timestamp: 1702693880207
+  size: 4724921
+  timestamp: 1706524445013
 - platform: linux-64
   name: re2
   version: 2023.06.02
@@ -33916,92 +33970,88 @@ package:
   timestamp: 1694242843889
 - platform: linux-64
   name: referencing
-  version: 0.32.1
+  version: 0.33.0
   category: main
   manager: conda
   dependencies:
   - attrs >=22.2.0
   - python >=3.8
   - rpds-py >=0.7.0
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.32.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.33.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 753a592b4e99d7d2cde6a8fd0797f414
-    sha256: 658beff40c6355af0eeec624bbe4e892b4c68c0af2d8ff4c06677e6547140506
+    md5: bc415a1c6cf049166215d6b596e0fcbe
+    sha256: 5707eb9ee2c7cfcc56a5223b24ab3133ff61aaa796931f3b22068e0a43ea6ecf
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
-  license_family: MIT
   noarch: python
-  size: 39009
-  timestamp: 1704489374195
+  size: 39055
+  timestamp: 1706711589688
 - platform: osx-64
   name: referencing
-  version: 0.32.1
+  version: 0.33.0
   category: main
   manager: conda
   dependencies:
   - attrs >=22.2.0
   - python >=3.8
   - rpds-py >=0.7.0
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.32.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.33.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 753a592b4e99d7d2cde6a8fd0797f414
-    sha256: 658beff40c6355af0eeec624bbe4e892b4c68c0af2d8ff4c06677e6547140506
+    md5: bc415a1c6cf049166215d6b596e0fcbe
+    sha256: 5707eb9ee2c7cfcc56a5223b24ab3133ff61aaa796931f3b22068e0a43ea6ecf
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
-  license_family: MIT
   noarch: python
-  size: 39009
-  timestamp: 1704489374195
+  size: 39055
+  timestamp: 1706711589688
 - platform: osx-arm64
   name: referencing
-  version: 0.32.1
+  version: 0.33.0
   category: main
   manager: conda
   dependencies:
   - attrs >=22.2.0
   - python >=3.8
   - rpds-py >=0.7.0
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.32.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.33.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 753a592b4e99d7d2cde6a8fd0797f414
-    sha256: 658beff40c6355af0eeec624bbe4e892b4c68c0af2d8ff4c06677e6547140506
+    md5: bc415a1c6cf049166215d6b596e0fcbe
+    sha256: 5707eb9ee2c7cfcc56a5223b24ab3133ff61aaa796931f3b22068e0a43ea6ecf
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
-  license_family: MIT
   noarch: python
-  size: 39009
-  timestamp: 1704489374195
+  size: 39055
+  timestamp: 1706711589688
 - platform: win-64
   name: referencing
-  version: 0.32.1
+  version: 0.33.0
   category: main
   manager: conda
   dependencies:
   - attrs >=22.2.0
   - python >=3.8
   - rpds-py >=0.7.0
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.32.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.33.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 753a592b4e99d7d2cde6a8fd0797f414
-    sha256: 658beff40c6355af0eeec624bbe4e892b4c68c0af2d8ff4c06677e6547140506
+    md5: bc415a1c6cf049166215d6b596e0fcbe
+    sha256: 5707eb9ee2c7cfcc56a5223b24ab3133ff61aaa796931f3b22068e0a43ea6ecf
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: MIT
-  license_family: MIT
   noarch: python
-  size: 39009
-  timestamp: 1704489374195
+  size: 39055
+  timestamp: 1706711589688
 - platform: linux-64
   name: requests
   version: 2.31.0
@@ -34876,7 +34926,7 @@ package:
   timestamp: 1695997456870
 - platform: linux-64
   name: ruff
-  version: 0.1.14
+  version: 0.1.15
   category: main
   manager: conda
   dependencies:
@@ -34884,44 +34934,44 @@ package:
   - libstdcxx-ng >=12
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.1.14-py311h7145743_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.1.15-py311h7145743_0.conda
   hash:
-    md5: 3ee5686f65a9ce8af5954ce97e80dd99
-    sha256: f43d390d82af805187175e5c760807e52cd22b6b7ba044bdfc37e1dcbe867d7f
-  build: py311h7145743_1
+    md5: 2aff79e0d8974f9c9c26e0893c0cf5dc
+    sha256: 807330e2f8f37fb0b164f2416978f280f156f4680688daf54cf4dd120c44f9a3
+  build: py311h7145743_0
   arch: x86_64
   subdir: linux-64
-  build_number: 1
+  build_number: 0
   license: MIT
   license_family: MIT
-  size: 5519824
-  timestamp: 1706122018783
+  size: 5526730
+  timestamp: 1706581630140
 - platform: osx-64
   name: ruff
-  version: 0.1.14
+  version: 0.1.15
   category: main
   manager: conda
   dependencies:
   - libcxx >=15
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.1.14-py311hfff7943_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.1.15-py311hfff7943_0.conda
   hash:
-    md5: eafb87af345555554ecbbf716da6509e
-    sha256: 8f351fa68de7171c877677f60af8b1dde377a7612efb562b1e1323b67ef1a889
-  build: py311hfff7943_1
+    md5: 1149b0c4d8abeb369520e25b9a3cec72
+    sha256: dd049906647ae154bed2a2768b147a7e16676c90600507053ecd86dada4b814f
+  build: py311hfff7943_0
   arch: x86_64
   subdir: osx-64
-  build_number: 1
+  build_number: 0
   constrains:
   - __osx >=10.12
   license: MIT
   license_family: MIT
-  size: 5336996
-  timestamp: 1706122613327
+  size: 5340139
+  timestamp: 1706582588849
 - platform: osx-arm64
   name: ruff
-  version: 0.1.14
+  version: 0.1.15
   category: main
   manager: conda
   dependencies:
@@ -34929,23 +34979,23 @@ package:
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.1.14-py311h8c97afb_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.1.15-py311h8c97afb_0.conda
   hash:
-    md5: a20feae4754402caa867a531bedfc889
-    sha256: 3fce34fb643db49066e886baa753973d138e4d8593a321cdaf9112b0b269da05
-  build: py311h8c97afb_1
+    md5: fd50dac5e17821a09f93c17ee95c0ce0
+    sha256: 34f647a35ad4166ee7e3ffa82b58f10da89b6779c3916bb0c184131b43ac6367
+  build: py311h8c97afb_0
   arch: aarch64
   subdir: osx-arm64
-  build_number: 1
+  build_number: 0
   constrains:
   - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 5144080
-  timestamp: 1706122778981
+  size: 5155254
+  timestamp: 1706582250027
 - platform: win-64
   name: ruff
-  version: 0.1.14
+  version: 0.1.15
   category: main
   manager: conda
   dependencies:
@@ -34954,38 +35004,38 @@ package:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.1.14-py311hc14472d_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.1.15-py311hc14472d_0.conda
   hash:
-    md5: ac3796db37bab6fa6cde4554ff78d3b0
-    sha256: d79094152fdb497b7bdb0163dd83b30ad50b2ceccf58ce0813b32e4d129f05b3
-  build: py311hc14472d_1
+    md5: 3b3401d1c12d34e0eff4358f204240c3
+    sha256: 8770d70437f32ec7f909fc6ec9888a8b5a99b8581cebaac89823c53023750ce1
+  build: py311hc14472d_0
   arch: x86_64
   subdir: win-64
-  build_number: 1
+  build_number: 0
   license: MIT
   license_family: MIT
-  size: 5445497
-  timestamp: 1706123274961
+  size: 5464376
+  timestamp: 1706582889700
 - platform: linux-64
   name: s2n
-  version: 1.4.1
+  version: 1.4.2
   category: main
   manager: conda
   dependencies:
   - libgcc-ng >=12
   - openssl >=3.2.0,<4.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.1-h06160fa_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.2-h06160fa_0.conda
   hash:
-    md5: 54ae57d17d038b6a7aa7fdb55350d338
-    sha256: 6f21a270e5fcf824d71b637ea26e389e469b3dc44a7e51062c27556c6e771b37
+    md5: cb0ddb996c2500eff369e80f48eac414
+    sha256: 18be0e5f78e109564458eb2d3f09c774106d66c480c76e1ff1b5f6d09ef29ce1
   build: h06160fa_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: Apache-2.0
   license_family: Apache
-  size: 331403
-  timestamp: 1703228891919
+  size: 333679
+  timestamp: 1706134070778
 - platform: linux-64
   name: scikit-learn
   version: 1.4.0
@@ -35121,6 +35171,7 @@ package:
   subdir: linux-64
   build_number: 2
   license: BSD-3-Clause
+  license_family: BSD
   size: 17270207
   timestamp: 1706042776987
 - platform: osx-64
@@ -35149,6 +35200,7 @@ package:
   subdir: osx-64
   build_number: 2
   license: BSD-3-Clause
+  license_family: BSD
   size: 16759101
   timestamp: 1706043392398
 - platform: osx-arm64
@@ -35178,6 +35230,7 @@ package:
   subdir: osx-arm64
   build_number: 2
   license: BSD-3-Clause
+  license_family: BSD
   size: 15535360
   timestamp: 1706043503868
 - platform: win-64
@@ -35205,6 +35258,7 @@ package:
   subdir: win-64
   build_number: 2
   license: BSD-3-Clause
+  license_family: BSD
   size: 15968999
   timestamp: 1706043936628
 - platform: linux-64
@@ -36346,25 +36400,25 @@ package:
   category: main
   manager: conda
   dependencies:
-  - libblas >=3.8.0,<4.0a0
-  - libcblas >=3.8.0,<4.0a0
-  - libgcc-ng >=9.4.0
-  - liblapack >=3.8.0,<4.0a0
-  - libstdcxx-ng >=9.4.0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
   - metis >=5.1.0,<5.1.1.0a0
-  - mpfr >=4.1.0,<5.0a0
-  - tbb >=2021.3.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/suitesparse-5.10.1-h9e50725_1.tar.bz2
+  - mpfr >=4.2.1,<5.0a0
+  - tbb >=2021.11.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/suitesparse-5.10.1-h5a4f163_3.conda
   hash:
-    md5: a3a685b5f9aeb890ed874502fe56accf
-    sha256: 176d004eafe3f07110315d1c96ab7245fbba8677364933213404890a0e2e9d1f
-  build: h9e50725_1
+    md5: f363554b9084fb9d5e3366fbbc0d18e0
+    sha256: 235c9321cb76896f3304eea87248a74f52d8c088a38b9cbd98a5366e34756b90
+  build: h5a4f163_3
   arch: x86_64
   subdir: linux-64
-  build_number: 1
-  license: LGPL-2.1-or-later (AMD, BTF, etc.), BSD-3-clause (UFget), GPL-2.0-or-later (UMFPACK, RBIO, SPQR, GPUQRENGINE), Apache-2.0 (Metis)
-  size: 2516475
-  timestamp: 1630001297117
+  build_number: 3
+  license: LGPL-2.1-or-later AND BSD-3-Clause AND GPL-2.0-or-later AND Apache-2.0
+  size: 1457359
+  timestamp: 1705676854887
 - platform: osx-64
   name: suitesparse
   version: 5.10.1
@@ -36518,24 +36572,25 @@ package:
   timestamp: 1665138565317
 - platform: linux-64
   name: tbb
-  version: 2021.7.0
+  version: 2021.11.0
   category: main
   manager: conda
   dependencies:
   - libgcc-ng >=12
+  - libhwloc >=2.9.3,<2.9.4.0a0
   - libstdcxx-ng >=12
-  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.7.0-h924138e_0.tar.bz2
+  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.11.0-h00ab1b0_1.conda
   hash:
-    md5: 819421f81b127a5547bf96ad57eccdd9
-    sha256: 452a6def24912d2a118d863095c3f9cb05fe5c997357431a0ca4452eb7f65f08
-  build: h924138e_0
+    md5: 4531d2927578e7e254ff3bcf6457518c
+    sha256: ded4de0d5a3eb7b47ed829f0ed0e3c61ccd428308bde52d8d22ced228038223b
+  build: h00ab1b0_1
   arch: x86_64
   subdir: linux-64
-  build_number: 0
+  build_number: 1
   license: Apache-2.0
   license_family: APACHE
-  size: 2055530
-  timestamp: 1668617473224
+  size: 195540
+  timestamp: 1706163436794
 - platform: osx-64
   name: tbb
   version: 2021.11.0
@@ -36553,6 +36608,7 @@ package:
   subdir: osx-64
   build_number: 1
   license: Apache-2.0
+  license_family: APACHE
   size: 173117
   timestamp: 1706163682083
 - platform: osx-arm64
@@ -36572,6 +36628,7 @@ package:
   subdir: osx-arm64
   build_number: 1
   license: Apache-2.0
+  license_family: APACHE
   size: 128174
   timestamp: 1706163796739
 - platform: win-64
@@ -36593,6 +36650,7 @@ package:
   subdir: win-64
   build_number: 1
   license: Apache-2.0
+  license_family: APACHE
   size: 161382
   timestamp: 1706164225098
 - platform: linux-64
@@ -36929,7 +36987,7 @@ package:
   timestamp: 1689261378222
 - platform: linux-64
   name: tiledb
-  version: 2.19.0
+  version: 2.19.1
   category: main
   manager: conda
   dependencies:
@@ -36943,26 +37001,26 @@ package:
   - libgcc-ng >=12
   - libgoogle-cloud >=2.12.0,<2.13.0a0
   - libstdcxx-ng >=12
-  - libxml2 >=2.12.3,<2.13.0a0
+  - libxml2 >=2.12.4,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - openssl >=3.2.0,<4.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.19.0-hc1131af_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.19.1-h4386cac_0.conda
   hash:
-    md5: 51f6de9ca86bdeeb92e89e4abccd03e8
-    sha256: b2896839b41289205562b211a6e45ebdbb97018e076c1ae4faecbfcc421810d0
-  build: hc1131af_0
+    md5: 8d16e7b2529607a12aa6722c7a7c7356
+    sha256: c75ff0cdcf3e3dac837739e056c2dbd74f0b1055ed17ac1523856c44f208e5c1
+  build: h4386cac_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 6108287
-  timestamp: 1703264040484
+  size: 6110843
+  timestamp: 1706569823547
 - platform: osx-64
   name: tiledb
-  version: 2.19.0
+  version: 2.19.1
   category: main
   manager: conda
   dependencies:
@@ -36976,26 +37034,26 @@ package:
   - libcurl >=8.5.0,<9.0a0
   - libcxx >=15
   - libgoogle-cloud >=2.12.0,<2.13.0a0
-  - libxml2 >=2.12.3,<3.0.0a0
+  - libxml2 >=2.12.4,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - openssl >=3.2.0,<4.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/tiledb-2.19.0-h4df5763_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/tiledb-2.19.1-h8fd0293_0.conda
   hash:
-    md5: eab42c6e4909c3901eaca7c5daf30be8
-    sha256: cf5f78eb9f2bd85d0d7eb69c5c816db15abac4010f46c972ba0f8ed1e1033b0c
-  build: h4df5763_0
+    md5: ae08850e4a0e58203a1cbfb14b452258
+    sha256: ccfd5f791c71c8484fd1b6d6402bc7330ea29c1f1d71abcd4c5fdcbe2daa4659
+  build: h8fd0293_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 5191749
-  timestamp: 1703265062981
+  size: 5172386
+  timestamp: 1706570859392
 - platform: osx-arm64
   name: tiledb
-  version: 2.19.0
+  version: 2.19.1
   category: main
   manager: conda
   dependencies:
@@ -37008,26 +37066,26 @@ package:
   - libcurl >=8.5.0,<9.0a0
   - libcxx >=15
   - libgoogle-cloud >=2.12.0,<2.13.0a0
-  - libxml2 >=2.12.3,<3.0.0a0
+  - libxml2 >=2.12.4,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - openssl >=3.2.0,<4.0a0
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tiledb-2.19.0-h567544c_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tiledb-2.19.1-h49d9ff7_0.conda
   hash:
-    md5: 60e4d67eedc2f19bfbdf964187f52d15
-    sha256: beeeefd593a5f0fa70b25d7d9563dd54c3840e85f6c5d982e2066f7904077191
-  build: h567544c_0
+    md5: dcd5b377b1d7784909acffd3bb6ca282
+    sha256: 9264b07951317c6ce50d5b5e0f02fb4cbddd45cb26de09edb7bd267424adc6e4
+  build: h49d9ff7_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 4679383
-  timestamp: 1703265601163
+  size: 4676615
+  timestamp: 1706571358589
 - platform: win-64
   name: tiledb
-  version: 2.19.0
+  version: 2.19.1
   category: main
   manager: conda
   dependencies:
@@ -37040,7 +37098,7 @@ package:
   - libcrc32c >=1.1.2,<1.2.0a0
   - libcurl >=8.5.0,<9.0a0
   - libgoogle-cloud >=2.12.0,<2.13.0a0
-  - libxml2 >=2.12.3,<3.0.0a0
+  - libxml2 >=2.12.4,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - openssl >=3.2.0,<4.0a0
@@ -37048,18 +37106,18 @@ package:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - zstd >=1.5.5,<1.6.0a0
-  url: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.19.0-h8e52ccb_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.19.1-h2657894_0.conda
   hash:
-    md5: f8ec375b1b4025c647fe0ceace2d944c
-    sha256: e1f715cf84085709a5e88eb83bbfed26cad2df203c03dd23903b35ca192e6fae
-  build: h8e52ccb_0
+    md5: 4dda2b1302437c7e06cf0cfca1bb16b1
+    sha256: 01ab52856318cbd7192bafdc9cf5461e143811ba0ed048ea531c0e313d6b4a2d
+  build: h2657894_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: MIT
   license_family: MIT
-  size: 4126320
-  timestamp: 1703268310493
+  size: 4126449
+  timestamp: 1706574174353
 - platform: linux-64
   name: tinycss2
   version: 1.2.1
@@ -37479,6 +37537,7 @@ package:
   subdir: linux-64
   build_number: 0
   license: BSD-3-Clause
+  license_family: BSD
   noarch: python
   size: 52358
   timestamp: 1706112720607
@@ -37498,6 +37557,7 @@ package:
   subdir: osx-64
   build_number: 0
   license: BSD-3-Clause
+  license_family: BSD
   noarch: python
   size: 52358
   timestamp: 1706112720607
@@ -37517,6 +37577,7 @@ package:
   subdir: osx-arm64
   build_number: 0
   license: BSD-3-Clause
+  license_family: BSD
   noarch: python
   size: 52358
   timestamp: 1706112720607
@@ -37536,6 +37597,7 @@ package:
   subdir: win-64
   build_number: 0
   license: BSD-3-Clause
+  license_family: BSD
   noarch: python
   size: 52358
   timestamp: 1706112720607
@@ -38074,80 +38136,80 @@ package:
   timestamp: 1704512704737
 - platform: linux-64
   name: types-pytz
-  version: 2023.3.1.1
+  version: 2023.4.0.20240130
   category: main
   manager: conda
   dependencies:
   - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2023.3.1.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2023.4.0.20240130-pyhd8ed1ab_0.conda
   hash:
-    md5: 13ce724cb44f7bc0ca0971d76e333c30
-    sha256: c1c54f4b2b5b39c420b3a47dd6196355147c798c0a4a2bdaaba80435e9591fb3
+    md5: 6258f43f81923ab4212a8eb24af176ab
+    sha256: 40ba46d9c5be4e690d23fb5d7e2a5843ff0a9bbb661a08447aa423ee6a811615
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
   license: Apache-2.0 AND MIT
   noarch: python
-  size: 18580
-  timestamp: 1695236716910
+  size: 18794
+  timestamp: 1706586269222
 - platform: osx-64
   name: types-pytz
-  version: 2023.3.1.1
+  version: 2023.4.0.20240130
   category: main
   manager: conda
   dependencies:
   - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2023.3.1.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2023.4.0.20240130-pyhd8ed1ab_0.conda
   hash:
-    md5: 13ce724cb44f7bc0ca0971d76e333c30
-    sha256: c1c54f4b2b5b39c420b3a47dd6196355147c798c0a4a2bdaaba80435e9591fb3
+    md5: 6258f43f81923ab4212a8eb24af176ab
+    sha256: 40ba46d9c5be4e690d23fb5d7e2a5843ff0a9bbb661a08447aa423ee6a811615
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
   license: Apache-2.0 AND MIT
   noarch: python
-  size: 18580
-  timestamp: 1695236716910
+  size: 18794
+  timestamp: 1706586269222
 - platform: osx-arm64
   name: types-pytz
-  version: 2023.3.1.1
+  version: 2023.4.0.20240130
   category: main
   manager: conda
   dependencies:
   - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2023.3.1.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2023.4.0.20240130-pyhd8ed1ab_0.conda
   hash:
-    md5: 13ce724cb44f7bc0ca0971d76e333c30
-    sha256: c1c54f4b2b5b39c420b3a47dd6196355147c798c0a4a2bdaaba80435e9591fb3
+    md5: 6258f43f81923ab4212a8eb24af176ab
+    sha256: 40ba46d9c5be4e690d23fb5d7e2a5843ff0a9bbb661a08447aa423ee6a811615
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   license: Apache-2.0 AND MIT
   noarch: python
-  size: 18580
-  timestamp: 1695236716910
+  size: 18794
+  timestamp: 1706586269222
 - platform: win-64
   name: types-pytz
-  version: 2023.3.1.1
+  version: 2023.4.0.20240130
   category: main
   manager: conda
   dependencies:
   - python >=3.6
-  url: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2023.3.1.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2023.4.0.20240130-pyhd8ed1ab_0.conda
   hash:
-    md5: 13ce724cb44f7bc0ca0971d76e333c30
-    sha256: c1c54f4b2b5b39c420b3a47dd6196355147c798c0a4a2bdaaba80435e9591fb3
+    md5: 6258f43f81923ab4212a8eb24af176ab
+    sha256: 40ba46d9c5be4e690d23fb5d7e2a5843ff0a9bbb661a08447aa423ee6a811615
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
   build_number: 0
   license: Apache-2.0 AND MIT
   noarch: python
-  size: 18580
-  timestamp: 1695236716910
+  size: 18794
+  timestamp: 1706586269222
 - platform: linux-64
   name: types-requests
   version: 2.31.0.20240125
@@ -38981,17 +39043,17 @@ package:
   timestamp: 1677713151746
 - platform: linux-64
   name: urllib3
-  version: 2.1.0
+  version: 2.2.0
   category: main
   manager: conda
   dependencies:
   - brotli-python >=1.0.9
   - pysocks >=1.5.6,<2.0,!=1.5.7
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: f8ced8ee63830dec7ecc1be048d1470a
-    sha256: eff5029820b4eaeab3a291a39854a6cd8fc8c4216264087f68c2d8d59822c869
+    md5: 6a7e0694921f668a030d52f0c47baebd
+    sha256: 61a8a3bd36d235c349aedaf1aa6a79cce15d6fe89dca4bb593b596d0211513c6
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: linux-64
@@ -38999,21 +39061,21 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 85324
-  timestamp: 1699933655057
+  size: 94513
+  timestamp: 1706638243438
 - platform: osx-64
   name: urllib3
-  version: 2.1.0
+  version: 2.2.0
   category: main
   manager: conda
   dependencies:
   - brotli-python >=1.0.9
   - pysocks >=1.5.6,<2.0,!=1.5.7
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: f8ced8ee63830dec7ecc1be048d1470a
-    sha256: eff5029820b4eaeab3a291a39854a6cd8fc8c4216264087f68c2d8d59822c869
+    md5: 6a7e0694921f668a030d52f0c47baebd
+    sha256: 61a8a3bd36d235c349aedaf1aa6a79cce15d6fe89dca4bb593b596d0211513c6
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: osx-64
@@ -39021,21 +39083,21 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 85324
-  timestamp: 1699933655057
+  size: 94513
+  timestamp: 1706638243438
 - platform: osx-arm64
   name: urllib3
-  version: 2.1.0
+  version: 2.2.0
   category: main
   manager: conda
   dependencies:
   - brotli-python >=1.0.9
   - pysocks >=1.5.6,<2.0,!=1.5.7
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: f8ced8ee63830dec7ecc1be048d1470a
-    sha256: eff5029820b4eaeab3a291a39854a6cd8fc8c4216264087f68c2d8d59822c869
+    md5: 6a7e0694921f668a030d52f0c47baebd
+    sha256: 61a8a3bd36d235c349aedaf1aa6a79cce15d6fe89dca4bb593b596d0211513c6
   build: pyhd8ed1ab_0
   arch: aarch64
   subdir: osx-arm64
@@ -39043,21 +39105,21 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 85324
-  timestamp: 1699933655057
+  size: 94513
+  timestamp: 1706638243438
 - platform: win-64
   name: urllib3
-  version: 2.1.0
+  version: 2.2.0
   category: main
   manager: conda
   dependencies:
   - brotli-python >=1.0.9
   - pysocks >=1.5.6,<2.0,!=1.5.7
   - python >=3.7
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.1.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: f8ced8ee63830dec7ecc1be048d1470a
-    sha256: eff5029820b4eaeab3a291a39854a6cd8fc8c4216264087f68c2d8d59822c869
+    md5: 6a7e0694921f668a030d52f0c47baebd
+    sha256: 61a8a3bd36d235c349aedaf1aa6a79cce15d6fe89dca4bb593b596d0211513c6
   build: pyhd8ed1ab_0
   arch: x86_64
   subdir: win-64
@@ -39065,8 +39127,8 @@ package:
   license: MIT
   license_family: MIT
   noarch: python
-  size: 85324
-  timestamp: 1699933655057
+  size: 94513
+  timestamp: 1706638243438
 - platform: win-64
   name: vc
   version: '14.3'
@@ -39866,6 +39928,7 @@ package:
   - matplotlib-base >=3.5
   - h5netcdf >=1.0
   license: Apache-2.0
+  license_family: APACHE
   noarch: python
   size: 730686
   timestamp: 1706057006199
@@ -39909,6 +39972,7 @@ package:
   - matplotlib-base >=3.5
   - h5netcdf >=1.0
   license: Apache-2.0
+  license_family: APACHE
   noarch: python
   size: 730686
   timestamp: 1706057006199
@@ -39952,6 +40016,7 @@ package:
   - matplotlib-base >=3.5
   - h5netcdf >=1.0
   license: Apache-2.0
+  license_family: APACHE
   noarch: python
   size: 730686
   timestamp: 1706057006199
@@ -39995,6 +40060,7 @@ package:
   - matplotlib-base >=3.5
   - h5netcdf >=1.0
   license: Apache-2.0
+  license_family: APACHE
   noarch: python
   size: 730686
   timestamp: 1706057006199

--- a/python/ribasim/ribasim/geometry/edge.py
+++ b/python/ribasim/ribasim/geometry/edge.py
@@ -40,12 +40,14 @@ class Edge(SpatialTableModel[EdgeSchema]):
     """
 
     def get_where_edge_type(self, edge_type: str) -> NDArray[np.bool_]:
+        assert self.df is not None
         return (self.df.edge_type == edge_type).to_numpy()
 
     def plot(self, **kwargs) -> Axes:
         ax = kwargs.get("ax", None)
         color_flow = kwargs.get("color_flow", None)
         color_control = kwargs.get("color_control", None)
+        assert self.df is not None
 
         if ax is None:
             _, ax = plt.subplots()

--- a/python/ribasim/ribasim/geometry/node.py
+++ b/python/ribasim/ribasim/geometry/node.py
@@ -80,6 +80,7 @@ class Node(SpatialTableModel[NodeSchema]):
         edge_geometry : np.ndarray
             Array of shapely LineStrings.
         """
+        assert self.df is not None
         geometry = self.df["geometry"]
         from_points = shapely.get_coordinates(geometry.loc[from_id])
         to_points = shapely.get_coordinates(geometry.loc[to_id])
@@ -109,6 +110,7 @@ class Node(SpatialTableModel[NodeSchema]):
         from_node_id : np.ndarray of int
         to_node_id : np.ndarray of int
         """
+        assert self.df is not None
         node_index = self.df.index
         node_xy = shapely.get_coordinates(self.df.geometry.values)
         edge_xy = shapely.get_coordinates(lines)
@@ -143,6 +145,7 @@ class Node(SpatialTableModel[NodeSchema]):
 
         contains_main_network = False
         contains_subnetworks = False
+        assert self.df is not None
 
         for allocation_subnetwork_id, df_subnetwork in self.df.groupby(
             "allocation_network_id"
@@ -223,6 +226,7 @@ class Node(SpatialTableModel[NodeSchema]):
             "User": "g",
             "": "k",
         }
+        assert self.df is not None
 
         for nodetype, df in self.df.groupby("type"):
             assert isinstance(nodetype, str)
@@ -237,6 +241,7 @@ class Node(SpatialTableModel[NodeSchema]):
                 label=nodetype,
             )
 
+        assert self.df is not None
         geometry = self.df["geometry"]
         for text, xy in zip(self.df.index, np.column_stack((geometry.x, geometry.y))):
             ax.annotate(text=text, xy=xy, xytext=(2.0, 2.0), textcoords="offset points")

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -468,6 +468,8 @@ class Model(FileModel):
         node_attrs, node_instances = zip(*self.nodes().items())
         node_clss = [node_cls.get_input_type() for node_cls in node_instances]
         truth_dict = {"T": ">", "F": "<"}
+        assert self.network.node.df is not None
+        assert self.network.edge.df is not None
 
         if self.discrete_control.condition.df is None:
             raise ValueError("This model has no control input.")


### PR DESCRIPTION
- Update `pixi.lock`
- Add asserts to satisfy mypy

This is #1025 (not #1064 since that moves to the new pixi.lock format version) but with the fixes needed for mypy.