### PR TITLE
Pin pixi version for now in CI

### DIFF
--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -35,7 +35,7 @@ jobs:
           cache-registries: "true"
       - uses: prefix-dev/setup-pixi@v0.5.1
         with:
-          pixi-version: "latest"
+          pixi-version: "v0.15.2"
       - name: Prepare pixi
         run: pixi run install-ci
       - name: Test Ribasim Core

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
           cache-registries: "true"
       - uses: prefix-dev/setup-pixi@v0.5.1
         with:
-          pixi-version: "latest"
+          pixi-version: "v0.15.2"
       - name: Prepare pixi
         run: pixi run install-ci
 

--- a/.github/workflows/julia_auto_update.yml
+++ b/.github/workflows/julia_auto_update.yml
@@ -16,7 +16,7 @@ jobs:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - uses: prefix-dev/setup-pixi@v0.5.1
         with:
-          pixi-version: "latest"
+          pixi-version: "v0.15.2"
       - name: Update Julia manifest file
         run: |
           pixi run install-julia

--- a/.github/workflows/pixi_auto_update.yml
+++ b/.github/workflows/pixi_auto_update.yml
@@ -16,7 +16,7 @@ jobs:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - uses: prefix-dev/setup-pixi@v0.5.1
         with:
-          pixi-version: "latest"
+          pixi-version: "v0.15.2"
           cache: false
       - name: Update pixi lock file
         run: |

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.5.1
         with:
-          pixi-version: "latest"
+          pixi-version: "v0.15.2"
       - name: Prepare pixi
         run: pixi run install-ci
       - name: Run mypy on python/ribasim

--- a/.github/workflows/qgis.yml
+++ b/.github/workflows/qgis.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.5.1
         with:
-          pixi-version: "latest"
+          pixi-version: "v0.15.2"
       - name: Prepare pixi
         run: |
           pixi run install-ci


### PR DESCRIPTION
Seems like v0.16 doesn't accept lock files created by older pixi versions