### PR TITLE
Smooth linear resistance flow rate bounding

### DIFF
--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -363,7 +363,7 @@ function formulate_flow!(
             _, h_a = get_level(p, inflow_edge, inflow_id, t; storage)
             _, h_b = get_level(p, outflow_edge, outflow_id, t; storage)
             q_unlimited = (h_a - h_b) / resistance[i]
-            q = clamp(q_unlimited, -max_flow_rate[i], max_flow_rate[i])
+            q = smooth_bounded_identity(q_unlimited, max_flow_rate[i], 0.1)
 
             # add reduction_factor on highest level
             if q > 0

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -780,3 +780,18 @@ function set_initial_allocation_mean_flows!(integrator)::Nothing
     end
     return nothing
 end
+
+function smooth_bounded_identity(x::T, max, frac)::T where {T}
+    x_abs = abs(x)
+    if x_abs <= (1 - frac) * max
+        x
+    elseif x_abs >= (1 + frac) * max
+        sign(x) * max
+    elseif x > 0
+        diff = x - max
+        -1 / (4 * frac * max) * diff^2 + 0.5 * diff + (1 - frac / 4) * max
+    else
+        diff = x + max
+        1 / (4 * frac * max) * diff^2 + 0.5 * diff - (1 - frac / 4) * max
+    end
+end


### PR DESCRIPTION
I figured that the hard clamping of the flow rate from a linear resistance node could be hard on the solver, which is why I added a smoothing function for this. I figured this hard clamping could be the reason that @DanielTollenaar experienced problems with linear resistance nodes.