### PR TITLE
Sort Node and Edge tables

### DIFF
--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -155,8 +155,7 @@ function valid_edges(graph::MetaGraph)::Bool
 
         if !(type_dst in neighbortypes(type_src))
             errors = true
-            edge_id = graph[id_src, id_dst].id
-            @error "Cannot connect a $type_src to a $type_dst." edge_id id_src id_dst
+            @error "Cannot connect a $type_src to a $type_dst." id_src id_dst
         end
     end
     return !errors

--- a/core/test/validation_test.jl
+++ b/core/test/validation_test.jl
@@ -254,7 +254,6 @@ end
     @test logger.logs[3].kwargs[:control_state] == ""
     @test logger.logs[4].level == Error
     @test logger.logs[4].message == "Cannot connect a basin to a fractional_flow."
-    @test logger.logs[4].kwargs[:edge_id] == 7
     @test logger.logs[4].kwargs[:id_src] == NodeID(:Basin, 2)
     @test logger.logs[4].kwargs[:id_dst] == NodeID(:FractionalFlow, 8)
 end

--- a/python/ribasim/ribasim/geometry/edge.py
+++ b/python/ribasim/ribasim/geometry/edge.py
@@ -85,6 +85,16 @@ class EdgeTable(SpatialTableModel[EdgeSchema]):
         assert self.df is not None
         return (self.df.edge_type == edge_type).to_numpy()
 
+    def sort(self):
+        assert self.df is not None
+        sort_keys = [
+            "from_node_type",
+            "from_node_id",
+            "to_node_type",
+            "to_node_id",
+        ]
+        self.df.sort_values(sort_keys, ignore_index=True, inplace=True)
+
     def plot(self, **kwargs) -> Axes:
         assert self.df is not None
         kwargs = kwargs.copy()  # Avoid side-effects

--- a/python/ribasim/ribasim/geometry/node.py
+++ b/python/ribasim/ribasim/geometry/node.py
@@ -38,6 +38,11 @@ class NodeTable(SpatialTableModel[NodeSchema]):
             self.df.drop(mask, inplace=True)
             self.df.reset_index(inplace=True, drop=True)
 
+    def sort(self):
+        assert self.df is not None
+        sort_keys = ["node_type", "node_id"]
+        self.df.sort_values(sort_keys, ignore_index=True, inplace=True)
+
     def plot_allocation_networks(self, ax=None, zorder=None) -> Any:
         if ax is None:
             _, ax = plt.subplots()

--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -363,10 +363,6 @@ class SpatialTableModel(TableModel[TableT], Generic[TableT]):
         assert self.df is not None
         self.df.to_file(path, layer=self.tablename(), driver="GPKG", mode="a")
 
-    def sort(self):
-        if self.df is not None:
-            self.df.sort_index(inplace=True)
-
 
 class ChildModel(BaseModel):
     _parent: Any | None = None

--- a/python/ribasim/tests/test_io.py
+++ b/python/ribasim/tests/test_io.py
@@ -97,6 +97,7 @@ def test_extra_columns(basic_transient):
 def test_sort(level_setpoint_with_minmax, tmp_path):
     model = level_setpoint_with_minmax
     table = model.discrete_control.condition
+    edge = model.edge
 
     # apply a wrong sort, then call the sort method to restore order
     table.df.sort_values("greater_than", ascending=False, inplace=True)
@@ -110,15 +111,24 @@ def test_sort(level_setpoint_with_minmax, tmp_path):
     table.sort()
     assert table.df.iloc[0]["greater_than"] == 5.0
 
+    edge.df.sort_values("from_node_type", ascending=False, inplace=True)
+    assert edge.df.iloc[0]["from_node_type"] != "Basin"
+    edge.sort()
+    assert edge.df.iloc[0]["from_node_type"] == "Basin"
+
     # re-apply wrong sort, then check if it gets sorted on write
     table.df.sort_values("greater_than", ascending=False, inplace=True)
+    edge.df.sort_values("from_node_type", ascending=False, inplace=True)
     model.write(tmp_path / "basic/ribasim.toml")
     # write sorts the model in place
     assert table.df.iloc[0]["greater_than"] == 5.0
     model_loaded = ribasim.Model(filepath=tmp_path / "basic/ribasim.toml")
     table_loaded = model_loaded.discrete_control.condition
+    edge_loaded = model_loaded.edge
     assert table_loaded.df.iloc[0]["greater_than"] == 5.0
+    assert edge.df.iloc[0]["from_node_type"] == "Basin"
     __assert_equal(table.df, table_loaded.df)
+    __assert_equal(edge.df, edge_loaded.df)
 
 
 @pytest.mark.xfail(reason="Needs Model read implementation")


### PR DESCRIPTION
This mainly makes it easier to visually scan these tables, but doesn't affect the core.