### PR TITLE
No need to formulate flow for Terminal anymore

### DIFF
--- a/core/src/graph.jl
+++ b/core/src/graph.jl
@@ -180,15 +180,6 @@ function set_flow!(graph::MetaGraph, id_src::NodeID, id_dst::NodeID, q::Number):
 end
 
 """
-Add the given flow q to the existing flow over the edge between the given nodes.
-"""
-function add_flow!(graph::MetaGraph, id_src::NodeID, id_dst::NodeID, q::Number)::Nothing
-    (; flow_dict, flow) = graph[]
-    get_tmp(flow, q)[flow_dict[(id_src, id_dst)]] += q
-    return nothing
-end
-
-"""
 Get the flow over the given edge (val is needed for get_tmp from ForwardDiff.jl).
 """
 function get_flow(graph::MetaGraph, id_src::NodeID, id_dst::NodeID, val)::Number

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -503,24 +503,6 @@ function formulate_flow!(
 end
 
 function formulate_flow!(
-    terminal::Terminal,
-    p::Parameters,
-    storage::AbstractVector,
-    t::Number,
-)::Nothing
-    (; graph) = p
-    (; node_id) = terminal
-
-    for id in node_id
-        for upstream_id in inflow_ids(graph, id)
-            q = get_flow(graph, upstream_id, id, storage)
-            add_flow!(graph, id, -q)
-        end
-    end
-    return nothing
-end
-
-function formulate_flow!(
     flow_boundary::FlowBoundary,
     p::Parameters,
     storage::AbstractVector,
@@ -637,12 +619,10 @@ function formulate_flows!(p::Parameters, storage::AbstractVector, t::Number)::No
         manning_resistance,
         tabulated_rating_curve,
         flow_boundary,
-        level_boundary,
         pump,
         outlet,
         user_demand,
         fractional_flow,
-        terminal,
     ) = p
 
     formulate_flow!(linear_resistance, p, storage, t)
@@ -653,7 +633,6 @@ function formulate_flows!(p::Parameters, storage::AbstractVector, t::Number)::No
     formulate_flow!(outlet, p, storage, t)
     formulate_flow!(user_demand, p, storage, t)
 
-    # do these last since they rely on formulated input flows
+    # do this last since they rely on formulated input flows
     formulate_flow!(fractional_flow, p, storage, t)
-    formulate_flow!(terminal, p, storage, t)
 end


### PR DESCRIPTION
This was missed from #1300. We don't store vertical flows anymore. Doing this was the only reason for `formulate_flows!` for Terminal nodes.

What I don't fully understand is why tests did not fail on this. Any test model with a Terminal should have failed since the 3-arg `add_flow!(graph, id, -q)` it called was removed in #1300. This PR also removes the 4-arg version that is no longer used.