### PR TITLE
Rename QGIS plugin to Ribasim

### DIFF
--- a/ribasim_qgis/metadata.txt
+++ b/ribasim_qgis/metadata.txt
@@ -4,7 +4,7 @@
 # This file should be included when you package your plugin.# Mandatory items:
 
 [general]
-name=Ribasim-QGIS
+name=Ribasim
 qgisMinimumVersion=3.0
 description=QGIS plugin to setup Ribasim models
 version=2024.7.0


### PR DESCRIPTION
Fixes #380

This changes the name as shown in QGIS, so no need to have QGIS in there, other plugins don't have that either.

![image](https://github.com/Deltares/Ribasim/assets/4471859/5b0ac921-e0a4-458a-aaf0-faad9e89b823)

The folder `./ribasim_qgis/` is kept as-is. I think this is good to avoid any potential confusion with Ribasim Python.