### PR TITLE
Add remaining water balance terms to basin.arrow

### DIFF
--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -1,5 +1,5 @@
 struct SavedResults{V1 <: ComponentVector{Float64}}
-    flow::SavedValues{Float64, Vector{Float64}}
+    flow::SavedValues{Float64, SavedFlow}
     vertical_flux::SavedValues{Float64, V1}
     subgrid_level::SavedValues{Float64, Vector{Float64}}
 end

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -135,6 +135,19 @@ end
 abstract type AbstractParameterNode end
 
 """
+In-memory storage of saved mean flows for writing to results.
+
+- `flow`: The mean flows on all edges
+- `inflow`: The sum of the mean flows coming into each basin
+- `outflow`: The sum of the mean flows going out of each basin
+"""
+@kwdef struct SavedFlow
+    flow::Vector{Float64}
+    inflow::Vector{Float64}
+    outflow::Vector{Float64}
+end
+
+"""
 Requirements:
 
 * Must be positive: precipitation, evaporation, infiltration, drainage

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -1010,12 +1010,21 @@ function exists(db::DB, tablename::String)
 end
 
 """
+    seconds(period::Millisecond)::Float64
+
+Convert a period of type Millisecond to a Float64 in seconds.
+You get Millisecond objects when subtracting two DateTime objects.
+Dates.value returns the number of milliseconds.
+"""
+seconds(period::Millisecond)::Float64 = 0.001 * Dates.value(period)
+
+"""
     seconds_since(t::DateTime, t0::DateTime)::Float64
 
 Convert a DateTime to a float that is the number of seconds since the start of the
 simulation. This is used to convert between the solver's inner float time, and the calendar.
 """
-seconds_since(t::DateTime, t0::DateTime)::Float64 = 0.001 * Dates.value(t - t0)
+seconds_since(t::DateTime, t0::DateTime)::Float64 = seconds(t - t0)
 
 """
     datetime_since(t::Real, t0::DateTime)::DateTime

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -534,6 +534,9 @@ function Base.getindex(fv::FlatVector, i::Int)
     return v[r + 1]
 end
 
