### PR TITLE
Unpin OteraEngine, switch to latest 0.5.1

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.10.0"
 manifest_format = "2.0"
-project_hash = "a66ce8b152bba81b582cbf6d8a2e07a88d016add"
+project_hash = "22708fb864a341d70b001d75765852e92f1f5399"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "41c37aa88889c171f1300ceac1313c06e891d245"
@@ -1075,9 +1075,9 @@ version = "6.74.0"
 
 [[deps.OteraEngine]]
 deps = ["Markdown", "Pkg", "TOML"]
-git-tree-sha1 = "0d57df750e20a4534a117398dc04eb237d86ea70"
+git-tree-sha1 = "69e36fecf524a1da7d76a8ae3e70a221d86d2867"
 uuid = "b2d7f28f-acd6-4007-8b26-bc27716e5513"
-version = "0.4.1"
+version = "0.5.1"
 
 [[deps.PackageCompiler]]
 deps = ["Artifacts", "Glob", "LazyArtifacts", "Libdl", "Pkg", "Printf", "RelocatableFolders", "TOML", "UUIDs", "p7zip_jll"]

--- a/Project.toml
+++ b/Project.toml
@@ -56,6 +56,3 @@ TestEnv = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-
-[compat]
-OteraEngine = "0.4"


### PR DESCRIPTION
Fixes #1240
It was not a breaking change but a regression, which I reported and then swiftly got fixed.
