### PR TITLE
Use token argument to all codecov-actions

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -47,5 +47,4 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           files: lcov.info
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -42,5 +42,5 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/qgis.yml
+++ b/.github/workflows/qgis.yml
@@ -32,3 +32,5 @@ jobs:
         run: pixi run test-ribasim-qgis-cov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Follow up to #1108
This also changes to the more compact token argument.