### PR TITLE
Run testmodels in parallel

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -142,7 +142,7 @@ mypy-ribasim-qgis = "mypy ribasim_qgis"
 ribasim-core = { cmd = "julia --project=core -e 'using Ribasim; Ribasim.main(ARGS)'", depends_on = [
     "initialize-julia",
 ] }
-ribasim-core-testmodels = { cmd = "julia --project utils/testmodelrun.jl", depends_on = [
+ribasim-core-testmodels = { cmd = "julia --project --threads=4 utils/testmodelrun.jl", depends_on = [
     "generate-testmodels",
     "initialize-julia",
 ] }

--- a/utils/testmodelrun.jl
+++ b/utils/testmodelrun.jl
@@ -1,4 +1,4 @@
-using Ribasim
+import Ribasim
 
 include("utils.jl")
 
@@ -7,21 +7,23 @@ function main(ARGS)
     n_model = length(toml_paths)
     n_pass = 0
     n_fail = 0
+    lk = ReentrantLock()
     failed = String[]
 
-    for toml_path in toml_paths
+    Threads.@threads for toml_path in toml_paths
         modelname = basename(dirname(toml_path))
-        @info "Running model $modelname"
-        if Ribasim.main(toml_path) != 0
-            @error "Simulation failed" modelname
-            push!(failed, modelname)
-            n_fail += 1
-        else
-            n_pass += 1
+        ret_code = Ribasim.main(toml_path)
+        lock(lk) do
+            if ret_code != 0
+                push!(failed, modelname)
+                n_fail += 1
+            else
+                n_pass += 1
+            end
         end
     end
 
-    @info "Ran $n_model models, $n_pass passed, $n_fail failed."
+    println("Ran $n_model models, $n_pass passed, $n_fail failed.\n")
     if n_fail > 0
         println("Failed models:")
         foreach(println, failed)


### PR DESCRIPTION
Fixes #1302, by spreading out the running of test models over four threads.

Before:
```
364.921784 seconds (562.47 M allocations: 40.793 GiB, 3.96% gc time, 61.46% compilation time: <1% of which was recompilation)
```

After:
```
264.766728 seconds (584.52 M allocations: 41.778 GiB, 3.79% gc time, 222.78% compilation time: <1% of which was recompilation)
```

I assume on CI the relative speed increase will be a bit better though.