### PR TITLE
Lock Julia patch version

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/Deltares/Ribasim"
 
 [tasks]
 # Installation
-install-julia = "juliaup add 1.10 && juliaup default 1.10"
+install-julia = "juliaup add 1.10.0 && juliaup default 1.10.0"
 install-ribasim-python = "pip install --no-deps --editable python/ribasim"
 install-ribasim-api = "pip install --no-deps --editable python/ribasim_api"
 install-ribasim-testmodels = "pip install --no-deps --editable python/ribasim_testmodels"


### PR DESCRIPTION
Julia 1.10.1 broke some things, like #1144 and this fixes #1157. Let's lock it so we decide when to upgrade.

The julia version listed in the Manifest.toml still mentions 1.10.1, but that doesn't cause any issues and will automatically be adjusted next time we update our dependencies.
