### PR TITLE
Testmodels: run one year instead of ten

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ report.xml
 
 # Designated working dir for working on Ribasim models
 models/
+
+# Result of build steps.
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,3 @@ report.xml
 
 # Designated working dir for working on Ribasim models
 models/
-
-# Result of build steps.
-build/

--- a/python/ribasim_testmodels/ribasim_testmodels/backwater.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/backwater.py
@@ -101,7 +101,7 @@ def backwater_model():
         flow_boundary=flow_boundary,
         manning_resistance=manning_resistance,
         starttime="2020-01-01 00:00:00",
-        endtime="2030-01-01 00:00:00",
+        endtime="2021-01-01 00:00:00",
     )
 
     return model

--- a/python/ribasim_testmodels/ribasim_testmodels/two_basin.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/two_basin.py
@@ -121,6 +121,6 @@ def two_basin_model() -> ribasim.Model:
         tabulated_rating_curve=rating_curve,
         terminal=terminal,
         starttime="2020-01-01 00:00:00",
-        endtime="2030-01-01 00:00:00",
+        endtime="2021-01-01 00:00:00",
     )
     return ribasim_model


### PR DESCRIPTION
No adverse effects: results have already achieved steady-state after one year.
This obviously reduces running times, especially when a MODFLOW6 model is run as well.

Fixes #1031
