### PR TITLE
Fix broken hyperlinks

### DIFF
--- a/docs/core/modelconcept.qmd
+++ b/docs/core/modelconcept.qmd
@@ -110,16 +110,16 @@ In addition to free flowing waterbodies, a watersystem typically has structures 
 free flowing conditions or structures.
 The following type of connector nodes are available for this purpose:
 
-- [TabulatedRatingCurve](.\usage.qmd#sec-tabulated-rating-curve): one-directional flow based on upstream head. Node type typically used for gravity flow conditions either free flowing open water channels
+- [TabulatedRatingCurve](usage.qmd#sec-tabulated-rating-curve): one-directional flow based on upstream head. Node type typically used for gravity flow conditions either free flowing open water channels
 or over a fixed structure.
-- [LinearResistance](.\usage.qmd#sec-linear-resistance): bi-directional flow based on head difference and linear resistance. Node type typically used for bi-directional flow
+- [LinearResistance](usage.qmd#sec-linear-resistance): bi-directional flow based on head difference and linear resistance. Node type typically used for bi-directional flow
 situations or situations where head difference over a structure determines its actual flow capacity.
-- [ManningResistance](.\usage.qmd#sec-manning-resistance): bi-directional flow based on head difference and resistance using Manning-Gauckler formula. Same usage as LinearResistance,
+- [ManningResistance](usage.qmd#sec-manning-resistance): bi-directional flow based on head difference and resistance using Manning-Gauckler formula. Same usage as LinearResistance,
 providing a better hydrological meaning to the resistance parameterization.
-- [Pump](.\usage.qmd#sec-pump): one-directional structure with a set flow rate. Node type typically used in combination with control to force water over the edge.
-- [Outlet](.\usage.qmd#sec-outlet): one-directional gravity structure with a set flow rate. Node type typically used in combination with control to force water over the edge, even if
+- [Pump](usage.qmd#sec-pump): one-directional structure with a set flow rate. Node type typically used in combination with control to force water over the edge.
+- [Outlet](usage.qmd#sec-outlet): one-directional gravity structure with a set flow rate. Node type typically used in combination with control to force water over the edge, even if
 their is a mismatch in actual hydraulic capacity. The node type has an automated mechanism to stop the flow when the head difference is zero.
-- [FractionalFlow](.\usage.qmd#sec-fractional-flow): to split an outflow over multiple edges based on a flow fraction. Node type is typically used for diversions or bifurcations with a known and fixed ratio.
+- [FractionalFlow](usage.qmd#sec-fractional-flow): to split an outflow over multiple edges based on a flow fraction. Node type is typically used for diversions or bifurcations with a known and fixed ratio.
 
 The control layer can activate or deactivate nodes, set flow rates for the Pump and Outlet, or choose different parameterizations for TabulatedRatingCurve, LinearResistance, ManningResistance or FractionalFlow.
 


### PR DESCRIPTION
With `quarto run docs` I couldn't reproduce #1138, but I'm fairly sure this will fix #1138 since these are the only links that have backslashes. 

With backslashes apparently these links keep their .qmd extenstion rather than .html: 

https://deltares.github.io/Ribasim/core/usage.qmd#sec-tabulated-rating-curve

