### PR TITLE
Use 32 bit signed integer for all IDs and priorities

### DIFF
--- a/core/src/allocation_init.jl
+++ b/core/src/allocation_init.jl
@@ -22,7 +22,7 @@ end
 Find all nodes in the subnetwork which will be used in the allocation network.
 Some nodes are skipped to optimize allocation optimization.
 """
-function allocation_graph_used_nodes!(p::Parameters, allocation_network_id::Int)::Nothing
+function allocation_graph_used_nodes!(p::Parameters, allocation_network_id::Int32)::Nothing
     (; graph, basin, fractional_flow, allocation) = p
     (; main_network_connections) = allocation
 
@@ -105,7 +105,7 @@ This loop finds allocation network edges in several ways:
 """
 function find_allocation_graph_edges!(
     p::Parameters,
-    allocation_network_id::Int,
+    allocation_network_id::Int32,
 )::Tuple{Vector{Vector{NodeID}}, SparseMatrixCSC{Float64, Int}}
     (; graph) = p
 
@@ -189,7 +189,7 @@ function process_allocation_graph_edges!(
     capacity::SparseMatrixCSC{Float64, Int},
     edges_composite::Vector{Vector{NodeID}},
     p::Parameters,
-    allocation_network_id::Int,
+    allocation_network_id::Int32,
 )::SparseMatrixCSC{Float64, Int}
     (; graph) = p
     node_ids = graph[].node_ids[allocation_network_id]
@@ -285,7 +285,7 @@ const allocation_source_nodetypes =
 """
 Remove allocation UserDemand return flow edges that are upstream of the UserDemand itself.
 """
-function avoid_using_own_returnflow!(p::Parameters, allocation_network_id::Int)::Nothing
+function avoid_using_own_returnflow!(p::Parameters, allocation_network_id::Int32)::Nothing
     (; graph) = p
     node_ids = graph[].node_ids[allocation_network_id]
     edge_ids = graph[].edge_ids[allocation_network_id]
@@ -310,7 +310,7 @@ end
 Add the edges connecting the main network work to a subnetwork to both the main network
 and subnetwork allocation network.
 """
-function add_subnetwork_connections!(p::Parameters, allocation_network_id::Int)::Nothing
+function add_subnetwork_connections!(p::Parameters, allocation_network_id::Int32)::Nothing
     (; graph, allocation) = p
     (; main_network_connections) = allocation
     edge_ids = graph[].edge_ids[allocation_network_id]
@@ -330,7 +330,7 @@ Build the graph used for the allocation problem.
 """
 function allocation_graph(
     p::Parameters,
-    allocation_network_id::Int,
+    allocation_network_id::Int32,
 )::SparseMatrixCSC{Float64, Int}
     # Find out which nodes in the subnetwork are used in the allocation network
     allocation_graph_used_nodes!(p, allocation_network_id)
@@ -360,7 +360,7 @@ Non-negativivity constraints are also immediately added to the flow variables.
 function add_variables_flow!(
     problem::JuMP.Model,
     p::Parameters,
-    allocation_network_id::Int,
+    allocation_network_id::Int32,
 )::Nothing
     (; graph) = p
     edge_ids = graph[].edge_ids[allocation_network_id]
