### PR TITLE
Resolve the SSL error produced when running the build task on windows

### DIFF
--- a/.teamcity/Ribasim/buildTypes/Windows_1.kt
+++ b/.teamcity/Ribasim/buildTypes/Windows_1.kt
@@ -7,10 +7,6 @@ object Windows_1 : Template({
     name = "Ribasim_Windows"
     description = "Template for agent that uses Windows OS"
 
-    params {
-        param("env.JULIA_SSL_CA_ROOTS_PATH", "")
-    }
-
     vcs {
         cleanCheckout = true
     }

--- a/.teamcity/Ribasim_Windows/buildTypes/Windows_TestRibasimBinaries.kt
+++ b/.teamcity/Ribasim_Windows/buildTypes/Windows_TestRibasimBinaries.kt
@@ -33,7 +33,7 @@ object Windows_TestRibasimBinaries : BuildType({
             id = "RUNNER_1503"
             workingDir = "ribasim"
             scriptContent = """
-                pixi run install
+                pixi run install-ci
                 pixi run test-ribasim-api
                 pixi run test-ribasim-cli
             """.trimIndent()

--- a/pixi.toml
+++ b/pixi.toml
@@ -77,7 +77,7 @@ lint = { depends_on = [
 build = { "cmd" = "julia --project build.jl", cwd = "build", depends_on = [
     "generate-testmodels",
     "initialize-julia",
-] }
+], env = {JULIA_SSL_CA_ROOTS_PATH = ""} }
 remove-artifacts = "julia --eval 'rm(joinpath(Base.DEPOT_PATH[1], \"artifacts\"), force=true, recursive=true)'"
 # Tests
 test-ribasim-cli = "pytest --numprocesses=4 --basetemp=build/tests/temp --junitxml=report.xml build/tests"


### PR DESCRIPTION
While building Ribasim on Windows an SLL error is produced. 
In the TeamCity pipelines the error is resolved by settings the environment variable `JULIA_SSL_CA_ROOTS_PATH`

in this commit that variable is now set in the pixi file, making the build succeed both on the teamcity server as on your own machine