### PR TITLE
Add max_flow_rate to LinearResistance

### DIFF
--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -205,6 +205,7 @@ struct LinearResistance <: AbstractParameterNode
     node_id::Vector{NodeID}
     active::BitVector
     resistance::Vector{Float64}
+    max_flow_rate::Vector{Float64}
     control_mapping::Dict{Tuple{NodeID, String}, NamedTuple}
 end
 

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -197,7 +197,8 @@ Requirements:
 
 node_id: node ID of the LinearResistance node
 active: whether this node is active and thus contributes flows
-resistance: the resistance to flow; Q = Δh/resistance
+resistance: the resistance to flow; `Q_unlimited = Δh/resistance`
+max_flow_rate: the maximum flow rate allowed through the node; `Q = clamp(Q_unlimited, -max_flow_rate, max_flow_rate)`
 control_mapping: dictionary from (node_id, control_state) to resistance and/or active state
 """
 struct LinearResistance <: AbstractParameterNode

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -226,7 +226,9 @@ end
 
 function LinearResistance(db::DB, config::Config)::LinearResistance
     static = load_structvector(db, config, LinearResistanceStaticV1)
-    parsed_parameters, valid = parse_static_and_time(db, config, "LinearResistance"; static)
+    defaults = (; max_flow_rate = Inf, active = true)
+    parsed_parameters, valid =
+        parse_static_and_time(db, config, "LinearResistance"; static, defaults)
 
     if !valid
         error(
@@ -238,6 +240,7 @@ function LinearResistance(db::DB, config::Config)::LinearResistance
         NodeID.(parsed_parameters.node_id),
         BitVector(parsed_parameters.active),
         parsed_parameters.resistance,
+        parsed_parameters.max_flow_rate,
         parsed_parameters.control_mapping,
     )
 end

--- a/core/src/schema.jl
+++ b/core/src/schema.jl
@@ -164,6 +164,7 @@ end
     node_id::Int
     active::Union{Missing, Bool}
     resistance::Float64
+    max_flow_rate::Union{Missing, Float64}
     control_state::Union{Missing, String}
 end
 

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -315,17 +315,16 @@ function formulate_flow!(
     t::Number,
 )::Nothing
     (; graph) = p
-    (; node_id, active, resistance) = linear_resistance
+    (; node_id, active, resistance, max_flow_rate) = linear_resistance
     for (i, id) in enumerate(node_id)
         basin_a_id = inflow_id(graph, id)
         basin_b_id = outflow_id(graph, id)
 
         if active[i]
-            q =
-                (
-                    get_level(p, basin_a_id, t; storage) -
-                    get_level(p, basin_b_id, t; storage)
-                ) / resistance[i]
+            h_a = get_level(p, basin_a_id, t; storage)
+            h_b = get_level(p, basin_b_id, t; storage)
+            q_unlimited = (h_a - h_b) / resistance[i]
+            q = clamp(q_unlimited, -max_flow_rate[i], max_flow_rate[i])
 
             # add reduction_factor on highest level
             if q > 0

--- a/core/test/equations_test.jl
+++ b/core/test/equations_test.jl
@@ -31,6 +31,7 @@
     # The storage of the basin when it has the same level as the level boundary
     limit_storage = 450.0
     decay_rate = -1 / (basin_area * p.linear_resistance.resistance[1])
+    # TODO adapt for max_flow_rate of 6e-5
     storage_analytic =
         @. limit_storage + (storage[1] - limit_storage) * exp.(decay_rate * t)
 

--- a/docs/core/equations.qmd
+++ b/docs/core/equations.qmd
@@ -271,15 +271,15 @@ of outlets, or even reversal of flows for high precipitation events.
 ### LinearResistance
 
 A `LinearResistance` connects two basins together. The flow between the two basins
-is determined by a linear relationship:
+is determined by a linear relationship, up to an optional maximum flow rate:
 
 $$
-    Q = \frac{h_a - h_b}{R}
+    Q = \mathrm{clamp}(\frac{h_a - h_b}{R}, -Q_{\max}, Q_{\max})
 $$ {#eq-basinflow}
 
-Here $h_a$ is the water level in the first basin, $h_b$ is the water level in
-the second basin, and $R$ is the resistance of the link. A `LinearResistance` makes
-no assumptions about the direction of the flow: water flows from high to low.
+Here $h_a$ is the water level in the first basin, $h_b$ is the water level in the second basin.
+$R$ is the resistance of the link, and $Q_{\max}$ is the maximum flow rate.
+A `LinearResistance` makes no assumptions about the direction of the flow: water flows from high to low.
 
 ### Terminal
 

--- a/docs/core/equations.qmd
+++ b/docs/core/equations.qmd
@@ -277,7 +277,7 @@ $$
     Q = \mathrm{clamp}(\frac{h_a - h_b}{R}, -Q_{\max}, Q_{\max})
 $$ {#eq-basinflow}
 
-Here $h_a$ is the water level in the first basin, $h_b$ is the water level in the second basin.
+Here $h_a$ is the water level in the first basin and $h_b$ is the water level in the second basin.
 $R$ is the resistance of the link, and $Q_{\max}$ is the maximum flow rate.
 A `LinearResistance` makes no assumptions about the direction of the flow: water flows from high to low.
 

--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -580,6 +580,7 @@ node_id       | Int     | -            | sorted
 control_state | String  | -            | (optional) sorted per node_id
 active        | Bool    | -            | (optional, default true)
 resistance    | Float64 | $sm^{-2}$    | -
+max_flow_rate | Float64 | $m^3 s^{-1}$ | non-negative
 
 # ManningResistance {#sec-manning-resistance}
 

--- a/python/ribasim/ribasim/schemas.py
+++ b/python/ribasim/ribasim/schemas.py
@@ -105,6 +105,7 @@ class LinearResistanceStaticSchema(_BaseSchema):
     node_id: Series[int] = pa.Field(nullable=False)
     active: Series[pa.BOOL] = pa.Field(nullable=True)
     resistance: Series[float] = pa.Field(nullable=False)
+    max_flow_rate: Series[float] = pa.Field(nullable=True)
     control_state: Series[str] = pa.Field(nullable=True)
 
 

--- a/python/ribasim_testmodels/ribasim_testmodels/equations.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/equations.py
@@ -48,9 +48,9 @@ def linear_resistance_model():
     # Setup the basins:
     profile = pd.DataFrame(
         data={
-            "node_id": [1, 1, 1],
-            "area": [0.01, 100.0, 100.0],
-            "level": [0.0, 1.0, 2.0],
+            "node_id": [1, 1],
+            "area": [100.0, 100.0],
+            "level": [0.0, 10.0],
         }
     )
 
@@ -68,7 +68,7 @@ def linear_resistance_model():
     state = pd.DataFrame(
         data={
             "node_id": [1],
-            "level": [10.5],
+            "level": [10.0],
         }
     )
 

--- a/python/ribasim_testmodels/ribasim_testmodels/equations.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/equations.py
@@ -76,7 +76,9 @@ def linear_resistance_model():
 
     # setup linear resistance:
     linear_resistance = ribasim.LinearResistance(
-        static=pd.DataFrame(data={"node_id": [2], "resistance": [5e4]})
+        static=pd.DataFrame(
+            data={"node_id": [2], "resistance": [5e4], "max_flow_rate": [6e-5]}
+        )
     )
 
     # Setup level boundary:


### PR DESCRIPTION
This is needed to be able to model structures that exchange flow based on a water level difference, but only up to a certain capacity.

Ref https://github.com/Deltares/Ribasim-NL/issues/62

The updated test model now looks like this:

![image](https://github.com/Deltares/Ribasim/assets/4471859/c2c88db2-51ce-48c3-a248-51e038711720)
