### PR TITLE
Make node ID unique to the node type

### DIFF
--- a/core/src/callback.jl
+++ b/core/src/callback.jl
@@ -418,7 +418,7 @@ function update_basin(integrator)::Nothing
     )
 
     for row in timeblock
-        hasindex, i = id_index(node_id, NodeID(row.node_id))
+        hasindex, i = id_index(node_id, NodeID(NodeType.Basin, row.node_id))
         @assert hasindex "Table 'Basin / time' contains non-Basin IDs"
         set_table_row!(table, row, i)
     end
@@ -461,7 +461,7 @@ function update_tabulated_rating_curve!(integrator)::Nothing
         id = first(group).node_id
         level = [row.level for row in group]
         flow_rate = [row.flow_rate for row in group]
-        i = searchsortedfirst(node_id, NodeID(id))
+        i = searchsortedfirst(node_id, NodeID(NodeType.TabulatedRatingCurve, id))
         tables[i] = LinearInterpolation(flow_rate, level; extrapolate = true)
     end
     return nothing

--- a/core/src/callback.jl
+++ b/core/src/callback.jl
@@ -123,29 +123,27 @@ function get_value(
     (; basin, flow_boundary, level_boundary) = p
 
     if variable == "level"
-        hasindex_basin, basin_idx = id_index(basin.node_id, node_id)
-        level_boundary_idx = findsorted(level_boundary.node_id, node_id)
-
-        if hasindex_basin
+        if node_id.type == NodeType.Basin
+            _, basin_idx = id_index(basin.node_id, node_id)
             _, level = get_area_and_level(basin, basin_idx, u[basin_idx])
-        elseif level_boundary_idx !== nothing
+        elseif node_id.type == NodeType.LevelBoundary
+            level_boundary_idx = findsorted(level_boundary.node_id, node_id)
             level = level_boundary.level[level_boundary_idx](t + Δt)
         else
             error(
                 "Level condition node '$node_id' is neither a basin nor a level boundary.",
             )
         end
-
         value = level
 
     elseif variable == "flow_rate"
-        flow_boundary_idx = findsorted(flow_boundary.node_id, node_id)
-
-        if flow_boundary_idx === nothing
+        if node_id.type == NodeType.FlowBoundary
+            flow_boundary_idx = findsorted(flow_boundary.node_id, node_id)
+            value = flow_boundary.flow_rate[flow_boundary_idx](t + Δt)
+        else
             error("Flow condition node $node_id is not a flow boundary.")
         end
 
-        value = flow_boundary.flow_rate[flow_boundary_idx](t + Δt)
     else
         error("Unsupported condition variable $variable.")
     end

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -1,14 +1,35 @@
+# EdgeType.flow and NodeType.FlowBoundary
+@enumx EdgeType flow control none
+@eval @enumx NodeType $(config.nodetypes...)
+
+# Support creating a NodeType enum instance from a symbol or string
+function NodeType.T(s::Symbol)::NodeType.T
+    symbol_map = EnumX.symbol_map(NodeType.T)
+    for (sym, val) in symbol_map
+        sym == s && return NodeType.T(val)
+    end
+    throw(ArgumentError("Invalid value for NodeType: $s"))
+end
+
+NodeType.T(str::AbstractString) = NodeType.T(Symbol(str))
+
 struct NodeID
+    type::NodeType.T
     value::Int
 end
 
+NodeID(type::Symbol, value::Int) = NodeID(NodeType.T(type), value)
+NodeID(type::AbstractString, value::Int) = NodeID(NodeType.T(type), value)
+
 Base.Int(id::NodeID) = id.value
-Base.convert(::Type{NodeID}, value::Int) = NodeID(value)
 Base.convert(::Type{Int}, id::NodeID) = id.value
 Base.broadcastable(id::NodeID) = Ref(id)
-Base.show(io::IO, id::NodeID) = print(io, '#', Int(id))
+Base.show(io::IO, id::NodeID) = print(io, id.type, " #", Int(id))
 
 function Base.isless(id_1::NodeID, id_2::NodeID)::Bool
+    if id_1.type != id_2.type
+        error("Cannot compare NodeIDs of different types")
+    end
     return Int(id_1) < Int(id_2)
 end
 
@@ -63,8 +84,6 @@ struct Allocation
         collect_demands::BitVector,
     }
 end
-
-@enumx EdgeType flow control none
 
 """
 Type for storing metadata of nodes in the graph

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -337,7 +337,7 @@ struct Pump{T} <: AbstractParameterNode
         control_mapping,
         is_pid_controlled,
     ) where {T}
-        if valid_flow_rates(node_id, get_tmp(flow_rate, 0), control_mapping, :Pump)
+        if valid_flow_rates(node_id, get_tmp(flow_rate, 0), control_mapping)
             return new{T}(
                 node_id,
                 active,
@@ -382,7 +382,7 @@ struct Outlet{T} <: AbstractParameterNode
         control_mapping,
         is_pid_controlled,
     ) where {T}
-        if valid_flow_rates(node_id, get_tmp(flow_rate, 0), control_mapping, :Outlet)
+        if valid_flow_rates(node_id, get_tmp(flow_rate, 0), control_mapping)
             return new{T}(
                 node_id,
                 active,

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -128,7 +128,7 @@ function parse_static_and_time(
                 end
                 # Add the parameter values to the control mapping
                 control_state_key = coalesce(control_state, "")
-                control_mapping[(NodeID(nodetype, node_id), control_state_key)] =
+                control_mapping[(node_id, control_state_key)] =
                     NamedTuple{Tuple(parameter_names)}(Tuple(parameter_values))
             end
         elseif node_id in time_node_ids
@@ -137,7 +137,7 @@ function parse_static_and_time(
             idx = findall(==(node_id), time_node_id_vec)
             time_subset = time[idx]
 
-            time_first_idx = searchsortedfirst(time_subset.node_id, node_id)
+            time_first_idx = searchsortedfirst(time_node_id_vec[idx], node_id)
 
             for parameter_name in parameter_names
                 # If the parameter is interpolatable, create an interpolation object
@@ -640,6 +640,8 @@ function User(db::DB, config::Config)::User
     static_node_ids, time_node_ids, node_ids, _, valid =
         static_and_time_node_ids(db, static, time, "User")
 
+    time_node_id_vec = NodeID.(NodeType.User, time.node_id)
+
     if !valid
         error("Problems encountered when parsing User static and time node IDs.")
     end
@@ -712,7 +714,7 @@ function User(db::DB, config::Config)::User
             end
             push!(demand_itp, demand_itp_node_id)
 
-            first_row_idx = searchsortedfirst(time_node_ids, node_id)
+            first_row_idx = searchsortedfirst(time_node_id_vec, node_id)
             first_row = time[first_row_idx]
             is_active = true
         else

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -859,12 +859,16 @@ function Parameters(db::DB, config::Config)::Parameters
     # Set is_pid_controlled to true for those pumps and outlets that are PID controlled
     for id in pid_control.node_id
         id_controlled = only(outneighbor_labels_type(graph, id, EdgeType.control))
-        pump_idx = findsorted(pump.node_id, id_controlled)
-        if pump_idx === nothing
+        if id_controlled.type == NodeType.Pump
+            pump_idx = findsorted(pump.node_id, id_controlled)
+            pump.is_pid_controlled[pump_idx] = true
+        elseif id_controlled.type == NodeType.Outlet
             outlet_idx = findsorted(outlet.node_id, id_controlled)
             outlet.is_pid_controlled[outlet_idx] = true
         else
-            pump.is_pid_controlled[pump_idx] = true
+            error(
+                "Only Pump and Outlet can be controlled by PidController, got $is_controlled",
+            )
         end
     end
 

--- a/core/src/schema.jl
+++ b/core/src/schema.jl
@@ -1,7 +1,5 @@
 # These schemas define the name of database tables and the configuration file structure
 # The identifier is parsed as ribasim.nodetype.kind, no capitals or underscores are allowed.
-@schema "ribasim.node" Node
-@schema "ribasim.edge" Edge
 @schema "ribasim.discretecontrol.condition" DiscreteControlCondition
 @schema "ribasim.discretecontrol.logic" DiscreteControlLogic
 @schema "ribasim.basin.static" BasinStatic
@@ -56,22 +54,6 @@ function nodetype(
     end
 
     return Symbol(node[begin:length(n)]), k
-end
-
-@version NodeV1 begin
-    fid::Int
-    name::String = isnothing(s) ? "" : String(s)
-    type::String = in(Symbol(type), nodetypes) ? type : error("Unknown node type $type")
-    allocation_network_id::Union{Missing, Int}
-end
-
-@version EdgeV1 begin
-    fid::Int
-    name::String = isnothing(s) ? "" : String(s)
-    from_node_id::Int
-    to_node_id::Int
-    edge_type::String
-    allocation_network_id::Union{Missing, Int}
 end
 
 @version PumpStaticV1 begin
@@ -199,6 +181,7 @@ end
 
 @version DiscreteControlConditionV1 begin
     node_id::Int
+    listen_feature_type::String
     listen_feature_id::Int
     variable::String
     greater_than::Float64
@@ -214,6 +197,7 @@ end
 @version PidControlStaticV1 begin
     node_id::Int
     active::Union{Missing, Bool}
+    listen_node_type::String
     listen_node_id::Int
     target::Float64
     proportional::Float64
@@ -224,6 +208,7 @@ end
 
 @version PidControlTimeV1 begin
     node_id::Int
+    listen_node_type::String
     listen_node_id::Int
     time::DateTime
     target::Float64

--- a/core/src/schema.jl
+++ b/core/src/schema.jl
@@ -181,7 +181,7 @@ end
 
 @version DiscreteControlConditionV1 begin
     node_id::Int
-    listen_feature_type::String
+    listen_feature_type::Union{Missing, String}
     listen_feature_id::Int
     variable::String
     greater_than::Float64
@@ -197,7 +197,7 @@ end
 @version PidControlStaticV1 begin
     node_id::Int
     active::Union{Missing, Bool}
-    listen_node_type::String
+    listen_node_type::Union{Missing, String}
     listen_node_id::Int
     target::Float64
     proportional::Float64
@@ -208,7 +208,7 @@ end
 
 @version PidControlTimeV1 begin
     node_id::Int
-    listen_node_type::String
+    listen_node_type::Union{Missing, String}
     listen_node_id::Int
     time::DateTime
     target::Float64

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -383,17 +383,15 @@ function get_level(
     storage::Union{AbstractArray, Number} = 0,
 )::Union{Real, Nothing}
     (; basin, level_boundary) = p
-    hasindex, i = id_index(basin.node_id, node_id)
-    current_level = get_tmp(basin.current_level, storage)
-    return if hasindex
+    return if node_id.type == NodeType.Basin
+        _, i = id_index(basin.node_id, node_id)
+        current_level = get_tmp(basin.current_level, storage)
         current_level[i]
-    else
+    elseif node_id.type == NodeType.LevelBoundary
         i = findsorted(level_boundary.node_id, node_id)
-        if i === nothing
-            nothing
-        else
-            level_boundary.level[i](t)
-        end
+        level_boundary.level[i](t)
+    else
+        nothing
     end
 end
 
@@ -479,7 +477,7 @@ function expand_logic_mapping(
             if haskey(logic_mapping_expanded, new_key)
                 control_state_existing = logic_mapping_expanded[new_key]
                 control_states = sort([control_state, control_state_existing])
-                msg = "Multiple control states found for DiscreteControl node $node_id for truth state `$truth_state_new`: $control_states."
+                msg = "Multiple control states found for $node_id for truth state `$truth_state_new`: $control_states."
                 @assert control_state_existing == control_state msg
             else
                 logic_mapping_expanded[new_key] = control_state

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -181,15 +181,8 @@ end
 For an element `id` and a vector of elements `ids`, get the range of indices of the last
 consecutive block of `id`.
 Returns the empty range `1:0` if `id` is not in `ids`.
-
-```jldoctest
-#                         1 2 3 4 5 6 7 8 9
-Ribasim.findlastgroup(2, [5,4,2,2,5,2,2,2,1])
-# output
-6:8
-```
 """
