### PR TITLE
Stricter TabulatedRatingCurve validation

### DIFF
--- a/core/test/control_test.jl
+++ b/core/test/control_test.jl
@@ -147,7 +147,7 @@ end
     t = Ribasim.datetime_since(discrete_control.record.time[2], model.config.starttime)
     @test Date(t) == Date("2020-03-16")
     # then the rating curve is updated to the "low" control_state
-    @test only(p.tabulated_rating_curve.tables).t[2] == 1.2
+    @test last(only(p.tabulated_rating_curve.tables).t) == 1.2
 end
 
 @testitem "Set PID target with DiscreteControl" begin

--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -368,24 +368,29 @@ fraction      | Float64 | -            | in the interval [0,1]
 
 # TabulatedRatingCurve {#sec-tabulated-rating-curve}
 
-This table is similar in structure to the Basin profile. The TabulatedRatingCurve gives a
-relation between the storage of a connected Basin (via the outlet level) and its outflow.
+This table is similar in structure to the Basin profile.
+The TabulatedRatingCurve gives a relation between the upstream level of a connected Basin and its outflow.
 
 column        | type    | unit         | restriction
 ------------- | ------- | ------------ | -----------
 node_id       | Int32   | -            | sorted
 control_state | String  | -            | (optional) sorted per node_id
 active        | Bool    | -            | (optional, default true)
-level         | Float64 | $m$          | sorted per control_state
-flow_rate     | Float64 | $m^3 s^{-1}$ | non-negative
+level         | Float64 | $m$          | sorted per control_state, unique
+flow_rate     | Float64 | $m^3 s^{-1}$ | start at 0, increasing
+
+Thus a single rating curve can be given by the following table:
 
 node_id | flow_rate  | level
 ------- |----------- |-------
-      2 | 0.0        | -0.105
-      2 | 0.0        |  0.095
-      2 | 0.00942702 |  0.295
-      2 | 0.942702   | 20.095
-      3 | 0.0        |  2.129
+      2 | 0.0        | -0.10
+      2 | 0.0001     |  0.09
+      2 | 0.01       |  0.29
+      2 | 0.9        | 20.09
+
+Below the lowest given level of -0.10, the flow rate is kept at 0.
+Between given levels the flow rate is interpolated linearly.
+Above the maximum given level of 20.09, the flow rate keeps increases linearly according to the slope of the last segment.
 
 ## TabulatedRatingCurve / time
 

--- a/docs/core/usage.qmd
+++ b/docs/core/usage.qmd
@@ -369,7 +369,7 @@ fraction      | Float64 | -            | in the interval [0,1]
 # TabulatedRatingCurve {#sec-tabulated-rating-curve}
 
 This table is similar in structure to the Basin profile.
-The TabulatedRatingCurve gives a relation between the upstream level of a connected Basin and its outflow.
+The TabulatedRatingCurve gives a relation between the level of a directly upstream Basin or LevelBoundary and its outflow.
 
 column        | type    | unit         | restriction
 ------------- | ------- | ------------ | -----------

--- a/python/ribasim_testmodels/ribasim_testmodels/equations.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/equations.py
@@ -67,7 +67,7 @@ def rating_curve_model() -> Model:
     )
 
     level_min = 1.0
-    level = np.linspace(0, 12, 100)
+    level = np.linspace(1, 12, 100)
     flow_rate = np.square(level - level_min) / (60 * 60 * 24)
     model.tabulated_rating_curve.add(
         Node(2, Point(1, 0)),

--- a/python/ribasim_testmodels/ribasim_testmodels/invalid.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/invalid.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-import pandas as pd
 from ribasim.config import Node, Solver
 from ribasim.input_base import TableModel
 from ribasim.model import Model
@@ -16,6 +15,12 @@ from shapely.geometry import Point
 
 
 def invalid_qh_model() -> Model:
+    """
+    Invalid TabulatedRatingCurve Q(h) table:
+    - levels must be unique
+    - flow_rate must start at 0
+    - flow_rate must not be decreasing
+    """
     model = Model(
         starttime="2020-01-01",
         endtime="2020-12-01",
@@ -24,29 +29,7 @@ def invalid_qh_model() -> Model:
 
     model.tabulated_rating_curve.add(
         Node(1, Point(0, 0)),
-        # Invalid: levels must not be repeated
-        [tabulated_rating_curve.Static(level=[0, 0], flow_rate=[1, 2])],
-    )
-    model.tabulated_rating_curve.add(
-        Node(2, Point(0, 1)),
-        [
-            tabulated_rating_curve.Time(
-                time=[
-                    pd.Timestamp("2020-01-01"),
-                    pd.Timestamp("2020-01-01"),
-                ],
-                # Invalid: levels must not be repeated
-                level=[0, 0],
-                flow_rate=[1, 2],
-            )
-        ],
-    )
-    model.basin.add(
-        Node(3, Point(0, 2)),
-        [
-            basin.State(level=[1.4112729908597084]),
-            basin.Profile(area=[0.01, 1], level=[0, 1]),
-        ],
+        [tabulated_rating_curve.Static(level=[0, 0, 1], flow_rate=[1, 2, 1.5])],
     )
 
     return model


### PR DESCRIPTION
Fixes a part of #279.

The four checks added here are:

- At least two datapoints are needed.
- The `flow_rate` must start at 0.
- The `level` cannot be repeated.
- The `flow_rate` cannot decrease with increasing `level`.

And additionally we now ensure that flow rates are kept at 0 for levels below the minimum.

~~I should still check the docs, they may need some updating.~~ The other part of #279 is best done in a separate PR as it relates to the Basin / profile table.