### PR TITLE
Run a model without compression

### DIFF
--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -246,7 +246,7 @@ end
 function write_arrow(
     path::AbstractString,
     table::NamedTuple,
-    compress::TranscodingStreams.Codec,
+    compress::Union{ZstdCompressor, Nothing},
 )::Nothing
     # ensure DateTime is encoded in a compatible manner
     # https://github.com/apache/arrow-julia/issues/303

--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -47,7 +47,7 @@ class Compression(str, Enum):
 
 class Results(ChildModel):
     outstate: str | None = None
-    compression: Compression = Compression.zstd
+    compression: bool = True
     compression_level: int = 6
     subgrid: bool = False
 

--- a/python/ribasim/ribasim/schemas.py
+++ b/python/ribasim/ribasim/schemas.py
@@ -11,21 +11,6 @@ class _BaseSchema(pa.DataFrameModel):
         coerce = True
 
 
-class TargetLevelStaticSchema(_BaseSchema):
-    node_id: Series[int] = pa.Field(nullable=False)
-    min_level: Series[float] = pa.Field(nullable=False)
-    max_level: Series[float] = pa.Field(nullable=False)
-    priority: Series[int] = pa.Field(nullable=False)
-
-
-class TargetLevelTimeSchema(_BaseSchema):
-    node_id: Series[int] = pa.Field(nullable=False)
-    time: Series[Timestamp] = pa.Field(nullable=False)
-    min_level: Series[float] = pa.Field(nullable=False)
-    max_level: Series[float] = pa.Field(nullable=False)
-    priority: Series[int] = pa.Field(nullable=False)
-
-
 class BasinProfileSchema(_BaseSchema):
     node_id: Series[int] = pa.Field(nullable=False)
     area: Series[float] = pa.Field(nullable=False)
@@ -182,6 +167,21 @@ class TabulatedRatingCurveTimeSchema(_BaseSchema):
     time: Series[Timestamp] = pa.Field(nullable=False)
     level: Series[float] = pa.Field(nullable=False)
     flow_rate: Series[float] = pa.Field(nullable=False)
+
+
+class TargetLevelStaticSchema(_BaseSchema):
+    node_id: Series[int] = pa.Field(nullable=False)
+    min_level: Series[float] = pa.Field(nullable=False)
+    max_level: Series[float] = pa.Field(nullable=False)
+    priority: Series[int] = pa.Field(nullable=False)
+
+
+class TargetLevelTimeSchema(_BaseSchema):
+    node_id: Series[int] = pa.Field(nullable=False)
+    time: Series[Timestamp] = pa.Field(nullable=False)
+    min_level: Series[float] = pa.Field(nullable=False)
+    max_level: Series[float] = pa.Field(nullable=False)
+    priority: Series[int] = pa.Field(nullable=False)
 
 
 class TerminalStaticSchema(_BaseSchema):

--- a/python/ribasim_testmodels/ribasim_testmodels/trivial.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/trivial.py
@@ -121,6 +121,6 @@ def trivial_model() -> ribasim.Model:
         tabulated_rating_curve=rating_curve,
         starttime="2020-01-01 00:00:00",
         endtime="2021-01-01 00:00:00",
-        results=ribasim.Results(subgrid=True),
+        results=ribasim.Results(subgrid=True, compression=False),
     )
     return model


### PR DESCRIPTION
#1147 missed a test model to run the no-compression path.

I see from the filesize that it is working. Ideally we'd confirm that in a test, but getting that out of Arrow.jl internals seems too finicky to be worth it.