### PR TITLE
Go back to the old FeatureFormSuppress to support older QGIS

### DIFF
--- a/ribasim_qgis/widgets/ribasim_widget.py
+++ b/ribasim_qgis/widgets/ribasim_widget.py
@@ -12,9 +12,9 @@ from typing import Any, cast
 
 from PyQt5.QtWidgets import QTabWidget, QVBoxLayout, QWidget
 from qgis.core import (
-    Qgis,
     QgsAbstractVectorLayerLabeling,
     QgsCoordinateReferenceSystem,
+    QgsEditFormConfig,
     QgsFeatureRenderer,
     QgsLayerTreeGroup,
     QgsMapLayer,
@@ -173,9 +173,9 @@ class RibasimWidget(QWidget):
         if suppress is not None:
             config = maplayer.editFormConfig()
             config.setSuppress(
-                Qgis.AttributeFormSuppression.On
+                QgsEditFormConfig.FeatureFormSuppress.SuppressOn
                 if suppress
-                else Qgis.AttributeFormSuppression.Default
+                else QgsEditFormConfig.FeatureFormSuppress.SuppressDefault
             )
             maplayer.setEditFormConfig(config)
         if renderer is not None:

--- a/ribasim_qgis/widgets/ribasim_widget.py
+++ b/ribasim_qgis/widgets/ribasim_widget.py
@@ -172,6 +172,7 @@ class RibasimWidget(QWidget):
         assert maplayer is not None
         if suppress is not None:
             config = maplayer.editFormConfig()
+            # From QGIS 3.32 on we can use https://github.com/Deltares/Ribasim/commit/8a22fc0630f343069fd3c285ae46e9fde0c71a32
             config.setSuppress(
                 QgsEditFormConfig.FeatureFormSuppress.SuppressOn
                 if suppress

--- a/ribasim_qgis/widgets/ribasim_widget.py
+++ b/ribasim_qgis/widgets/ribasim_widget.py
@@ -174,9 +174,9 @@ class RibasimWidget(QWidget):
             config = maplayer.editFormConfig()
             # From QGIS 3.32 on we can use https://github.com/Deltares/Ribasim/commit/8a22fc0630f343069fd3c285ae46e9fde0c71a32
             config.setSuppress(
-                QgsEditFormConfig.FeatureFormSuppress.SuppressOn
+                QgsEditFormConfig.FeatureFormSuppress.SuppressOn  # type: ignore
                 if suppress
-                else QgsEditFormConfig.FeatureFormSuppress.SuppressDefault
+                else QgsEditFormConfig.FeatureFormSuppress.SuppressDefault  # type: ignore
             )
             maplayer.setEditFormConfig(config)
         if renderer is not None:


### PR DESCRIPTION
Fixes #1090
LTS is 3.28, the new enum is only from QGIS 3.32.
