### PR TITLE
Fix ruff warnings

### DIFF
--- a/ribasim_qgis/core/topology.py
+++ b/ribasim_qgis/core/topology.py
@@ -46,8 +46,8 @@ def explode_lines(edge: QgsVectorLayer) -> None:
 
 def derive_connectivity(
     node_index: NDArray[np.int_],
-    node_xy: NDArray[np.float_],
-    edge_xy: NDArray[np.float_],
+    node_xy: NDArray[np.float64],
+    edge_xy: NDArray[np.float64],
 ) -> tuple[NDArray[np.int_], NDArray[np.int_]]:
     """
     Derive connectivity on the basis of xy locations.

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,3 +1,8 @@
+exclude = ["ribasim_qgis/tomllib/*"]
+extend-include = ["*.ipynb"]
+target-version = "py39"
+
+[lint]
 # See https://docs.astral.sh/ruff/rules/
 select = ["C4", "D2", "D3", "D4", "E", "F", "I", "NPY", "PD", "UP"]
 ignore = [
@@ -13,9 +18,6 @@ ignore = [
     "PD901",
 ]
 fixable = ["I"]
-extend-include = ["*.ipynb"]
-exclude = ["ribasim_qgis/tomllib/*"]
-target-version = "py39"
 
-[pydocstyle]
+[lint.pydocstyle]
 convention = "numpy"


### PR DESCRIPTION
Fixes the warnings shown below.

```
❯ pixi run ruff .
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `ruff.toml`:
  - 'fixable' -> 'lint.fixable'
  - 'ignore' -> 'lint.ignore'
  - 'select' -> 'lint.select'
  - 'pydocstyle' -> 'lint.pydocstyle'
ribasim_qgis\core\topology.py:49:22: NPY201 `np.float_` will be removed in NumPy 2.0. Use `numpy.float64` instead.
ribasim_qgis\core\topology.py:50:22: NPY201 `np.float_` will be removed in NumPy 2.0. Use `numpy.float64` instead.
Found 2 errors.
```