### PR TITLE
Correct precipitation equation

### DIFF
--- a/docs/core/equations.qmd
+++ b/docs/core/equations.qmd
@@ -149,19 +149,21 @@ plt.show()
 The precipitation term is given by
 
 $$
-    Q_P = P \cdot A(u).
+    Q_P = P \cdot A
 $$ {#eq-precip}
 
-Here $P = P(t)$ is the precipitation rate and $A$ is the wetted area. $A$ is a
-function of the storage $u = u(t)$: as the volume of water changes, the area of the free water
-surface may change as well, depending on the slopes of the surface waters.
+Here $P = P(t)$ is the precipitation rate and $A$ is the maximum area given in the `Basin / profile` table.
+Precipitation in the Basin area is assumed to be directly added to the Basin storage.
+The modeler needs to ensure all precipitation enters the model, and there is no overlap in the maximum profile areas, else extra water is created.
+If a part of the catchment is not in any Basin profile, the modeler has to verify that water source is not forgotten.
+It can for instance be converted to a flow rate and added to a Basin as a FlowBoundary.
 
 ## Evaporation
 
 The evaporation term is given by
 
 $$
-    Q_E = E_\text{pot} \cdot A(u) \cdot \phi(d;0.1).
+    Q_E = E_\text{pot} \cdot A(u) \cdot \phi(d;0.1)
 $$ {#eq-evap}
 
 Here $E_\text{pot} = E_\text{pot}(t)$ is the potential evaporation rate and $A$ is the wetted area. $\phi$ is the [reduction factor](equations.qmd#sec-reduction_factor) which depends on the depth $d$. It provides a smooth gradient as $u \rightarrow 0$.

--- a/docs/core/equations.qmd
+++ b/docs/core/equations.qmd
@@ -149,7 +149,7 @@ plt.show()
 The precipitation term is given by
 
 $$
-    Q_P = P \cdot A
+    Q_P = P \cdot A.
 $$ {#eq-precip}
 
 Here $P = P(t)$ is the precipitation rate and $A$ is the maximum area given in the `Basin / profile` table.
@@ -163,7 +163,7 @@ It can for instance be converted to a flow rate and added to a Basin as a FlowBo
 The evaporation term is given by
 
 $$
-    Q_E = E_\text{pot} \cdot A(u) \cdot \phi(d;0.1)
+    Q_E = E_\text{pot} \cdot A(u) \cdot \phi(d;0.1).
 $$ {#eq-evap}
 
 Here $E_\text{pot} = E_\text{pot}(t)$ is the potential evaporation rate and $A$ is the wetted area. $\phi$ is the [reduction factor](equations.qmd#sec-reduction_factor) which depends on the depth $d$. It provides a smooth gradient as $u \rightarrow 0$.
@@ -194,7 +194,7 @@ MODFLOW 6 boundary conditions in the basin:
 
 $$
     Q_\text{inf} = \sum_{i=1}^{n} \sum_{j=1}^{m} \max(Q_{\mathrm{mf6}_{i,j}}, 0.0)
-$$ {#eq-inf}.
+$$ {#eq-inf}
 
 Where $i$ is the index of the boundary condition, $j$ the MODFLOW 6 cell index,
 $n$ the number of boundary conditions, and $m$ the number of MODFLOW 6 cells in


### PR DESCRIPTION
Before we used the current wetted area to convert the precipitation $m/s$ input to a flow rate $m^3/s$. It was deemed simpler and more stable to use the maximum profile area instead, otherwise empty Basins with 0 wetted area could never fill back up due to rain. This updates the equations to reflect that.