### PR TITLE
Fix precompile script

### DIFF
--- a/build/precompile.jl
+++ b/build/precompile.jl
@@ -3,5 +3,5 @@
 
 using Ribasim
 
-toml_path = normpath(@__DIR__, "../../generated_testmodels/basic/ribasim.toml")
-Ribasim.main(toml_path)
+toml_path = normpath(@__DIR__, "../generated_testmodels/basic/ribasim.toml")
+@assert Ribasim.main(toml_path) == 0


### PR DESCRIPTION
Taken out of #1204 whilst that is on hold.

The directories changed in #1021, causing our precompile run to return error code 1 with a "TOML not found error". That means we were not precompiling an actual run and therefore probably need to wait a bit longer before the start of a simulation. This fixes the directory and adds an assertion to make sure the simulation is successful.