-function findlastgroup(id::Int, ids::AbstractVector{Int})::UnitRange{Int}
+function findlastgroup(id::NodeID, ids::AbstractVector{NodeID})::UnitRange{Int}
     idx_block_end = findlast(==(id), ids)
     if idx_block_end === nothing
         return 1:0

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -209,11 +209,12 @@ function get_scalar_interpolation(
     starttime::DateTime,
     t_end::Float64,
     time::AbstractVector,
-    node_id::Int,
+    node_id::NodeID,
     param::Symbol;
     default_value::Float64 = 0.0,
 )::Tuple{LinearInterpolation, Bool}
-    rows = searchsorted(time.node_id, node_id)
+    nodetype = node_id.type
+    rows = searchsorted(NodeID.(nodetype, time.node_id), node_id)
     parameter = getfield.(time, param)[rows]
     parameter = coalesce(parameter, default_value)
     times = seconds_since.(time.time[rows], starttime)
@@ -271,10 +272,11 @@ From a table with columns node_id, flow_rate (Q) and level (h),
 create a LinearInterpolation from level to flow rate for a given node_id.
 """
 function qh_interpolation(
-    node_id::Int,
+    node_id::NodeID,
     table::StructVector,
 )::Tuple{LinearInterpolation, Bool}
-    rowrange = findlastgroup(node_id, table.node_id)
+    nodetype = node_id.type
+    rowrange = findlastgroup(node_id, NodeID.(nodetype, table.node_id))
     @assert !isempty(rowrange) "timeseries starts after model start time"
     return qh_interpolation(table.level[rowrange], table.flow_rate[rowrange])
 end

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -378,7 +378,7 @@ function get_level(
     storage::Union{AbstractArray, Number} = 0,
 )::Union{Real, Nothing}
     (; basin, level_boundary) = p
-    return if node_id.type == NodeType.Basin
+   if node_id.type == NodeType.Basin
         _, i = id_index(basin.node_id, node_id)
         current_level = get_tmp(basin.current_level, storage)
         current_level[i]

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -35,7 +35,7 @@ function get_storage_from_level(basin::Basin, state_idx::Int, level::Float64)::F
 
     if level < bottom
         node_id = basin.node_id.values[state_idx]
-        @error "The level $level of basin $node_id is lower than the bottom of this basin $bottom."
+        @error "The level $level of $node_id is lower than the bottom of this basin; $bottom."
         return NaN
     end
 

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -172,21 +172,20 @@ function valid_profiles(
     for (id, levels, areas) in zip(node_id, level, area)
         if !allunique(levels)
             errors = true
-            @error "Basin $id has repeated levels, this cannot be interpolated."
+            @error "$id has repeated levels, this cannot be interpolated."
         end
 
         if areas[1] <= 0
             errors = true
             @error(
-                "Basin profiles cannot start with area <= 0 at the bottom for numerical reasons.",
-                node_id = id,
+                "$id profile cannot start with area <= 0 at the bottom for numerical reasons.",
                 area = areas[1],
             )
         end
 
         if areas[end] < areas[end - 1]
             errors = true
-            @error "Basin profiles cannot have decreasing area at the top since extrapolating could lead to negative areas, found decreasing top areas for node $id."
+            @error "$id profile cannot have decreasing area at the top since extrapolating could lead to negative areas."
         end
     end
     return !errors

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -98,8 +98,6 @@ sort_by_subgrid_level(row) = (row.subgrid_id, row.basin_level)
 
 # get the right sort by function given the Schema, with sort_by_id as the default
 sort_by_function(table::StructVector{<:Legolas.AbstractRecord}) = sort_by_id
-sort_by_function(table::StructVector{NodeV1}) = sort_by_fid
-sort_by_function(table::StructVector{EdgeV1}) = sort_by_fid
 sort_by_function(table::StructVector{TabulatedRatingCurveStaticV1}) = sort_by_id_state_level
 sort_by_function(table::StructVector{BasinProfileV1}) = sort_by_id_level
 sort_by_function(table::StructVector{UserStaticV1}) = sort_by_priority

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -243,7 +243,7 @@ function valid_pid_connectivity(
     for (id, listen_id) in zip(pid_control_node_id, pid_control_listen_node_id)
         has_index, _ = id_index(basin_node_id, listen_id)
         if !has_index
-            @error "Listen node $listen_id of PidControl node $id is not a Basin"
+            @error "Listen node $listen_id of $id is not a Basin"
             errors = true
         end
 
@@ -252,7 +252,7 @@ function valid_pid_connectivity(
         if controlled_id in pump_node_id
             pump_intake_id = inflow_id(graph, controlled_id)
             if pump_intake_id != listen_id
-                @error "Listen node $listen_id of PidControl node $id is not upstream of controlled pump $controlled_id"
+                @error "Listen node $listen_id of $id is not upstream of controlled $controlled_id"
                 errors = true
             end
         else
@@ -293,7 +293,7 @@ function valid_fractional_flow(
         if src_outneighbor_ids ⊈ node_id_set
             errors = true
             @error(
-                "Node $src_id combines fractional flow outneighbors with other outneigbor types."
+                "$src_id combines fractional flow outneighbors with other outneigbor types."
             )
         end
 
@@ -441,22 +441,22 @@ function valid_n_neighbors(node::AbstractParameterNode, graph::MetaGraph)::Bool
             n_outneighbors = count(x -> true, outneighbor_labels_type(graph, id, edge_type))
 
             if n_inneighbors < bounds.in_min
-                @error "Nodes of type $node_type must have at least $(bounds.in_min) $edge_type inneighbor(s) (got $n_inneighbors for node $id)."
+                @error "$id must have at least $(bounds.in_min) $edge_type inneighbor(s) (got $n_inneighbors)."
                 errors = true
             end
 
             if n_inneighbors > bounds.in_max
-                @error "Nodes of type $node_type can have at most $(bounds.in_max) $edge_type inneighbor(s) (got $n_inneighbors for node $id)."
+                @error "$id can have at most $(bounds.in_max) $edge_type inneighbor(s) (got $n_inneighbors)."
                 errors = true
             end
 
             if n_outneighbors < bounds.out_min
-                @error "Nodes of type $node_type must have at least $(bounds.out_min) $edge_type outneighbor(s) (got $n_outneighbors for node $id)."
+                @error "$id must have at least $(bounds.out_min) $edge_type outneighbor(s) (got $n_outneighbors)."
                 errors = true
             end
 
             if n_outneighbors > bounds.out_max
-                @error "Nodes of type $node_type can have at most $(bounds.out_max) $edge_type outneighbor(s) (got $n_outneighbors for node $id)."
+                @error "$id can have at most $(bounds.out_max) $edge_type outneighbor(s) (got $n_outneighbors)."
                 errors = true
             end
         end
@@ -518,7 +518,7 @@ function valid_discrete_control(p::Parameters, config::Config)::Bool
 
         if !isempty(truth_states_wrong_length)
             errors = true
-            @error "DiscreteControl node $id has $n_conditions condition(s), which is inconsistent with these truth state(s): $truth_states_wrong_length."
+            @error "$id has $n_conditions condition(s), which is inconsistent with these truth state(s): $truth_states_wrong_length."
         end
 
         # Check whether these control states are defined for the
@@ -545,7 +545,7 @@ function valid_discrete_control(p::Parameters, config::Config)::Bool
             if !isempty(undefined_control_states)
                 undefined_list = collect(undefined_control_states)
                 node_type = typeof(node).name.name
-                @error "These control states from DiscreteControl node $id are not defined for controlled $node_type $id_outneighbor: $undefined_list."
+                @error "These control states from $id are not defined for controlled $id_outneighbor: $undefined_list."
                 errors = true
             end
         end

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -199,7 +199,6 @@ function valid_flow_rates(
     node_id::Vector{NodeID},
     flow_rate::Vector,
     control_mapping::Dict{Tuple{NodeID, String}, NamedTuple},
-    node_type::Symbol,
 )::Bool
     errors = false
 
@@ -215,7 +214,7 @@ function valid_flow_rates(
         if flow_rate_ < 0.0
             errors = true
             control_state = key[2]
-            @error "$node_type flow rates must be non-negative, found $flow_rate_ for control state '$control_state' of $id_controlled."
+            @error "$id_controlled flow rates must be non-negative, found $flow_rate_ for control state '$control_state'."
         end
     end
 
@@ -225,7 +224,7 @@ function valid_flow_rates(
         end
         if flow_rate_ < 0.0
             errors = true
-            @error "$node_type flow rates must be non-negative, found $flow_rate_ for static $id."
+            @error "$id flow rates must be non-negative, found $flow_rate_."
         end
     end
 
@@ -351,17 +350,17 @@ function valid_subgrid(
 
     if !(node_id in keys(node_to_basin))
         errors = true
-        @error "The node_id of the Basin / subgrid_level does not refer to a basin." node_id subgrid_id
+        @error "The node_id of the Basin / subgrid does not exist." node_id subgrid_id
     end
 
     if !allunique(basin_level)
         errors = true
-        @error "Basin / subgrid_level subgrid_id $(subgrid_id) has repeated basin levels, this cannot be interpolated."
+        @error "Basin / subgrid subgrid_id $(subgrid_id) has repeated basin levels, this cannot be interpolated."
     end
 
     if !allunique(subgrid_level)
         errors = true
-        @error "Basin / subgrid_level subgrid_id $(subgrid_id) has repeated element levels, this cannot be interpolated."
+        @error "Basin / subgrid subgrid_id $(subgrid_id) has repeated element levels, this cannot be interpolated."
     end
 
     return !errors
@@ -379,7 +378,7 @@ function valid_demand(
     for (col, id) in zip(demand_itp, node_id)
         for (demand_p_itp, p_itp) in zip(col, priorities)
             if any(demand_p_itp.u .< 0.0)
-                @error "Demand of user node $id with priority $p_itp should be non-negative"
+                @error "Demand of $id with priority $p_itp should be non-negative"
                 errors = true
             end
         end

--- a/core/test/allocation_test.jl
+++ b/core/test/allocation_test.jl
@@ -209,7 +209,11 @@ end
 
     # main-sub connections are part of main network allocation graph
     allocation_edges_main_network = graph[].edge_ids[1]
-    @test Tuple{NodeID, NodeID}[(2, 11), (6, 24), (10, 38)] ⊆ allocation_edges_main_network
+    @test [
+        (NodeID(:Basin, 2), NodeID(:Pump, 11)),
+        (NodeID(:Basin, 6), NodeID(:Pump, 24)),
+        (NodeID(:Basin, 10), NodeID(:Pump, 38)),
+    ] ⊆ allocation_edges_main_network
 
     # Subnetworks interpreted as users require variables and constraints to
     # support absolute value expressions in the objective function
@@ -222,11 +226,11 @@ end
     # In each subnetwork, the connection from the main network to the subnetwork is
     # interpreted as a source
     @test Ribasim.get_allocation_model(p, 3).problem[:source].axes[1] ==
-          Tuple{NodeID, NodeID}[(2, 11)]
+          [(NodeID(:Basin, 2), NodeID(:Pump, 11))]
     @test Ribasim.get_allocation_model(p, 5).problem[:source].axes[1] ==
-          Tuple{NodeID, NodeID}[(6, 24)]
+          [(NodeID(:Basin, 6), NodeID(:Pump, 24))]
     @test Ribasim.get_allocation_model(p, 7).problem[:source].axes[1] ==
-          Tuple{NodeID, NodeID}[(10, 38)]
+          [(NodeID(:Basin, 10), NodeID(:Pump, 38))]
 end
 
 @testitem "allocation with main network optimization problem" begin
@@ -275,7 +279,7 @@ end
     @test F_abs[NodeID(:Pump, 38)] ∈ objective_variables
 
     # Running full allocation algorithm
-    Ribasim.set_flow!(graph, NodeID(1), NodeID(:Basin, 2), 4.5)
+    Ribasim.set_flow!(graph, NodeID(:FlowBoundary, 1), NodeID(:Basin, 2), 4.5)
     Ribasim.update_allocation!((; p, t))
 
     @test subnetwork_allocateds[NodeID(:Basin, 2), NodeID(:Pump, 11)] ≈

--- a/core/test/allocation_test.jl
+++ b/core/test/allocation_test.jl
@@ -23,17 +23,17 @@
         end
     end
 
-    Ribasim.set_flow!(graph, NodeID(1), NodeID(2), 4.5) # Source flow
+    Ribasim.set_flow!(graph, NodeID(:FlowBoundary, 1), NodeID(:Basin, 2), 4.5) # Source flow
     allocation_model = p.allocation.allocation_models[1]
     Ribasim.allocate!(p, allocation_model, 0.0)
 
     F = allocation_model.problem[:F]
-    @test JuMP.value(F[(NodeID(2), NodeID(6))]) ≈ 0.0
-    @test JuMP.value(F[(NodeID(2), NodeID(10))]) ≈ 0.5
-    @test JuMP.value(F[(NodeID(8), NodeID(12))]) ≈ 0.0
-    @test JuMP.value(F[(NodeID(6), NodeID(8))]) ≈ 0.0
-    @test JuMP.value(F[(NodeID(1), NodeID(2))]) ≈ 0.5
-    @test JuMP.value(F[(NodeID(6), NodeID(11))]) ≈ 0.0
+    @test JuMP.value(F[(NodeID(:Basin, 2), NodeID(:Basin, 6))]) ≈ 0.0
+    @test JuMP.value(F[(NodeID(:Basin, 2), NodeID(:User, 10))]) ≈ 0.5
+    @test JuMP.value(F[(NodeID(:Basin, 8), NodeID(:User, 12))]) ≈ 0.0
+    @test JuMP.value(F[(NodeID(:Basin, 6), NodeID(:Basin, 8))]) ≈ 0.0
+    @test JuMP.value(F[(NodeID(:FlowBoundary, 1), NodeID(:Basin, 2))]) ≈ 0.5
+    @test JuMP.value(F[(NodeID(:Basin, 6), NodeID(:User, 11))]) ≈ 0.0
 
     allocated = p.user.allocated
     @test allocated[1] ≈ [0.0, 0.5]
@@ -42,9 +42,9 @@
 
     # Test getting and setting user demands
     (; user) = p
-    Ribasim.set_user_demand!(user, NodeID(11), 2, Float64(π))
+    Ribasim.set_user_demand!(user, NodeID(:User, 11), 2, Float64(π))
     @test user.demand[4] ≈ π
-    @test Ribasim.get_user_demand(user, NodeID(11), 2) ≈ π
+    @test Ribasim.get_user_demand(user, NodeID(:User, 11), 2) ≈ π
 end
 
 @testitem "Allocation objective types" begin
@@ -65,12 +65,12 @@ end
     @test objective isa JuMP.QuadExpr # Quadratic expression
     F = problem[:F]
     @test JuMP.UnorderedPair{JuMP.VariableRef}(
-        F[(NodeID(4), NodeID(5))],
-        F[(NodeID(4), NodeID(5))],
+        F[(NodeID(:Basin, 4), NodeID(:User, 5))],
+        F[(NodeID(:Basin, 4), NodeID(:User, 5))],
     ) in keys(objective.terms) # F[4,5]^2 term
     @test JuMP.UnorderedPair{JuMP.VariableRef}(
-        F[(NodeID(4), NodeID(6))],
-        F[(NodeID(4), NodeID(6))],
+        F[(NodeID(:Basin, 4), NodeID(:User, 6))],
+        F[(NodeID(:Basin, 4), NodeID(:User, 6))],
     ) in keys(objective.terms) # F[4,6]^2 term
 
     config = Ribasim.Config(toml_path; allocation_objective_type = "quadratic_relative")
@@ -82,12 +82,12 @@ end
     @test objective.aff.constant == 2.0
     F = problem[:F]
     @test JuMP.UnorderedPair{JuMP.VariableRef}(
-        F[(NodeID(4), NodeID(5))],
-        F[(NodeID(4), NodeID(5))],
+        F[(NodeID(:Basin, 4), NodeID(:User, 5))],
+        F[(NodeID(:Basin, 4), NodeID(:User, 5))],
     ) in keys(objective.terms) # F[4,5]^2 term
     @test JuMP.UnorderedPair{JuMP.VariableRef}(
-        F[(NodeID(4), NodeID(6))],
-        F[(NodeID(4), NodeID(6))],
+        F[(NodeID(:Basin, 4), NodeID(:User, 6))],
+        F[(NodeID(:Basin, 4), NodeID(:User, 6))],
     ) in keys(objective.terms) # F[4,6]^2 term
 
     config = Ribasim.Config(toml_path; allocation_objective_type = "linear_absolute")
@@ -100,12 +100,12 @@ end
     F = problem[:F]
     F_abs = problem[:F_abs]
 
-    @test objective.terms[F_abs[NodeID(5)]] == 1.0
-    @test objective.terms[F_abs[NodeID(6)]] == 1.0
-    @test objective.terms[F[(NodeID(4), NodeID(6))]] ≈ 0.125
-    @test objective.terms[F[(NodeID(1), NodeID(2))]] ≈ 0.125
-    @test objective.terms[F[(NodeID(4), NodeID(5))]] ≈ 0.125
-    @test objective.terms[F[(NodeID(2), NodeID(4))]] ≈ 0.125
+    @test objective.terms[F_abs[NodeID(:User, 5)]] == 1.0
+    @test objective.terms[F_abs[NodeID(:User, 6)]] == 1.0
+    @test objective.terms[F[(NodeID(:Basin, 4), NodeID(:User, 6))]] ≈ 0.125
+    @test objective.terms[F[(NodeID(:FlowBoundary, 1), NodeID(:Basin, 2))]] ≈ 0.125
+    @test objective.terms[F[(NodeID(:Basin, 4), NodeID(:User, 5))]] ≈ 0.125
+    @test objective.terms[F[(NodeID(:Basin, 2), NodeID(:Basin, 4))]] ≈ 0.125
 
     config = Ribasim.Config(toml_path; allocation_objective_type = "linear_relative")
     model = Ribasim.run(config)
@@ -117,12 +117,13 @@ end
     F = problem[:F]
     F_abs = problem[:F_abs]
 
-    @test objective.terms[F_abs[NodeID(5)]] == 1.0
-    @test objective.terms[F_abs[NodeID(6)]] == 1.0
-    @test objective.terms[F[(NodeID(4), NodeID(6))]] ≈ 62.585499316005475
-    @test objective.terms[F[(NodeID(1), NodeID(2))]] ≈ 62.585499316005475
-    @test objective.terms[F[(NodeID(4), NodeID(5))]] ≈ 62.585499316005475
-    @test objective.terms[F[(NodeID(2), NodeID(4))]] ≈ 62.585499316005475
+    @test objective.terms[F_abs[NodeID(:User, 5)]] == 1.0
+    @test objective.terms[F_abs[NodeID(:User, 6)]] == 1.0
+    @test objective.terms[F[(NodeID(:Basin, 4), NodeID(:User, 6))]] ≈ 62.585499316005475
+    @test objective.terms[F[(NodeID(:FlowBoundary, 1), NodeID(:Basin, 2))]] ≈
+          62.585499316005475
+    @test objective.terms[F[(NodeID(:Basin, 4), NodeID(:User, 5))]] ≈ 62.585499316005475
+    @test objective.terms[F[(NodeID(:Basin, 2), NodeID(:Basin, 4))]] ≈ 62.585499316005475
 end
 
 @testitem "Allocation with controlled fractional flow" begin
@@ -139,12 +140,12 @@ end
     problem = model.integrator.p.allocation.allocation_models[1].problem
     F = problem[:F]
     @test JuMP.normalized_coefficient(
-        problem[:fractional_flow][(NodeID(3), NodeID(5))],
-        F[(NodeID(2), NodeID(3))],
+        problem[:fractional_flow][(NodeID(:TabulatedRatingCurve, 3), NodeID(:Basin, 5))],
+        F[(NodeID(:Basin, 2), NodeID(:TabulatedRatingCurve, 3))],
     ) ≈ -0.75
     @test JuMP.normalized_coefficient(
-        problem[:fractional_flow][(NodeID(3), NodeID(8))],
-        F[(NodeID(2), NodeID(3))],
+        problem[:fractional_flow][(NodeID(:TabulatedRatingCurve, 3), NodeID(:Basin, 8))],
+        F[(NodeID(:Basin, 2), NodeID(:TabulatedRatingCurve, 3))],
     ) ≈ -0.25
 
     solve!(model)
@@ -161,8 +162,8 @@ end
     allocated_9_after = groups[(9, 1)][groups[(9, 1)].time .> t_control, :].allocated
     @test all(
         allocated_9_before ./ allocated_6_before .<=
-        control_mapping[(NodeID(7), "A")].fraction /
-        control_mapping[(NodeID(4), "A")].fraction,
+        control_mapping[(NodeID(:FractionalFlow, 7), "A")].fraction /
+        control_mapping[(NodeID(:FractionalFlow, 4), "A")].fraction,
     )
     @test all(allocated_9_after ./ allocated_6_after .<= 1.0)
 
@@ -172,12 +173,12 @@ end
     fractional_flow_constraints =
         model.integrator.p.allocation.allocation_models[1].problem[:fractional_flow]
     @test JuMP.normalized_coefficient(
-        problem[:fractional_flow][(NodeID(3), NodeID(5))],
-        F[(NodeID(2), NodeID(3))],
+        problem[:fractional_flow][(NodeID(:TabulatedRatingCurve, 3), NodeID(:Basin, 5))],
+        F[(NodeID(:Basin, 2), NodeID(:TabulatedRatingCurve, 3))],
     ) ≈ -0.75
     @test JuMP.normalized_coefficient(
-        problem[:fractional_flow][(NodeID(3), NodeID(8))],
-        F[(NodeID(2), NodeID(3))],
+        problem[:fractional_flow][(NodeID(:TabulatedRatingCurve, 3), NodeID(:Basin, 8))],
+        F[(NodeID(:Basin, 2), NodeID(:TabulatedRatingCurve, 3))],
     ) ≈ -0.25
 end
 
@@ -202,9 +203,9 @@ end
 
     # Connections from main network to subnetworks
     @test isempty(main_network_connections[1])
-    @test only(main_network_connections[2]) == (NodeID(2), NodeID(11))
-    @test only(main_network_connections[3]) == (NodeID(6), NodeID(24))
-    @test only(main_network_connections[4]) == (NodeID(10), NodeID(38))
+    @test only(main_network_connections[2]) == (NodeID(:Basin, 2), NodeID(:Pump, 11))
+    @test only(main_network_connections[3]) == (NodeID(:Basin, 6), NodeID(:Pump, 24))
+    @test only(main_network_connections[4]) == (NodeID(:Basin, 10), NodeID(:Pump, 38))
 
     # main-sub connections are part of main network allocation graph
     allocation_edges_main_network = graph[].edge_ids[1]
@@ -214,9 +215,9 @@ end
     # support absolute value expressions in the objective function
     allocation_model_main_network = Ribasim.get_allocation_model(p, 1)
     problem = allocation_model_main_network.problem
-    @test problem[:F_abs].axes[1] == NodeID[11, 24, 38]
-    @test problem[:abs_positive].axes[1] == NodeID[11, 24, 38]
-    @test problem[:abs_negative].axes[1] == NodeID[11, 24, 38]
+    @test problem[:F_abs].axes[1] == NodeID.(:Pump, [11, 24, 38])
+    @test problem[:abs_positive].axes[1] == NodeID.(:Pump, [11, 24, 38])
+    @test problem[:abs_negative].axes[1] == NodeID.(:Pump, [11, 24, 38])
 
     # In each subnetwork, the connection from the main network to the subnetwork is
     # interpreted as a source
@@ -253,9 +254,11 @@ end
         Ribasim.allocate!(p, allocation_model, t; collect_demands = true)
     end
 
-    @test subnetwork_demands[(NodeID(2), NodeID(11))] ≈ [4.0, 4.0, 0.0]
-    @test subnetwork_demands[(NodeID(6), NodeID(24))] ≈ [0.001333333333, 0.0, 0.0]
-    @test subnetwork_demands[(NodeID(10), NodeID(38))] ≈ [0.001, 0.002, 0.002]
+    @test subnetwork_demands[(NodeID(:Basin, 2), NodeID(:Pump, 11))] ≈ [4.0, 4.0, 0.0]
+    @test subnetwork_demands[(NodeID(:Basin, 6), NodeID(:Pump, 24))] ≈
+          [0.001333333333, 0.0, 0.0]
+    @test subnetwork_demands[(NodeID(:Basin, 10), NodeID(:Pump, 38))] ≈
+          [0.001, 0.002, 0.002]
 
     # Solving for the main network,
     # containing subnetworks as users
@@ -267,17 +270,19 @@ end
     objective = JuMP.objective_function(problem)
     objective_variables = keys(objective.terms)
     F_abs = problem[:F_abs]
-    @test F_abs[NodeID(11)] ∈ objective_variables
-    @test F_abs[NodeID(24)] ∈ objective_variables
-    @test F_abs[NodeID(38)] ∈ objective_variables
+    @test F_abs[NodeID(:Pump, 11)] ∈ objective_variables
+    @test F_abs[NodeID(:Pump, 24)] ∈ objective_variables
+    @test F_abs[NodeID(:Pump, 38)] ∈ objective_variables
 
     # Running full allocation algorithm
-    Ribasim.set_flow!(graph, NodeID(1), NodeID(2), 4.5)
+    Ribasim.set_flow!(graph, NodeID(1), NodeID(:Basin, 2), 4.5)
     Ribasim.update_allocation!((; p, t))
 
-    @test subnetwork_allocateds[NodeID(2), NodeID(11)] ≈ [4.0, 0.49766666, 0.0]
-    @test subnetwork_allocateds[NodeID(6), NodeID(24)] ≈ [0.00133333333, 0.0, 0.0]
-    @test subnetwork_allocateds[NodeID(10), NodeID(38)] ≈ [0.001, 0.0, 0.0]
+    @test subnetwork_allocateds[NodeID(:Basin, 2), NodeID(:Pump, 11)] ≈
+          [4.0, 0.49766666, 0.0]
+    @test subnetwork_allocateds[NodeID(:Basin, 6), NodeID(:Pump, 24)] ≈
+          [0.00133333333, 0.0, 0.0]
+    @test subnetwork_allocateds[NodeID(:Basin, 10), NodeID(:Pump, 38)] ≈ [0.001, 0.0, 0.0]
 
     @test user.allocated[2] ≈ [4.0, 0.0, 0.0]
     @test user.allocated[7] ≈ [0.001, 0.0, 0.0]

--- a/core/test/control_test.jl
+++ b/core/test/control_test.jl
@@ -1,5 +1,6 @@
 @testitem "Pump discrete control" begin
     using PreallocationTools: get_tmp
+    using Ribasim: NodeID
 
     toml_path =
         normpath(@__DIR__, "../../generated_testmodels/pump_discrete_control/ribasim.toml")
@@ -10,16 +11,16 @@
 
     # Control input
     pump_control_mapping = p.pump.control_mapping
-    @test pump_control_mapping[(Ribasim.NodeID(4), "off")].flow_rate == 0
-    @test pump_control_mapping[(Ribasim.NodeID(4), "on")].flow_rate == 1.0e-5
+    @test pump_control_mapping[(NodeID(:Pump, 4), "off")].flow_rate == 0
+    @test pump_control_mapping[(NodeID(:Pump, 4), "on")].flow_rate == 1.0e-5
 
-    logic_mapping::Dict{Tuple{Ribasim.NodeID, String}, String} = Dict(
-        (Ribasim.NodeID(5), "TT") => "on",
-        (Ribasim.NodeID(6), "F") => "active",
-        (Ribasim.NodeID(5), "TF") => "off",
-        (Ribasim.NodeID(5), "FF") => "on",
-        (Ribasim.NodeID(5), "FT") => "off",
-        (Ribasim.NodeID(6), "T") => "inactive",
+    logic_mapping::Dict{Tuple{NodeID, String}, String} = Dict(
+        (NodeID(:DiscreteControl, 5), "TT") => "on",
+        (NodeID(:DiscreteControl, 6), "F") => "active",
+        (NodeID(:DiscreteControl, 5), "TF") => "off",
+        (NodeID(:DiscreteControl, 5), "FF") => "on",
+        (NodeID(:DiscreteControl, 5), "FT") => "off",
+        (NodeID(:DiscreteControl, 6), "T") => "inactive",
     )
 
     @test discrete_control.logic_mapping == logic_mapping
@@ -182,6 +183,8 @@ end
 end
 
 @testitem "Set PID target with DiscreteControl" begin
+    using Ribasim: NodeID
+
     toml_path = normpath(
         @__DIR__,
         "../../generated_testmodels/discrete_control_of_pid_control/ribasim.toml",
@@ -195,8 +198,9 @@ end
     level = Ribasim.get_storages_and_levels(model).level[1, :]
 
     target_high =
-        pid_control.control_mapping[(Ribasim.NodeID(6), "target_high")].target.u[1]
-    target_low = pid_control.control_mapping[(Ribasim.NodeID(6), "target_low")].target.u[1]
+        pid_control.control_mapping[(NodeID(:PidControl, 6), "target_high")].target.u[1]
+    target_low =
+        pid_control.control_mapping[(NodeID(:PidControl, 6), "target_low")].target.u[1]
 
     t_target_jump = discrete_control.record.time[2]
     t_idx_target_jump = searchsortedlast(timesteps, t_target_jump)

--- a/core/test/create_test.jl
+++ b/core/test/create_test.jl
@@ -2,27 +2,27 @@
     using MetaGraphsNext
     using Graphs
     using Logging
-    using Ribasim
+    using Ribasim: NodeID
     using Accessors: @set
 
     graph = MetaGraph(
         DiGraph();
-        label_type = Ribasim.NodeID,
+        label_type = NodeID,
         vertex_data_type = Ribasim.NodeMetadata,
         edge_data_type = Symbol,
         graph_data = Tuple,
     )
 
-    graph[Ribasim.NodeID(1)] = Ribasim.NodeMetadata(Symbol(:delft), 1)
-    graph[Ribasim.NodeID(2)] = Ribasim.NodeMetadata(Symbol(:denhaag), -1)
+    graph[NodeID(:Basin, 1)] = Ribasim.NodeMetadata(Symbol(:delft), 1)
+    graph[NodeID(:Basin, 2)] = Ribasim.NodeMetadata(Symbol(:denhaag), -1)
 
     graph[1, 2] = :yes
 
-    node_ids = Dict{Int, Set{Ribasim.NodeID}}()
-    node_ids[0] = Set{Ribasim.NodeID}()
-    node_ids[-1] = Set{Ribasim.NodeID}()
-    push!(node_ids[0], Ribasim.NodeID(1))
-    push!(node_ids[-1], Ribasim.NodeID(2))
+    node_ids = Dict{Int, Set{NodeID}}()
+    node_ids[0] = Set{NodeID}()
+    node_ids[-1] = Set{NodeID}()
+    push!(node_ids[0], NodeID(:Basin, 1))
+    push!(node_ids[-1], NodeID(:Basin, 2))
 
     graph_data = (; node_ids,)
     graph = @set graph.graph_data = graph_data
@@ -45,35 +45,35 @@ end
     using MetaGraphsNext
     using Graphs
     using Logging
-    using Ribasim
+    using Ribasim: NodeID
 
     graph = MetaGraph(
         DiGraph();
-        label_type = Ribasim.NodeID,
+        label_type = NodeID,
         vertex_data_type = Ribasim.NodeMetadata,
         edge_data_type = Symbol,
         graph_data = Tuple,
     )
 
-    node_ids = Dict{Int, Set{Ribasim.NodeID}}()
-    node_ids[1] = Set{Ribasim.NodeID}()
-    push!(node_ids[1], Ribasim.NodeID(1))
-    push!(node_ids[1], Ribasim.NodeID(2))
-    push!(node_ids[1], Ribasim.NodeID(3))
-    node_ids[2] = Set{Ribasim.NodeID}()
-    push!(node_ids[2], Ribasim.NodeID(4))
-    push!(node_ids[2], Ribasim.NodeID(5))
-    push!(node_ids[2], Ribasim.NodeID(6))
+    node_ids = Dict{Int, Set{NodeID}}()
+    node_ids[1] = Set{NodeID}()
+    push!(node_ids[1], NodeID(:Basin, 1))
+    push!(node_ids[1], NodeID(:Basin, 2))
+    push!(node_ids[1], NodeID(:Basin, 3))
+    node_ids[2] = Set{NodeID}()
+    push!(node_ids[2], NodeID(:Basin, 4))
+    push!(node_ids[2], NodeID(:Basin, 5))
+    push!(node_ids[2], NodeID(:Basin, 6))
 
-    graph[Ribasim.NodeID(1)] = Ribasim.NodeMetadata(Symbol(:delft), 1)
-    graph[Ribasim.NodeID(2)] = Ribasim.NodeMetadata(Symbol(:denhaag), 1)
-    graph[Ribasim.NodeID(3)] = Ribasim.NodeMetadata(Symbol(:rdam), 1)
-    graph[Ribasim.NodeID(4)] = Ribasim.NodeMetadata(Symbol(:adam), 2)
-    graph[Ribasim.NodeID(5)] = Ribasim.NodeMetadata(Symbol(:utrecht), 2)
-    graph[Ribasim.NodeID(6)] = Ribasim.NodeMetadata(Symbol(:leiden), 2)
+    graph[NodeID(:Basin, 1)] = Ribasim.NodeMetadata(Symbol(:delft), 1)
+    graph[NodeID(:Basin, 2)] = Ribasim.NodeMetadata(Symbol(:denhaag), 1)
+    graph[NodeID(:Basin, 3)] = Ribasim.NodeMetadata(Symbol(:rdam), 1)
+    graph[NodeID(:Basin, 4)] = Ribasim.NodeMetadata(Symbol(:adam), 2)
+    graph[NodeID(:Basin, 5)] = Ribasim.NodeMetadata(Symbol(:utrecht), 2)
+    graph[NodeID(:Basin, 6)] = Ribasim.NodeMetadata(Symbol(:leiden), 2)
 
-    graph[Ribasim.NodeID(1), Ribasim.NodeID(2)] = :yes
-    graph[Ribasim.NodeID(1), Ribasim.NodeID(3)] = :yes
+    graph[NodeID(:Basin, 1), NodeID(:Basin, 2)] = :yes
+    graph[NodeID(:Basin, 1), NodeID(:Basin, 3)] = :yes
     graph[4, 5] = :yes
 
     logger = TestLogger()

--- a/core/test/io_test.jl
+++ b/core/test/io_test.jl
@@ -50,9 +50,15 @@ end
 end
 
 @testitem "findlastgroup" begin
-    @test Ribasim.findlastgroup(2, [5, 4, 2, 2, 5, 2, 2, 2, 1]) === 6:8
-    @test Ribasim.findlastgroup(2, [2]) === 1:1
-    @test Ribasim.findlastgroup(3, [5, 4, 2, 2, 5, 2, 2, 2, 1]) === 1:0
+    @test Ribasim.findlastgroup(
+        NodeID(:Pump, 2),
+        NodeID.(:Pump, [5, 4, 2, 2, 5, 2, 2, 2, 1]),
+    ) === 6:8
+    @test Ribasim.findlastgroup(NodeID(:Pump, 2), NodeID.(:Pump, [2])) === 1:1
+    @test Ribasim.findlastgroup(
+        NodeID(:Pump, 3),
+        NodeID.(:Pump, [5, 4, 2, 2, 5, 2, 2, 2, 1]),
+    ) === 1:0
 end
 
 @testitem "table sort" begin

--- a/core/test/io_test.jl
+++ b/core/test/io_test.jl
@@ -50,15 +50,13 @@ end
 end
 
 @testitem "findlastgroup" begin
-    @test Ribasim.findlastgroup(
-        NodeID(:Pump, 2),
-        NodeID.(:Pump, [5, 4, 2, 2, 5, 2, 2, 2, 1]),
-    ) === 6:8
-    @test Ribasim.findlastgroup(NodeID(:Pump, 2), NodeID.(:Pump, [2])) === 1:1
-    @test Ribasim.findlastgroup(
-        NodeID(:Pump, 3),
-        NodeID.(:Pump, [5, 4, 2, 2, 5, 2, 2, 2, 1]),
-    ) === 1:0
+    using Ribasim: NodeID, findlastgroup
+
+    @test findlastgroup(NodeID(:Pump, 2), NodeID.(:Pump, [5, 4, 2, 2, 5, 2, 2, 2, 1])) ===
+          6:8
+    @test findlastgroup(NodeID(:Pump, 2), NodeID.(:Pump, [2])) === 1:1
+    @test findlastgroup(NodeID(:Pump, 3), NodeID.(:Pump, [5, 4, 2, 2, 5, 2, 2, 2, 1])) ===
+          1:0
 end
 
 @testitem "table sort" begin

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -458,8 +458,12 @@ end
     @test all(isapprox.(h_expected, h_actual; atol = 0.02))
     # Test for conservation of mass, flow at the beginning == flow at the end
     n_self_loops = length(p.graph[].flow_dict)
-    @test Ribasim.get_flow(p.graph, NodeID(1), NodeID(2), 0) ≈ 5.0 atol = 0.001 skip =
-        Sys.isapple()
-    @test Ribasim.get_flow(p.graph, NodeID(101), NodeID(102), 0) ≈ 5.0 atol = 0.001 skip =
-        Sys.isapple()
+    @test Ribasim.get_flow(p.graph, NodeID(:FlowBoundary, 1), NodeID(:Basin, 2), 0) ≈ 5.0 atol =
+        0.001 skip = Sys.isapple()
+    @test Ribasim.get_flow(
+        p.graph,
+        NodeID(:ManningResistance, 101),
+        NodeID(:LevelBoundary, 102),
+        0,
+    ) ≈ 5.0 atol = 0.001 skip = Sys.isapple()
 end

--- a/core/test/utils_test.jl
+++ b/core/test/utils_test.jl
@@ -184,7 +184,7 @@ end
     new_key = (NodeID(:DiscreteControl, 1), "TTF")
     logic_mapping[new_key] = "bar"
 
-    @test_throws "AssertionError: Multiple control states found for DiscreteControl node #1 for truth state `TTF`: [\"bar\", \"foo\"]." Ribasim.expand_logic_mapping(
+    @test_throws "AssertionError: Multiple control states found for DiscreteControl #1 for truth state `TTF`: [\"bar\", \"foo\"]." Ribasim.expand_logic_mapping(
         logic_mapping,
     )
 end

--- a/core/test/utils_test.jl
+++ b/core/test/utils_test.jl
@@ -71,7 +71,7 @@ end
         NodeID(:Basin, 7),
         NodeID(:Pump, 6),
     ) === (4.0, 4.0)
-    @test_throws "No bottom defined on either side of #6" Ribasim.basin_bottoms(
+    @test_throws "No bottom defined on either side of Pump #6" Ribasim.basin_bottoms(
         basin,
         NodeID(:Basin, 0),
         NodeID(:Basin, 1),
@@ -132,7 +132,7 @@ end
     @test length(logger.logs) == 1
     @test logger.logs[1].level == Error
     @test logger.logs[1].message ==
-          "The level -1.0 of basin #1 is lower than the bottom of this basin 0.0."
+          "The level -1.0 of Basin #1 is lower than the bottom of this basin; 0.0."
 
     # Converting from storages to levels and back should return the same storages
     storages = range(0.0, 2 * storage[end], 50)

--- a/core/test/utils_test.jl
+++ b/core/test/utils_test.jl
@@ -1,22 +1,21 @@
 @testitem "NodeID" begin
     using Ribasim: NodeID
-    id = NodeID(2)
-    @test sprint(show, id) === "#2"
-    @test id < NodeID(3)
+
+    id = NodeID(:Basin, 2)
+    @test sprint(show, id) === "Basin #2"
+    @test id < NodeID(:Basin, 3)
+    @test_throws ErrorException id < NodeID(:Pump, 3)
     @test Int(id) === 2
     @test convert(Int, id) === 2
-    @test convert(NodeID, 2) === NodeID(2)
-    a = [1, 0, 3]
-    a[id] = id
-    @test a[2] === 2
 end
 
 @testitem "id_index" begin
     using Dictionaries: Indices
+    using Ribasim: NodeID
 
-    ids = Indices(Ribasim.NodeID[2, 4, 6])
-    @test Ribasim.id_index(ids, Ribasim.NodeID(4)) === (true, 2)
-    @test Ribasim.id_index(ids, Ribasim.NodeID(5)) === (false, 0)
+    ids = Indices(NodeID.(:Basin, [2, 4, 6]))
+    @test Ribasim.id_index(ids, NodeID(:Basin, 4)) === (true, 2)
+    @test Ribasim.id_index(ids, NodeID(:Basin, 5)) === (false, 0)
 end
 
 @testitem "profile_storage" begin
@@ -29,6 +28,7 @@ end
 @testitem "bottom" begin
     using Dictionaries: Indices
     using StructArrays: StructVector
+    using Ribasim: NodeID
 
     # create two basins with different bottoms/levels
     area = [[0.01, 1.0], [0.01, 1.0]]
@@ -36,7 +36,7 @@ end
     darea = zeros(2)
     storage = Ribasim.profile_storage.(level, area)
     basin = Ribasim.Basin(
-        Indices(Ribasim.NodeID[5, 7]),
+        Indices(NodeID.(:Basin, [5, 7])),
         [2.0, 3.0],
         [2.0, 3.0],
         [2.0, 3.0],
@@ -50,32 +50,32 @@ end
     )
 
     @test basin.level[2][1] === 4.0
-    @test Ribasim.basin_bottom(basin, Ribasim.NodeID(5)) === 0.0
-    @test Ribasim.basin_bottom(basin, Ribasim.NodeID(7)) === 4.0
-    @test Ribasim.basin_bottom(basin, Ribasim.NodeID(6)) === nothing
+    @test Ribasim.basin_bottom(basin, NodeID(:Basin, 5)) === 0.0
+    @test Ribasim.basin_bottom(basin, NodeID(:Basin, 7)) === 4.0
+    @test Ribasim.basin_bottom(basin, NodeID(:Basin, 6)) === nothing
     @test Ribasim.basin_bottoms(
         basin,
-        Ribasim.NodeID(5),
-        Ribasim.NodeID(7),
-        Ribasim.NodeID(6),
+        NodeID(:Basin, 5),
+        NodeID(:Basin, 7),
+        NodeID(:Pump, 6),
     ) === (0.0, 4.0)
     @test Ribasim.basin_bottoms(
         basin,
-        Ribasim.NodeID(5),
-        Ribasim.NodeID(0),
-        Ribasim.NodeID(6),
+        NodeID(:Basin, 5),
+        NodeID(:Basin, 0),
+        NodeID(:Pump, 6),
     ) === (0.0, 0.0)
     @test Ribasim.basin_bottoms(
         basin,
-        Ribasim.NodeID(0),
-        Ribasim.NodeID(7),
-        Ribasim.NodeID(6),
+        NodeID(:Basin, 0),
+        NodeID(:Basin, 7),
+        NodeID(:Pump, 6),
     ) === (4.0, 4.0)
     @test_throws "No bottom defined on either side of #6" Ribasim.basin_bottoms(
         basin,
-        Ribasim.NodeID(0),
-        Ribasim.NodeID(1),
-        Ribasim.NodeID(6),
+        NodeID(:Basin, 0),
+        NodeID(:Basin, 1),
+        NodeID(:Pump, 6),
     )
 end
 
@@ -83,6 +83,7 @@ end
     using Dictionaries: Indices
     using StructArrays: StructVector
     using Logging
+    using Ribasim: NodeID
 
     level = [
         0.0,
@@ -110,7 +111,7 @@ end
     ]
     storage = Ribasim.profile_storage(level, area)
     basin = Ribasim.Basin(
-        Indices(Ribasim.NodeID[1]),
+        Indices(NodeID.(:Basin, [1])),
         zeros(1),
         zeros(1),
         zeros(1),
@@ -142,19 +143,21 @@ end
 end
 
 @testitem "Expand logic_mapping" begin
-    logic_mapping = Dict{Tuple{Ribasim.NodeID, String}, String}()
-    logic_mapping[(Ribasim.NodeID(1), "*T*")] = "foo"
-    logic_mapping[(Ribasim.NodeID(2), "FF")] = "bar"
+    using Ribasim: NodeID
+
+    logic_mapping = Dict{Tuple{NodeID, String}, String}()
+    logic_mapping[(NodeID(:DiscreteControl, 1), "*T*")] = "foo"
+    logic_mapping[(NodeID(:DiscreteControl, 2), "FF")] = "bar"
     logic_mapping_expanded = Ribasim.expand_logic_mapping(logic_mapping)
 
-    @test logic_mapping_expanded[(Ribasim.NodeID(1), "TTT")] == "foo"
-    @test logic_mapping_expanded[(Ribasim.NodeID(1), "FTT")] == "foo"
-    @test logic_mapping_expanded[(Ribasim.NodeID(1), "TTF")] == "foo"
-    @test logic_mapping_expanded[(Ribasim.NodeID(1), "FTF")] == "foo"
-    @test logic_mapping_expanded[(Ribasim.NodeID(2), "FF")] == "bar"
+    @test logic_mapping_expanded[(NodeID(:DiscreteControl, 1), "TTT")] == "foo"
+    @test logic_mapping_expanded[(NodeID(:DiscreteControl, 1), "FTT")] == "foo"
+    @test logic_mapping_expanded[(NodeID(:DiscreteControl, 1), "TTF")] == "foo"
+    @test logic_mapping_expanded[(NodeID(:DiscreteControl, 1), "FTF")] == "foo"
+    @test logic_mapping_expanded[(NodeID(:DiscreteControl, 2), "FF")] == "bar"
     @test length(logic_mapping_expanded) == 5
 
-    new_key = (Ribasim.NodeID(3), "duck")
+    new_key = (NodeID(:DiscreteControl, 3), "duck")
     logic_mapping[new_key] = "quack"
 
     @test_throws "Truth state 'duck' contains illegal characters or is empty." Ribasim.expand_logic_mapping(
@@ -163,7 +166,7 @@ end
 
     delete!(logic_mapping, new_key)
 
-    new_key = (Ribasim.NodeID(3), "")
+    new_key = (NodeID(:DiscreteControl, 3), "")
     logic_mapping[new_key] = "bar"
 
     @test_throws "Truth state '' contains illegal characters or is empty." Ribasim.expand_logic_mapping(
@@ -172,13 +175,13 @@ end
 
     delete!(logic_mapping, new_key)
 
-    new_key = (Ribasim.NodeID(1), "FTT")
+    new_key = (NodeID(:DiscreteControl, 1), "FTT")
     logic_mapping[new_key] = "foo"
 
     # This should not throw an error, as although "FTT" for node_id = 1 is already covered above, this is consistent
     Ribasim.expand_logic_mapping(logic_mapping)
 
-    new_key = (Ribasim.NodeID(1), "TTF")
+    new_key = (NodeID(:DiscreteControl, 1), "TTF")
     logic_mapping[new_key] = "bar"
 
     @test_throws "AssertionError: Multiple control states found for DiscreteControl node #1 for truth state `TTF`: [\"bar\", \"foo\"]." Ribasim.expand_logic_mapping(
@@ -249,11 +252,46 @@ end
 
 @testitem "low_storage_factor" begin
     using Ribasim: NodeID, low_storage_factor, Indices
-    @test low_storage_factor([-2.0], Indices(NodeID[5]), NodeID(5), 2.0) === 0.0
-    @test low_storage_factor([0.0f0], Indices(NodeID[5]), NodeID(5), 2.0) === 0.0f0
-    @test low_storage_factor([0.0], Indices(NodeID[5]), NodeID(5), 2.0) === 0.0
-    @test low_storage_factor([1.0f0], Indices(NodeID[5]), NodeID(5), 2.0) === 0.5f0
-    @test low_storage_factor([1.0], Indices(NodeID[5]), NodeID(5), 2.0) === 0.5
-    @test low_storage_factor([3.0f0], Indices(NodeID[5]), NodeID(5), 2.0) === 1.0f0
-    @test low_storage_factor([3.0], Indices(NodeID[5]), NodeID(5), 2.0) === 1.0
+    @test low_storage_factor(
+        [-2.0],
+        Indices(NodeID.(:Basin, [5])),
+        NodeID(:Basin, 5),
+        2.0,
+    ) === 0.0
+    @test low_storage_factor(
+        [0.0f0],
+        Indices(NodeID.(:Basin, [5])),
+        NodeID(:Basin, 5),
+        2.0,
+    ) === 0.0f0
+    @test low_storage_factor(
+        [0.0],
+        Indices(NodeID.(:Basin, [5])),
+        NodeID(:Basin, 5),
+        2.0,
+    ) === 0.0
+    @test low_storage_factor(
+        [1.0f0],
+        Indices(NodeID.(:Basin, [5])),
+        NodeID(:Basin, 5),
+        2.0,
+    ) === 0.5f0
+    @test low_storage_factor(
+        [1.0],
+        Indices(NodeID.(:Basin, [5])),
+        NodeID(:Basin, 5),
+        2.0,
+    ) === 0.5
+    @test low_storage_factor(
+        [3.0f0],
+        Indices(NodeID.(:Basin, [5])),
+        NodeID(:Basin, 5),
+        2.0,
+    ) === 1.0f0
+    @test low_storage_factor(
+        [3.0],
+        Indices(NodeID.(:Basin, [5])),
+        NodeID(:Basin, 5),
+        2.0,
+    ) === 1.0
 end

--- a/core/test/validation_test.jl
+++ b/core/test/validation_test.jl
@@ -329,8 +329,7 @@ end
 
     @test length(logger.logs) == 1
     @test logger.logs[1].level == Error
-    @test logger.logs[1].message ==
-          "Outlet flow rates must be non-negative, found -1.0 for static #1."
+    @test logger.logs[1].message == "Outlet #1 flow rates must be non-negative, found -1.0."
 
     logger = TestLogger()
 
@@ -352,7 +351,7 @@ end
     @test length(logger.logs) == 1
     @test logger.logs[1].level == Error
     @test logger.logs[1].message ==
-          "Pump flow rates must be non-negative, found -1.0 for control state 'foo' of #1."
+          "Pump #1 flow rates must be non-negative, found -1.0 for control state 'foo'."
 end
 
 @testitem "Edge type validation" begin
@@ -393,8 +392,7 @@ end
 
     @test length(logger.logs) == 1
     @test logger.logs[1].level == Error
-    @test logger.logs[1].message ==
-          "The node_id of the Basin / subgrid_level does not refer to a basin."
+    @test logger.logs[1].message == "The node_id of the Basin / subgrid does not exist."
     @test logger.logs[1].kwargs[:node_id] == NodeID(:Basin, 10)
     @test logger.logs[1].kwargs[:subgrid_id] == 1
 
@@ -412,10 +410,10 @@ end
     @test length(logger.logs) == 2
     @test logger.logs[1].level == Error
     @test logger.logs[1].message ==
-          "Basin / subgrid_level subgrid_id 1 has repeated basin levels, this cannot be interpolated."
+          "Basin / subgrid subgrid_id 1 has repeated basin levels, this cannot be interpolated."
     @test logger.logs[2].level == Error
     @test logger.logs[2].message ==
-          "Basin / subgrid_level subgrid_id 1 has repeated element levels, this cannot be interpolated."
+          "Basin / subgrid subgrid_id 1 has repeated element levels, this cannot be interpolated."
 end
 
 @testitem "negative demand" begin
@@ -443,5 +441,5 @@ end
     @test length(logger.logs) == 1
     @test logger.logs[1].level == Error
     @test logger.logs[1].message ==
-          "Demand of user node #1 with priority 1 should be non-negative"
+          "Demand of User #1 with priority 1 should be non-negative"
 end

--- a/core/test/validation_test.jl
+++ b/core/test/validation_test.jl
@@ -19,12 +19,11 @@
           "Basin #1 has repeated levels, this cannot be interpolated."
     @test logger.logs[2].level == Error
     @test logger.logs[2].message ==
-          "Basin profiles cannot start with area <= 0 at the bottom for numerical reasons."
-    @test logger.logs[2].kwargs[:node_id] == NodeID(:Basin, 1)
+          "Basin #1 profile cannot start with area <= 0 at the bottom for numerical reasons."
     @test logger.logs[2].kwargs[:area] == 0
     @test logger.logs[3].level == Error
     @test logger.logs[3].message ==
-          "Basin profiles cannot have decreasing area at the top since extrapolating could lead to negative areas, found decreasing top areas for node #1."
+          "Basin #1 profile cannot have decreasing area at the top since extrapolating could lead to negative areas."
 
     itp, valid = qh_interpolation([0.0, 0.0], [1.0, 2.0])
     @test !valid

--- a/core/test/validation_test.jl
+++ b/core/test/validation_test.jl
@@ -54,10 +54,10 @@ end
     @test length(logger.logs) == 2
     @test logger.logs[1].level == Error
     @test logger.logs[1].message ==
-          "A Q(h) relationship for TabulatedRatingCurve \"\" #1 from the static table has repeated levels, this can not be interpolated."
+          "A Q(h) relationship for TabulatedRatingCurve #1 from the static table has repeated levels, this can not be interpolated."
     @test logger.logs[2].level == Error
     @test logger.logs[2].message ==
-          "A Q(h) relationship for TabulatedRatingCurve \"\" #2 from the time table has repeated levels, this can not be interpolated."
+          "A Q(h) relationship for TabulatedRatingCurve #2 from the time table has repeated levels, this can not be interpolated."
 end
 
 @testitem "Neighbor count validation" begin
@@ -134,10 +134,10 @@ end
     @test length(logger.logs) == 2
     @test logger.logs[1].level == Error
     @test logger.logs[1].message ==
-          "Nodes of type Ribasim.FractionalFlow can have at most 1 flow outneighbor(s) (got 2 for node #5)."
+          "FractionalFlow #5 can have at most 1 flow outneighbor(s) (got 2)."
     @test logger.logs[2].level == Error
     @test logger.logs[2].message ==
-          "Nodes of type Ribasim.FractionalFlow can have at most 0 control outneighbor(s) (got 1 for node #5)."
+          "FractionalFlow #5 can have at most 0 control outneighbor(s) (got 1)."
 
     @test_throws "'n_neighbor_bounds_flow' not defined for Val{:foo}()." Ribasim.n_neighbor_bounds_flow(
         :foo,

--- a/core/test/validation_test.jl
+++ b/core/test/validation_test.jl
@@ -75,16 +75,12 @@ end
         graph_data = nothing,
     )
 
-    for i in 1:6
-        if i in [1, 6]
-            type = :pump
-            node_id = NodeID(:Pump, i)
-        else
-            type = :other
-            node_id = NodeID(:Basin, i)
-        end
-        graph[node_id] = NodeMetadata(type, 9)
-    end
+    graph[NodeID(:Pump, 1)] = NodeMetadata(:pump, 9)
+    graph[NodeID(:Basin, 2)] = NodeMetadata(:pump, 9)
+    graph[NodeID(:Basin, 3)] = NodeMetadata(:pump, 9)
+    graph[NodeID(:Basin, 4)] = NodeMetadata(:pump, 9)
+    graph[NodeID(:FractionalFlow, 5)] = NodeMetadata(:pump, 9)
+    graph[NodeID(:Pump, 6)] = NodeMetadata(:pump, 9)
 
     function set_edge_metadata!(id_1, id_2, edge_type)
         graph[id_1, id_2] = EdgeMetadata(0, edge_type, 0, id_1, id_2, false, NodeID[])
@@ -94,7 +90,7 @@ end
     set_edge_metadata!(NodeID(:Basin, 2), NodeID(:Pump, 1), EdgeType.flow)
     set_edge_metadata!(NodeID(:Basin, 3), NodeID(:Pump, 1), EdgeType.flow)
     set_edge_metadata!(NodeID(:Pump, 6), NodeID(:Basin, 2), EdgeType.flow)
-    set_edge_metadata!(NodeID(:Basin, 5), NodeID(:Pump, 6), EdgeType.control)
+    set_edge_metadata!(NodeID(:FractionalFlow, 5), NodeID(:Pump, 6), EdgeType.control)
 
     pump = Ribasim.Pump(
         NodeID.(:Pump, [1, 6]),

--- a/docs/contribute/addnode.qmd
+++ b/docs/contribute/addnode.qmd
@@ -57,7 +57,7 @@ function NewNodeType(db::DB, config::Config)::NewNodeType
 
     # Unpack the fields of static as inputs for the NewNodeType constructor
     return NewNodeType(
-        NodeID.(parsed_parameters.node_id),
+        NodeID.(NodeType.NewNodeType, parsed_parameters.node_id),
         parsed_parameters.some_property,
         parsed_parameters.control_mapping)
 end

--- a/docs/core/allocation.qmd
+++ b/docs/core/allocation.qmd
@@ -233,6 +233,7 @@ The following is an example of an optimization problem for the example shown [he
 ```{julia}
 # | code-fold: true
 using Ribasim
+using Ribasim: NodeID
 using SQLite
 
 toml_path = normpath(@__DIR__, "../../generated_testmodels/allocation_example/ribasim.toml")
@@ -242,7 +243,7 @@ allocation_model = p.allocation.allocation_models[1]
 t = 0.0
 priority_idx = 1
 
-Ribasim.set_flow!(p.graph, Ribasim.NodeID(1), Ribasim.NodeID(2), 1.0)
+Ribasim.set_flow!(p.graph, NodeID(:FlowBoundary, 1), NodeID(:Basin, 2), 1.0)
 
 Ribasim.adjust_source_capacities!(allocation_model, p, priority_idx)
 Ribasim.adjust_edge_capacities!(allocation_model, p, priority_idx)

--- a/python/ribasim/ribasim/geometry/edge.py
+++ b/python/ribasim/ribasim/geometry/edge.py
@@ -17,7 +17,9 @@ __all__ = ("Edge",)
 
 class EdgeSchema(pa.SchemaModel):
     name: Series[str] = pa.Field(default="")
+    from_node_type: Series[str] = pa.Field(nullable=True)
     from_node_id: Series[int] = pa.Field(default=0, coerce=True)
+    to_node_type: Series[str] = pa.Field(nullable=True)
     to_node_id: Series[int] = pa.Field(default=0, coerce=True)
     edge_type: Series[str] = pa.Field(default="flow", coerce=True)
     allocation_network_id: Series[pd.Int64Dtype] = pa.Field(

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -332,7 +332,7 @@ class Model(FileModel):
         )
 
     @classmethod
-    def read(cls, filepath: FilePath) -> "Model":
+    def read(cls, filepath: FilePath) -> Self:
         """Read model from TOML file."""
         return cls(filepath=filepath)  # type: ignore
 

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -309,6 +309,28 @@ class Model(FileModel):
         self.validate_model_node_field_ids()
         self.validate_model_node_ids()
 
+    def _add_node_type(self, df: pd.DataFrame | None, id_col: str, type_col: str):
+        node = self.network.node.df
+        assert node is not None
+        if df is not None:
+            df[type_col] = node.loc[df[id_col], "type"].to_numpy()
+
+    def _add_node_types(self):
+        """Add the from/to node types to tables that reference external node IDs.
+
+        Only valid with globally unique node IDs, which is assured by using the node index.
+        """
+        self._add_node_type(self.network.edge.df, "from_node_id", "from_node_type")
+        self._add_node_type(self.network.edge.df, "to_node_id", "to_node_type")
+        id_col, type_col = "listen_node_id", "listen_node_type"
+        self._add_node_type(self.pid_control.static.df, id_col, type_col)
+        self._add_node_type(self.pid_control.time.df, id_col, type_col)
+        self._add_node_type(
+            self.discrete_control.condition.df,
+            "listen_feature_id",
+            "listen_feature_type",
+        )
+
     @classmethod
     def read(cls, filepath: FilePath) -> "Model":
         """Read model from TOML file."""
@@ -325,6 +347,7 @@ class Model(FileModel):
         filepath: FilePath ending in .toml
         """
         self.validate_model()
