### PR TITLE
Add `model.node_table()`

### DIFF
--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -147,10 +147,7 @@ class MultiNodeModel(NodeModel):
         return self.node.df
 
     def __getitem__(self, index):
-        is_node_id = self.node.df["node_id"] == index
-        rows = self.node.df[is_node_id]
-        row = rows.iloc[0]
-        # bug: self.node.df contains only the last added Basin #12
+        row = self.node.df[self.node.df["node_id"] == index].iloc[0]
         return NodeData(
             node_id=index, node_type=row["node_type"], geometry=row["geometry"]
         )

--- a/python/ribasim/ribasim/geometry/node.py
+++ b/python/ribasim/ribasim/geometry/node.py
@@ -35,8 +35,12 @@ class NodeTable(SpatialTableModel[NodeSchema]):
         """Filter the node table based on the node type."""
         if self.df is not None:
             mask = self.df[self.df["node_type"] != nodetype].index
-            self.df.drop(mask, inplace=True)
-            self.df.reset_index(inplace=True, drop=True)
+            if mask.empty:
+                # Avoid creating tables for unused node types
+                self.df = None
+            else:
+                self.df.drop(mask, inplace=True)
+                self.df.reset_index(inplace=True, drop=True)
 
     def sort(self):
         assert self.df is not None

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -247,8 +247,7 @@ class Model(FileModel):
             ax.axis("off")
 
         self.edge.plot(ax=ax, zorder=2)
-        for node in self._nodes():
-            node.node.plot(ax=ax, zorder=3)
+        self.node_table().plot(ax=ax, zorder=3)
         # TODO
         # self.plot_control_listen(ax)
         # self.node.plot(ax=ax, zorder=3)

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -3,6 +3,7 @@ from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 
+import pandas as pd
 import tomli
 import tomli_w
 from matplotlib import pyplot as plt
@@ -37,6 +38,7 @@ from ribasim.config import (
     UserDemand,
 )
 from ribasim.geometry.edge import EdgeTable
+from ribasim.geometry.node import NodeTable
 from ribasim.input_base import (
     ChildModel,
     FileModel,
@@ -139,6 +141,14 @@ class Model(FileModel):
             attr = getattr(self, key)
             if isinstance(attr, MultiNodeModel) and attr.node.df is not None:
                 yield attr
+
+    def node_table(self) -> NodeTable:
+        """Compute the full NodeTable from all node types."""
+        df_chunks = [node.node.df for node in self._nodes()]
+        df = pd.concat(df_chunks, ignore_index=True)  # type: ignore
+        node_table = NodeTable(df=df)
+        node_table.sort()
+        return node_table
 
     def _children(self):
         return {

--- a/python/ribasim/tests/test_io.py
+++ b/python/ribasim/tests/test_io.py
@@ -131,7 +131,6 @@ def test_sort(level_setpoint_with_minmax, tmp_path):
     __assert_equal(edge.df, edge_loaded.df)
 
 
-@pytest.mark.xfail(reason="Needs Model read implementation")
 def test_roundtrip(trivial, tmp_path):
     model1 = trivial
     model1dir = tmp_path / "model1"
@@ -148,9 +147,9 @@ def test_roundtrip(trivial, tmp_path):
         model2dir / "ribasim.toml"
     ).read_text()
 
-    # check if all tables are the same
-    __assert_equal(model1.network.node.df, model2.network.node.df, is_network=True)
-    __assert_equal(model1.network.edge.df, model2.network.edge.df, is_network=True)
+    # check if all tables are the sameF
+    __assert_equal(model1.node_table().df, model2.node_table().df, is_network=True)
+    __assert_equal(model1.edge.df, model2.edge.df, is_network=True)
     for node1, node2 in zip(model1._nodes(), model2._nodes()):
         for table1, table2 in zip(node1._tables(), node2._tables()):
             __assert_equal(table1.df, table2.df)

--- a/python/ribasim/tests/test_model.py
+++ b/python/ribasim/tests/test_model.py
@@ -173,3 +173,12 @@ def test_write_adds_fid_in_tables(basic, tmp_path):
         query = "select fid from Edge"
         df = pd.read_sql_query(query, connection)
         assert "fid" in df.columns
+
+
+def test_node_table(basic):
+    model = basic
+    node_table = model.node_table()
+    df = node_table.df
+    assert df.geometry.is_unique
+    assert df.node_type.iloc[0] == "Basin"
+    assert df.node_type.iloc[-1] == "Terminal"


### PR DESCRIPTION
With the add API the full Node table is never created in memory, but the rows are available per node type. Users that need just the network need a way to compute the table when needed.

Marking this as a draft because I'm stuck. The new function works fine, but I tried re-enabling the round trip test, and found that the read from #1243 creates empty node tables for each node type due to the way it filters. I wanted to fix that by setting `node.df = None` if the filtered Node table was empty (if the node type doesn't occur).

But that triggers behavior I do not understand.

```python
from ribasim import Model, Node
from ribasim.nodes import basin
from shapely.geometry import Point

model = Model(
    starttime="2020-01-01",
    endtime="2020-01-20",
)

model.basin.add(Node(5, Point(0, 0)), [basin.State(level=[1.0])])
# now both model.basin.node and model.basin.state have 1 row
model.basin.add(Node(8, Point(3, 0)), [basin.State(level=[2.0])])
# now model.basin.state has 2 rows, but model.basin.node only the last node 8
```

The `setattr` in the `add` method triggers this, so if you pass no tables like `basin.State`, `model.basin.node` contains both rows. I rewrote the if/else in `add` a bit but no real changes, the logic there seems ok. We just seem to trigger something pydantic that I find hard to debug, so any help welcome.

This is all triggered by my change to `filter`, so perhaps if there are better ways to fix that, by e.g. pruning empty node types at the end of model reading or something like that, I'm also happy.