### PR TITLE
Log stacktraces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ playground/output
 # Ruff
 .ruff_cache
 .teamcity/.idea/
+
+# https://github.com/Deltares/Ribasim/issues/1652
+ribasim_qgis/tests/data/database.gpkg

--- a/core/src/main.jl
+++ b/core/src/main.jl
@@ -40,23 +40,38 @@ function main(toml_path::AbstractString)::Cint
                     @warn "The Ribasim version in the TOML config file does not match the used Ribasim CLI version." config.ribasim_version cli.ribasim_version
                 end
                 @info "Starting a Ribasim simulation." cli.ribasim_version starttime endtime
-                model = run(config)
 
-                if successful_retcode(model)
-                    log_bottlenecks(model; converged = true)
-                    @info "The model finished successfully"
-                    return 0
-                else
-                    log_bottlenecks(model; converged = false)
-                    t = datetime_since(model.integrator.t, starttime)
-                    retcode = model.integrator.sol.retcode
-                    @error """The model exited at model time $t with return code $retcode.
-                    See https://docs.sciml.ai/DiffEqDocs/stable/basics/solution/#retcodes"""
+                try
+                    model = run(config)
+
+                    if successful_retcode(model)
+                        log_bottlenecks(model; converged = true)
+                        @info "The model finished successfully."
+                        return 0
+                    else
+                        # OrdinaryDiffEq doesn't error on e.g. convergence failure,
+                        # but we want a non-zero exit code in that case.
+                        log_bottlenecks(model; converged = false)
+                        t = datetime_since(model.integrator.t, starttime)
+                        retcode = model.integrator.sol.retcode
+                        @error """The model exited at model time $t with return code $retcode.
+                        See https://docs.sciml.ai/DiffEqDocs/stable/basics/solution/#retcodes"""
+                        return 1
+                    end
+
+                catch
+                    # Both validation errors that we throw and unhandled exceptions are caught here.
+                    # To make it easier to find the cause, log the stacktrace to the terminal and log file.
+                    stack = current_exceptions()
+                    Base.invokelatest(Base.display_error, stack)
+                    Base.invokelatest(Base.display_error, io, stack)
                     return 1
                 end
             end
         end
     catch
+        # If it fails before we get to setup the logger, we can't log to a file.
+        # This happens if e.g. the config is invalid.
         Base.invokelatest(Base.display_error, current_exceptions())
         return 1
     end

--- a/core/test/main_test.jl
+++ b/core/test/main_test.jl
@@ -1,7 +1,7 @@
-
-@testitem "toml_path" begin
+@testitem "main output" begin
     using IOCapture: capture
     import TOML
+    using Ribasim: Config, results_path
 
     model_path = normpath(@__DIR__, "../../generated_testmodels/basic/")
     toml_path = normpath(model_path, "ribasim.toml")
@@ -25,4 +25,27 @@
     end
     @test occursin("version in the TOML config file does not match", output)
     @test occursin("Info: Convergence bottlenecks in descending order of severity:", output)
+end
+
+@testitem "main error logging" begin
+    using IOCapture: capture
+    import TOML
+    using Ribasim: Config, results_path
+
+    model_path = normpath(@__DIR__, "../../generated_testmodels/invalid_edge_types/")
+    toml_path = normpath(model_path, "ribasim.toml")
+
+    @test ispath(toml_path)
+    (; value, output) = capture() do
+        Ribasim.main(toml_path)
+    end
+    @test value == 1
+
+    # Stacktraces should be written to both the terminal and log file.
+    @test occursin("\nStacktrace:\n", output)
+    config = Config(toml_path)
+    log_path = results_path(config, "ribasim.log")
+    @test ispath(log_path)
+    log_str = read(log_path, String)
+    @test occursin("\nStacktrace:\n", log_str)
 end


### PR DESCRIPTION
Fixes #1350

This is an example `ribasim.log`:

