### PR TITLE
Add plotting support for multiple line segment edges

### DIFF
--- a/python/ribasim/ribasim/geometry/edge.py
+++ b/python/ribasim/ribasim/geometry/edge.py
@@ -87,12 +87,10 @@ class Edge(SpatialTableModel[EdgeSchema]):
         angle = np.degrees(np.arctan2(dy, dx)) - 90
 
         # Set the color of the marker to match the line.
+        # Black is default, set color_flow otherwise; then set color_control.
         color_index = index[1:][keep]
-        string_length = max((1, len(color_flow), len(color_control)))
-        # Default color is black
-        color = np.full(x.size, fill_value="k", dtype=f"<U{string_length}")
-        color[where_flow[color_index]] = color_flow
-        color[where_control[color_index]] = color_control
+        color = np.where(where_flow[color_index], color_flow, "k")
+        color = np.where(where_control[color_index], color_control, color)
 
         # A faster alternative may be ax.quiver(). However, getting the scaling
         # right is tedious.

--- a/python/ribasim/ribasim/geometry/edge.py
+++ b/python/ribasim/ribasim/geometry/edge.py
@@ -46,10 +46,11 @@ class Edge(SpatialTableModel[EdgeSchema]):
         return (self.df.edge_type == edge_type).to_numpy()
 
     def plot(self, **kwargs) -> Axes:
+        assert self.df is not None  # Pleases mypy
+        kwargs = kwargs.copy()  # Avoid side-effects
         ax = kwargs.get("ax", None)
-        color_flow = kwargs.get("color_flow", None)
-        color_control = kwargs.get("color_control", None)
-        assert self.df is not None
+        color_flow = kwargs.pop("color_flow", None)
+        color_control = kwargs.pop("color_control", None)
 
         if ax is None:
             _, ax = plt.subplots()
@@ -63,17 +64,10 @@ class Edge(SpatialTableModel[EdgeSchema]):
             color_flow = "#3690c0"  # lightblue
             kwargs_flow["color"] = color_flow
             kwargs_flow["label"] = "Flow edge"
-        else:
-            color_flow = kwargs["color_flow"]
-            del kwargs_flow["color_flow"], kwargs_control["color_flow"]
-
         if color_control is None:
             color_control = "grey"
             kwargs_control["color"] = color_control
             kwargs_control["label"] = "Control edge"
-        else:
-            color_control = kwargs["color_flow"]
-            del kwargs_flow["color_control"], kwargs_control["color_control"]
 
         where_flow = self.get_where_edge_type("flow")
         where_control = self.get_where_edge_type("control")
@@ -85,23 +79,23 @@ class Edge(SpatialTableModel[EdgeSchema]):
             self.df[where_control].plot(**kwargs_control)
 
         # Determine the angle for every caret marker and where to place it.
-        coords = shapely.get_coordinates(self.df.geometry).reshape(-1, 2, 2)
-        x, y = np.mean(coords, axis=1).T
-        dx, dy = np.diff(coords, axis=1)[:, 0, :].T
+        coords, index = shapely.get_coordinates(self.df.geometry, return_index=True)
+        keep = np.diff(index) == 0
+        edge_coords = np.stack((coords[:-1, :], coords[1:, :]), axis=1)[keep]
+        x, y = np.mean(edge_coords, axis=1).T
+        dx, dy = np.diff(edge_coords, axis=1)[:, 0, :].T
         angle = np.degrees(np.arctan2(dy, dx)) - 90
+
+        # Set the color of the marker to match the line.
+        color_index = index[1:][keep]
+        string_length = max((1, len(color_flow), len(color_control)))
+        # Default color is black
+        color = np.full(x.size, fill_value="k", dtype=f"<U{string_length}")
+        color[where_flow[color_index]] = color_flow
+        color[where_control[color_index]] = color_control
 
         # A faster alternative may be ax.quiver(). However, getting the scaling
         # right is tedious.
-        color = []
-
-        for i in range(len(self.df)):
-            if where_flow[i]:
-                color.append(color_flow)
-            elif where_control[i]:
-                color.append(color_control)
-            else:
-                color.append("k")
-
         for m_x, m_y, m_angle, c in zip(x, y, angle, color):
             ax.plot(
                 m_x,

--- a/python/ribasim/tests/test_edge.py
+++ b/python/ribasim/tests/test_edge.py
@@ -9,12 +9,13 @@ from ribasim.geometry.edge import Edge
 def edge() -> Edge:
     a = (0.0, 0.0)
     b = (0.0, 1.0)
-    c = (1.0, 1.0)
-    geometry = [sg.LineString([a, b]), sg.LineString([a, c])]
+    c = (0.2, 0.5)
+    d = (1.0, 1.0)
+    geometry = [sg.LineString([a, b, c]), sg.LineString([a, d])]
     df = gpd.GeoDataFrame(
         data={"from_node_id": [1, 1], "to_node_id": [2, 3]}, geometry=geometry
     )
-    edge = Edge(static=df)
+    edge = Edge(df=df)
     return edge
 
 
@@ -27,3 +28,7 @@ def test_validation(edge):
             geometry=[None, None],
         )
         Edge(df=df)
+
+
+def test_edge_plot(edge):
+    edge.plot()


### PR DESCRIPTION
Fixes #1218

test_edge_plot:
![image](https://github.com/Deltares/Ribasim/assets/13662783/a6d270c5-407e-4234-9e27-001499273500)

And one of the testmodels I edited in QGIS to add additional vertices:
![image](https://github.com/Deltares/Ribasim/assets/13662783/58ff9234-6aa9-46b1-b9d6-b1c9b058ef77)

I also took the opportunity to use `.pop()` on the kwargs dicts.

The marker colors also had to be adjusted since there's no longer a 1:1 marked:edge_geometry relationship. I'm using a numpy array instead of generating the list, since the arrays support indexing.
Using boolean indexing for setting the colors doesn't work very well because the lengths of the color names might differ, and need to be supplied as the dtype. `np.where` is clever enough to take care of it, generating the right dtype on the fly.