### PR TITLE
Add `model.node_table()`, take two

### DIFF
--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -3,6 +3,7 @@ from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 
+import pandas as pd
 import tomli
 import tomli_w
 from matplotlib import pyplot as plt
@@ -37,6 +38,7 @@ from ribasim.config import (
     UserDemand,
 )
 from ribasim.geometry.edge import EdgeTable
+from ribasim.geometry.node import NodeTable
 from ribasim.input_base import (
     ChildModel,
     FileModel,
@@ -133,11 +135,24 @@ class Model(FileModel):
         for sub in self._nodes():
             sub._save(directory, input_dir)
 
+    def node_table(self) -> NodeTable:
+        """Compute the full NodeTable from all node types."""
+        df_chunks = [node.node.df for node in self._nodes()]
+        df = pd.concat(df_chunks, ignore_index=True)  # type: ignore
+        node_table = NodeTable(df=df)
+        node_table.sort()
+        return node_table
+
     def _nodes(self) -> Generator[MultiNodeModel, Any, None]:
         """Return all non-empty MultiNodeModel instances."""
         for key in self.model_fields.keys():
             attr = getattr(self, key)
-            if isinstance(attr, MultiNodeModel) and attr.node.df is not None:
+            if (
+                isinstance(attr, MultiNodeModel)
+                and attr.node.df is not None
+                # Model.read creates empty node tables (#1278)
+                and not attr.node.df.empty
+            ):
                 yield attr
 
     def _children(self):
@@ -236,12 +251,12 @@ class Model(FileModel):
             _, ax = plt.subplots()
             ax.axis("off")
 
+        node = self.node_table()
         self.edge.plot(ax=ax, zorder=2)
-        for node in self._nodes():
-            node.node.plot(ax=ax, zorder=3)
+        node.plot(ax=ax, zorder=3)
         # TODO
         # self.plot_control_listen(ax)
-        # self.node.plot(ax=ax, zorder=3)
+        # node.plot(ax=ax, zorder=3)
 
         handles, labels = ax.get_legend_handles_labels()
 
@@ -250,7 +265,7 @@ class Model(FileModel):
         #     (
         #         handles_subnetworks,
         #         labels_subnetworks,
-        #     ) = self.network.node.plot_allocation_networks(ax=ax, zorder=1)
+        #     ) = node.plot_allocation_networks(ax=ax, zorder=1)
         #     handles += handles_subnetworks
         #     labels += labels_subnetworks
 

--- a/python/ribasim/tests/test_io.py
+++ b/python/ribasim/tests/test_io.py
@@ -4,54 +4,45 @@ import tomli
 from pandas import DataFrame
 from pandas.testing import assert_frame_equal
 from pydantic import ValidationError
+from ribasim import Model
 from ribasim.nodes import pump, terminal
 
 
-def __assert_equal(a: DataFrame, b: DataFrame, is_network=False) -> None:
-    """Like pandas.testing.assert_frame_equal, but ignoring the index."""
+def __assert_equal(a: DataFrame, b: DataFrame) -> None:
+    """Lenient version of pandas.testing.assert_frame_equal."""
     if a is None and b is None:
-        return True
-
-    if is_network:
-        # We set this on write, needed for GeoPackage.
-        a.index.name = "fid"
-        a.index.name = "fid"
+        return
+    elif a is None or b is None:
+        assert False
 
     a = a.reset_index(drop=True)
     b = b.reset_index(drop=True)
+    a.drop(columns=["fid"], inplace=True, errors="ignore")
+    b.drop(columns=["fid"], inplace=True, errors="ignore")
 
-    # avoid comparing datetime64[ns] with datetime64[ms]
-    if "time" in a:
-        a["time"] = a.time.astype("datetime64[ns]")
-        b["time"] = b.time.astype("datetime64[ns]")
-
-    if "fid" in a:
-        a.drop(columns=["fid"], inplace=True)
-    if "fid" in b:
-        b.drop(columns=["fid"], inplace=True)
-
-    return assert_frame_equal(a, b)
+    assert_frame_equal(a, b)
 
 
 def test_basic(basic, tmp_path):
     model_orig = basic
     toml_path = tmp_path / "basic/ribasim.toml"
     model_orig.write(toml_path)
-    model_loaded = ribasim.Model(filepath=toml_path)
+    model_loaded = Model.read(toml_path)
 
     with open(toml_path, "rb") as f:
         toml_dict = tomli.load(f)
 
     assert toml_dict["ribasim_version"] == ribasim.__version__
 
-    __assert_equal(model_orig.edge.df, model_loaded.edge.df, is_network=True)
+    __assert_equal(model_orig.edge.df, model_loaded.edge.df)
+    __assert_equal(model_orig.node_table().df, model_loaded.node_table().df)
     assert model_loaded.basin.time.df is None
 
 
 def test_basic_arrow(basic_arrow, tmp_path):
     model_orig = basic_arrow
     model_orig.write(tmp_path / "basic_arrow/ribasim.toml")
-    model_loaded = ribasim.Model(filepath=tmp_path / "basic_arrow/ribasim.toml")
+    model_loaded = Model.read(tmp_path / "basic_arrow/ribasim.toml")
 
     __assert_equal(model_orig.basin.profile.df, model_loaded.basin.profile.df)
 
@@ -59,9 +50,9 @@ def test_basic_arrow(basic_arrow, tmp_path):
 def test_basic_transient(basic_transient, tmp_path):
     model_orig = basic_transient
     model_orig.write(tmp_path / "basic_transient/ribasim.toml")
-    model_loaded = ribasim.Model(filepath=tmp_path / "basic_transient/ribasim.toml")
+    model_loaded = Model.read(tmp_path / "basic_transient/ribasim.toml")
 
-    __assert_equal(model_orig.edge.df, model_loaded.edge.df, is_network=True)
+    __assert_equal(model_orig.edge.df, model_loaded.edge.df)
 
     time = model_loaded.basin.time
     assert model_orig.basin.time.df.time[0] == time.df.time[0]
@@ -131,14 +122,13 @@ def test_sort(level_setpoint_with_minmax, tmp_path):
     __assert_equal(edge.df, edge_loaded.df)
 
 
-@pytest.mark.xfail(reason="Needs Model read implementation")
 def test_roundtrip(trivial, tmp_path):
     model1 = trivial
     model1dir = tmp_path / "model1"
     model2dir = tmp_path / "model2"
     # read a model and then write it to a different path
     model1.write(model1dir / "ribasim.toml")
-    model2 = ribasim.Model(filepath=model1dir / "ribasim.toml")
+    model2 = Model.read(model1dir / "ribasim.toml")
     model2.write(model2dir / "ribasim.toml")
 
     assert (model1dir / "database.gpkg").is_file()
@@ -149,8 +139,8 @@ def test_roundtrip(trivial, tmp_path):
     ).read_text()
 
     # check if all tables are the same
