### PR TITLE
Include Ribasim Python API reference

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,8 +1,7 @@
 /.quarto/
 /_site/
 /site_libs/
-python/reference/
-python/data/
+/reference/python/
 guide/data/
 *.html
 objects.json

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -63,6 +63,7 @@ website:
         - reference/index.qmd
         - reference/usage.qmd
         - reference/validation.qmd
+        - reference/python/index.qmd
         - reference/test-models.qmd
         - section: "Nodes"
           contents:
@@ -104,7 +105,7 @@ number-sections: true
 
 quartodoc:
   style: pkgdown
-  dir: python/reference
+  dir: reference/python
   title: API Reference
   package: ribasim
   sections:

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -106,7 +106,7 @@ number-sections: true
 quartodoc:
   style: pkgdown
   dir: reference/python
-  title: API Reference
+  title: Python API
   package: ribasim
   sections:
     - title: Model

--- a/pixi.toml
+++ b/pixi.toml
@@ -49,7 +49,7 @@ quartodoc-build = { cmd = "quartodoc build && rm objects.json", cwd = "docs", in
     "docs/_quarto.yml",
     "python/ribasim",
 ], outputs = [
-    "docs/python/reference",
+    "docs/reference/python",
 ] }
 quarto-preview = { cmd = "quarto preview docs", depends_on = [
     "quartodoc-build",


### PR DESCRIPTION
In the recent doc restructuring these pages were no longer included.
Related to #1439, but does not fix that issue.