+        self._add_node_types()
         filepath = Path(filepath)
         if not filepath.suffix == ".toml":
             raise ValueError(f"Filepath '{filepath}' is not a .toml file.")

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -332,7 +332,7 @@ class Model(FileModel):
         )
 
     @classmethod
-    def read(cls, filepath: FilePath) -> Self:
+    def read(cls, filepath: FilePath) -> "Model":
         """Read model from TOML file."""
         return cls(filepath=filepath)  # type: ignore
 

--- a/python/ribasim/ribasim/schemas.py
+++ b/python/ribasim/ribasim/schemas.py
@@ -50,6 +50,7 @@ class BasinTimeSchema(_BaseSchema):
 
 class DiscreteControlConditionSchema(_BaseSchema):
     node_id: Series[int] = pa.Field(nullable=False)
+    listen_feature_type: Series[str] = pa.Field(nullable=True)
     listen_feature_id: Series[int] = pa.Field(nullable=False)
     variable: Series[str] = pa.Field(nullable=False)
     greater_than: Series[float] = pa.Field(nullable=False)
@@ -60,15 +61,6 @@ class DiscreteControlLogicSchema(_BaseSchema):
     node_id: Series[int] = pa.Field(nullable=False)
     truth_state: Series[str] = pa.Field(nullable=False)
     control_state: Series[str] = pa.Field(nullable=False)
