### PR TITLE
QGIS: don't crash on unknown layers in database

### DIFF
--- a/ribasim_qgis/core/nodes.py
+++ b/ribasim_qgis/core/nodes.py
@@ -867,5 +867,7 @@ def load_nodes_from_geopackage(path: Path) -> dict[str, Input]:
     gpkg_names = geopackage.layers(path)
     nodes = {}
     for layername in gpkg_names:
-        nodes[layername] = NODES[layername](path)
+        klass = NODES.get(layername)
+        if klass is not None:
+            nodes[layername] = NODES[layername](path)
     return nodes

--- a/ribasim_qgis/core/nodes.py
+++ b/ribasim_qgis/core/nodes.py
@@ -869,5 +869,5 @@ def load_nodes_from_geopackage(path: Path) -> dict[str, Input]:
     for layername in gpkg_names:
         klass = NODES.get(layername)
         if klass is not None:
-            nodes[layername] = NODES[layername](path)
+            nodes[layername] = klass(path)
     return nodes


### PR DESCRIPTION
Currently both Ribasim Python and the core silently ignore extra unknown tables. This makes QGIS do the same.

```
An error has occurred while executing Python code: 

KeyError: 'Basin / boundaryconcentration' 
Traceback (most recent call last):
  File "C:\Users/visser_mn/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\ribasim_qgis\widgets\dataset_widget.py", line 286, in open_model
    self.load_geopackage()
  File "C:\Users/visser_mn/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\ribasim_qgis\widgets\dataset_widget.py", line 221, in load_geopackage
    nodes = load_nodes_from_geopackage(geo_path)
  File "C:\Users/visser_mn/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\ribasim_qgis\core\nodes.py", line 870, in load_nodes_from_geopackage
    nodes[layername] = NODES[layername](path)
KeyError: 'Basin / boundaryconcentration'
```