### PR TITLE
Standardize neighbor ID naming

### DIFF
--- a/core/src/allocation_init.jl
+++ b/core/src/allocation_init.jl
@@ -368,8 +368,8 @@ function add_constraints_conservation_node!(
 
         # No flow conservation on nodes with FractionalFlow outneighbors
         has_fractional_flow_outneighbors = any(
-            outneighbor_id.type == NodeType.FractionalFlow for
-            outneighbor_id in outflow_ids(graph, node_id)
+            outflow_id.type == NodeType.FractionalFlow for
+            outflow_id in outflow_ids(graph, node_id)
         )
 
         if is_source_sink | has_fractional_flow_outneighbors

--- a/core/src/callback.jl
+++ b/core/src/callback.jl
@@ -153,16 +153,16 @@ function save_flow(u, t, integrator)
     outflow_mean = zeros(length(node_id))
 
     for (i, basin_id) in enumerate(node_id)
-        for in_id in inflow_ids(graph, basin_id)
-            q = flow_mean[flow_dict[in_id, basin_id]]
+        for inflow_id in inflow_ids(graph, basin_id)
+            q = flow_mean[flow_dict[inflow_id, basin_id]]
             if q > 0
                 inflow_mean[i] += q
             else
                 outflow_mean[i] -= q
             end
         end
-        for out_id in outflow_ids(graph, basin_id)
-            q = flow_mean[flow_dict[basin_id, out_id]]
+        for outflow_id in outflow_ids(graph, basin_id)
+            q = flow_mean[flow_dict[basin_id, outflow_id]]
             if q > 0
                 outflow_mean[i] += q
             else

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -515,7 +515,7 @@ function formulate_flow!(
 
     for (i, id) in enumerate(node_id)
         # Requirement: edge points away from the flow boundary
-        for dst_id in outflow_ids(graph, id)
+        for outflow_id in outflow_ids(graph, id)
             if !active[i]
                 continue
             end
@@ -523,7 +523,7 @@ function formulate_flow!(
             rate = flow_rate[i](t)
 
             # Adding water is always possible
-            set_flow!(graph, id, dst_id, rate)
+            set_flow!(graph, id, outflow_id, rate)
         end
     end
 end
@@ -605,11 +605,11 @@ function formulate_du!(
     # subtract all outgoing flows
     # add all ingoing flows
     for (i, basin_id) in enumerate(basin.node_id)
-        for in_id in inflow_ids(graph, basin_id)
-            du[i] += get_flow(graph, in_id, basin_id, storage)
+        for inflow_id in inflow_ids(graph, basin_id)
+            du[i] += get_flow(graph, inflow_id, basin_id, storage)
         end
-        for out_id in outflow_ids(graph, basin_id)
-            du[i] -= get_flow(graph, basin_id, out_id, storage)
+        for outflow_id in outflow_ids(graph, basin_id)
+            du[i] -= get_flow(graph, basin_id, outflow_id, storage)
         end
     end
     return nothing

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -486,15 +486,15 @@ function get_fractional_flow_connected_basins(
 
     has_fractional_flow_outneighbors = false
 
-    for first_outneighbor_id in outflow_ids(graph, node_id)
-        if first_outneighbor_id in fractional_flow.node_id
+    for first_outflow_id in outflow_ids(graph, node_id)
+        if first_outflow_id in fractional_flow.node_id
             has_fractional_flow_outneighbors = true
-            second_outneighbor_id = outflow_id(graph, first_outneighbor_id)
-            has_index, basin_idx = id_index(basin.node_id, second_outneighbor_id)
+            second_outflow_id = outflow_id(graph, first_outflow_id)
+            has_index, basin_idx = id_index(basin.node_id, second_outflow_id)
             if has_index
                 push!(
                     fractional_flow_idxs,
-                    searchsortedfirst(fractional_flow.node_id, first_outneighbor_id),
+                    searchsortedfirst(fractional_flow.node_id, first_outflow_id),
                 )
                 push!(basin_idxs, basin_idx)
             end

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -307,19 +307,17 @@ function valid_fractional_flow(
     control_states = Set{String}([key[2] for key in keys(control_mapping)])
 
     for src_id in src_ids
-        src_outneighbor_ids = Set(outflow_ids(graph, src_id))
-        if src_outneighbor_ids ⊈ node_id_set
+        src_outflow_ids = Set(outflow_ids(graph, src_id))
+        if src_outflow_ids ⊈ node_id_set
             errors = true
-            @error(
-                "$src_id combines fractional flow outneighbors with other outneigbor types."
-            )
+            @error("$src_id has outflow to FractionalFlow and other node types.")
         end
 
         # Each control state (including missing) must sum to 1
         for control_state in control_states
             fraction_sum = 0.0
 
-            for ff_id in intersect(src_outneighbor_ids, node_id_set)
+            for ff_id in intersect(src_outflow_ids, node_id_set)
                 parameter_values = get(control_mapping, (ff_id, control_state), nothing)
                 if parameter_values === nothing
                     continue

--- a/core/test/validation_test.jl
+++ b/core/test/validation_test.jl
@@ -239,7 +239,7 @@ end
     @test length(logger.logs) == 4
     @test logger.logs[1].level == Error
     @test logger.logs[1].message ==
-          "TabulatedRatingCurve #7 combines fractional flow outneighbors with other outneigbor types."
+          "TabulatedRatingCurve #7 has outflow to FractionalFlow and other node types."
     @test logger.logs[2].level == Error
     @test logger.logs[2].message ==
           "Fractional flow nodes must have non-negative fractions."

--- a/python/ribasim_testmodels/ribasim_testmodels/invalid.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/invalid.py
@@ -87,7 +87,7 @@ def invalid_fractional_flow_model() -> Model:
         model.basin[1],
         model.tabulated_rating_curve[7],
     )
-    # Invalid: TabulatedRatingCurve #7 combines FractionalFlow outneighbors with other outneigbor types.
+    # Invalid: TabulatedRatingCurve #7 has outflow to FractionalFlow and other node types.
     model.edge.add(
         model.tabulated_rating_curve[7],
         model.basin[2],


### PR DESCRIPTION
I like the `inflow_id` name since it is clear what the edge direction is, the edge type, and that it concerns an ID. It is both the name of the function and used as a variable. I think that's fine because you never want to mix both usages.

These are some preparations for #889.