-
-
-class EdgeSchema(_BaseSchema):
-    fid: Series[int] = pa.Field(nullable=False)
-    name: Series[str] = pa.Field(nullable=False)
-    from_node_id: Series[int] = pa.Field(nullable=False)
-    to_node_id: Series[int] = pa.Field(nullable=False)
-    edge_type: Series[str] = pa.Field(nullable=False)
-    allocation_network_id: Series[int] = pa.Field(nullable=True)
 
 
 class FlowBoundaryStaticSchema(_BaseSchema):
@@ -119,13 +111,6 @@ class ManningResistanceStaticSchema(_BaseSchema):
     control_state: Series[str] = pa.Field(nullable=True)
 
 
-class NodeSchema(_BaseSchema):
-    fid: Series[int] = pa.Field(nullable=False)
-    name: Series[str] = pa.Field(nullable=False)
-    type: Series[str] = pa.Field(nullable=False)
-    allocation_network_id: Series[int] = pa.Field(nullable=True)
-
-
 class OutletStaticSchema(_BaseSchema):
     node_id: Series[int] = pa.Field(nullable=False)
     active: Series[pa.BOOL] = pa.Field(nullable=True)
@@ -139,6 +124,7 @@ class OutletStaticSchema(_BaseSchema):
 class PidControlStaticSchema(_BaseSchema):
     node_id: Series[int] = pa.Field(nullable=False)
     active: Series[pa.BOOL] = pa.Field(nullable=True)