+"Construct a FlatVector from one of the fields of SavedFlow."
+FlatVector(saveval::Vector{SavedFlow}, sym::Symbol) = FlatVector(getfield.(saveval, sym))
+
 """
 Function that goes smoothly from 0 to 1 in the interval [0,threshold],
 and is constant outside this interval.

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -134,8 +134,8 @@ function basin_table(
 
     for i in 1:nrows
         storage_flow = storage_rate[i]
-        storage_increase = storage_flow > 0.0 ? storage_flow : 0.0
-        storage_decrease = storage_flow > 0.0 ? 0.0 : -storage_flow
+        storage_increase = max(storage_flow, 0.0)
+        storage_decrease = max(-storage_flow, 0.0)
 
         total_in = inflow_rate[i] + precipitation[i] + drainage[i] - storage_increase
         total_out = outflow_rate[i] + evaporation[i] + infiltration[i] - storage_decrease

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -115,9 +115,9 @@ function basin_table(
     relative_error = zeros(nrows)
 
     idx_row = 0
-    for vec in saved.vertical_flux.saveval
+    for cvec in saved.vertical_flux.saveval
         for (precipitation_, evaporation_, drainage_, infiltration_) in
-            zip(vec.precipitation, vec.evaporation, vec.drainage, vec.infiltration)
+            zip(cvec.precipitation, cvec.evaporation, cvec.drainage, cvec.infiltration)
             idx_row += 1
             precipitation[idx_row] = precipitation_
             evaporation[idx_row] = evaporation_

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -133,16 +133,16 @@ function basin_table(
     storage_rate = Δstorage ./ Δtime
 
     for i in 1:nrows
-        balance_error[i] =
-            (
-                inflow_rate[i] + precipitation[i] + drainage[i] - outflow_rate[i] -
-                evaporation[i] - infiltration[i]
-            ) - storage_rate[i]
-        min_flow_rate = min(inflow_rate[i], outflow_rate[i])
-        relative_error[i] = if min_flow_rate == 0
-            0.0
-        else
-            balance_error[i] ./ min_flow_rate
+        storage_flow = storage_rate[i]
+        storage_increase = storage_flow > 0.0 ? storage_flow : 0.0
+        storage_decrease = storage_flow > 0.0 ? 0.0 : -storage_flow
+
+        total_in = inflow_rate[i] + precipitation[i] + drainage[i] - storage_increase
+        total_out = outflow_rate[i] + evaporation[i] + infiltration[i] - storage_decrease
+        balance_error[i] = total_in - total_out
+        mean_flow_rate = 0.5 * (total_in + total_out)
+        if mean_flow_rate != 0
+            relative_error[i] = balance_error[i] / mean_flow_rate
         end
     end
 

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -127,7 +127,7 @@ function basin_table(
     end
 
     time = repeat(data.time[begin:(end - 1)]; inner = nbasin)
-    Δtime_seconds = 0.001 * Dates.value.(diff(data.time))
+    Δtime_seconds = seconds.(diff(data.time))
     Δtime = repeat(Δtime_seconds; inner = nbasin)
     node_id = repeat(Int32.(data.node_id); outer = ntsteps)
     storage_rate = Δstorage ./ Δtime

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -140,9 +140,8 @@
         @test flow.flow_rate[1] == basin.outflow_rate[1]
         @test all(==(0), basin.drainage)
         @test all(==(0), basin.infiltration)
-        @test all(q -> abs(q) < 1e-5, basin.balance_error)
-        # No inflow, so relative error is 0
-        @test all(==(0), basin.relative_error)
+        @test all(q -> abs(q) < 1e-7, basin.balance_error)
+        @test all(q -> abs(q) < 0.01, basin.relative_error)
 
         # The exporter interpolates 1:1 for three subgrid elements, but shifted by 1.0 meter.
         basin_level = basin.level[1]

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -8,7 +8,8 @@
 
     toml_path = normpath(@__DIR__, "../../generated_testmodels/trivial/ribasim.toml")
     @test ispath(toml_path)
-    model = Ribasim.run(toml_path)
+    config = Ribasim.Config(toml_path)
+    model = Ribasim.run(config)
     @test model isa Ribasim.Model
     @test successful_retcode(model)
     (; p) = model.integrator
@@ -49,12 +50,29 @@
                 :node_id,
                 :storage,
                 :level,
+                :inflow_rate,
+                :outflow_rate,
+                :storage_rate,
                 :precipitation,
                 :evaporation,
                 :drainage,
                 :infiltration,
+                :error,
             ),
-            (DateTime, Int32, Float64, Float64, Float64, Float64, Float64, Float64),
+            (
+                DateTime,
+                Int32,
+                Float64,
+                Float64,
+                Float64,
+                Float64,
+                Float64,
+                Float64,
+                Float64,
+                Float64,
+                Float64,
+                Float64,
+            ),
         )
         @test Tables.schema(control) == Tables.Schema(
             (:time, :control_node_id, :truth_state, :control_state),
@@ -113,6 +131,14 @@
 
         @test basin.storage[1] ≈ 1.0
         @test basin.level[1] ≈ 0.044711584
+        @test basin.storage_rate[1] ≈
+              (basin.storage[2] - basin.storage[1]) / config.solver.saveat
+        @test all(==(0), basin.inflow_rate)
+        @test all(>(0), basin.outflow_rate)
+        @test flow.flow_rate[1] == basin.outflow_rate[1]
+        @test all(==(0), basin.drainage)
+        @test all(==(0), basin.infiltration)
+        @test all(q -> abs(q) < 1e-5, basin.error)
 
         # The exporter interpolates 1:1 for three subgrid elements, but shifted by 1.0 meter.
         basin_level = basin.level[1]

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -57,11 +57,13 @@
                 :evaporation,
                 :drainage,
                 :infiltration,
-                :error,
+                :balance_error,
+                :relative_error,
             ),
             (
                 DateTime,
                 Int32,
+                Float64,
                 Float64,
                 Float64,
                 Float64,
@@ -138,7 +140,9 @@
         @test flow.flow_rate[1] == basin.outflow_rate[1]
         @test all(==(0), basin.drainage)
         @test all(==(0), basin.infiltration)
-        @test all(q -> abs(q) < 1e-5, basin.error)
+        @test all(q -> abs(q) < 1e-5, basin.balance_error)
+        # No inflow, so relative error is 0
+        @test all(==(0), basin.relative_error)
 
         # The exporter interpolates 1:1 for three subgrid elements, but shifted by 1.0 meter.
         basin_level = basin.level[1]

--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -707,11 +707,16 @@ derivative       | Float64  | -        | -
 
 The Basin table contains:
 
-- Results of the storage and level of each basin, which are instantaneous values;
-- Results of the vertical fluxes on each basin, which are mean values over the `saveat` intervals. In the time column the start of the period is indicated.
-- The final state of the model is not part of this file, and will be placed in a separate output state file in the future.
-
-The initial condition is also written to the file.
+- Results of the storage and level of each Basin, which are instantaneous values;
+- Results of the fluxes on each Basin, which are mean values over the `saveat` intervals.
+  In the time column the start of the period is indicated.
+- The initial condition is written to the file, but the final state is not.
+  It will be placed in a separate output state file in the future.
+- The `inflow_rate` and `outflow_rate` are the sum of the flows into and out of the Basin respectively.
+  The actual flows determine in which term they are counted, not the edge direction.
+- The `storage_rate` is flow that adds to the storage in the Basin, increasing the water level.
+- The `error` is the result of adding all terms of the water balance; `inflow_rate` - `outflow_rate` - `storage_rate` + `precipitation` - `evaporation` + `drainage` - `infiltration`.
+  It can be used to check if the numerical error when solving the water balance is sufficiently small.
 
 column        | type     | unit
 ------------- | ---------| ----
@@ -719,11 +724,14 @@ time          | DateTime | -
 node_id       | Int32    | -
 storage       | Float64  | $m^3$
 level         | Float64  | $m$
+inflow_rate   | Float64  | $m^3 s^{-1}$
+outflow_rate  | Float64  | $m^3 s^{-1}$
+storage_rate  | Float64  | $m^3 s^{-1}$
 precipitation | Float64  | $m^3 s^{-1}$
 evaporation   | Float64  | $m^3 s^{-1}$
 drainage      | Float64  | $m^3 s^{-1}$
 infiltration  | Float64  | $m^3 s^{-1}$
-
+error         | Float64  | $m^3 s^{-1}$
 
 The table is sorted by time, and per time it is sorted by `node_id`.
 

--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -715,23 +715,25 @@ The Basin table contains:
 - The `inflow_rate` and `outflow_rate` are the sum of the flows into and out of the Basin respectively.
   The actual flows determine in which term they are counted, not the edge direction.
 - The `storage_rate` is flow that adds to the storage in the Basin, increasing the water level.
-- The `error` is the result of adding all terms of the water balance; `inflow_rate` - `outflow_rate` - `storage_rate` + `precipitation` - `evaporation` + `drainage` - `infiltration`.
+- The `balance_error` is the difference of all Basin flows and the `storage_rate`, that is (`inflow_rate` + `precipitation` + `drainage` - `outflow_rate` - `evaporation` - `infiltration`) - `storage_rate`.
   It can be used to check if the numerical error when solving the water balance is sufficiently small.
+- The `relative_error` is the fraction of the `balance_error` over the `inflow_rate` or `outflow_rate`, whichever is the smallest.
 
-column        | type     | unit
-------------- | ---------| ----
-time          | DateTime | -
-node_id       | Int32    | -
-storage       | Float64  | $m^3$
-level         | Float64  | $m$
-inflow_rate   | Float64  | $m^3 s^{-1}$
-outflow_rate  | Float64  | $m^3 s^{-1}$
-storage_rate  | Float64  | $m^3 s^{-1}$
-precipitation | Float64  | $m^3 s^{-1}$
-evaporation   | Float64  | $m^3 s^{-1}$
-drainage      | Float64  | $m^3 s^{-1}$
-infiltration  | Float64  | $m^3 s^{-1}$
-error         | Float64  | $m^3 s^{-1}$
+column         | type     | unit
+-------------- | ---------| ----
+time           | DateTime | -
+node_id        | Int32    | -
+storage        | Float64  | $m^3$
+level          | Float64  | $m$
+inflow_rate    | Float64  | $m^3 s^{-1}$
+outflow_rate   | Float64  | $m^3 s^{-1}$
+storage_rate   | Float64  | $m^3 s^{-1}$
+precipitation  | Float64  | $m^3 s^{-1}$
+evaporation    | Float64  | $m^3 s^{-1}$
+drainage       | Float64  | $m^3 s^{-1}$
+infiltration   | Float64  | $m^3 s^{-1}$
+balance_error  | Float64  | $m^3 s^{-1}$
+relative_error | Float64  | -
 
 The table is sorted by time, and per time it is sorted by `node_id`.
 

--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -712,12 +712,12 @@ The Basin table contains:
   In the time column the start of the period is indicated.
 - The initial condition is written to the file, but the final state is not.
   It will be placed in a separate output state file in the future.
-- The `inflow_rate` and `outflow_rate` are the sum of the flows into and out of the Basin respectively.
+- The `inflow_rate` and `outflow_rate` are the sum of the flows from other nodes into and out of the Basin respectively.
   The actual flows determine in which term they are counted, not the edge direction.
-- The `storage_rate` is flow that adds to the storage in the Basin, increasing the water level.
-- The `balance_error` is the difference of all Basin flows and the `storage_rate`, that is (`inflow_rate` + `precipitation` + `drainage` - `outflow_rate` - `evaporation` - `infiltration`) - `storage_rate`.
+- The `storage_rate` is flow that adds to the storage in the Basin, increasing the water level. In the equations below this number is split out into two non-negative numbers, `storage_increase` and `storage_decrease`.
+- The `balance_error` is the difference of all Basin inflows (`total_inflow`) and outflows (`total_outflow`), that is (`inflow_rate` + `precipitation` + `drainage` - `storage_increase`) - (`outflow_rate` + `evaporation` + `infiltration` - `storage_decrease`).
   It can be used to check if the numerical error when solving the water balance is sufficiently small.
-- The `relative_error` is the fraction of the `balance_error` over the `inflow_rate` or `outflow_rate`, whichever is the smallest.
+- The `relative_error` is the fraction of the `balance_error` over the mean of the `total_inflow` and `total_outflow`.
 
 column         | type     | unit
 -------------- | ---------| ----

--- a/utils/runstats.jl
+++ b/utils/runstats.jl
@@ -106,7 +106,7 @@ toml_paths = get_testmodels()
 runs = OrderedDict{String, Any}[]
 for toml_path in toml_paths
     config = Ribasim.Config(toml_path)
-    println(basename(toml_path))
+    println(basename(dirname(toml_path)))
     # run first to compile, if this takes too long perhaps we can shorten the duration
     Ribasim.run(config)
     timed = @timed Ribasim.run(config)


### PR DESCRIPTION
Technically these terms can be calculated from flow.arrow and the storage. But since calculating the water balance for a Basin is such a common operation, we include them directly. This also makes it easier to locate water balance errors in time and space, by including the error term.

At some point we may also want to add the instantaneous inflow and outflow to the Basin struct, and update them in `formulate_du!`. This would allow us to reject steps with too large of a balance error, using one of the metrics mentioned in #1271. But for now this only adds them to the output via a callback.
