### PR TITLE
QGIS: Update minimal TOML with new required fields

### DIFF
--- a/python/ribasim/tests/test_io.py
+++ b/python/ribasim/tests/test_io.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -202,3 +203,10 @@ def test_datetime_timezone():
     assert isinstance(model.endtime, datetime)
     assert model.starttime.tzinfo is None
     assert model.endtime.tzinfo is None
+
+
+def test_minimal_toml():
+    # Check if the TOML used in QGIS tests is still valid.
+    toml_path = Path(__file__).parents[3] / "ribasim_qgis/tests/data/simple_valid.toml"
+    model = ribasim.Model.read(toml_path)
+    assert model.crs == "EPSG:28992"

--- a/ribasim_qgis/tests/data/simple_valid.toml
+++ b/ribasim_qgis/tests/data/simple_valid.toml
@@ -1,4 +1,6 @@
 starttime = 2020-01-01 00:00:00
 endtime = 2021-01-01 00:00:00
+crs = "EPSG:28992"
 input_dir = "."
 results_dir = "results"
+ribasim_version = "2024.9.0"

--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -93,8 +93,8 @@ class DatasetTreeWidget(QTreeWidget):
 
         # Start deleting
         elements = {item.element for item in selection}  # type: ignore[attr-defined] # TODO: dynamic item.element should be in some dict.
-        qgs_instance = QgsProject.instance()
-        assert qgs_instance is not None
+        project = QgsProject.instance()
+        assert project is not None
 
         for element in elements:
             layer = element.layer
@@ -102,7 +102,7 @@ class DatasetTreeWidget(QTreeWidget):
             if layer is None:
                 continue
             try:
-                qgs_instance.removeMapLayer(layer.id())
+                project.removeMapLayer(layer.id())
             except (RuntimeError, AttributeError) as e:
                 if e.args[0] in (
                     "wrapped C/C++ object of type QgsVectorLayer has been deleted",
@@ -268,8 +268,10 @@ class DatasetWidget(QWidget):
                 [
                     f"starttime = {datetime(2020, 1, 1)}\n",
                     f"endtime = {datetime(2021, 1, 1)}\n",
+                    f'crs = "{self.ribasim_widget.crs.authid()}"\n',
                     'input_dir = "."\n',
                     'results_dir = "results"\n',
+                    'ribasim_version = "2024.9.0"\n',
                 ]
             )
 


### PR DESCRIPTION
For CRS it uses the current QGIS project CRS.
The minimal TOML used in QGIS tests is now also checked by Ribasim Python to avoid it getting outdated.