### PR TITLE
Add tstops for more timeseries

### DIFF
--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -78,12 +78,19 @@ function Model(config::Config)::Model
         end
 
         # tell the solver to stop when new data comes in
-        # TODO add all time tables here
-        time_flow_boundary = load_structvector(db, config, FlowBoundaryTimeV1)
         tstops = Vector{Float64}[]
-        push!(tstops, get_tstops(time_flow_boundary.time, config.starttime))
-        time_user_demand = load_structvector(db, config, UserDemandTimeV1)
-        push!(tstops, get_tstops(time_user_demand.time, config.starttime))
+        for schema_version in [
+            FlowBoundaryTimeV1,
+            LevelBoundaryTimeV1,
+            UserDemandTimeV1,
+            LevelDemandTimeV1,
+            FlowDemandTimeV1,
+            TabulatedRatingCurveTimeV1,
+            PidControlTimeV1,
+        ]
+            time_schema = load_structvector(db, config, schema_version)
+            push!(tstops, get_tstops(time_schema.time, config.starttime))
+        end
 
         # use state
         state = load_structvector(db, config, BasinStateV1)

--- a/python/ribasim_testmodels/ribasim_testmodels/basic.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/basic.py
@@ -323,7 +323,6 @@ def outlet_model():
         starttime="2020-01-01",
         endtime="2021-01-01",
         crs="EPSG:28992",
-        solver=ribasim.Solver(saveat=0),
     )
 
     # Set up the basins
@@ -331,7 +330,7 @@ def outlet_model():
         Node(3, Point(2.0, 0.0)),
         [
             basin.Profile(area=[1000.0, 1000.0], level=[0.0, 1.0]),
-            basin.State(level=[1e-3]),
+            basin.State(level=[0.0]),
         ],
     )
 


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/595



This problem shown in the issue seems to be resolved, I can't reproduce it. When I went back to the default solver and initial level of $0$, I still get the same graph:
![fine_graph](https://github.com/Deltares/Ribasim/assets/74617371/cfdc91fd-9ab4-4126-995a-0b9712be406b)
