### PR TITLE
Stop using local JULIAUP_DEPOT_PATH

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -2,9 +2,6 @@
 # https://domluna.github.io/JuliaFormatter.jl/stable/
 # https://docs.sciml.ai/SciMLStyle/stable/
 
-# We don't use SciML style since aligning with opening brackets doesn't look good if
-# the opening bracket is near the end of the line. This squeezes the code to the right,
-# and this alignment confuses auto indent.
 # Based on the default style we do pick these non-default options from SciML style:
 whitespace_ops_in_indices = true
 remove_extra_newlines = true

--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -13,3 +13,5 @@ whitespace_typedefs = true
 
 # And add other options we like:
 separate_kwargs_with_semicolon = true
+
+ignore = [".pixi"]

--- a/.gitignore
+++ b/.gitignore
@@ -146,7 +146,6 @@ dmypy.json
 build/tests/temp/
 python/ribasim_api/tests/temp/
 report.xml
-/utils/juliaup
 
 # Designated working dir for working on Ribasim models
 models/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,8 +21,7 @@
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "julia.lint.disabledDirs": [
-        ".pixi",
-        "utils/juliaup"
+        ".pixi"
     ],
     "julia.lint.run": true
 }

--- a/pixi.toml
+++ b/pixi.toml
@@ -20,7 +20,7 @@ test-ribasim-api = "pytest --basetemp=python/ribasim_api/tests/temp --junitxml=r
 
 [feature.dev.tasks]
 # Installation
-install-julia = "juliaup add 1.10.4 && juliaup default 1.10.4"
+install-julia = "juliaup add 1.10.4 && juliaup override set 1.10.4"
 install-pre-commit = "pre-commit install"
 install-ci = { depends_on = ["install-julia", "update-registry-julia"] }
 install = { depends_on = [

--- a/utils/env_setup.bat
+++ b/utils/env_setup.bat
@@ -1,4 +1,3 @@
-set JULIAUP_DEPOT_PATH=%~dp0
 set QUARTO_PYTHON=python
 
 setlocal EnableDelayedExpansion

--- a/utils/env_setup.sh
+++ b/utils/env_setup.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-JULIAUP_DEPOT_PATH=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
-export JULIAUP_DEPOT_PATH
 QUARTO_PYTHON=python
 export QUARTO_PYTHON
 relative_conda_prefix=$(realpath --relative-to="$PWD" "$CONDA_PREFIX")


### PR DESCRIPTION
In #878 we started installing julia via pixi. We kept the packages shared under `~/.julia` to avoid unnecessary duplication. We did put the julia installation under `utils/juliaup` by setting JULIAUP_DEPOT_PATH. This way we could set a default channel for our juliaup.

However if we can manage to set the default channel for our repository having the julia installations in the normal place is preferred, because it won't have to download julia versions that are already installed. Looking at [`juliaup override`](https://github.com/JuliaLang/juliaup?tab=readme-ov-file#overrides) we can achieve this with `juliaup override set 1.10.4`. This also has the advantage that you get the desired channel with both `pixi run julia` and `julia`. That's nice because my global default channel is 1.11.

```
❯ juliaup override status
 Path  Channel
---------------

Ribasim on  home-depot [$!?] via ஃ v1.10.4 via 🐍
❯ pixi run install-julia
✨ Pixi task (install-julia in dev): juliaup add 1.10.4 && juliaup override set 1.10.4
'1.10.4' is already installed.

Ribasim on  home-depot [$!?] via ஃ v1.10.4 via 🐍 took 3s
❯ juliaup override status
 Path                     Channel
----------------------------------
 D:\repo\ribasim\Ribasim  1.10.4
```