### PR TITLE
Use only explicit imports

### DIFF
--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -14,7 +14,6 @@ For more granular access, see:
 """
 module Ribasim
 
-import Arrow
 import BasicModelInterface as BMI
 import HiGHS
 import IterTools
@@ -23,6 +22,7 @@ import LoggingExtras
 import TranscodingStreams
 
 using Accessors: @set
+using Arrow: Table
 using CodecZstd: ZstdCompressor
 using ComponentArrays: ComponentVector
 using DataInterpolations: LinearInterpolation, derivative

--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -14,39 +14,31 @@ For more granular access, see:
 """
 module Ribasim
 
-import IterTools
+import Arrow
 import BasicModelInterface as BMI
 import HiGHS
+import IterTools
 import JuMP
-import TranscodingStreams
 import LoggingExtras
+import TranscodingStreams
 
 using Accessors: @set
-using Arrow: Arrow, Table
 using CodecZstd: ZstdCompressor
-using Configurations: from_toml
 using ComponentArrays: ComponentVector
 using DataInterpolations: LinearInterpolation, derivative
-using Dates
-using DBInterface: execute, prepare
-using Dictionaries: Indices, Dictionary, gettoken, dictionary
-using DiffEqCallbacks
-using EnumX
+using Dates: Dates, DateTime, Millisecond, @dateformat_str
+using DBInterface: execute
+using Dictionaries: Indices, gettoken
+using DiffEqCallbacks:
+    FunctionCallingCallback,
+    PeriodicCallback,
+    PresetTimeCallback,
+    SavedValues,
+    SavingCallback
+using EnumX: EnumX, @enumx
 using ForwardDiff: pickchunksize
 using Graphs:
-    add_edge!,
-    adjacency_matrix,
-    all_neighbors,
-    DiGraph,
-    Edge,
-    edges,
-    inneighbors,
-    nv,
-    outneighbors,
-    rem_edge!,
-    induced_subgraph,
-    is_connected
-
+    DiGraph, Edge, edges, inneighbors, nv, outneighbors, induced_subgraph, is_connected
 using Legolas: Legolas, @schema, @version, validate, SchemaVersion, declared
 using Logging: with_logger, LogLevel, AbstractLogger
 using MetaGraphsNext:
@@ -57,17 +49,26 @@ using MetaGraphsNext:
     labels,
     outneighbor_labels,
     inneighbor_labels
-using OrdinaryDiffEq
 using OrdinaryDiffEq: OrdinaryDiffEqRosenbrockAdaptiveAlgorithm
-using PreallocationTools: DiffCache, FixedSizeDiffCache, get_tmp
-using SciMLBase
-using SciMLBase: successful_retcode
-using SparseArrays
+using PreallocationTools: DiffCache, get_tmp
+using SciMLBase:
+    init,
+    solve!,
+    step!,
+    SciMLBase,
+    successful_retcode,
+    CallbackSet,
+    ODEFunction,
+    ODEProblem,
+    ODESolution,
+    VectorContinuousCallback,
+    get_proposed_dt
+using SparseArrays: SparseMatrixCSC, spzeros
 using SQLite: SQLite, DB, Query, esc_id
 using StructArrays: StructVector
-using Tables: Tables, AbstractRow, columntable, getcolumn
+using Tables: Tables, AbstractRow, columntable
 using TerminalLoggers: TerminalLogger
-using TimerOutputs
+using TimerOutputs: TimerOutputs, TimerOutput, @timeit_debug
 
 export libribasim
 

--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -22,7 +22,7 @@ import LoggingExtras
 import TranscodingStreams
 
 using Accessors: @set
-using Arrow: Table
+using Arrow: Arrow, Table
 using CodecZstd: ZstdCompressor
 using ComponentArrays: ComponentVector
 using DataInterpolations: LinearInterpolation, derivative

--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -49,7 +49,7 @@ using MetaGraphsNext:
     labels,
     outneighbor_labels,
     inneighbor_labels
-using OrdinaryDiffEq: OrdinaryDiffEqRosenbrockAdaptiveAlgorithm
+using OrdinaryDiffEq: OrdinaryDiffEq, OrdinaryDiffEqRosenbrockAdaptiveAlgorithm
 using PreallocationTools: DiffCache, get_tmp
 using SciMLBase:
     init,

--- a/core/src/config.jl
+++ b/core/src/config.jl
@@ -10,10 +10,20 @@ module config
 
 using Configurations: Configurations, @option, from_toml, @type_alias
 using DataStructures: DefaultDict
-using Dates
+using Dates: DateTime
 using Logging: LogLevel, Debug, Info, Warn, Error
 using ..Ribasim: Ribasim, isnode, nodetype
-using OrdinaryDiffEq
+using OrdinaryDiffEq:
+    OrdinaryDiffEqAlgorithm,
+    Euler,
+    ImplicitEuler,
+    KenCarp4,
+    QNDF,
+    RK4,
+    Rodas5,
+    Rosenbrock23,
+    TRBDF2,
+    Tsit5
 
 export Config, Solver, Results, Logging, Toml
 export algorithm, snake_case, input_path, results_path, convert_saveat, convert_dt

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -998,7 +998,7 @@ function load_data(
 
     table = if !isnothing(path)
         table_path = input_path(config, path)
-        Table(read(table_path))
+        Arrow.Table(read(table_path))
     elseif exists(db, sqltable)
         execute(db, "select * from $(esc_id(sqltable))")
     else

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -998,7 +998,7 @@ function load_data(
 
     table = if !isnothing(path)
         table_path = input_path(config, path)
-        Arrow.Table(read(table_path))
+        Table(read(table_path))
     elseif exists(db, sqltable)
         execute(db, "select * from $(esc_id(sqltable))")
     else


### PR DESCRIPTION
We were mostly doing this already, but not entirely. ExplicitImports.jl just came out and I wanted to try it on this codebase. Works quite well! See this post for the advantages of explicit imports, especially for packages like Ribasim.

https://discourse.julialang.org/t/ann-explicitimports-jl-tooling-to-help-use-and-maintain-explicit-imports-in-your-package/110973
