### PR TITLE
testmodelrun: Actually exit with an error code if it fails

### DIFF
--- a/utils/testmodelrun.jl
+++ b/utils/testmodelrun.jl
@@ -27,6 +27,7 @@ function main(ARGS)
     if n_fail > 0
         println("Failed models:")
         foreach(println, failed)
+        error("Model run failed")
     end
 end
 


### PR DESCRIPTION
That was the reason why the broken model slipped through CI