-    __assert_equal(model1.network.node.df, model2.network.node.df, is_network=True)
-    __assert_equal(model1.network.edge.df, model2.network.edge.df, is_network=True)
+    __assert_equal(model1.node_table().df, model2.node_table().df)
+    __assert_equal(model1.edge.df, model2.edge.df)
     for node1, node2 in zip(model1._nodes(), model2._nodes()):
         for table1, table2 in zip(node1._tables(), node2._tables()):
             __assert_equal(table1.df, table2.df)

--- a/python/ribasim/tests/test_model.py
+++ b/python/ribasim/tests/test_model.py
@@ -173,3 +173,12 @@ def test_write_adds_fid_in_tables(basic, tmp_path):
         query = "select fid from Edge"
         df = pd.read_sql_query(query, connection)
         assert "fid" in df.columns
+
+
+def test_node_table(basic):
+    model = basic
+    node = model.node_table()
+    df = node.df
+    assert df.geometry.is_unique
+    assert df.node_type.iloc[0] == "Basin"
+    assert df.node_type.iloc[-1] == "Terminal"


### PR DESCRIPTION
This supersedes #1276 by working around #1278 and still enabling the round tripping tests.

Also simplifies `__assert_equal` a bit and stimulates `Model.read(toml_path)` usage over `Model(filepath=toml_path)`.