### PR TITLE
Allow for meta_ prefix in spatial tables.

### DIFF
--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -97,18 +97,20 @@ class Node(pydantic.BaseModel):
     name: str = ""
     subnetwork_id: int | None = None
 
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
 
     def __init__(self, node_id: int, geometry: Point, **kwargs) -> None:
         super().__init__(node_id=node_id, geometry=geometry, **kwargs)
 
     def into_geodataframe(self, node_type: str) -> GeoDataFrame:
+        extra = self.model_extra if self.model_extra is not None else {}
         return GeoDataFrame(
             data={
                 "node_id": pd.Series([self.node_id], dtype=np.int32),
                 "node_type": pd.Series([node_type], dtype=str),
                 "name": pd.Series([self.name], dtype=str),
                 "subnetwork_id": pd.Series([self.subnetwork_id], dtype=pd.Int32Dtype()),
+                **extra,
             },
             geometry=[self.geometry],
         )

--- a/python/ribasim/ribasim/geometry/edge.py
+++ b/python/ribasim/ribasim/geometry/edge.py
@@ -51,6 +51,7 @@ class EdgeTable(SpatialTableModel[EdgeSchema]):
         geometry: LineString | MultiLineString | None = None,
         name: str = "",
         subnetwork_id: int | None = None,
+        **kwargs,
     ):
         geometry_to_append = (
             [LineString([from_node.geometry, to_node.geometry])]
@@ -71,6 +72,7 @@ class EdgeTable(SpatialTableModel[EdgeSchema]):
                 "edge_type": pd.Series([edge_type], dtype=str),
                 "name": pd.Series([name], dtype=str),
                 "subnetwork_id": pd.Series([subnetwork_id], dtype=pd.Int32Dtype()),
+                **kwargs,
             },
             geometry=geometry_to_append,
             crs=self.df.crs,


### PR DESCRIPTION
Fixes #1560 

Requires just passing the extra kwargs to the relevant tables, and the existing validation errors actually trigger. 👍🏻 