### PR TITLE
Update vertical fluxes all at once

### DIFF
--- a/core/src/callback.jl
+++ b/core/src/callback.jl
@@ -452,9 +452,7 @@ function update_basin(integrator)::Nothing
         set_table_row!(table, row, i)
     end
 
-    for (i, id) in enumerate(basin.node_id)
-        update_vertical_flux!(basin, storage, i)
-    end
+    update_vertical_flux!(basin, storage)
 
     # Forget about vertical fluxes to handle discontinuous forcing from basin_update
     copyto!(vertical_flux_prev, vertical_flux)


### PR DESCRIPTION
When doing a profile of the HWS model I saw this line take 25-40% of the time:

```julia
vertical_flux = get_tmp(vertical_flux, storage)
```

I seems like PreallocationTools doesn't like `get_tmp` on ComponentArrays, because that call led to the array being copied, leading to lots of allocations. This works around this issue by calling this once per timestep rather than once per timestep for each Basin. Perhaps this can still be fixed rather than worked around, though I think this refactor makes sense anyway.
