### PR TITLE
Don't add the endtime to basin.arrow results

### DIFF
--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -84,26 +84,27 @@ function basin_table(
     node_id::Vector{Int32},
     storage::Vector{Float64},
     level::Vector{Float64},
-    precipitation::Vector{Union{Missing, Float64}},
-    evaporation::Vector{Union{Missing, Float64}},
-    drainage::Vector{Union{Missing, Float64}},
-    infiltration::Vector{Union{Missing, Float64}},
+    precipitation::Vector{Float64},
+    evaporation::Vector{Float64},
+    drainage::Vector{Float64},
+    infiltration::Vector{Float64},
 }
     (; saved) = model
     (; vertical_flux) = saved
 
+    # The last timestep is not included; there is no period over which to compute flows.
     data = get_storages_and_levels(model)
-    storage = vec(data.storage)
-    level = vec(data.level)
+    storage = vec(data.storage[:, begin:(end - 1)])
+    level = vec(data.level[:, begin:(end - 1)])
 
     nbasin = length(data.node_id)
-    ntsteps = length(data.time)
+    ntsteps = length(data.time) - 1
     nrows = nbasin * ntsteps
 
-    precipitation = Vector{Union{Missing, Float64}}(missing, nrows)
-    evaporation = Vector{Union{Missing, Float64}}(missing, nrows)
-    drainage = Vector{Union{Missing, Float64}}(missing, nrows)
-    infiltration = Vector{Union{Missing, Float64}}(missing, nrows)
+    precipitation = zeros(nrows)
+    evaporation = zeros(nrows)
+    drainage = zeros(nrows)
+    infiltration = zeros(nrows)
 
     idx_row = 0
 
@@ -118,7 +119,7 @@ function basin_table(
         end
     end
 
-    time = repeat(data.time; inner = nbasin)
+    time = repeat(data.time[begin:(end - 1)]; inner = nbasin)
     node_id = repeat(Int32.(data.node_id); outer = ntsteps)
 
     return (;

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -99,7 +99,7 @@
         @test nsaved > 10
         # t0 has no flow, 2 flow edges
         @test nrow(flow) == (nsaved - 1) * 2
-        @test nrow(basin) == nsaved
+        @test nrow(basin) == nsaved - 1
         @test nrow(control) == 0
         @test nrow(allocation) == 0
         @test nrow(subgrid) == nsaved * length(p.subgrid.level)

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -54,16 +54,7 @@
                 :drainage,
                 :infiltration,
             ),
-            (
-                DateTime,
-                Int32,
-                Float64,
-                Float64,
-                Union{Missing, Float64},
-                Union{Missing, Float64},
-                Union{Missing, Float64},
-                Union{Missing, Float64},
-            ),
+            (DateTime, Int32, Float64, Float64, Float64, Float64, Float64, Float64),
         )
         @test Tables.schema(control) == Tables.Schema(
             (:time, :control_node_id, :truth_state, :control_state),

--- a/core/test/time_test.jl
+++ b/core/test/time_test.jl
@@ -34,14 +34,6 @@ end
     n_basin = length(basin.node_id)
     basin_table = DataFrame(Ribasim.basin_table(model))
 
-    # No vertical flux data for last saveat
-    t_end = last(basin_table).time
-    data_end = filter(:time => t -> t == t_end, basin_table)
-    @test all(ismissing.(data_end.precipitation))
-    @test all(ismissing.(data_end.evaporation))
-    @test all(ismissing.(data_end.drainage))
-    @test all(ismissing.(data_end.infiltration))
-
     time_table = DataFrame(basin.time)
     time_table[!, "basin_idx"] = [
         Ribasim.id_index(basin.node_id, node_id)[2] for
@@ -65,9 +57,6 @@ end
             time_table.mean_area[idx_1] = mean_area
         end
     end
-
-    filter!(:time => t -> t !== t_end, basin_table)
-    filter!(:time => t -> t !== t_end, time_table)
 
     @test all(
         isapprox(

--- a/core/test/time_test.jl
+++ b/core/test/time_test.jl
@@ -35,6 +35,9 @@ end
     basin_table = DataFrame(Ribasim.basin_table(model))
 
     time_table = DataFrame(basin.time)
+    t_end = time_table.time[end]
+    filter!(:time => t -> t !== t_end, time_table)
+
     time_table[!, "basin_idx"] = [
         Ribasim.id_index(basin.node_id, node_id)[2] for
         node_id in Ribasim.NodeID.(:Basin, time_table.node_id)

--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -705,10 +705,11 @@ derivative       | Float64  | -        | -
 
 ## Basin - `basin.arrow`
 
-The basin table contains:
+The Basin table contains:
 
-- results of the storage and level of each basin, which are instantaneous values;
-- results of the vertical fluxes on each basin, which are mean values over the `saveat` intervals. In the time column the start of the period is indicated.
+- Results of the storage and level of each basin, which are instantaneous values;
+- Results of the vertical fluxes on each basin, which are mean values over the `saveat` intervals. In the time column the start of the period is indicated.
+- The final state of the model is not part of this file, and will be placed in a separate output state file in the future.
 
 The initial condition is also written to the file.
 

--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -708,20 +708,20 @@ derivative       | Float64  | -        | -
 The basin table contains:
 
 - results of the storage and level of each basin, which are instantaneous values;
-- results of the vertical fluxes on each basin, which are mean values over the `saveat` intervals. In the time column the start of the period is indicated. This means that for the final time in the table the mean vertical fluxes are not computed, and thus are `missing`.
+- results of the vertical fluxes on each basin, which are mean values over the `saveat` intervals. In the time column the start of the period is indicated.
 
 The initial condition is also written to the file.
 
-column        | type                     | unit
-------------- | ------------------------ | ----
-time          | DateTime                 | -
-node_id       | Int32                    | -
-storage       | Float64                  | $m^3$
-level         | Float64                  | $m$
-precipitation | Union{Float64, Missing}  | $m^3 s^{-1}$
-evaporation   | Union{Float64, Missing}  | $m^3 s^{-1}$
-drainage      | Union{Float64, Missing}  | $m^3 s^{-1}$
-infiltration  | Union{Float64, Missing}  | $m^3 s^{-1}$
+column        | type     | unit
+------------- | ---------| ----
+time          | DateTime | -
+node_id       | Int32    | -
+storage       | Float64  | $m^3$
+level         | Float64  | $m$
+precipitation | Float64  | $m^3 s^{-1}$
+evaporation   | Float64  | $m^3 s^{-1}$
+drainage      | Float64  | $m^3 s^{-1}$
+infiltration  | Float64  | $m^3 s^{-1}$
 
 
 The table is sorted by time, and per time it is sorted by `node_id`.


### PR DESCRIPTION
This reverts a part of 4ff9987710fac6642d723d97bceb574517b09f24

On Tuesday we discussed the `basin.arrow` with @SouthEndMusic and @Huite. A few issues/PRs will come out of this, but this already removes the endtime, such that we don't have `missing` vertical fluxes in `basin.arrow` anymore. The downside is that the final storage is not currently available, but we have #1358 for that, and plan to add `dS/dt (m3/s)` as well to be able to compute it.