### PR TITLE
Remove xugrid return type annotation, bump patch version

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1247,7 +1247,7 @@ version = "3.5.14"
 deps = ["Accessors", "Arrow", "BasicModelInterface", "CodecZstd", "ComponentArrays", "Configurations", "DBInterface", "DataInterpolations", "DataStructures", "Dates", "Dictionaries", "DiffEqCallbacks", "EnumX", "FiniteDiff", "ForwardDiff", "Graphs", "HiGHS", "IterTools", "JuMP", "Legolas", "LinearSolve", "Logging", "LoggingExtras", "MetaGraphsNext", "OrdinaryDiffEq", "PreallocationTools", "SQLite", "SciMLBase", "SparseArrays", "StructArrays", "Tables", "TerminalLoggers", "TimeZones", "TimerOutputs", "TranscodingStreams"]
 path = "core"
 uuid = "aac5e3d9-0b8f-4d4f-8241-b1a7a9632635"
-version = "2024.6.0"
+version = "2024.6.1"
 
 [[deps.RuntimeGeneratedFunctions]]
 deps = ["ExprTools", "SHA", "Serialization"]

--- a/core/Project.toml
+++ b/core/Project.toml
@@ -2,7 +2,7 @@ name = "Ribasim"
 uuid = "aac5e3d9-0b8f-4d4f-8241-b1a7a9632635"
 authors = ["Deltares and contributors <ribasim.info@deltares.nl>"]
 manifest = "../Manifest.toml"
-version = "2024.6.0"
+version = "2024.6.1"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/core/test/data/config_test.toml
+++ b/core/test/data/config_test.toml
@@ -2,7 +2,7 @@ starttime = 2019-01-01
 endtime = 2019-12-31
 input_dir = "../../generated_testmodels/lhm"
 results_dir = "../../generated_testmodels/lhm"
-ribasim_version = "2024.6.0"
+ribasim_version = "2024.6.1"
 
 [basin]
 time = "basin/time.arrow"

--- a/core/test/data/logging_test_loglevel_debug.toml
+++ b/core/test/data/logging_test_loglevel_debug.toml
@@ -2,7 +2,7 @@ starttime = 2019-01-01
 endtime = 2019-12-31
 input_dir = "."
 results_dir = "results"
-ribasim_version = "2024.6.0"
+ribasim_version = "2024.6.1"
 
 [logging]
 verbosity = "debug"

--- a/core/test/data/logging_test_no_loglevel.toml
+++ b/core/test/data/logging_test_no_loglevel.toml
@@ -2,4 +2,4 @@ starttime = 2019-01-01
 endtime = 2019-12-31
 input_dir = "."
 results_dir = "results"
-ribasim_version = "2024.6.0"
+ribasim_version = "2024.6.1"

--- a/core/test/docs.toml
+++ b/core/test/docs.toml
@@ -7,7 +7,7 @@ endtime = 2021-01-01   # required
 input_dir = "."         # required
 results_dir = "results" # required
 
-ribasim_version = "2024.6.0" # required
+ribasim_version = "2024.6.1" # required
 
 # Specific tables can also go into Arrow files rather than the database.
 # For large tables this can benefit from better compressed file sizes.

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Ribasim"
-version = "2024.6.0"
+version = "2024.6.1"
 description = "Water resources modeling"
 authors = ["Deltares and contributors <ribasim.info@deltares.nl>"]
 channels = ["conda-forge"]

--- a/python/ribasim/ribasim/__init__.py
+++ b/python/ribasim/ribasim/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2024.6.0"
+__version__ = "2024.6.1"
 
 
 from ribasim.config import Allocation, Logging, Node, Solver

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -349,7 +349,7 @@ class Model(FileModel):
 
         return ax
 
-    def to_xugrid(self) -> xugrid.UgridDataset:
+    def to_xugrid(self):
         """Convert the network to a xugrid.UgridDataset."""
         node_df = self.node_table().df
 

--- a/python/ribasim_api/ribasim_api/__init__.py
+++ b/python/ribasim_api/ribasim_api/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2024.6.0"
+__version__ = "2024.6.1"
 
 from ribasim_api.ribasim_api import RibasimApi
 

--- a/ribasim_qgis/metadata.txt
+++ b/ribasim_qgis/metadata.txt
@@ -7,7 +7,7 @@
 name=Ribasim-QGIS
 qgisMinimumVersion=3.0
 description=QGIS plugin to setup Ribasim models
-version=2024.6.0
+version=2024.6.1
 author=Deltares and contributors
 email=ribasim.info@deltares.nl
 


### PR DESCRIPTION
```
    def to_xugrid(self) -> xugrid.UgridDataset:
```

This return type annotation is removed, since it only works for required dependencies.