### PR TITLE
Stop pinning Python version for default environment

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -190,7 +190,6 @@ python = "3.11.*"
 python = "3.10.*"
 
 [environments]
-default=["py312"]
 py312=["py312"]
 py311=["py311"]
 py310=["py310"]


### PR DESCRIPTION
Thinking about that more, there is no reason for that