### PR TITLE
Don't write empty result tables

### DIFF
--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -176,7 +176,7 @@ function Model(config::Config)::Model
     end
 
     model = Model(integrator, config, saved)
-    write_results(model)  # check permissions
+    write_results(model)  # check whether we can write results to file
     return model
 end
 

--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -174,7 +174,9 @@ function Model(config::Config)::Model
         set_initial_allocation_mean_flows!(integrator)
     end
 
-    return Model(integrator, config, saved)
+    model = Model(integrator, config, saved)
+    write_results(model)  # check permissions
+    return model
 end
 
 "Get all saved times in seconds since start"

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -330,6 +330,10 @@ function write_arrow(
     table::NamedTuple,
     compress::Union{ZstdCompressor, Nothing},
 )::Nothing
+    # Don't write empty tables
+    if isempty(table.time)
+        return nothing
+    end
     # ensure DateTime is encoded in a compatible manner
     # https://github.com/apache/arrow-julia/issues/303
     table = merge(table, (; time = convert.(Arrow.DATETIME, table.time)))

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -332,6 +332,8 @@ function write_arrow(
 )::Nothing
     # Don't write empty tables
     if isempty(table.time)
+        # Avoid confusion with old files
+        rm(path; force = true)
         return nothing
     end
     # ensure DateTime is encoded in a compatible manner

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -333,7 +333,11 @@ function write_arrow(
     # Don't write empty tables
     if isempty(table.time)
         # Avoid confusion with old files
-        rm(path; force = true)
+        try
+            rm(path; force = true)
+        catch
+            @warn "Failed to remove outdated results, file may be locked." path
+        end
         return nothing
     end
     # ensure DateTime is encoded in a compatible manner

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -7,37 +7,37 @@ function write_results(model::Model)::Model
     (; config) = model
     (; results) = model.config
     compress = get_compressor(results)
-    init = model.integrator.t == 0
+    remove_empty_table = model.integrator.t != 0
 
     # basin
     table = basin_table(model)
     path = results_path(config, RESULTS_FILENAME.basin)
-    write_arrow(path, table, compress; init)
+    write_arrow(path, table, compress; remove_empty_table)
 
     # flow
     table = flow_table(model)
     path = results_path(config, RESULTS_FILENAME.flow)
-    write_arrow(path, table, compress; init)
+    write_arrow(path, table, compress; remove_empty_table)
 
     # discrete control
     table = discrete_control_table(model)
     path = results_path(config, RESULTS_FILENAME.control)
-    write_arrow(path, table, compress; init)
+    write_arrow(path, table, compress; remove_empty_table)
 
     # allocation
     table = allocation_table(model)
     path = results_path(config, RESULTS_FILENAME.allocation)
-    write_arrow(path, table, compress; init)
+    write_arrow(path, table, compress; remove_empty_table)
 
     # allocation flow
     table = allocation_flow_table(model)
     path = results_path(config, RESULTS_FILENAME.allocation_flow)
-    write_arrow(path, table, compress; init)
+    write_arrow(path, table, compress; remove_empty_table)
 
     # exported levels
     table = subgrid_level_table(model)
     path = results_path(config, RESULTS_FILENAME.subgrid_level)
-    write_arrow(path, table, compress; init)
+    write_arrow(path, table, compress; remove_empty_table)
 
     @debug "Wrote results."
     return model
@@ -330,16 +330,16 @@ function write_arrow(
     path::AbstractString,
     table::NamedTuple,
     compress::Union{ZstdCompressor, Nothing};
-    init::Bool,
+    remove_empty_table::Bool = false,
 )::Nothing
     # At the start of the simulation, write an empty table to ensure we have permissions
     # and fail early.
     # At the end of the simulation, write all non-empty tables, and remove existing empty ones.
-    if !init && isempty(table.time)
+    if isempty(table.time) && remove_empty_table
         try
             rm(path; force = true)
         catch
-            @warn "Failed to remove outdated results, file may be locked." path
+            @warn "Failed to remove results, file may be locked." path
         end
         return nothing
     end
@@ -351,7 +351,7 @@ function write_arrow(
     try
         Arrow.write(path, table; compress, metadata)
     catch
-        @error "Failed to write results, it may be locked." path
+        @error "Failed to write results, file may be locked." path
         error("Failed to write results.")
     end
     return nothing

--- a/core/test/control_test.jl
+++ b/core/test/control_test.jl
@@ -1,6 +1,8 @@
 @testitem "Pump discrete control" begin
     using PreallocationTools: get_tmp
     using Ribasim: NodeID
+    import Arrow
+    import Tables
 
     toml_path =
         normpath(@__DIR__, "../../generated_testmodels/pump_discrete_control/ribasim.toml")
@@ -45,6 +47,14 @@
 
     flow = get_tmp(graph[].flow, 0)
     @test all(iszero, flow)
+
+    # results/control.arrow
+    control_bytes = read(normpath(dirname(toml_path), "results/control.arrow"))
+    control = Arrow.Table(control_bytes)
+    @test Tables.schema(control) == Tables.Schema(
+        (:time, :control_node_id, :truth_state, :control_state),
+        (DateTime, Int32, String, String),
+    )
 end
 
 @testitem "Flow condition control" begin

--- a/core/test/control_test.jl
+++ b/core/test/control_test.jl
@@ -1,6 +1,7 @@
 @testitem "Pump discrete control" begin
     using PreallocationTools: get_tmp
     using Ribasim: NodeID
+    using Dates: DateTime
     import Arrow
     import Tables
 

--- a/core/test/control_test.jl
+++ b/core/test/control_test.jl
@@ -29,10 +29,19 @@
     @test discrete_control.logic_mapping == logic_mapping
 
     # Control result
+    control_bytes = read(normpath(dirname(toml_path), "results/control.arrow"))
+    control = Arrow.Table(control_bytes)
+    @test Tables.schema(control) == Tables.Schema(
+        (:time, :control_node_id, :truth_state, :control_state),
+        (DateTime, Int32, String, String),
+    )
     @test discrete_control.record.control_node_id == [5, 6, 5, 5, 6]
+    @test discrete_control.record.control_node_id == control.control_node_id
     @test discrete_control.record.truth_state == ["TF", "F", "FF", "FT", "T"]
+    @test discrete_control.record.truth_state == control.truth_state
     @test discrete_control.record.control_state ==
           ["off", "active", "on", "off", "inactive"]
+    @test discrete_control.record.control_state == control.control_state
 
     level = Ribasim.get_storages_and_levels(model).level
     t = Ribasim.tsaves(model)
@@ -48,14 +57,6 @@
 
     flow = get_tmp(graph[].flow, 0)
     @test all(iszero, flow)
-
-    # results/control.arrow
-    control_bytes = read(normpath(dirname(toml_path), "results/control.arrow"))
-    control = Arrow.Table(control_bytes)
-    @test Tables.schema(control) == Tables.Schema(
-        (:time, :control_node_id, :truth_state, :control_state),
-        (DateTime, Int32, String, String),
-    )
 end
 
 @testitem "Flow condition control" begin

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -28,15 +28,10 @@
     # which can have cleanup issues due to file locking
     flow_bytes = read(normpath(dirname(toml_path), "results/flow.arrow"))
     basin_bytes = read(normpath(dirname(toml_path), "results/basin.arrow"))
-    allocation_bytes = read(normpath(dirname(toml_path), "results/allocation.arrow"))
-    allocation_flow_bytes =
-        read(normpath(dirname(toml_path), "results/allocation_flow.arrow"))
     subgrid_bytes = read(normpath(dirname(toml_path), "results/subgrid_levels.arrow"))
 
     flow = Arrow.Table(flow_bytes)
     basin = Arrow.Table(basin_bytes)
-    allocation = Arrow.Table(allocation_bytes)
-    allocation_flow = Arrow.Table(allocation_flow_bytes)
     subgrid = Arrow.Table(subgrid_bytes)
 
     @testset "Schema" begin
@@ -84,34 +79,6 @@
                 Float64,
             ),
         )
