### PR TITLE
Set the Node fid back to the node_id

### DIFF
--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -3,6 +3,7 @@ from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 
+import geopandas as gpd
 import pandas as pd
 import tomli
 import tomli_w
@@ -137,6 +138,16 @@ class Model(FileModel):
         self.edge._save(directory, input_dir)
         for sub in self._nodes():
             sub._save(directory, input_dir)
+
+        # Temporarily require unique node_id for #1262
+        # and copy them to the fid for #1306.
+        df = gpd.read_file(db_path, layer="Node")
+        if not df["node_id"].is_unique:
+            raise ValueError("node_id must be unique")
+        df.set_index("node_id", drop=False, inplace=True)
+        df.sort_index(inplace=True)
+        df.index.name = "fid"
+        df.to_file(db_path, layer="Node", driver="GPKG", index=True)
 
     def node_table(self) -> NodeTable:
         """Compute the full NodeTable from all node types."""


### PR DESCRIPTION
The idea was that the Node table `fid` would not be used anymore, but #1306 showed that is unfortunately not yet the case. So this changes the `fid` after it is initially written to be equal to the `node_id`. Any users should still not rely on the `fid`, because this is only temporary.

This is like #1311 but now also catching non unique node IDs on `model.write`.
It also provides a temporary fix to #1306. It's not great, but I feel that especially #1306 is bad enough to warrant a quick fix. This would've been a bit cleaner to implement using #1312 to avoid having to read and re-write the Node table, but that PR still has issues we don't understand, so best not to wait on that.

![image](https://github.com/Deltares/Ribasim/assets/4471859/3efc2f8c-6be5-459d-929a-7ce8568fca3d)
