### PR TITLE
Fix QGIS crash on plugin initialization

### DIFF
--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -17,7 +17,6 @@ from PyQt5.QtWidgets import (
     QCheckBox,
     QFileDialog,
     QHBoxLayout,
-    QHeaderView,
     QLineEdit,
     QMessageBox,
     QPushButton,
@@ -48,12 +47,9 @@ class DatasetTreeWidget(QTreeWidget):
         self.setHeaderHidden(True)
         self.setSortingEnabled(True)
         self.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Preferred)
-        self.setHeaderLabels([""])
+        self.setHeaderLabels(["  Layer"])
         self.setHeaderHidden(False)
         self.setColumnCount(1)
-        header = self.header()
-        header.setSectionResizeMode(0, QHeaderView.Stretch)
-        header.setSectionsMovable(False)
 
     def items(self) -> list[QTreeWidgetItem]:
         root = self.invisibleRootItem()

--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -50,10 +50,10 @@ class DatasetTreeWidget(QTreeWidget):
         self.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Preferred)
         self.setHeaderLabels([""])
         self.setHeaderHidden(False)
-        header = self.header()
-        header.setSectionResizeMode(1, QHeaderView.Stretch)
-        header.setSectionsMovable(False)
         self.setColumnCount(1)
+        header = self.header()
+        header.setSectionResizeMode(0, QHeaderView.Stretch)
+        header.setSectionsMovable(False)
 
     def items(self) -> list[QTreeWidgetItem]:
         root = self.invisibleRootItem()


### PR DESCRIPTION
Fixes #993, by creating the column count first before setting their properties, and changing the index to 0 (0-based, first), since we now have only one column.

Based on the suggestion by @Huite in https://github.com/Deltares/Ribasim/issues/993#issuecomment-2187242512.
By repeatedly running `pixi run test-ribasim-qgis-ui` I am quite confident this fixes the issue. If I change the 0 back to 1 I got a crash again within a few tries.


