### PR TITLE
Use install-ci on CI

### DIFF
--- a/.teamcity/Ribasim_Linux/buildTypes/Linux_TestRibasimBinaries.kt
+++ b/.teamcity/Ribasim_Linux/buildTypes/Linux_TestRibasimBinaries.kt
@@ -44,7 +44,7 @@ object Linux_TestRibasimBinaries : BuildType({
                 source /usr/share/Modules/init/bash
 
                 module load pixi
-                pixi run install
+                pixi run install-ci
                 pixi run test-ribasim-api
                 pixi run test-ribasim-cli
             """.trimIndent()

--- a/.teamcity/Ribasim_Windows/buildTypes/Windows_TestDelwaqCoupling.kt
+++ b/.teamcity/Ribasim_Windows/buildTypes/Windows_TestDelwaqCoupling.kt
@@ -28,7 +28,7 @@ object Windows_TestDelwaqCoupling : BuildType({
             id = "Run_Delwaq"
             workingDir = "ribasim"
             scriptContent = """
-                pixi install
+                pixi install-ci
                 pixi run ribasim-core-testmodels basic
                 set D3D_HOME=%teamcity.build.checkoutDir%/dimr
                 pixi run delwaq


### PR DESCRIPTION
These are the last two occurrences in our TeamCity config. This avoids installing QGIS plugins and pre-commit, both of which are not needed on TeamCity.

```toml
install = { depends_on = [
    "install-ci",
    "install-qgis-plugins",
    "install-pre-commit",
] }
```