### PR TITLE
Also allow Missing in basin.static

### DIFF
--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -175,11 +175,11 @@ end
 
 @version BasinStaticV1 begin
     node_id::Int
-    drainage::Float64
-    potential_evaporation::Float64
-    infiltration::Float64
-    precipitation::Float64
-    urban_runoff::Float64
+    drainage::Union{Missing, Float64}
+    potential_evaporation::Union{Missing, Float64}
+    infiltration::Union{Missing, Float64}
+    precipitation::Union{Missing, Float64}
+    urban_runoff::Union{Missing, Float64}
 end
 
 @version BasinTimeV1 begin

--- a/docs/schema/BasinStatic.schema.json
+++ b/docs/schema/BasinStatic.schema.json
@@ -10,24 +10,59 @@
             "type": "integer"
         },
         "drainage": {
-            "format": "double",
-            "type": "number"
+            "format": "default",
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "number"
+                }
+            ]
         },
         "potential_evaporation": {
-            "format": "double",
-            "type": "number"
+            "format": "default",
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "number"
+                }
+            ]
         },
         "infiltration": {
-            "format": "double",
-            "type": "number"
+            "format": "default",
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "number"
+                }
+            ]
         },
         "precipitation": {
-            "format": "double",
-            "type": "number"
+            "format": "default",
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "number"
+                }
+            ]
         },
         "urban_runoff": {
-            "format": "double",
-            "type": "number"
+            "format": "default",
+            "anyOf": [
+                {
+                    "type": "null"
+                },
+                {
+                    "type": "number"
+                }
+            ]
         },
         "remarks": {
             "description": "a hack for pandera",
@@ -37,11 +72,6 @@
         }
     },
     "required": [
-        "node_id",
-        "drainage",
-        "potential_evaporation",
-        "infiltration",
-        "precipitation",
-        "urban_runoff"
+        "node_id"
     ]
 }

--- a/python/ribasim/ribasim/models.py
+++ b/python/ribasim/ribasim/models.py
@@ -25,11 +25,11 @@ class BasinState(BaseModel):
 
 class BasinStatic(BaseModel):
     node_id: int
-    drainage: float
-    potential_evaporation: float
-    infiltration: float
-    precipitation: float
-    urban_runoff: float
+    drainage: float | None = None
+    potential_evaporation: float | None = None
+    infiltration: float | None = None
+    precipitation: float | None = None
+    urban_runoff: float | None = None
     remarks: str = Field("", description="a hack for pandera")
 
 

--- a/python/ribasim_testmodels/ribasim_testmodels/bucket.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/bucket.py
@@ -60,11 +60,11 @@ def bucket_model() -> ribasim.Model:
     static = pd.DataFrame(
         data={
             "node_id": [1],
-            "drainage": [0.0],
-            "potential_evaporation": [0.0],
-            "infiltration": [0.0],
-            "precipitation": [0.0],
-            "urban_runoff": [0.0],
+            "drainage": [np.nan],
+            "potential_evaporation": [np.nan],
+            "infiltration": [np.nan],
+            "precipitation": [np.nan],
+            "urban_runoff": [np.nan],
         }
     )
     basin = ribasim.Basin(profile=profile, static=static, state=state)


### PR DESCRIPTION
Missing is currently only allowed in the basin.time, thanks to https://github.com/Deltares/Ribasim/pull/1028.

This makes it consistent and allows it for basin.static as well (which is currently the reason a bunch of imod_coupler tests are failing).
