### PR TITLE
Support `model.to_xugrid(add_allocation = True)`

### DIFF
--- a/python/ribasim/ribasim/utils.py
+++ b/python/ribasim/ribasim/utils.py
@@ -1,5 +1,10 @@
 import re
 
+import numpy as np
+import pandas as pd
+from pandera.dtypes import Int32
+from pandera.typing import Series
+
 
 def _pascal_to_snake(pascal_str):
     # Insert a '_' before all uppercase letters that are not at the start of the string
@@ -15,3 +20,46 @@ class MissingOptionalModule:
 
     def __getattr__(self, name):
         raise ImportError(f"{self.name} is required for this functionality")
+
+
+def _node_lookup_numpy(node_id) -> Series[Int32]:
+    """Create a lookup table from from node_id to the node dimension index.
+
+    Used when adding data onto the nodes of an xugrid dataset.
+    """
+    return pd.Series(
+        index=node_id,
+        data=node_id.argsort().astype(np.int32),
+        name="node_index",
+    )
+
+
+def _node_lookup(uds) -> Series[Int32]:
+    """Create a lookup table from from node_id to the node dimension index.
+
+    Used when adding data onto the nodes of an xugrid dataset.
+    """
+    return pd.Series(
+        index=uds["node_id"],
+        data=uds[uds.grid.node_dimension],
+        name="node_index",
+    )
+
+
+def _edge_lookup(uds) -> Series[Int32]:
+    """Create a lookup table from edge_id to the edge dimension index.
+
+    Used when adding data onto the edges of an xugrid dataset.
+    """
+
+    return pd.Series(
+        index=uds["edge_id"],
+        data=uds[uds.grid.edge_dimension],
+        name="edge_index",
+    )
+
+
+def _time_in_ns(df) -> None:
+    """Convert the time column to datetime64[ns] dtype."""
+    # datetime64[ms] gives trouble; https://github.com/pydata/xarray/issues/6318
+    df["time"] = df["time"].astype("datetime64[ns]")

--- a/python/ribasim/tests/test_model.py
+++ b/python/ribasim/tests/test_model.py
@@ -222,7 +222,7 @@ def test_indexing(basic):
 
 
 def test_xugrid(basic, tmp_path):
-    uds = basic.to_xugrid(add_results=False)
+    uds = basic.to_xugrid(add_flow=False)
     assert isinstance(uds, xugrid.UgridDataset)
     assert uds.grid.edge_dimension == "ribasim_nEdges"
     assert uds.grid.node_dimension == "ribasim_nNodes"
@@ -233,11 +233,15 @@ def test_xugrid(basic, tmp_path):
     assert uds.attrs["Conventions"] == "CF-1.9 UGRID-1.0"
 
     with pytest.raises(FileNotFoundError, match="Model must be written to disk"):
-        basic.to_xugrid(add_results=True)
+        basic.to_xugrid(add_flow=True)
 
     basic.write(tmp_path / "ribasim.toml")
     with pytest.raises(FileNotFoundError, match="Cannot find results"):
-        basic.to_xugrid(add_results=True)
+        basic.to_xugrid(add_flow=True)
+    with pytest.raises(FileNotFoundError, match="or allocation is not used"):
+        basic.to_xugrid(add_flow=False, add_allocation=True)
+    with pytest.raises(ValueError, match="Cannot add both allocation and flow results"):
+        basic.to_xugrid(add_flow=True, add_allocation=True)
 
 
 def test_to_crs(bucket: Model):


### PR DESCRIPTION
Fixes #1066, see https://github.com/Deltares/Ribasim/issues/1066#issuecomment-2115647552 for more information on the approach used here. I just modified the keywords a bit, defaulting to `to_xugrid(add_flow = False, add_allocation = False)`. That means there are three options resulting in three different datasets:

```python
import ribasim

model = ribasim.Model.read(toml_path)
uds = model.to_xugrid()
uds.ugrid.to_netcdf(toml_path.parent / "results" / "ugrid-network.nc")
uds = model.to_xugrid(add_flow=True)
uds.ugrid.to_netcdf(toml_path.parent / "results" / "ugrid-flow.nc")
uds = model.to_xugrid(add_allocation=True)
uds.ugrid.to_netcdf(toml_path.parent / "results" / "ugrid-allocation.nc")
```

The last `uds`, with `add_allocation=True`, looks like this in xugrid / xarray:

![image](https://github.com/Deltares/Ribasim/assets/4471859/69d2f63a-1a44-44a1-b4f0-47403ff85091)

And like this in QGIS, this is for `main_network_with_subnetworks`:

![image](https://github.com/Deltares/Ribasim/assets/4471859/57e783f0-179f-4415-b609-d60d6c44ba40)

I refactored the code a bit to avoid duplication.