### PR TITLE
Support only fixed saving intervals, set default at daily

### DIFF
--- a/core/src/config.jl
+++ b/core/src/config.jl
@@ -16,7 +16,7 @@ using ..Ribasim: Ribasim, isnode, nodetype
 using OrdinaryDiffEq
 
 export Config, Solver, Results, Logging, Toml
-export algorithm, snake_case, input_path, results_path
+export algorithm, snake_case, input_path, results_path, convert_saveat
 
 const schemas =
     getfield.(
@@ -77,7 +77,7 @@ const nodetypes = collect(keys(nodekinds))
 
 @option struct Solver <: TableOption
     algorithm::String = "QNDF"
-    saveat::Union{Float64, Vector{Float64}} = Float64[]
+    saveat::Float64 = 86400.0
     adaptive::Bool = true
     dt::Union{Float64, Nothing} = nothing
     dtmin::Float64 = 0.0
@@ -166,11 +166,6 @@ function Configurations.from_dict(::Type{Logging}, ::Type{LogLevel}, level::Abst
     )
 end
 
-# [] in TOML is parsed as a Vector{Union{}}
-function Configurations.from_dict(::Type{Solver}, t::Type, saveat::Vector{Union{}})
-    return Float64[]
-end
-
 # TODO Use with proper alignment
 function Base.show(io::IO, c::Config)
     println(io, "Ribasim Config")
@@ -233,6 +228,23 @@ function algorithm(solver::Solver)::OrdinaryDiffEqAlgorithm
         algotype(; solver.autodiff)
     catch
         algotype()
+    end
+end
+
+"Convert the saveat Float64 from our Config to SciML's saveat"
+function convert_saveat(saveat::Float64, t_end::Float64)::Union{Float64, Vector{Float64}}
+    if iszero(saveat)
+        # every step
+        Float64[]
+    elseif saveat == Inf
+        # only the start and end
+        [0.0, t_end]
+    elseif isfinite(saveat)
+        # every saveat seconds
+        saveat
+    else
+        @error "Invalid saveat" saveat
+        error("Invalid saveat")
     end
 end
 

--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -105,6 +105,7 @@ function Model(config::Config)::Model
     @assert eps(t_end) < 3600 "Simulation time too long"
     t0 = zero(t_end)
     timespan = (t0, t_end)
+    saveat = convert_saveat(config.solver.saveat, t_end)
 
     jac_prototype = config.solver.sparse ? get_jac_prototype(parameters) : nothing
     RHS = ODEFunction(water_balance!; jac_prototype)
@@ -114,7 +115,7 @@ function Model(config::Config)::Model
     end
     @debug "Setup ODEProblem."
 
-    callback, saved = create_callbacks(parameters, config; config.solver.saveat)
+    callback, saved = create_callbacks(parameters, config; saveat)
     @debug "Created callbacks."
 
     # Initialize the integrator, providing all solver options as described in
@@ -130,7 +131,7 @@ function Model(config::Config)::Model
         callback,
         tstops,
         isoutofdomain = (u, p, t) -> any(<(0), u.storage),
-        config.solver.saveat,
+        saveat,
         config.solver.adaptive,
         dt = something(config.solver.dt, t0),
         config.solver.dtmin,

--- a/core/test/data/config_test.toml
+++ b/core/test/data/config_test.toml
@@ -11,4 +11,4 @@ database = "database.gpkg"
 time = "basin/time.arrow"
 
 [solver]
-saveat = 86400
+saveat = 3600

--- a/core/test/docs.toml
+++ b/core/test/docs.toml
@@ -20,7 +20,7 @@ objective_type = "linear_absolute" # optional, default "linear_absolute"
 
 [solver]
 algorithm = "QNDF"  # optional, default "QNDF"
-saveat = []         # optional, default [], which saves every timestep
+saveat = 86400      # optional, default 86400, 0 saves every timestep, inf saves only at start- and endtime
 adaptive = true     # optional, default true
 dt = 0.0            # optional when adaptive = true, default automatically determined
 dtmin = 0.0         # optional, default 0.0

--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -47,9 +47,10 @@ When `adaptive = true`, `dtmin` and `dtmax` control the minimum and maximum allo
 If a smaller `dt` than `dtmin` is needed to meet the set error tolerances, the simulation stops, unless `force_dtmin` is set to `true`.
 `force_dtmin` is off by default to ensure an accurate solution.
 
-By default the calculation and result stepsize are the same, with `saveat = []`, which will save every timestep.
-`saveat` can be a number, which is the saving interval in seconds, or it can be a list of numbers, which are the times in seconds since start that are saved.
-For instance, `saveat = 86400.0` will save results after every day that passed.
+The default result stepsize, `saveat = 86400` will save results after every day that passed.
+The calculation and result stepsize need not be the same.
+If you wish to save every calculation step, set `saveat = 0`.
+If you wish to not save any intermediate steps, set `saveat = inf`.
 
 The Jacobian matrix provides information about the local sensitivity of the model with respect to changes in the states.
 For implicit solvers it must be calculated often, which can be expensive to do.

--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -49,7 +49,7 @@ class Results(ChildModel):
 
 class Solver(ChildModel):
     algorithm: str = "QNDF"
-    saveat: float | list[float] = []
+    saveat: float = 86400.0
     adaptive: bool = True
     dt: float | None = None
     dtmin: float | None = None

--- a/python/ribasim/tests/test_model.py
+++ b/python/ribasim/tests/test_model.py
@@ -17,13 +17,16 @@ def test_repr(basic):
 def test_solver():
     solver = Solver()
     assert solver.algorithm == "QNDF"  # default
-    assert solver.saveat == []
+    assert solver.saveat == 86400.0
 
     solver = Solver(saveat=3600.0)
     assert solver.saveat == 3600.0
 
-    solver = Solver(saveat=[3600.0, 7200.0])
-    assert solver.saveat == [3600.0, 7200.0]
+    solver = Solver(saveat=float("inf"))
+    assert solver.saveat == float("inf")
+
+    solver = Solver(saveat=0)
+    assert solver.saveat == 0
 
     with pytest.raises(ValidationError):
         Solver(saveat="a")

--- a/python/ribasim_testmodels/ribasim_testmodels/basic.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/basic.py
@@ -481,6 +481,7 @@ def outlet_model():
         level_boundary=level_boundary,
         starttime="2020-01-01 00:00:00",
         endtime="2021-01-01 00:00:00",
+        solver=ribasim.Solver(saveat=0),
     )
 
     return model


### PR DESCRIPTION
The default `saveat` was to save every timestep. This is nice for small test models to see exactly what is happening, but not great for any serious model, where it quickly leads to very large output files. Users that didn't know about `saveat` had trouble processing results due to the large size. Daily may be too coarse for some applications, but it is less likely to lead to such issues.

This also removes a feature that nobody asked for or, to my knowledge, used. You could set `saveat` with a list to save results at irregular intervals:

```toml
[solver]
saveat = [3600, 3660]
```

The default of the empty list was sometimes confusing, and the schema was a bit odd supporting either a float or list of floats. We copied SciML here 1:1, but I think it is clearer to let this go, and require either fixed intervals or every timestep with `saveat = 0`.