### PR TITLE
test is_flow_constraining

### DIFF
--- a/core/test/utils_test.jl
+++ b/core/test/utils_test.jl
@@ -299,3 +299,21 @@ end
         2.0,
     ) === 1.0
 end
+
+@testitem "constrains_from_nodes" begin
+    toml_path = normpath(@__DIR__, "../../generated_testmodels/basic/ribasim.toml")
+    @test ispath(toml_path)
+    model = Ribasim.BMI.initialize(Ribasim.Model, toml_path)
+    (; p) = model.integrator
+    constraining_types = (:pump, :outlet, :linear_resistance)
+
+    for type in Ribasim.nodefields(p)
+        node = getfield(p, type)
+        println(node)
+        if type in constraining_types
+            @test Ribasim.is_flow_constraining(node)
+        else
+            @test !Ribasim.is_flow_constraining(node)
+        end
+    end
+end

--- a/core/test/utils_test.jl
+++ b/core/test/utils_test.jl
@@ -300,16 +300,15 @@ end
     ) === 1.0
 end
 
-@testitem "constrains_from_nodes" begin
+@testitem "constraints_from_nodes" begin
     toml_path = normpath(@__DIR__, "../../generated_testmodels/basic/ribasim.toml")
     @test ispath(toml_path)
-    model = Ribasim.BMI.initialize(Ribasim.Model, toml_path)
+    model = Ribasim.Model(toml_path)
     (; p) = model.integrator
     constraining_types = (:pump, :outlet, :linear_resistance)
 
     for type in Ribasim.nodefields(p)
         node = getfield(p, type)
-        println(node)
         if type in constraining_types
             @test Ribasim.is_flow_constraining(node)
         else


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/1128.

I'm pretty sure this wasn't an issue to begin with, since `LinearResistance` was automatically detected as a flow restricting node now that the struct has a `max_flow_rate` field. I just added a test for the `is_flow_constraining` function to be sure.
