### PR TITLE
Move version from YYYY.0M.MICRO to YYYY.MINOR.MICRO

### DIFF
--- a/core/Project.toml
+++ b/core/Project.toml
@@ -2,7 +2,7 @@ name = "Ribasim"
 uuid = "aac5e3d9-0b8f-4d4f-8241-b1a7a9632635"
 authors = ["Deltares and contributors <ribasim.info@deltares.nl>"]
 manifest = "../Manifest.toml"
-version = "2024.02.0"
+version = "2024.2.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/docs/contribute/release.qmd
+++ b/docs/contribute/release.qmd
@@ -21,7 +21,7 @@ Before starting the release process, ensure that all tests are passing and that 
 
 ## Update version numbers of the components
 
-Determine the new version number like `2023.1.0`, filling in the current year, a bumped `MINOR` number for major updates or breaking changes and a bumped `MICRO` number for small, non-breaking changes.
+Determine the new version number like `2023.1.0`, filling in the current year, a bumped `MINOR` number for normal releases and a bumped `MICRO` number for non-breaking, hotfix releases.
 This follows `YYYY.MINOR.MICRO` from [calver](https://calver.org/).
 
 Update the version numbers in the repository to the new version number.

--- a/docs/contribute/release.qmd
+++ b/docs/contribute/release.qmd
@@ -21,8 +21,8 @@ Before starting the release process, ensure that all tests are passing and that 
 
 ## Update version numbers of the components
 
-Determine the new version number like `2023.8.0`, filling in the current year, month and a sequential "MICRO" number.
-This follows `YYYY.MM.MICRO` from [calver](https://calver.org/).
+Determine the new version number like `2023.1.0`, filling in the current year, a bumped `MINOR` number for major updates or breaking changes and a bumped `MICRO` number for small, non-breaking changes.
+This follows `YYYY.MINOR.MICRO` from [calver](https://calver.org/).
 
 Update the version numbers in the repository to the new version number.
 A single find and replace can update all 5 locations:

--- a/docs/contribute/release.qmd
+++ b/docs/contribute/release.qmd
@@ -21,8 +21,8 @@ Before starting the release process, ensure that all tests are passing and that 
 
 ## Update version numbers of the components
 
-Determine the new version number like `2023.08.0`, filling in the current year, month and a sequential "MICRO" number.
-This follows `YYYY.0M.MICRO` from [calver](https://calver.org/).
+Determine the new version number like `2023.8.0`, filling in the current year, month and a sequential "MICRO" number.
+This follows `YYYY.MM.MICRO` from [calver](https://calver.org/).
 
 Update the version numbers in the repository to the new version number.
 A single find and replace can update all 5 locations:
@@ -39,7 +39,7 @@ Now submit a pull request to update the version numbers.
 
 When the pull request is merged to main, checkout the commit that updates the version numbers.
 
-Create a new tag, which is the letter `v` followed by the version number, like, `v2023.08.0`.
+Create a new tag, which is the letter `v` followed by the version number, like, `v2023.8.0`.
 
 This can be done by executing:
 ```bash

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Ribasim"
-version = "2024.02.0"
+version = "2024.2.0"
 description = "Water resources modeling"
 authors = ["Deltares and contributors <ribasim.info@deltares.nl>"]
 channels = ["conda-forge"]

--- a/python/ribasim/ribasim/__init__.py
+++ b/python/ribasim/ribasim/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2024.02.0"
+__version__ = "2024.2.0"
 
 
 from ribasim import models, utils

--- a/python/ribasim_api/ribasim_api/__init__.py
+++ b/python/ribasim_api/ribasim_api/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2024.02.0"
+__version__ = "2024.2.0"
 
 from ribasim_api.ribasim_api import RibasimApi
 

--- a/ribasim_qgis/metadata.txt
+++ b/ribasim_qgis/metadata.txt
@@ -7,7 +7,7 @@
 name=Ribasim-QGIS
 qgisMinimumVersion=3.0
 description=QGIS plugin to setup Ribasim models
-version=2024.02.1
+version=2024.2.0
 author=Deltares and contributors
 email=ribasim.info@deltares.nl
 


### PR DESCRIPTION
Some implementations trim the 0 at the beginning, which makes it harder to test things. 
https://dpcbuild.deltares.nl/buildConfiguration/Ribasim_Windows_TestRibasimApi/3306663?buildTab=log&linesState=165.206.233&logView=flowAware&focusLine=190
