### PR TITLE
Delwaq pixi run install-ci

### DIFF
--- a/.teamcity/Ribasim_Windows/buildTypes/Windows_TestDelwaqCoupling.kt
+++ b/.teamcity/Ribasim_Windows/buildTypes/Windows_TestDelwaqCoupling.kt
@@ -28,7 +28,7 @@ object Windows_TestDelwaqCoupling : BuildType({
             id = "Run_Delwaq"
             workingDir = "ribasim"
             scriptContent = """
-                pixi run install-ci
+                pixi install
                 pixi run ribasim-core-testmodels basic
                 set D3D_HOME=%teamcity.build.checkoutDir%/dimr
                 pixi run delwaq

--- a/.teamcity/Ribasim_Windows/buildTypes/Windows_TestDelwaqCoupling.kt
+++ b/.teamcity/Ribasim_Windows/buildTypes/Windows_TestDelwaqCoupling.kt
@@ -28,7 +28,7 @@ object Windows_TestDelwaqCoupling : BuildType({
             id = "Run_Delwaq"
             workingDir = "ribasim"
             scriptContent = """
-                pixi install-ci
+                pixi run install-ci
                 pixi run ribasim-core-testmodels basic
                 set D3D_HOME=%teamcity.build.checkoutDir%/dimr
                 pixi run delwaq


### PR DESCRIPTION
Does not fix a regression from #1656. I thought it said `pixi run install`, but it was `pixi install`.

The Delwaq regression may also be related to https://github.com/Deltares/Ribasim/pull/1649