### PR TITLE
Ruff: apply all fixes

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -17,7 +17,7 @@ ignore = [
     "PD002",
     "PD901",
 ]
-fixable = ["I"]
+fixable = ["ALL"]
 
 [lint.pydocstyle]
 convention = "numpy"


### PR DESCRIPTION
This is the default. I'm not sure why we only fixed `isort` rules before.
