### PR TITLE
Fix cascading polders image in docs

### DIFF
--- a/docs/guide/examples.ipynb
+++ b/docs/guide/examples.ipynb
@@ -1684,7 +1684,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "![](https://github.com/Deltares/Ribasim/assets/4471859/6dba5af2-14fb-47a5-bdfe-69c2c41f761d)"
+    "<img alt=\"Cascading polders\" src=\"https://github.com/Deltares/Ribasim/assets/4471859/6dba5af2-14fb-47a5-bdfe-69c2c41f761d\" class=\"img-fluid\">"
    ]
   },
   {


### PR DESCRIPTION
@Jingru923 I suggest this as an alternative to #1612. We try to keep this repository as small as possible and therefore prefer to not add images to it. So far we've uploaded images into #1 and used those. Recently GitHub changed something:

> Uploading images here won't work anymore for displaying them in our docs, due to GitHub changes, see https://github.blog/changelog/2023-05-09-more-secure-private-attachments/

So using those directly in Markdown no longer seems to work (for newly uploaded images). But @evetion noticed that putting them in an `img` HTML tag works fine. 