### PR TITLE
change int to string for PID listen_node_type

### DIFF
--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -647,7 +647,7 @@ column           | type     | unit     | restriction
 node_id          | Int32    | -        | sorted
 control_state    | String   | -        | (optional) sorted per node_id
 active           | Bool     | -        | (optional, default true)
-listen_node_type | Int32    | -        | known node type
+listen_node_type | String   | -        | known node type
 listen_node_id   | Int32    | -        | -
 target           | Float64  | $m$      | -
 proportional     | Float64  | $s^{-1}$ | -


### PR DESCRIPTION
In documentation of PID node, [Usage](https://deltares.github.io/Ribasim/core/usage.html#sec-pid-control) under Julia core, the listen_note_type is supposed to be "String" but in the document it says "Int32". It is incorrect, and therefore should be changed.