-        @test Tables.schema(allocation) == Tables.Schema(
-            (
-                :time,
-                :subnetwork_id,
-                :node_type,
-                :node_id,
-                :priority,
-                :demand,
-                :allocated,
-                :realized,
-            ),
-            (DateTime, Int32, String, Int32, Int32, Float64, Float64, Float64),
-        )
-        @test Tables.schema(allocation_flow) == Tables.Schema(
-            (
-                :time,
-                :edge_id,
-                :from_node_type,
-                :from_node_id,
-                :to_node_type,
-                :to_node_id,
-                :subnetwork_id,
-                :priority,
-                :flow_rate,
-                :optimization_type,
-            ),
-            (DateTime, Int32, String, Int32, String, Int32, Int32, Int32, Float64, String),
-        )
         @test Tables.schema(subgrid) == Tables.Schema(
             (:time, :subgrid_id, :subgrid_level),
             (DateTime, Int32, Float64),
@@ -124,8 +91,6 @@
         # t0 has no flow, 2 flow edges
         @test nrow(flow) == (nsaved - 1) * 2
         @test nrow(basin) == nsaved - 1
-        @test nrow(control) == 0
-        @test nrow(allocation) == 0
         @test nrow(subgrid) == nsaved * length(p.subgrid.level)
     end
 

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -203,7 +203,7 @@ end
     @test model.integrator.sol.u[end] ≈ Float32[519.8817, 519.8798, 339.3959, 1418.4331] skip =
         Sys.isapple() atol = 1.5
 
-    @test length(logger.logs) == 11
+    @test length(logger.logs) > 10
     @test logger.logs[1].level == Debug
     @test logger.logs[1].message == "Read database into memory."
 

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -6,14 +6,15 @@
     import Arrow
     using Ribasim: get_tstops, tsaves
 
+    toml_path = normpath(@__DIR__, "../../generated_testmodels/trivial/ribasim.toml")
+    @test ispath(toml_path)
+
     # There is no control. That means we don't write the control.arrow,
     # and we remove it if it exists.
     control_path = normpath(dirname(toml_path), "results/control.arrow")
     touch(control_path)
     @test ispath(control_path)
 
-    toml_path = normpath(@__DIR__, "../../generated_testmodels/trivial/ribasim.toml")
-    @test ispath(toml_path)
     config = Ribasim.Config(toml_path)
     model = Ribasim.run(config)
     @test model isa Ribasim.Model

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -12,6 +12,7 @@
     # There is no control. That means we don't write the control.arrow,
     # and we remove it if it exists.
     control_path = normpath(dirname(toml_path), "results/control.arrow")
+    mkpath(dirname(control_path))
     touch(control_path)
     @test ispath(control_path)
 


### PR DESCRIPTION
Came up in https://github.com/Deltares/Ribasim/pull/1525#discussion_r1627515435

At first I thought it would be better to write e.g. `subgrid_levels.arrow` if `Basin / subgrid` is defined. That would still write an empty file if the input table is empty or there were no timesteps. But just never writing empty tables is much easier to implement and explain, and I expect the difference not to matter in practice.
