### PR TITLE
Add `ribasim_version` metadata to Arrow results

### DIFF
--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -251,8 +251,9 @@ function write_arrow(
     # ensure DateTime is encoded in a compatible manner
     # https://github.com/apache/arrow-julia/issues/303
     table = merge(table, (; time = convert.(Arrow.DATETIME, table.time)))
+    metadata = ["ribasim_version" => string(pkgversion(Ribasim))]
     mkpath(dirname(path))
-    Arrow.write(path, table; compress)
+    Arrow.write(path, table; compress, metadata)
     return nothing
 end
 

--- a/core/test/io_test.jl
+++ b/core/test/io_test.jl
@@ -110,3 +110,18 @@ end
     # reversed_arrow_table throws an AssertionError
     @test_throws "not sorted as required" Ribasim.sorted_table!(reversed_arrow_table)
 end
+
+@testitem "results" begin
+    using SciMLBase: successful_retcode
+
+    toml_path = normpath(@__DIR__, "../../generated_testmodels/bucket/ribasim.toml")
+    @test ispath(toml_path)
+    config = Ribasim.Config(toml_path)
+    model = Ribasim.run(config)
+    @test successful_retcode(model)
+
+    path = Ribasim.results_path(config, Ribasim.RESULTS_FILENAME.basin)
+    bytes = read(path)
+    tbl = Arrow.Table(bytes)
+    @test Arrow.getmetadata(tbl) === Base.ImmutableDict("ribasim_version" => "2024.2.0")
+end

--- a/core/test/io_test.jl
+++ b/core/test/io_test.jl
@@ -123,5 +123,7 @@ end
     path = Ribasim.results_path(config, Ribasim.RESULTS_FILENAME.basin)
     bytes = read(path)
     tbl = Arrow.Table(bytes)
-    @test Arrow.getmetadata(tbl) === Base.ImmutableDict("ribasim_version" => "2024.2.0")
+    ribasim_version = string(pkgversion(Ribasim))
+    @test Arrow.getmetadata(tbl) ===
+          Base.ImmutableDict("ribasim_version" => ribasim_version)
 end

--- a/core/test/io_test.jl
+++ b/core/test/io_test.jl
@@ -113,6 +113,7 @@ end
 
 @testitem "results" begin
     using SciMLBase: successful_retcode
+    import Arrow
 
     toml_path = normpath(@__DIR__, "../../generated_testmodels/bucket/ribasim.toml")
     @test ispath(toml_path)

--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -114,6 +114,7 @@ of different values are repeated many times. To reduce file sizes it may be a go
 apply [dictionary
 encoding](https://arrow.apache.org/docs/format/Columnar.html#dictionary-encoded-layout) to
 those columns.
+The Ribasim version that was used to create the results is written to each file in the `ribasim_version` schema metadata.
 
 ## Table requirements
 


### PR DESCRIPTION
The Arrow IPC format supports adding metadata both at the table and column level. The table metadata is a `Dict{String, String}`. This adds `ribasim_version` = `2024.2.0` to each output Arrow table. That way we can always check what Ribasim version was used to simulate a particular model, helping reproducability.

We don't test any results with Ribasim Python, but if you want to read the `ribasim_version` with Python, you can use:

```python
from pyarrow import feather
table = feather.read_table("results/flow.arrow")
table.schema.metadata[b"ribasim_version"]
table.schema.metadata
# {b'ribasim_version': b'2024.2.0'}
```
