### PR TITLE
Update to HiGHS 1.7.0

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.10.0"
 manifest_format = "2.0"
-project_hash = "06df95f6b7c964c608a5ed8a5c4e20c48a701a3c"
+project_hash = "01c388f950ce89ba903c883c710bf25774a0b7a3"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "41c37aa88889c171f1300ceac1313c06e891d245"
@@ -591,9 +591,9 @@ version = "1.9.0"
 
 [[deps.HiGHS]]
 deps = ["HiGHS_jll", "MathOptInterface", "PrecompileTools", "SparseArrays"]
-git-tree-sha1 = "f869b0a17d1a4f13aac08af8d0a050bdb70bccfd"
+git-tree-sha1 = "a216e32299172b83abfe699604584f413ffbb045"
 uuid = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
-version = "1.8.1"
+version = "1.9.0"
 
 [[deps.HiGHS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Zlib_jll"]


### PR DESCRIPTION
The monthly deps update just missed this, but it is significant enough to try updating it in isolation.

https://github.com/ERGO-Code/HiGHS/releases/tag/v1.7.0
https://github.com/jump-dev/HiGHS.jl/releases/tag/v1.9.0
