### PR TITLE
Let coverage tests only run on non-integration tests

### DIFF
--- a/core/test/allocation_test.jl
+++ b/core/test/allocation_test.jl
@@ -35,7 +35,7 @@
     close(db)
 end
 
-@testitem "Allocation objective" begin
+@testitem "integration_Allocation objective" begin
     using DataFrames: DataFrame
     using SciMLBase: successful_retcode
     using Ribasim: NodeID
@@ -422,7 +422,7 @@ end
     @test all(isapprox.(realized_numeric[3:end], df_user_3.realized[4:end], atol = 5e-4))
 end
 
-@testitem "Flow demand" begin
+@testitem "integration_Flow demand" begin
     using JuMP
     using Ribasim: NodeID, OptimizationType
     using DataFrames: DataFrame
@@ -608,7 +608,7 @@ end
     @test constraint.set.upper == 2.0
 end
 
-@testitem "equal_fraction_allocation" begin
+@testitem "integration_equal_fraction_allocation" begin
     using Ribasim: NodeID, NodeType
     using StructArrays: StructVector
     using DataFrames: DataFrame

--- a/core/test/control_test.jl
+++ b/core/test/control_test.jl
@@ -1,4 +1,4 @@
-@testitem "Pump discrete control" begin
+@testitem "integration_Pump discrete control" begin
     using PreallocationTools: get_tmp
     using Ribasim: NodeID
     using Dates: DateTime
@@ -61,7 +61,7 @@
     @test all(iszero, flow)
 end
 