```
┌ Info: Starting a Ribasim simulation.
│   cli.ribasim_version = 2024.9.0
│   starttime = 2020-01-01T00:00:00
│   endtime = 2020-12-01T00:00:00
└ @ Ribasim D:\repo\ribasim\Ribasim\core\src\main.jl:42
┌ Error: Invalid edge type 'foo' for edge #0 from node #1 to node #2.
└ @ Ribasim D:\repo\ribasim\Ribasim\core\src\validation.jl:520
┌ Error: Invalid edge type 'bar' for edge #1 from node #2 to node #3.
└ @ Ribasim D:\repo\ribasim\Ribasim\core\src\validation.jl:520
ERROR: Invalid edge types found.
Stacktrace:
  [1] error(s::String)
    @ Base .\error.jl:35
  [2] Ribasim.Model(config::Ribasim.config.Config)
    @ Ribasim D:\repo\ribasim\Ribasim\core\src\model.jl:59
  [3] run(config::Ribasim.config.Config)
    @ Ribasim D:\repo\ribasim\Ribasim\core\src\main.jl:11
  [4] (::Ribasim.var"#215#217"{IOStream, Ribasim.config.Config})()
    @ Ribasim D:\repo\ribasim\Ribasim\core\src\main.jl:45
  [5] with_logstate(f::Function, logstate::Any)
    @ Base.CoreLogging .\logging.jl:515
  [6] with_logger
    @ .\logging.jl:627 [inlined]
  [7] #214
    @ D:\repo\ribasim\Ribasim\core\src\main.jl:36 [inlined]
  [8] open(::Ribasim.var"#214#216"{Ribasim.config.Config}, ::String, ::Vararg{String}; kwargs::@Kwargs{})
    @ Base .\io.jl:396
  [9] open
    @ .\io.jl:393 [inlined]
 [10] main(toml_path::String)
    @ Ribasim D:\repo\ribasim\Ribasim\core\src\main.jl:34
 [11] (::Main.var"##227".var"#1#2")()
    @ Main.var"##227" d:\repo\ribasim\Ribasim\core\test\main_test.jl:42
 [12] (::IOCapture.var"#5#9"{DataType, Main.var"##227".var"#1#2", IOContext{Base.PipeEndpoint}, IOContext{Base.PipeEndpoint}, Base.PipeEndpoint, Base.PipeEndpoint})()
    @ IOCapture C:\Users\visser_mn\.julia\packages\IOCapture\Y5rEA\src\IOCapture.jl:170
 [13] with_logstate(f::Function, logstate::Any)
    @ Base.CoreLogging .\logging.jl:515
 [14] with_logger
    @ .\logging.jl:627 [inlined]
 [15] capture(f::Main.var"##227".var"#1#2"; rethrow::Type, color::Bool, passthrough::Bool, capture_buffer::IOBuffer, io_context::Vector{Any})
    @ IOCapture C:\Users\visser_mn\.julia\packages\IOCapture\Y5rEA\src\IOCapture.jl:167
 [16] capture(f::Function)
    @ IOCapture C:\Users\visser_mn\.julia\packages\IOCapture\Y5rEA\src\IOCapture.jl:100
 [17] top-level scope
    @ d:\repo\ribasim\Ribasim\core\test\main_test.jl:41
 [18] eval
    @ .\boot.jl:385 [inlined]
 [19] include_string(mapexpr::typeof(identity), mod::Module, code::String, filename::String)
    @ Base .\loading.jl:2076
 [20] include_string(m::Module, txt::String, fname::String)
    @ Base .\loading.jl:2086
 [21] #invokelatest#2
    @ .\essentials.jl:892 [inlined]
 [22] invokelatest
    @ .\essentials.jl:889 [inlined]
 [23] #8
    @ c:\Users\visser_mn\.vscode\extensions\julialang.language-julia-1.83.2\scripts\packages\VSCodeTestServer\src\VSCodeTestServer.jl:115 [inlined]
 [24] withpath(f::VSCodeTestServer.var"#8#10"{UInt64, String, String, Module}, path::String)
    @ VSCodeTestServer c:\Users\visser_mn\.vscode\extensions\julialang.language-julia-1.83.2\scripts\packages\VSCodeTestServer\src\VSCodeTestServer.jl:20
 [25] run_testitem_handler(conn::VSCodeTestServer.JSONRPC.JSONRPCEndpoint{Base.PipeEndpoint, Base.PipeEndpoint}, params::VSCodeTestServer.TestserverRunTestitemRequestParams)
    @ VSCodeTestServer c:\Users\visser_mn\.vscode\extensions\julialang.language-julia-1.83.2\scripts\packages\VSCodeTestServer\src\VSCodeTestServer.jl:114
 [26] dispatch_msg(x::VSCodeTestServer.JSONRPC.JSONRPCEndpoint{Base.PipeEndpoint, Base.PipeEndpoint}, dispatcher::VSCodeTestServer.JSONRPC.MsgDispatcher, msg::Dict{String, Any})
    @ VSCodeTestServer.JSONRPC c:\Users\visser_mn\.vscode\extensions\julialang.language-julia-1.83.2\scripts\packages\JSONRPC\src\typed.jl:67
 [27] serve_in_env(conn::Base.PipeEndpoint)
    @ VSCodeTestServer c:\Users\visser_mn\.vscode\extensions\julialang.language-julia-1.83.2\scripts\packages\VSCodeTestServer\src\VSCodeTestServer.jl:215
 [28] #14
    @ c:\Users\visser_mn\.vscode\extensions\julialang.language-julia-1.83.2\scripts\packages\VSCodeTestServer\src\VSCodeTestServer.jl:234 [inlined]
 [29] (::VSCodeTestServer.TestEnv.var"#3#4"{VSCodeTestServer.var"#14#16"{Base.PipeEndpoint}})()
    @ VSCodeTestServer.TestEnv c:\Users\visser_mn\.vscode\extensions\julialang.language-julia-1.83.2\scripts\packages\TestEnv\src\julia-1.9\activate_do.jl:19
 [30] withenv(::VSCodeTestServer.TestEnv.var"#3#4"{VSCodeTestServer.var"#14#16"{Base.PipeEndpoint}}, ::Pair{String, String}, ::Vararg{Pair{String}})
    @ Base .\env.jl:257
 [31] (::Pkg.Operations.var"#117#122"{String, Bool, Bool, Bool, VSCodeTestServer.TestEnv.var"#3#4"{VSCodeTestServer.var"#14#16"{Base.PipeEndpoint}}, Pkg.Types.PackageSpec})()
    @ Pkg.Operations C:\Users\visser_mn\.julia\juliaup\julia-1.10.4+0.x64.w64.mingw32\share\julia\stdlib\v1.10\Pkg\src\Operations.jl:1825
 [32] with_temp_env(fn::Pkg.Operations.var"#117#122"{String, Bool, Bool, Bool, VSCodeTestServer.TestEnv.var"#3#4"{VSCodeTestServer.var"#14#16"{Base.PipeEndpoint}}, Pkg.Types.PackageSpec}, temp_env::String)
    @ Pkg.Operations C:\Users\visser_mn\.julia\juliaup\julia-1.10.4+0.x64.w64.mingw32\share\julia\stdlib\v1.10\Pkg\src\Operations.jl:1706
 [33] (::Pkg.Operations.var"#115#120"{Nothing, Bool, Bool, Bool, VSCodeTestServer.TestEnv.var"#3#4"{VSCodeTestServer.var"#14#16"{Base.PipeEndpoint}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String})(tmp::String)
    @ Pkg.Operations C:\Users\visser_mn\.julia\juliaup\julia-1.10.4+0.x64.w64.mingw32\share\julia\stdlib\v1.10\Pkg\src\Operations.jl:1795
 [34] mktempdir(fn::Pkg.Operations.var"#115#120"{Nothing, Bool, Bool, Bool, VSCodeTestServer.TestEnv.var"#3#4"{VSCodeTestServer.var"#14#16"{Base.PipeEndpoint}}, Pkg.Types.Context, Pkg.Types.PackageSpec, String, Pkg.Types.Project, String}, parent::String; prefix::String)
    @ Base.Filesystem .\file.jl:766
 [35] mktempdir(fn::Function, parent::String)
    @ Base.Filesystem .\file.jl:762
 [36] mktempdir
    @ .\file.jl:762 [inlined]
 [37] sandbox(fn::Function, ctx::Pkg.Types.Context, target::Pkg.Types.PackageSpec, target_path::String, sandbox_path::String, sandbox_project_override::Pkg.Types.Project; preferences::Nothing, force_latest_compatible_version::Bool, allow_earlier_backwards_compatible_versions::Bool, allow_reresolve::Bool)
    @ Pkg.Operations C:\Users\visser_mn\.julia\juliaup\julia-1.10.4+0.x64.w64.mingw32\share\julia\stdlib\v1.10\Pkg\src\Operations.jl:1753
 [38] sandbox
    @ C:\Users\visser_mn\.julia\juliaup\julia-1.10.4+0.x64.w64.mingw32\share\julia\stdlib\v1.10\Pkg\src\Operations.jl:1744 [inlined]
 [39] activate(f::VSCodeTestServer.var"#14#16"{Base.PipeEndpoint}, pkg::String; allow_reresolve::Bool)
    @ VSCodeTestServer.TestEnv c:\Users\visser_mn\.vscode\extensions\julialang.language-julia-1.83.2\scripts\packages\TestEnv\src\julia-1.9\activate_do.jl:17
 [40] activate
    @ c:\Users\visser_mn\.vscode\extensions\julialang.language-julia-1.83.2\scripts\packages\TestEnv\src\julia-1.9\activate_do.jl:12 [inlined]
 [41] serve(conn::Base.PipeEndpoint, project_path::String, package_path::String, package_name::String; is_dev::Bool, crashreporting_pipename::Nothing)
    @ VSCodeTestServer c:\Users\visser_mn\.vscode\extensions\julialang.language-julia-1.83.2\scripts\packages\VSCodeTestServer\src\VSCodeTestServer.jl:233
 [42] serve(conn::Base.PipeEndpoint, project_path::String, package_path::String, package_name::String)
    @ VSCodeTestServer c:\Users\visser_mn\.vscode\extensions\julialang.language-julia-1.83.2\scripts\packages\VSCodeTestServer\src\VSCodeTestServer.jl:219
 [43] top-level scope
    @ c:\Users\visser_mn\.vscode\extensions\julialang.language-julia-1.83.2\scripts\testserver\testserver_main.jl:17
 [44] include(mod::Module, _path::String)
    @ Base .\Base.jl:495
 [45] exec_options(opts::Base.JLOptions)
    @ Base .\client.jl:318
 [46] _start()
    @ Base .\client.jl:552
```