@@ -375,7 +375,7 @@ The variable indices are the node_ids of the basins in the subnetwork.
 function add_variables_basin!(
     problem::JuMP.Model,
     p::Parameters,
-    allocation_network_id::Int,
+    allocation_network_id::Int32,
 )::Nothing
     (; graph) = p
     node_ids_basin = [
@@ -398,7 +398,7 @@ posing the appropriate constraints.
 function add_variables_absolute_value!(
     problem::JuMP.Model,
     p::Parameters,
-    allocation_network_id::Int,
+    allocation_network_id::Int32,
 )::Nothing
     (; graph, allocation) = p
     (; main_network_connections) = allocation
@@ -444,7 +444,7 @@ function add_constraints_capacity!(
     problem::JuMP.Model,
     capacity::SparseMatrixCSC{Float64, Int},
     p::Parameters,
-    allocation_network_id::Int,
+    allocation_network_id::Int32,
 )::Nothing
     (; graph) = p
     main_network_source_edges = get_main_network_connections(p, allocation_network_id)
@@ -476,7 +476,7 @@ flow over source edge <= source flow in subnetwork
 function add_constraints_source!(
     problem::JuMP.Model,
     p::Parameters,
-    allocation_network_id::Int,
+    allocation_network_id::Int32,
 )::Nothing
     (; graph) = p
     edge_ids = graph[].edge_ids[allocation_network_id]
@@ -556,7 +556,7 @@ sum(flows out of node node) == flows into node + flow from storage and vertical 
 function add_constraints_flow_conservation!(
     problem::JuMP.Model,
     p::Parameters,
-    allocation_network_id::Int,
+    allocation_network_id::Int32,
 )::Nothing
     (; graph) = p
     F = problem[:F]
@@ -594,7 +594,7 @@ outflow from user_demand <= return factor * inflow to user_demand
 function add_constraints_user_demand_returnflow!(
     problem::JuMP.Model,
     p::Parameters,
-    allocation_network_id::Int,
+    allocation_network_id::Int32,
 )::Nothing
     (; graph, user_demand) = p
     F = problem[:F]
@@ -710,7 +710,7 @@ flow after fractional_flow node <= fraction * inflow
 function add_constraints_fractional_flow!(
     problem::JuMP.Model,
     p::Parameters,
-    allocation_network_id::Int,
+    allocation_network_id::Int32,
 )::Nothing
     (; graph, fractional_flow) = p
     F = problem[:F]
@@ -775,7 +775,7 @@ Construct the allocation problem for the current subnetwork as a JuMP.jl model.
 function allocation_problem(
     p::Parameters,
     capacity::SparseMatrixCSC{Float64, Int},
-    allocation_network_id::Int,
+    allocation_network_id::Int32,
 )::JuMP.Model
     optimizer = JuMP.optimizer_with_attributes(HiGHS.Optimizer, "log_to_console" => false)
     problem = JuMP.direct_model(optimizer)
@@ -811,7 +811,7 @@ Outputs
 An AllocationModel object.
 """
 function AllocationModel(
-    allocation_network_id::Int,
+    allocation_network_id::Int32,
     p::Parameters,
     Δt_allocation::Float64,
 )::AllocationModel

--- a/core/src/allocation_optim.jl
+++ b/core/src/allocation_optim.jl
@@ -438,7 +438,7 @@ function save_demands_and_allocations!(
             push!(record_demand.time, t)
             push!(record_demand.subnetwork_id, allocation_network_id)
             push!(record_demand.node_type, string(node_id.type))
-            push!(record_demand.node_id, Int(node_id))
+            push!(record_demand.node_id, Int32(node_id))
             push!(record_demand.priority, priorities[priority_idx])
             push!(record_demand.demand, demand)
             push!(record_demand.allocated, allocated)
@@ -458,7 +458,7 @@ function save_allocation_flows!(
     p::Parameters,
     t::Float64,
     allocation_model::AllocationModel,
-    priority::Int,
+    priority::Int32,
     collect_demands::Bool,
 )::Nothing
     (; problem, allocation_network_id) = allocation_model
@@ -478,9 +478,9 @@ function save_allocation_flows!(
             push!(record_flow.time, t)
             push!(record_flow.edge_id, edge_metadata.id)
             push!(record_flow.from_node_type, string(node_ids[i].type))
-            push!(record_flow.from_node_id, Int(node_ids[i]))
+            push!(record_flow.from_node_id, Int32(node_ids[i]))
             push!(record_flow.to_node_type, string(node_ids[i + 1].type))
-            push!(record_flow.to_node_id, Int(node_ids[i + 1]))
+            push!(record_flow.to_node_id, Int32(node_ids[i + 1]))
             push!(record_flow.subnetwork_id, allocation_network_id)
             push!(record_flow.priority, priority)
             push!(record_flow.flow_rate, flow_rate)

--- a/core/src/callback.jl
+++ b/core/src/callback.jl
@@ -331,7 +331,7 @@ function discrete_control_affect!(
         record = discrete_control.record
 
         push!(record.time, integrator.t)
-        push!(record.control_node_id, Int(discrete_control_node_id))
+        push!(record.control_node_id, Int32(discrete_control_node_id))
         push!(record.truth_state, truth_state_used)
         push!(record.control_state, control_state_new)
 
@@ -347,7 +347,7 @@ function discrete_control_affect!(
     return control_state_change
 end
 
-function get_allocation_model(p::Parameters, allocation_network_id::Int)::AllocationModel
+function get_allocation_model(p::Parameters, allocation_network_id::Int32)::AllocationModel
     (; allocation) = p
     (; allocation_network_ids, allocation_models) = allocation
     idx = findsorted(allocation_network_ids, allocation_network_id)
@@ -360,7 +360,7 @@ end
 
 function get_main_network_connections(
     p::Parameters,
-    allocation_network_id::Int,
+    allocation_network_id::Int32,
 )::Vector{Tuple{NodeID, NodeID}}
     (; allocation) = p
     (; allocation_network_ids, main_network_connections) = allocation

--- a/core/src/graph.jl
+++ b/core/src/graph.jl
@@ -15,11 +15,11 @@ function create_graph(db::DB, config::Config, chunk_sizes::Vector{Int})::MetaGra
         "SELECT fid, from_node_type, from_node_id, to_node_type, to_node_id, edge_type, subnetwork_id FROM Edge ORDER BY fid",
     )
     # Node IDs per subnetwork
-    node_ids = Dict{Int, Set{NodeID}}()
+    node_ids = Dict{Int32, Set{NodeID}}()
     # Allocation edges per subnetwork
-    edge_ids = Dict{Int, Set{Tuple{NodeID, NodeID}}}()
+    edge_ids = Dict{Int32, Set{Tuple{NodeID, NodeID}}}()
     # Source edges per subnetwork
-    edges_source = Dict{Int, Set{EdgeMetadata}}()
+    edges_source = Dict{Int32, Set{EdgeMetadata}}()
     # The number of flow edges
     flow_counter = 0
     # Dictionary from flow edge to index in flow vector

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -15,25 +15,25 @@ NodeType.T(str::AbstractString) = NodeType.T(Symbol(str))
 
 struct NodeID
     type::NodeType.T
-    value::Int
+    value::Int32
 end
 
-NodeID(type::Symbol, value::Int) = NodeID(NodeType.T(type), value)
-NodeID(type::AbstractString, value::Int) = NodeID(NodeType.T(type), value)
+NodeID(type::Symbol, value::Integer) = NodeID(NodeType.T(type), value)
+NodeID(type::AbstractString, value::Integer) = NodeID(NodeType.T(type), value)
 
-Base.Int(id::NodeID) = id.value
-Base.convert(::Type{Int}, id::NodeID) = id.value
+Base.Int32(id::NodeID) = id.value
+Base.convert(::Type{Int32}, id::NodeID) = id.value
 Base.broadcastable(id::NodeID) = Ref(id)
-Base.show(io::IO, id::NodeID) = print(io, id.type, " #", Int(id))
+Base.show(io::IO, id::NodeID) = print(io, id.type, " #", id.value)
 
 function Base.isless(id_1::NodeID, id_2::NodeID)::Bool
     if id_1.type != id_2.type
         error("Cannot compare NodeIDs of different types")
     end
-    return Int(id_1) < Int(id_2)
+    return id_1.value < id_2.value
 end
 
-Base.to_index(id::NodeID) = Int(id)
+Base.to_index(id::NodeID) = Int(id.value)
 
 const ScalarInterpolation =
     LinearInterpolation{Vector{Float64}, Vector{Float64}, true, Float64}
@@ -49,7 +49,7 @@ problem: The JuMP.jl model for solving the allocation problem
 Δt_allocation: The time interval between consecutive allocation solves
 """
 struct AllocationModel
-    allocation_network_id::Int
+    allocation_network_id::Int32
     capacity::SparseMatrixCSC{Float64, Int}
     problem::JuMP.Model
     Δt_allocation::Float64
@@ -68,31 +68,31 @@ record_flow: A record of all flows computed by allocation optimization, eventual
     output file
 """
 struct Allocation
-    allocation_network_ids::Vector{Int}
+    allocation_network_ids::Vector{Int32}
     allocation_models::Vector{AllocationModel}
     main_network_connections::Vector{Vector{Tuple{NodeID, NodeID}}}
-    priorities::Vector{Int}
+    priorities::Vector{Int32}
     subnetwork_demands::Dict{Tuple{NodeID, NodeID}, Vector{Float64}}
     subnetwork_allocateds::Dict{Tuple{NodeID, NodeID}, Vector{Float64}}
     record_demand::@NamedTuple{
         time::Vector{Float64},
-        subnetwork_id::Vector{Int},
+        subnetwork_id::Vector{Int32},
         node_type::Vector{String},
-        node_id::Vector{Int},
-        priority::Vector{Int},
+        node_id::Vector{Int32},
+        priority::Vector{Int32},
         demand::Vector{Float64},
         allocated::Vector{Float64},
         realized::Vector{Float64},
     }
     record_flow::@NamedTuple{
         time::Vector{Float64},
-        edge_id::Vector{Int},
+        edge_id::Vector{Int32},
         from_node_type::Vector{String},
-        from_node_id::Vector{Int},
+        from_node_id::Vector{Int32},
         to_node_type::Vector{String},
-        to_node_id::Vector{Int},
-        subnetwork_id::Vector{Int},
-        priority::Vector{Int},
+        to_node_id::Vector{Int32},
+        subnetwork_id::Vector{Int32},
+        priority::Vector{Int32},
         flow_rate::Vector{Float64},
         collect_demands::BitVector,
     }
@@ -107,7 +107,7 @@ allocation_network_id: Allocation network ID (0 if not in subnetwork)
 """
 struct NodeMetadata
     type::Symbol
-    allocation_network_id::Int
+    allocation_network_id::Int32
 end
 
 """
@@ -123,9 +123,9 @@ node_ids: if this edge has allocation flow, these are all the
     nodes from the physical layer this edge consists of
 """
 struct EdgeMetadata
-    id::Int
+    id::Int32
     type::EdgeType.T
-    allocation_network_id_source::Int
+    allocation_network_id_source::Int32
     from_id::NodeID
     to_id::NodeID
     allocation_flow::Bool
@@ -447,7 +447,7 @@ struct DiscreteControl <: AbstractParameterNode
     logic_mapping::Dict{Tuple{NodeID, String}, String}
     record::@NamedTuple{
         time::Vector{Float64},
-        control_node_id::Vector{Int},
+        control_node_id::Vector{Int32},
         truth_state::Vector{String},
         control_state::Vector{String},
     }
@@ -535,12 +535,12 @@ struct LevelDemand
     node_id::Vector{NodeID}
     min_level::Vector{LinearInterpolation}
     max_level::Vector{LinearInterpolation}
-    priority::Vector{Int}
+    priority::Vector{Int32}
 end
 
 "Subgrid linearly interpolates basin levels."
 struct Subgrid
-    basin_index::Vector{Int}
+    basin_index::Vector{Int32}
     interpolations::Vector{ScalarInterpolation}
     level::Vector{Float64}
 end
@@ -555,9 +555,9 @@ struct Parameters{T, C1, C2}
         NodeMetadata,
         EdgeMetadata,
         @NamedTuple{
-            node_ids::Dict{Int, Set{NodeID}},
-            edge_ids::Dict{Int, Set{Tuple{NodeID, NodeID}}},
-            edges_source::Dict{Int, Set{EdgeMetadata}},
+            node_ids::Dict{Int32, Set{NodeID}},
+            edge_ids::Dict{Int32, Set{Tuple{NodeID, NodeID}}},
+            edges_source::Dict{Int32, Set{EdgeMetadata}},
             flow_dict::Dict{Tuple{NodeID, NodeID}, Int},
             flow::T,
             flow_prev::Vector{Float64},

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -560,7 +560,7 @@ function DiscreteControl(db::DB, config::Config)::DiscreteControl
 
     record = (
         time = Float64[],
-        control_node_id = Int[],
+        control_node_id = Int32[],
         truth_state = String[],
         control_state = String[],
     )
@@ -666,7 +666,7 @@ function UserDemand(db::DB, config::Config)::UserDemand
     t_end = seconds_since(config.endtime, config.starttime)
 
     # Create a dictionary priority => time data for that priority
-    time_priority_dict::Dict{Int, StructVector{UserDemandTimeV1}} = Dict(
+    time_priority_dict::Dict{Int32, StructVector{UserDemandTimeV1}} = Dict(
         first(group).priority => StructVector(group) for
         group in IterTools.groupby(row -> row.priority, time)
     )
@@ -788,7 +788,7 @@ function Subgrid(db::DB, config::Config, basin::Basin)::Subgrid
     node_to_basin = Dict(node_id => index for (index, node_id) in enumerate(basin.node_id))
     tables = load_structvector(db, config, BasinSubgridV1)
 
-    basin_ids = Int[]
+    basin_ids = Int32[]
     interpolations = ScalarInterpolation[]
     has_error = false
     for group in IterTools.groupby(row -> row.subgrid_id, tables)
@@ -820,10 +820,10 @@ end
 function Allocation(db::DB, config::Config)::Allocation
     record_demand = (
         time = Float64[],
-        subnetwork_id = Int[],
+        subnetwork_id = Int32[],
         node_type = String[],
-        node_id = Int[],
-        priority = Int[],
+        node_id = Int32[],
+        priority = Int32[],
         demand = Float64[],
         allocated = Float64[],
         realized = Float64[],
@@ -831,19 +831,19 @@ function Allocation(db::DB, config::Config)::Allocation
 
     record_flow = (
         time = Float64[],
-        edge_id = Int[],
+        edge_id = Int32[],
         from_node_type = String[],
-        from_node_id = Int[],
+        from_node_id = Int32[],
         to_node_type = String[],
-        to_node_id = Int[],
-        subnetwork_id = Int[],
-        priority = Int[],
+        to_node_id = Int32[],
+        subnetwork_id = Int32[],
+        priority = Int32[],
         flow_rate = Float64[],
         collect_demands = BitVector(),
     )
 
     allocation = Allocation(
-        Int[],
+        Int32[],
         AllocationModel[],
         Vector{Tuple{NodeID, NodeID}}[],
         get_all_priorities(db, config),
@@ -930,7 +930,7 @@ function Parameters(db::DB, config::Config)::Parameters
     return p
 end
 
-function get_ids(db::DB, nodetype)::Vector{Int}
+function get_ids(db::DB, nodetype)::Vector{Int32}
     sql = "SELECT node_id FROM Node WHERE node_type = $(esc_id(nodetype)) ORDER BY node_id"
     return only(execute(columntable, db, sql))
 end

--- a/core/src/schema.jl
+++ b/core/src/schema.jl
@@ -59,7 +59,7 @@ function nodetype(
 end
 
 @version PumpStaticV1 begin
-    node_id::Int
+    node_id::Int32
     active::Union{Missing, Bool}
     flow_rate::Float64
     min_flow_rate::Union{Missing, Float64}
@@ -68,7 +68,7 @@ end
 end
 
 @version OutletStaticV1 begin
-    node_id::Int
+    node_id::Int32
     active::Union{Missing, Bool}
     flow_rate::Float64
     min_flow_rate::Union{Missing, Float64}
@@ -78,7 +78,7 @@ end
 end
 
 @version BasinStaticV1 begin
-    node_id::Int
+    node_id::Int32
     drainage::Union{Missing, Float64}
     potential_evaporation::Union{Missing, Float64}
     infiltration::Union{Missing, Float64}
@@ -87,7 +87,7 @@ end
 end
 
 @version BasinTimeV1 begin
-    node_id::Int
+    node_id::Int32
     time::DateTime
     drainage::Union{Missing, Float64}
     potential_evaporation::Union{Missing, Float64}
@@ -97,55 +97,55 @@ end
 end
 
 @version BasinProfileV1 begin
-    node_id::Int
+    node_id::Int32
     area::Float64
     level::Float64
 end
 
 @version BasinStateV1 begin
-    node_id::Int
+    node_id::Int32
     level::Float64
 end
 
 @version BasinSubgridV1 begin
-    subgrid_id::Int
-    node_id::Int
+    subgrid_id::Int32
+    node_id::Int32
     basin_level::Float64
     subgrid_level::Float64
 end
 
 @version FractionalFlowStaticV1 begin
-    node_id::Int
+    node_id::Int32
     fraction::Float64
     control_state::Union{Missing, String}
 end
 
 @version LevelBoundaryStaticV1 begin
-    node_id::Int
+    node_id::Int32
     active::Union{Missing, Bool}
     level::Float64
 end
 
 @version LevelBoundaryTimeV1 begin
-    node_id::Int
+    node_id::Int32
     time::DateTime
     level::Float64
 end
 
 @version FlowBoundaryStaticV1 begin
-    node_id::Int
+    node_id::Int32
     active::Union{Missing, Bool}
     flow_rate::Float64
 end
 
 @version FlowBoundaryTimeV1 begin
-    node_id::Int
+    node_id::Int32
     time::DateTime
     flow_rate::Float64
 end
 
 @version LinearResistanceStaticV1 begin
-    node_id::Int
+    node_id::Int32
     active::Union{Missing, Bool}
     resistance::Float64
     max_flow_rate::Union{Missing, Float64}
@@ -153,7 +153,7 @@ end
 end
 
 @version ManningResistanceStaticV1 begin
-    node_id::Int
+    node_id::Int32
     active::Union{Missing, Bool}
     length::Float64
     manning_n::Float64
@@ -163,7 +163,7 @@ end
 end
 
 @version TabulatedRatingCurveStaticV1 begin
-    node_id::Int
+    node_id::Int32
     active::Union{Missing, Bool}
     level::Float64
     flow_rate::Float64
@@ -171,36 +171,36 @@ end
 end
 
 @version TabulatedRatingCurveTimeV1 begin
-    node_id::Int
+    node_id::Int32
     time::DateTime
     level::Float64
     flow_rate::Float64
 end
 
 @version TerminalStaticV1 begin
-    node_id::Int
+    node_id::Int32
 end
 
 @version DiscreteControlConditionV1 begin
-    node_id::Int
+    node_id::Int32
     listen_node_type::String
-    listen_node_id::Int
+    listen_node_id::Int32
     variable::String
     greater_than::Float64
     look_ahead::Union{Missing, Float64}
 end
 
 @version DiscreteControlLogicV1 begin
-    node_id::Int
+    node_id::Int32
     truth_state::String
     control_state::String
 end
 
 @version PidControlStaticV1 begin
-    node_id::Int
+    node_id::Int32
     active::Union{Missing, Bool}
     listen_node_type::String
-    listen_node_id::Int
+    listen_node_id::Int32
     target::Float64
     proportional::Float64
     integral::Float64
@@ -209,9 +209,9 @@ end
 end
 
 @version PidControlTimeV1 begin
-    node_id::Int
+    node_id::Int32
     listen_node_type::String
-    listen_node_id::Int
+    listen_node_id::Int32
     time::DateTime
     target::Float64
     proportional::Float64
@@ -221,34 +221,34 @@ end
 end
 
 @version UserDemandStaticV1 begin
-    node_id::Int
+    node_id::Int32
     active::Union{Missing, Bool}
     demand::Float64
     return_factor::Float64
     min_level::Float64
-    priority::Int
+    priority::Int32
 end
 
 @version UserDemandTimeV1 begin
-    node_id::Int
+    node_id::Int32
     time::DateTime
     demand::Float64
     return_factor::Float64
     min_level::Float64
-    priority::Int
+    priority::Int32
 end
 
 @version LevelDemandStaticV1 begin
-    node_id::Int
+    node_id::Int32
     min_level::Float64
     max_level::Float64
-    priority::Int
+    priority::Int32
 end
 
 @version LevelDemandTimeV1 begin
-    node_id::Int
+    node_id::Int32
     time::DateTime
     min_level::Float64
     max_level::Float64
-    priority::Int
+    priority::Int32
 end

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -312,7 +312,7 @@ Data is matched based on the node_id, which is sorted.
 """
 function set_static_value!(
     table::NamedTuple,
-    node_id::Vector{Int},
+    node_id::Vector{Int32},
     static::StructVector,
 )::NamedTuple
     for (i, id) in enumerate(node_id)
@@ -331,7 +331,7 @@ The most recent applicable data is non-NaN data for a given ID that is on or bef
 """
 function set_current_value!(
     table::NamedTuple,
-    node_id::Vector{Int},
+    node_id::Vector{Int32},
     time::StructVector,
     t::DateTime,
 )::NamedTuple
@@ -620,7 +620,7 @@ function has_main_network(allocation::Allocation)::Bool
     end
 end
 
-function is_main_network(allocation_network_id::Int)::Bool
+function is_main_network(allocation_network_id::Int32)::Bool
     return allocation_network_id == 1
 end
 
@@ -646,8 +646,8 @@ function set_user_demand!(
     return nothing
 end
 
-function get_all_priorities(db::DB, config::Config)::Vector{Int}
-    priorities = Set{Int}()
+function get_all_priorities(db::DB, config::Config)::Vector{Int32}
+    priorities = Set{Int32}()
 
     # TODO: Is there a way to automatically grab all tables with a priority column?
     for type in

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -338,7 +338,7 @@ end
 Validate the entries for a single subgrid element.
 """
 function valid_subgrid(
-    subgrid_id::Int,
+    subgrid_id::Int32,
     node_id::NodeID,
     node_to_basin::Dict{NodeID, Int},
     basin_level::Vector{Float64},
@@ -369,7 +369,7 @@ function valid_demand(
     demand_itp::Vector{
         Vector{LinearInterpolation{Vector{Float64}, Vector{Float64}, true, Float64}},
     },
-    priorities::Vector{Int},
+    priorities::Vector{Int32},
 )::Bool
     errors = false
 
@@ -384,7 +384,7 @@ function valid_demand(
     return !errors
 end
 
-function incomplete_subnetwork(graph::MetaGraph, node_ids::Dict{Int, Set{NodeID}})::Bool
+function incomplete_subnetwork(graph::MetaGraph, node_ids::Dict{Int32, Set{NodeID}})::Bool
     errors = false
     for (allocation_network_id, subnetwork_node_ids) in node_ids
         subnetwork, _ = induced_subgraph(graph, code_for.(Ref(graph), subnetwork_node_ids))
@@ -582,7 +582,7 @@ end
 """
 The source nodes must only have one allocation outneighbor and no allocation inneighbors.
 """
-function valid_sources(p::Parameters, allocation_network_id::Int)::Bool
+function valid_sources(p::Parameters, allocation_network_id::Int32)::Bool
     (; graph) = p
 
     edge_ids = graph[].edge_ids[allocation_network_id]

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -81,7 +81,7 @@ function basin_table(
     model::Model,
 )::@NamedTuple{
     time::Vector{DateTime},
-    node_id::Vector{Int},
+    node_id::Vector{Int32},
     storage::Vector{Float64},
     level::Vector{Float64},
 }
@@ -90,7 +90,7 @@ function basin_table(
     ntsteps = length(data.time)
 
     time = repeat(data.time; inner = nbasin)
-    node_id = repeat(Int.(data.node_id); outer = ntsteps)
+    node_id = repeat(Int32.(data.node_id); outer = ntsteps)
 
     return (; time, node_id, storage = vec(data.storage), level = vec(data.level))
 end
@@ -100,11 +100,11 @@ function flow_table(
     model::Model,
 )::@NamedTuple{
     time::Vector{DateTime},
-    edge_id::Vector{Union{Int, Missing}},
+    edge_id::Vector{Union{Int32, Missing}},
     from_node_type::Vector{String},
-    from_node_id::Vector{Int},
+    from_node_id::Vector{Int32},
     to_node_type::Vector{String},
-    to_node_id::Vector{Int},
+    to_node_id::Vector{Int32},
     flow_rate::FlatVector{Float64},
 }
     (; config, saved, integrator) = model
@@ -114,10 +114,10 @@ function flow_table(
 
     # self-loops have no edge ID
     from_node_type = String[]
-    from_node_id = Int[]
+    from_node_id = Int32[]
     to_node_type = String[]
-    to_node_id = Int[]
-    unique_edge_ids_flow = Union{Int, Missing}[]
+    to_node_id = Int32[]
+    unique_edge_ids_flow = Union{Int32, Missing}[]
 
     vertical_flow_node_ids = Vector{NodeID}(undef, length(flow_vertical_dict))
     for (node_id, index) in flow_vertical_dict
@@ -177,7 +177,7 @@ function discrete_control_table(
     model::Model,
 )::@NamedTuple{
     time::Vector{DateTime},
-    control_node_id::Vector{Int},
+    control_node_id::Vector{Int32},
     truth_state::Vector{String},
     control_state::Vector{String},
 }
@@ -193,10 +193,10 @@ function allocation_table(
     model::Model,
 )::@NamedTuple{
     time::Vector{DateTime},
-    subnetwork_id::Vector{Int},
+    subnetwork_id::Vector{Int32},
     node_type::Vector{String},
-    node_id::Vector{Int},
-    priority::Vector{Int},
+    node_id::Vector{Int32},
+    priority::Vector{Int32},
     demand::Vector{Float64},
     allocated::Vector{Float64},
     realized::Vector{Float64},
@@ -221,13 +221,13 @@ function allocation_flow_table(
     model::Model,
 )::@NamedTuple{
     time::Vector{DateTime},
-    edge_id::Vector{Int},
+    edge_id::Vector{Int32},
     from_node_type::Vector{String},
-    from_node_id::Vector{Int},
+    from_node_id::Vector{Int32},
     to_node_type::Vector{String},
-    to_node_id::Vector{Int},
-    subnetwork_id::Vector{Int},
-    priority::Vector{Int},
+    to_node_id::Vector{Int32},
+    subnetwork_id::Vector{Int32},
+    priority::Vector{Int32},
     flow_rate::Vector{Float64},
     collect_demands::BitVector,
 }
@@ -254,7 +254,7 @@ function subgrid_level_table(
     model::Model,
 )::@NamedTuple{
     time::Vector{DateTime},
-    subgrid_id::Vector{Int},
+    subgrid_id::Vector{Int32},
     subgrid_level::Vector{Float64},
 }
     (; config, saved, integrator) = model

--- a/core/test/allocation_test.jl
+++ b/core/test/allocation_test.jl
@@ -180,7 +180,7 @@ end
 
     # Subnetworks interpreted as user_demands require variables and constraints to
     # support absolute value expressions in the objective function
-    allocation_model_main_network = Ribasim.get_allocation_model(p, 1)
+    allocation_model_main_network = Ribasim.get_allocation_model(p, Int32(1))
     problem = allocation_model_main_network.problem
     @test problem[:F_abs_user_demand].axes[1] == NodeID.(:Pump, [11, 24, 38])
     @test problem[:abs_positive_user_demand].axes[1] == NodeID.(:Pump, [11, 24, 38])
@@ -188,11 +188,11 @@ end
 
     # In each subnetwork, the connection from the main network to the subnetwork is
     # interpreted as a source
-    @test Ribasim.get_allocation_model(p, 3).problem[:source].axes[1] ==
+    @test Ribasim.get_allocation_model(p, Int32(3)).problem[:source].axes[1] ==
           [(NodeID(:Basin, 2), NodeID(:Pump, 11))]
-    @test Ribasim.get_allocation_model(p, 5).problem[:source].axes[1] ==
+    @test Ribasim.get_allocation_model(p, Int32(5)).problem[:source].axes[1] ==
           [(NodeID(:Basin, 6), NodeID(:Pump, 24))]
-    @test Ribasim.get_allocation_model(p, 7).problem[:source].axes[1] ==
+    @test Ribasim.get_allocation_model(p, Int32(7)).problem[:source].axes[1] ==
           [(NodeID(:Basin, 10), NodeID(:Pump, 38))]
 end
 

--- a/core/test/create_test.jl
+++ b/core/test/create_test.jl
@@ -18,7 +18,7 @@
 
     graph[1, 2] = :yes
 
-    node_ids = Dict{Int, Set{NodeID}}()
+    node_ids = Dict{Int32, Set{NodeID}}()
     node_ids[0] = Set{NodeID}()
     node_ids[-1] = Set{NodeID}()
     push!(node_ids[0], NodeID(:Basin, 1))
@@ -55,7 +55,7 @@ end
         graph_data = Tuple,
     )
 
-    node_ids = Dict{Int, Set{NodeID}}()
+    node_ids = Dict{Int32, Set{NodeID}}()
     node_ids[1] = Set{NodeID}()
     push!(node_ids[1], NodeID(:Basin, 1))
     push!(node_ids[1], NodeID(:Basin, 2))

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -41,15 +41,15 @@
                 :to_node_id,
                 :flow_rate,
             ),
-            (DateTime, Union{Int, Missing}, String, Int, String, Int, Float64),
+            (DateTime, Union{Int32, Missing}, String, Int32, String, Int32, Float64),
         )
         @test Tables.schema(basin) == Tables.Schema(
             (:time, :node_id, :storage, :level),
-            (DateTime, Int, Float64, Float64),
+            (DateTime, Int32, Float64, Float64),
         )
         @test Tables.schema(control) == Tables.Schema(
             (:time, :control_node_id, :truth_state, :control_state),
-            (DateTime, Int, String, String),
+            (DateTime, Int32, String, String),
         )
         @test Tables.schema(allocation) == Tables.Schema(
             (
@@ -62,7 +62,7 @@
                 :allocated,
                 :realized,
             ),
-            (DateTime, Int, String, Int, Int, Float64, Float64, Float64),
+            (DateTime, Int32, String, Int32, Int32, Float64, Float64, Float64),
         )
         @test Tables.schema(allocation_flow) == Tables.Schema(
             (
@@ -77,10 +77,12 @@
                 :flow_rate,
                 :collect_demands,
             ),
-            (DateTime, Int, String, Int, String, Int, Int, Int, Float64, Bool),
+            (DateTime, Int32, String, Int32, String, Int32, Int32, Int32, Float64, Bool),
         )
-        @test Tables.schema(subgrid) ==
-              Tables.Schema((:time, :subgrid_id, :subgrid_level), (DateTime, Int, Float64))
+        @test Tables.schema(subgrid) == Tables.Schema(
+            (:time, :subgrid_id, :subgrid_level),
+            (DateTime, Int32, Float64),
+        )
     end
 
     @testset "Results size" begin
@@ -358,7 +360,7 @@ end
     t = model.saved.flow.t
     flow = DataFrame(Ribasim.flow_table(model))
     outlet_flow =
-        filter([:from_node_id, :to_node_id] => (from, to) -> from === 2 && to === 3, flow)
+        filter([:from_node_id, :to_node_id] => (from, to) -> from == 2 && to == 3, flow)
 
     t_min_crest_level =
         level.t[2] * (outlet.min_crest_level[1] - level.u[1]) / (level.u[2] - level.u[1])
@@ -489,7 +491,7 @@ end
         df = DataFrame(Ribasim.flow_table(model))
         flow =
             filter(
-                [:from_node_id, :to_node_id] => (from, to) -> from === 3 && to === 2,
+                [:from_node_id, :to_node_id] => (from, to) -> from == 3 && to == 2,
                 df,
             ).flow_rate
         flow, Ribasim.tsaves(model)

--- a/core/test/time_test.jl
+++ b/core/test/time_test.jl
@@ -16,12 +16,12 @@
     flow_added_1 =
         filter(
             [:time, :from_node_id, :to_node_id] =>
-                (t, from, to) -> is_summer(t) && from === 1 && to === 1,
+                (t, from, to) -> is_summer(t) && from == 1 && to == 1,
             flow,
         ).flow_rate
     flow_1_to_2 = filter(
         [:time, :from_node_id, :to_node_id] =>
-            (t, from, to) -> is_summer(t) && from === 1 && to === 2,
+            (t, from, to) -> is_summer(t) && from == 1 && to == 2,
         flow,
     )
     @test flow_added_1 == flow_1_to_2.flow_rate

--- a/core/test/utils_test.jl
+++ b/core/test/utils_test.jl
@@ -5,8 +5,8 @@
     @test sprint(show, id) === "Basin #2"
     @test id < NodeID(:Basin, 3)
     @test_throws ErrorException id < NodeID(:Pump, 3)
-    @test Int(id) === 2
-    @test convert(Int, id) === 2
+    @test Int32(id) === Int32(2)
+    @test convert(Int32, id) === Int32(2)
 end
 
 @testitem "id_index" begin

--- a/core/test/validation_test.jl
+++ b/core/test/validation_test.jl
@@ -123,7 +123,7 @@ end
     fractional_flow = Ribasim.FractionalFlow(
         [NodeID(:FractionalFlow, 5)],
         [1.0],
-        Dict{Tuple{Int, String}, NamedTuple}(),
+        Dict{Tuple{NodeID, String}, NamedTuple}(),
     )
 
     logger = TestLogger(; min_level = Debug)
@@ -376,7 +376,13 @@ end
 
     logger = TestLogger()
     with_logger(logger) do
-        @test !valid_subgrid(1, NodeID(:Basin, 10), node_to_basin, [-1.0, 0.0], [-1.0, 0.0])
+        @test !valid_subgrid(
+            Int32(1),
+            NodeID(:Basin, 10),
+            node_to_basin,
+            [-1.0, 0.0],
+            [-1.0, 0.0],
+        )
     end
 
     @test length(logger.logs) == 1
@@ -388,7 +394,7 @@ end
     logger = TestLogger()
     with_logger(logger) do
         @test !valid_subgrid(
-            1,
+            Int32(1),
             NodeID(:Basin, 9),
             node_to_basin,
             [-1.0, 0.0, 0.0],
@@ -423,7 +429,7 @@ end
             [0.0, -0.0],
             [0.9],
             [0.9],
-            [1],
+            Int32[1],
         )
     end
 

--- a/docs/contribute/addnode.qmd
+++ b/docs/contribute/addnode.qmd
@@ -33,7 +33,7 @@ There can be several schemas associated with a single node type. To define a sch
 node_id: node ID of the NewNodeType node
 """
 @version NewNodeTypeStaticV1 begin
-    node_id::Int
+    node_id::Int32
     # Other fields
 end
 ```

--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -122,11 +122,11 @@ like this:
 
 column    | type    | unit         | restriction
 --------- | ------- | ------------ | -----------
-node_id   | Int     | -            | sorted
+node_id   | Int32   | -            | sorted
 storage   | Float64 | $m^3$        | non-negative
 
 This means that two columns are required, one named `node_id`, that contained elements of
-type `Int`, and a column named `storage` that contains elements of type `Float64`. The order
+type `Int32`, and a column named `storage` that contains elements of type `Float64`. The order
 of the columns does not matter. In some cases there may be restrictions on the values. This
 is indicated under `restriction`.
 
@@ -157,11 +157,11 @@ between nodes, and never have storage of their own.
 
 column        | type     | restriction
 --------------| -------- | -----------
-node_id       | Int      | -
+node_id       | Int32    | -
 node_type     | String   | known node type
 geom          | Point    | (optional)
 name          | String   | (optional, does not have to be unique)
-subnetwork_id |  Int     | (optional)
+subnetwork_id | Int32    | (optional)
 
 The available node types as of this writing are listed as the top level bullets below. The
 sub-bullets indicate which tables are associated to the node type. The table name is the
@@ -231,13 +231,13 @@ There are currently 2 possible edge types:
 column        | type                          | restriction
 --------------| ----------------------------- | -----------
 from_node_type| String                        | -
-from_node_id  | Int                           | -
+from_node_id  | Int32                         | -
 to_node_type  | String                        | -
-to_node_id    | Int                           | -
+to_node_id    | Int32                         | -
 edge_type     | String                        | must be "flow" or "control"
 geom          | LineString or MultiLineString | (optional)
 name          | String                        | (optional, does not have to be unique)
-subnetwork_id | Int                           | (optional, denotes source in allocation network)
+subnetwork_id | Int32                         | (optional, denotes source in allocation network)
 
 Similarly to the node table, you can use a geometry to visualize the connections between the
 nodes in QGIS. For instance, you can draw a line connecting the two node coordinates.
@@ -251,7 +251,7 @@ time table, it is empty, or all timestamps of that variable are missing.
 
 column                | type    | unit         | restriction
 ---------             | ------- | ------------ | -----------
-node_id               | Int     | -            | sorted
+node_id               | Int32   | -            | sorted
 precipitation         | Float64 | $m s^{-1}$   | non-negative
 potential_evaporation | Float64 | $m s^{-1}$   | non-negative
 drainage              | Float64 | $m^3 s^{-1}$ | non-negative
@@ -277,7 +277,7 @@ Basin node types have state.
 
 column    | type    | unit         | restriction
 --------- | ------- | ------------ | -----------
-node_id   | Int     | -            | sorted
+node_id   | Int32   | -            | sorted
 level     | Float64 | $m$          | $\ge$ basin bottom
 
 Each Basin ID needs to be in the table.
@@ -288,7 +288,7 @@ The profile table defines the physical dimensions of the storage reservoir of ea
 
 column    | type    | unit         | restriction
 --------- | ------- | ------------ | -----------
-node_id   | Int     | -            | sorted
+node_id   | Int32   | -            | sorted
 area      | Float64 | $m^2$        | non-negative, per node_id: start positive and increasing
 level     | Float64 | $m$          | per node_id: increasing
 
@@ -317,7 +317,7 @@ Using this makes it easier to recognize which water or land surfaces are represe
 
 column    | type                    | restriction
 --------- | ----------------------- | -----------
-node_id   | Int                     | sorted
+node_id   | Int32                   | sorted
 geom      | Polygon or MultiPolygon | (optional)
 
 ## Basin / subgrid
@@ -328,8 +328,8 @@ This functionality can be used to translate a single lumped basin level to a mor
 
 column        | type    | unit  | restriction
 ------------- | ------- | ----- | ------------------------
-subgrid_id    | Int     | -     | sorted
-node_id       | Int     | -     | constant per subgrid_id
+subgrid_id    | Int32   | -     | sorted
+node_id       | Int32   | -     | constant per subgrid_id
 basin_level   | Float64 | $m$   | sorted per subgrid_id
 subgrid_level | Float64 | $m$   | sorted per subgrid_id
 
@@ -358,7 +358,7 @@ Lets a fraction (in [0,1]) of the incoming flow trough.
 
 column        | type    | unit         | restriction
 ------------- | ------- | ------------ | -----------
-node_id       | Int     | -            | sorted
+node_id       | Int32   | -            | sorted
 control_state | String  | -            | (optional) sorted per node_id
 fraction      | Float64 | -            | in the interval [0,1]
 
@@ -369,7 +369,7 @@ relation between the storage of a connected Basin (via the outlet level) and its
 
 column        | type    | unit         | restriction
 ------------- | ------- | ------------ | -----------
-node_id       | Int     | -            | sorted
+node_id       | Int32   | -            | sorted
 control_state | String  | -            | (optional) sorted per node_id
 active        | Bool    | -            | (optional, default true)
 level         | Float64 | $m$          | sorted per control_state
@@ -393,7 +393,7 @@ Note that a `node_id` can be either in this table or in the static one, but not 
 
 column    | type     | unit         | restriction
 --------- | -------  | ------------ | -----------
-node_id   | Int      | -            | sorted
+node_id   | Int32    | -            | sorted
 time      | DateTime | -            | sorted per node_id
 level     | Float64  | $m$          | sorted per node_id per time
 flow_rate | Float64  | $m^3 s^{-1}$ | non-negative
@@ -408,7 +408,7 @@ When PID controlled, the pump must point away from the controlled basin in terms
 
 column                | type    | unit         | restriction
 ---------             | ------- | ------------ | -----------
-node_id               | Int     | -            | sorted
+node_id               | Int32   | -            | sorted
 control_state         | String  | -            | (optional) sorted per node_id
 active                | Bool    | -            | (optional, default true)
 flow_rate             | Float64 | $m^3 s^{-1}$ | non-negative
@@ -422,7 +422,7 @@ When PID controlled, the outlet must point towards the controlled basin in terms
 
 column                | type    | unit         | restriction
 ---------             | ------- | ------------ | -----------
-node_id               | Int     | -            | sorted
+node_id               | Int32   | -            | sorted
 control_state         | String  | -            | (optional) sorted per node_id
 active                | Bool    | -            | (optional, default true)
 flow_rate             | Float64 | $m^3 s^{-1}$ | non-negative
@@ -445,12 +445,12 @@ The difference is consumed by the UserDemand.
 
 column        | type    | unit         | restriction
 ------------- | ------- | ------------ | -----------
-node_id       | Int     | -            | sorted
+node_id       | Int32   | -            | sorted
 active        | Bool    | -            | (optional, default true)
 demand        | Float64 | $m^3 s^{-1}$ | -
 return_factor | Float64 | -            | between [0 - 1]
 min_level     | Float64 | $m$          | -
-priority      | Int     | -            | positive, sorted per node id
+priority      | Int32   | -            | positive, sorted per node id
 
 ## UserDemand / time
 
@@ -464,8 +464,8 @@ Note that a `node_id` can be either in this table or in the static one, but not 
 
 column        | type     | unit         | restriction
 ------------- | -------- | ------------ | -----------
-node_id       | Int      | -            | sorted
-priority      | Int      | -            | positive, sorted per node id
+node_id       | Int32    | -            | sorted
+priority      | Int32    | -            | positive, sorted per node id
 time          | DateTime | -            | sorted per priority per node id
 demand        | Float64  | $m^3 s^{-1}$ | -
 return_factor | Float64  | -            | between [0 - 1]
@@ -480,10 +480,10 @@ The same `LevelDemand` node can be used for basins in different subnetworks.
 
 column        | type    | unit         | restriction
 ------------- | ------- | ------------ | -----------
-node_id       | Int     | -            | sorted
+node_id       | Int32   | -            | sorted
 min_level     | Float64 | $m$          | -
 max_level     | Float64 | $m$          | -
-priority      | Int     | -            | positive
+priority      | Int32   | -            | positive
 
 ## LevelDemand / time
 
@@ -492,11 +492,11 @@ Similar to the static version, only a single priority per `LevelDemand` node can
 
 column        | type     | unit         | restriction
 ------------- | -------  | ------------ | -----------
-node_id       | Int      | -            | sorted
+node_id       | Int32    | -            | sorted
 time          | DateTime | -            | sorted per node id
 min_level     | Float64  | $m$          | -
 max_level     | Float64  | $m$          | -
-priority      | Int      | -            | positive
+priority      | Int32    | -            | positive
 
 # LevelBoundary {#sec-level-boundary}
 
@@ -507,7 +507,7 @@ exchange water with the basin based on the difference in water level between the
 
 column        | type    | unit         | restriction
 ------------- | ------- | ------------ | -----------
-node_id       | Int     | -            | sorted
+node_id       | Int32   | -            | sorted
 active        | Bool    | -            | (optional, default true)
 level         | Float64 | $m$          | -
 
@@ -523,7 +523,7 @@ Note that a `node_id` can be either in this table or in the static one, but not 
 
 column    | type     | unit         | restriction
 --------- | -------  | ------------ | -----------
-node_id   | Int      | -            | sorted
+node_id   | Int32    | -            | sorted
 time      | DateTime | -            | sorted per node_id
 level     | Float64  | $m$          | -
 
@@ -538,7 +538,7 @@ Note that the connected node must always be a Basin.
 
 column        | type    | unit         | restriction
 ------------- | ------- | ------------ | -----------
-node_id       | Int     | -            | sorted
+node_id       | Int32   | -            | sorted
 active        | Bool    | -            | (optional, default true)
 flow_rate     | Float64 | $m^3 s^{-1}$ | non-negative
 
@@ -554,7 +554,7 @@ Note that a `node_id` can be either in this table or in the static one, but not 
 
 column    | type     | unit         | restriction
 --------- | -------  | ------------ | -----------
-node_id   | Int      | -            | sorted
+node_id   | Int32    | -            | sorted
 time      | DateTime | -            | sorted per node_id
 flow_rate | Float64  | $m^3 s^{-1}$ | non-negative
 
@@ -564,7 +564,7 @@ Flow proportional to the level difference between the connected basins.
 
 column        | type    | unit         | restriction
 ------------- | ------- | ------------ | -----------
-node_id       | Int     | -            | sorted
+node_id       | Int32   | -            | sorted
 control_state | String  | -            | (optional) sorted per node_id
 active        | Bool    | -            | (optional, default true)
 resistance    | Float64 | $sm^{-2}$    | -
@@ -576,7 +576,7 @@ Flow through this connection is estimated by conservation of energy and the Mann
 
 column        | type    | unit         | restriction
 ------------- | ------- | ------------ | -----------
-node_id       | Int     | -            | sorted
+node_id       | Int32   | -            | sorted
 control_state | String  | -            | (optional) sorted per node_id
 active        | Bool    | -            | (optional, default true)
 length        | Float64 | $m$          | positive
@@ -593,7 +593,7 @@ For example, terminal nodes can be used as a downstream boundary.
 
 column                | type    | unit         | restriction
 ---------             | ------- | ------------ | -----------
-node_id               | Int     | -            | sorted
+node_id               | Int32   | -            | sorted
 
 # DisceteControl {#sec-discrete-control}
 
@@ -605,9 +605,9 @@ The condition schema defines conditions of the form 'the discrete_control node w
 
 column            | type     | unit    | restriction
 ----------------- | -------- | ------- | -----------
-node_id           | Int      | -       | sorted
+node_id           | Int32    | -       | sorted
 listen_node_type  | String   | -       | known node type
-listen_node_id    | Int      | -       | sorted per node_id
+listen_node_id    | Int32    | -       | sorted per node_id
 variable          | String   | -       | must be "level" or "flow_rate", sorted per listen_node_id
 greater_than      | Float64  | various | sorted per variable
 look_ahead        | Float64  | $s$     | Only on transient boundary conditions, non-negative (optional, default 0)
@@ -632,7 +632,7 @@ Users can provide tables in any order, but when writing the model it gets sorted
 
 column         | type     | unit | restriction
 -------------- | -------- | ---- | -----------
-node_id        | Int      | -    | sorted
+node_id        | Int32    | -    | sorted
 control_state  | String   | -    | -
 truth_state    | String   | -    | Consists of the characters "T" (true), "F" (false), "U" (upcrossing), "D" (downcrossing) and "*" (any), sorted per node_id
 
@@ -644,11 +644,11 @@ In the future controlling the flow on a particular edge could be supported.
 
 column           | type     | unit     | restriction
 ---------------- | -------- | -------- | -----------
-node_id          | Int      | -        | sorted
+node_id          | Int32    | -        | sorted
 control_state    | String   | -        | (optional) sorted per node_id
 active           | Bool     | -        | (optional, default true)
-listen_node_type | Int      | -        | known node type
-listen_node_id   | Int      | -        | -
+listen_node_type | Int32    | -        | known node type
+listen_node_id   | Int32    | -        | -
 target           | Float64  | $m$      | -
 proportional     | Float64  | $s^{-1}$ | -
 integral         | Float64  | $s^{-2}$ | -
@@ -666,10 +666,10 @@ Note that a `node_id` can be either in this table or in the static one, but not 
 
 column           | type     | unit     | restriction
 ---------------- | -------- | -------- | -----------
-node_id          | Int      | -        | sorted
+node_id          | Int32    | -        | sorted
 time             | DateTime | -        | sorted per node_id
-listen_node_type | Int      | -        | known node type
-listen_node_id   | Int      | -        | -
+listen_node_type | Int32    | -        | known node type
+listen_node_id   | Int32    | -        | -
 target           | Float64  | $m$      | -
 proportional     | Float64  | $s^{-1}$ | -
 integral         | Float64  | $s^{-2}$ | -
@@ -685,7 +685,7 @@ timestep. The initial condition is also written to the file.
 column   | type     | unit
 -------- | -------- | ----
 time     | DateTime | -
-node_id  | Int      | -
+node_id  | Int32    | -
 storage  | Float64  | $m^3$
 level    | Float64  | $m$
 
@@ -696,15 +696,15 @@ The table is sorted by time, and per time it is sorted by `node_id`.
 The flow table contains calculated mean flows for every flow edge in the model.
 In the time column the start of the period is indicated.
 
-column         | type                | unit
--------------- | ------------------- | ----
-time           | DateTime            | -
-edge_id        | Union{Int, Missing} | -
-from_node_type | String              | -
-from_node_id   | Int                 | -
-to_node_type   | String              | -
-to_node_id     | Int                 | -
-flow_rate      | Float64             | $m^3 s^{-1}$
+column         | type                  | unit
+-------------- | --------------------- | ----
+time           | DateTime              | -
+edge_id        | Union{Int32, Missing} | -
+from_node_type | String                | -
+from_node_id   | Int32                 | -
+to_node_type   | String                | -
+to_node_id     | Int32                 | -
+flow_rate      | Float64               | $m^3 s^{-1}$
 
 The table is sorted by time, and per time the same `edge_id` order is used, though not sorted.
 The `edge_id` value is the same as the `fid` written to the Edge table, and can be used to directly look up the Edge geometry.
@@ -718,7 +718,7 @@ The control table contains a record of each change of control state: when it hap
 column          | type
 --------------- | ----------
 time            | DateTime
-control_node_id | Int
+control_node_id | Int32
 truth_state     | String
 control_state   | String
 
@@ -729,10 +729,10 @@ The allocation table contains a record of allocation results: when it happened, 
 column        | type
 --------------| -----
 time          | DateTime
-subnetwork_id | Int
+subnetwork_id | Int32
 node_type     | String
-node_id       | Int
-priority      | Int
+node_id       | Int32
+priority      | Int32
 demand        | Float64
 allocated     | Float64
 realized      | Float64
@@ -753,12 +753,12 @@ types of optimization for the subnetwork: collecting its total demand per priori
 column          | type
 ----------------| -----
 time            | DateTime
-edge_id         | Int
+edge_id         | Int32
 from_node_type  | String
-from_node_id    | Int
+from_node_id    | Int32
 to_node_type    | String
-to_node_id      | Int
-subnetwork_id   | Int
-priority        | Int
+to_node_id      | Int32
+subnetwork_id   | Int32
+priority        | Int32
 flow_rate       | Float64
 collect_demands | Bool

--- a/python/ribasim_testmodels/ribasim_testmodels/backwater.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/backwater.py
@@ -18,7 +18,7 @@ def backwater_model():
     node_type[0] = "FlowBoundary"
     node_type[-1] = "LevelBoundary"
 
-    ids = np.arange(1, node_type.size + 1, dtype=np.int64)
+    ids = np.arange(1, node_type.size + 1, dtype=int)
 
     model = ribasim.Model(
         starttime="2020-01-01 00:00:00",


### PR DESCRIPTION
We used to have a test that `typemax(Int64)` was working as a node ID, but this broke in the add API. Rather than fixing that I think Int32 IDs will always suffice (goes to over 2 billion), and save some memory and (uncompressed) output file size.

Also when creating a new table in QGIS it creates Int32:
![image](https://github.com/Deltares/Ribasim/assets/4471859/c12f2baf-bc84-4086-8696-27c7e6d0d9fb)

Diff is fairly large since we are restrictive in our function type signatures. `Int` is still used for indices.