### PR TITLE
Tighten edge validation

### DIFF
--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -556,14 +556,14 @@ min_level: The minimum target level of the connected basin(s)
 max_level: The maximum target level of the connected basin(s)
 priority: If in a shortage state, the priority of the demand of the connected basin(s)
 """
-struct LevelDemand
+struct LevelDemand <: AbstractParameterNode
     node_id::Vector{NodeID}
     min_level::Vector{LinearInterpolation}
     max_level::Vector{LinearInterpolation}
     priority::Vector{Int32}
 end
 
-struct FlowDemand
+struct FlowDemand <: AbstractParameterNode
     node_id::Vector{NodeID}
     demand_itp::Vector{ScalarInterpolation}
     demand::Vector{Float64}

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -47,8 +47,8 @@ end
 
 n_neighbor_bounds_flow(nodetype::Symbol) = n_neighbor_bounds_flow(Val(nodetype))
 n_neighbor_bounds_flow(::Val{:Basin}) = n_neighbor_bounds(0, typemax(Int), 0, typemax(Int))
-n_neighbor_bounds_flow(::Val{:LinearResistance}) = n_neighbor_bounds(1, 1, 1, typemax(Int))
-n_neighbor_bounds_flow(::Val{:ManningResistance}) = n_neighbor_bounds(1, 1, 1, typemax(Int))
+n_neighbor_bounds_flow(::Val{:LinearResistance}) = n_neighbor_bounds(1, 1, 1, 1)
+n_neighbor_bounds_flow(::Val{:ManningResistance}) = n_neighbor_bounds(1, 1, 1, 1)
 n_neighbor_bounds_flow(::Val{:TabulatedRatingCurve}) =
     n_neighbor_bounds(1, 1, 1, typemax(Int))
 n_neighbor_bounds_flow(::Val{:FractionalFlow}) = n_neighbor_bounds(1, 1, 1, 1)
@@ -67,7 +67,7 @@ n_neighbor_bounds_flow(nodetype) =
     error("'n_neighbor_bounds_flow' not defined for $nodetype.")
 
 n_neighbor_bounds_control(nodetype::Symbol) = n_neighbor_bounds_control(Val(nodetype))
-n_neighbor_bounds_control(::Val{:Basin}) = n_neighbor_bounds(0, 1, 0, typemax(Int))
+n_neighbor_bounds_control(::Val{:Basin}) = n_neighbor_bounds(0, 1, 0, 0)
 n_neighbor_bounds_control(::Val{:LinearResistance}) = n_neighbor_bounds(0, 1, 0, 0)
 n_neighbor_bounds_control(::Val{:ManningResistance}) = n_neighbor_bounds(0, 1, 0, 0)
 n_neighbor_bounds_control(::Val{:TabulatedRatingCurve}) = n_neighbor_bounds(0, 1, 0, 0)

--- a/docs/contribute/addnode.qmd
+++ b/docs/contribute/addnode.qmd
@@ -11,7 +11,7 @@ Several parts of the code have to be made aware of the new node type. In the res
 The parameters object (defined in `parameter.jl`) passed to the ODE solver must be made aware of the new node type. Therefore define a struct in `parameter.jl` which holds the data for each node of the new node type:
 
 ```julia
-struct NewNodeType
+struct NewNodeType <: AbstractParameterNode
     node_id::Vector{NodeID}
     # Other fields
 end

--- a/docs/python/examples.ipynb
+++ b/docs/python/examples.ipynb
@@ -397,8 +397,6 @@
     "subprocess.run([cli_path, toml_path], check=True)\n",
     "```\n",
     "\n",
-    "Windows users should note that if you put the `ribasim_cli` folder in your Path, `cli_path` needs to have the cmd suffix; `ribasim.cmd`.\n",
-    "\n",
     "Or similarly you can from the terminal with:\n",
     "```bash\n",
     "ribasim basic/ribasim.toml\n",


### PR DESCRIPTION
Since LevelDemand and FlowDemand were not AbstractParameterNodes, their connections were not being validated despite the constraints being set properly. I noticed since they don't show up in the tables in https://deltares.github.io/Ribasim/core/validation.html.

LinearResistance and ManningResistance already required 1 in and 1 outflow, just not in validation.

Basin already cannot have outgoing control edges.

Also removes an outdated comment about `ribasim.cmd`. We now only have one `ribasim.exe` since #1415.