+    listen_node_type: Series[str] = pa.Field(nullable=True)
     listen_node_id: Series[int] = pa.Field(nullable=False)
     target: Series[float] = pa.Field(nullable=False)
     proportional: Series[float] = pa.Field(nullable=False)
@@ -149,6 +135,7 @@ class PidControlStaticSchema(_BaseSchema):
 
 class PidControlTimeSchema(_BaseSchema):
     node_id: Series[int] = pa.Field(nullable=False)
+    listen_node_type: Series[str] = pa.Field(nullable=True)
     listen_node_id: Series[int] = pa.Field(nullable=False)
     time: Series[Timestamp] = pa.Field(nullable=False)
     target: Series[float] = pa.Field(nullable=False)

--- a/python/ribasim_testmodels/ribasim_testmodels/invalid.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/invalid.py
@@ -137,7 +137,7 @@ def invalid_fractional_flow_model():
     )
 
     # Setup the edges:
-    # Invalid: Node #7 combines fractional flow outneighbors with other outneigbor types.
+    # Invalid: TabulatedRatingCurve #7 combines FractionalFlow outneighbors with other outneigbor types.
     from_id = np.array([1, 7, 7, 3, 7, 4, 2], dtype=np.int64)
     to_id = np.array([7, 2, 3, 5, 4, 6, 8], dtype=np.int64)
     lines = node.geometry_from_connectivity(from_id, to_id)


### PR DESCRIPTION
Needed for #1110.

Before node IDs were globally unique. If you had the ID, you could look up the type in the Node table. When designing #1110 we came to the conclusion that this was not the right choice. It requires you to be aware of the IDs that are used throughout the model, whereas with this you only need to make sure that `Pump #5` doesn't already exist.

Most of the updates in this PR were to correct the tests. Some of the code and error messages became easier to read. If we talk about a node then we always know what the type is, there is no need to look it up first.

Most tables stay the same, e.g. if you have a `Terminal / static` table with a `node_id` Int column, you know that this refers to a Terminal NodeID. Only when connecting to other nodes do we need to specify the type next to the ID. So the `Edge` table now gets `from_node_type` next to `from_node_id`, the `PidControl / static` gets `listen_node_type` next to `listen_node_id`, etc. These extra columns are currently automatically filled in by Ribasim-Python on model save, hence they don't require changing the test models.

In terms of implementation, this basically adds the `type` field to `NodeID` and fixes the resulting errors.

```julia
struct NodeID
    type::NodeType.T
    value::Int
end
```

It does not yet test if models with the same node IDs (`Pump #1` and `Basin #1`) work, but this is hard to do right now with Ribasim Python, so best left for a later moment.