-@testitem "Flow condition control" begin
+@testitem "integration_Flow condition control" begin
     toml_path = normpath(@__DIR__, "../../generated_testmodels/flow_condition/ribasim.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
@@ -82,7 +82,7 @@ end
     @test isapprox(flow_t_control_ahead, greater_than, rtol = 0.005)
 end
 
-@testitem "Transient level boundary condition control" begin
+@testitem "integration_Transient level boundary condition control" begin
     toml_path = normpath(
         @__DIR__,
         "../../generated_testmodels/level_boundary_condition/ribasim.toml",
@@ -106,7 +106,7 @@ end
     @test isapprox(level_t_control_ahead, greater_than, rtol = 0.005)
 end
 
-@testitem "PID control" begin
+@testitem "integration_PID control" begin
     toml_path = normpath(@__DIR__, "../../generated_testmodels/pid_control/ribasim.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
@@ -144,7 +144,7 @@ end
     )
 end
 
-@testitem "TabulatedRatingCurve control" begin
+@testitem "integration_TabulatedRatingCurve control" begin
     using Dates: Date
 
     toml_path = normpath(
@@ -165,7 +165,7 @@ end
     @test last(only(p.tabulated_rating_curve.table).t) == 1.2
 end
 
-@testitem "Set PID target with DiscreteControl" begin
+@testitem "integration_Set PID target with DiscreteControl" begin
     using Ribasim: NodeID
 
     toml_path = normpath(
@@ -196,7 +196,7 @@ end
     @test isapprox(level[end], target_low, atol = 1e-1)
 end
 
-@testitem "Compound condition" begin
+@testitem "integration_Compound condition" begin
     using Ribasim: NodeID
 
     toml_path = normpath(
@@ -230,7 +230,7 @@ end
     @test record.control_state == ["Off", "On"]
 end
 
-@testitem "Flow through node control" begin
+@testitem "integration_Flow through node control" begin
     using DataFrames: DataFrame
 
     toml_path = normpath(

--- a/core/test/equations_test.jl
+++ b/core/test/equations_test.jl
@@ -15,7 +15,7 @@
 # Equation: storage' = -(2*level(storage)-C)/resistance, storage(t0) = storage0
 # Solution: storage(t) = limit_storage + (storage0 - limit_storage)*exp(-t/(basin_area*resistance))
 # Here limit_storage is the storage at which the level of the basin is equal to the level of the level boundary
-@testitem "LinearResistance" begin
+@testitem "integration_LinearResistance" begin
     using SciMLBase: successful_retcode
 
     toml_path =
@@ -48,7 +48,7 @@ end
 # Equation: w' = -α/basin_area * w^2, w = (level(storage) - level_min)/basin_area
 # Solution: w = 1/(α(t-t0)/basin_area + 1/w(t0)),
 # storage = storage_min + 1/(α(t-t0)/basin_area^2 + 1/(storage(t0)-storage_min))
-@testitem "TabulatedRatingCurve" begin
+@testitem "integration_TabulatedRatingCurve" begin
     using SciMLBase: successful_retcode
 
     toml_path = normpath(@__DIR__, "../../generated_testmodels/rating_curve/ribasim.toml")
@@ -82,7 +82,7 @@ end
 # Solution: (implicit, given by Wolfram Alpha).
 # Note: The Wolfram Alpha solution contains a factor of the hypergeometric function 2F1, but these values are
 # so close to 1 that they are omitted.
-@testitem "ManningResistance" begin
+@testitem "integration_ManningResistance" begin
     using SciMLBase: successful_retcode
 
     toml_path =
@@ -119,7 +119,7 @@ end
 # The second order linear inhomogeneous ODE for this model is derived by
 # differentiating the equation for the storage of the controlled basin
 # once to time to get rid of the integral term.
-@testitem "PID control" begin
+@testitem "integration_PID control" begin
     using SciMLBase: successful_retcode
 
     toml_path =

--- a/core/test/io_test.jl
+++ b/core/test/io_test.jl
@@ -121,7 +121,7 @@ end
     @test_throws "not sorted as required" Ribasim.sorted_table!(reversed_arrow_table)
 end
 
-@testitem "results" begin
+@testitem "integration_results" begin
     using SciMLBase: successful_retcode
     import Arrow
 

--- a/core/test/main_test.jl
+++ b/core/test/main_test.jl
@@ -1,5 +1,5 @@
 
-@testitem "toml_path" begin
+@testitem "integration_toml_path" begin
     using IOCapture: capture
     import TOML
 

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -1,4 +1,4 @@
-@testitem "trivial model" begin
+@testitem "integration_trivial model" begin
     using SciMLBase: successful_retcode
     using Tables: Tables
     using Tables.DataAPI: nrow
@@ -123,7 +123,7 @@
     end
 end
 
-@testitem "bucket model" begin
+@testitem "integration_bucket model" begin
     using SciMLBase: successful_retcode
 
     toml_path = normpath(@__DIR__, "../../generated_testmodels/bucket/ribasim.toml")
@@ -176,7 +176,7 @@ end
     @test successful_retcode(Ribasim.solve!(model))
 end
 
-@testitem "basic model" begin
+@testitem "integration_basic model" begin
     using Logging: Debug, with_logger
     using LoggingExtras
     using SciMLBase: successful_retcode
@@ -223,7 +223,7 @@ end
     end
 end
 
-@testitem "basic arrow model" begin
+@testitem "integration_basic arrow model" begin
     using SciMLBase: successful_retcode
 
     toml_path = normpath(@__DIR__, "../../generated_testmodels/basic_arrow/ribasim.toml")
@@ -233,7 +233,7 @@ end
     @test successful_retcode(model)
 end
 
-@testitem "basic transient model" begin
+@testitem "integration_basic transient model" begin
     using SciMLBase: successful_retcode
 
     toml_path =
@@ -249,7 +249,7 @@ end
         Sys.isapple()
 end
 
-@testitem "Allocation example model" begin
+@testitem "integration_Allocation example model" begin
     using SciMLBase: successful_retcode
 
     toml_path =
@@ -260,7 +260,7 @@ end
     @test successful_retcode(model)
 end
 
-@testitem "sparse and AD/FDM jac solver options" begin
+@testitem "integration_sparse and AD/FDM jac solver options" begin
     using SciMLBase: successful_retcode
 
     toml_path =
@@ -290,7 +290,7 @@ end
     @test time_ad.integrator.sol.u[end] ≈ sparse_ad.integrator.sol.u[end] atol = 1
 end
 
-@testitem "TabulatedRatingCurve model" begin
+@testitem "integration_TabulatedRatingCurve model" begin
     using SciMLBase: successful_retcode
 
     toml_path =
@@ -363,7 +363,7 @@ end
     @test A ≈ 10 * h
 end
 
-@testitem "Outlet constraints" begin
+@testitem "integration_Outlet constraints" begin
     using DataFrames: DataFrame
     using SciMLBase: successful_retcode
 
@@ -396,7 +396,7 @@ end
     all(isapprox.(level_basin[t .>= t_maximum_level], level.u[3], atol = 5e-2))
 end
 
-@testitem "UserDemand" begin
+@testitem "integration_UserDemand" begin
     using SciMLBase: successful_retcode
 
     toml_path = normpath(@__DIR__, "../../generated_testmodels/user_demand/ribasim.toml")
@@ -412,7 +412,7 @@ end
     @test only(model.integrator.sol(180day)) ≈ 509 atol = 1
 end
 
-@testitem "ManningResistance" begin
+@testitem "integration_ManningResistance" begin
     using PreallocationTools: get_tmp
     using SciMLBase: successful_retcode
     using Ribasim: NodeID
@@ -499,7 +499,7 @@ end
     ) ≈ 5.0 atol = 0.001 skip = Sys.isapple()
 end
 
-@testitem "mean_flow" begin
+@testitem "integration_mean_flow" begin
     using DataFrames: DataFrame
 
     toml_path =

--- a/core/test/runtests.jl
+++ b/core/test/runtests.jl
@@ -1,3 +1,10 @@
 using ReTestItems, Ribasim
 
-runtests(Ribasim; nworkers = min(4, Sys.CPU_THREADS ÷ 2), nworker_threads = 2)
+name_regex = ifelse("coverage" in ARGS, r"^(?!integration_).*", nothing)
+
+runtests(
+    Ribasim;
+    name = name_regex,
+    nworkers = min(4, Sys.CPU_THREADS ÷ 2),
+    nworker_threads = 2,
+)

--- a/core/test/time_test.jl
+++ b/core/test/time_test.jl
@@ -1,4 +1,4 @@
-@testitem "Time dependent flow boundary" begin
+@testitem "integration_Time dependent flow boundary" begin
     using Dates
     using DataFrames: DataFrame
     using SciMLBase: successful_retcode
@@ -23,7 +23,7 @@
     @test isapprox(flow_1_to_2.flow_rate, flow_expected, rtol = 0.005)
 end
 
-@testitem "vertical_flux_means" begin
+@testitem "integration_vertical_flux_means" begin
     using DataFrames: DataFrame, transform!, ByRow
 
     toml_path =

--- a/core/test/validation_test.jl
+++ b/core/test/validation_test.jl
@@ -438,7 +438,7 @@ end
     )
 end
 
-@testitem "Convergence bottleneck" begin
+@testitem "integration_Convergence bottleneck" begin
     using IOCapture: capture
     toml_path =
         normpath(@__DIR__, "../../generated_testmodels/invalid_unstable/ribasim.toml")

--- a/pixi.toml
+++ b/pixi.toml
@@ -84,7 +84,7 @@ test-ribasim-cli = "pytest --numprocesses=4 --basetemp=build/tests/temp --junitx
 test-ribasim-core = { cmd = "julia --project=core --eval 'using Pkg; Pkg.test()'", depends_on = [
     "generate-testmodels",
 ] }
-test-ribasim-core-cov = { cmd = "julia --project=core --eval 'using Pkg; Pkg.test(coverage=true, julia_args=[\"--check-bounds=yes\"])'", depends_on = [
+test-ribasim-core-cov = { cmd = "julia --project=core --eval 'using Pkg; Pkg.test(coverage=true, julia_args=[\"--check-bounds=yes\"], test_args=[\"coverage\"])'", depends_on = [
     "generate-testmodels",
 ] }
 generate-testmodels = { cmd = "python utils/generate-testmodels.py", inputs = [


### PR DESCRIPTION
Marked all tests that contain Ribasim.run as integration.
Use a regex to check for "integration_" when running tests.
Excludes a total of 215 tests when calculating coverage.
