### PR TITLE
Plot labels + clean up running instructions in examples notebook

### DIFF
--- a/docs/guide/examples.ipynb
+++ b/docs/guide/examples.ipynb
@@ -430,7 +430,8 @@
     "df_basin_wide = df_basin.pivot_table(\n",
     "    index=\"time\", columns=\"node_id\", values=[\"storage\", \"level\"]\n",
     ")\n",
-    "df_basin_wide[\"level\"].plot()"
+    "ax = df_basin_wide[\"level\"].plot()\n",
+    "ax.set_ylabel(\"level [m]\");"
    ]
   },
   {
@@ -443,7 +444,8 @@
     "df_flow[\"edge\"] = list(zip(df_flow.from_node_id, df_flow.to_node_id))\n",
     "df_flow[\"flow_m3d\"] = df_flow.flow_rate * 86400\n",
     "ax = df_flow.pivot_table(index=\"time\", columns=\"edge\", values=\"flow_m3d\").plot()\n",
-    "ax.legend(bbox_to_anchor=(1.3, 1), title=\"Edge\")"
+    "ax.legend(bbox_to_anchor=(1.3, 1), title=\"Edge\")\n",
+    "ax.set_ylabel(\"flow [m³day⁻¹]\");"
    ]
   },
   {
@@ -1986,9 +1988,11 @@
    "outputs": [],
    "source": [
     "df_input = df_pivot.loc[:, [(1, 2), (13, 1)]]\n",
-    "df_input.plot(ylim=[-1.0, 20.0])\n",
+    "ax = df_input.plot(ylim=[-1.0, 20.0])\n",
+    "ax.set_ylabel(\"flow [m³day⁻¹]\")\n",
     "df_weirs = df_pivot.loc[:, [(4, 5), (6, 7), (8, 9), (10, 11)]]\n",
-    "df_weirs.plot(ylim=[-1.0, 15.0])"
+    "ax = df_weirs.plot(ylim=[-1.0, 15.0])\n",
+    "ax.set_ylabel(\"flow [m³day⁻¹]\");"
    ]
   },
   {
@@ -2015,7 +2019,9 @@
     "df_basin_wide = df_basin.pivot_table(\n",
     "    index=\"time\", columns=\"node_id\", values=[\"storage\", \"level\", \"vertical_flux\"]\n",
     ")\n",
-    "df_basin_wide[\"vertical_flux\"].plot()"
+    "df_basin_wide[\"vertical_flux\"] *= 86400\n",
+    "ax = df_basin_wide[\"vertical_flux\"].plot()\n",
+    "ax.set_ylabel(\"vertical flux [m³day⁻¹]\");"
    ]
   },
   {
@@ -2031,7 +2037,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_basin_wide[\"level\"].plot()"
+    "ax = df_basin_wide[\"level\"].plot()\n",
+    "ax.set_ylabel(\"level [m]\");"
    ]
   },
   {
@@ -2296,7 +2303,6 @@
    "outputs": [],
    "source": [
     "df_flow = pd.read_feather(datadir / \"outlet_continuous_control/results/flow.arrow\")\n",
-    "\n",
     "fig, ax = plt.subplots()\n",
     "\n",
     "\n",
@@ -2311,13 +2317,14 @@
     "        x=\"time\",\n",
     "        y=\"flow_rate\",\n",
     "        ax=ax,\n",
-    "        label=f\"{from_node_type} #{from_node_id} -> {to_node_type} #{to_node_id}\",\n",
+    "        label=f\"{from_node_type} #{from_node_id} → {to_node_type} #{to_node_id}\",\n",
     "    )\n",
     "\n",
     "\n",
     "plot_edge_flow(\"LinearResistance\", 1, \"Basin\", 1)\n",
     "plot_edge_flow(\"Basin\", 1, \"Outlet\", 1)\n",
-    "plot_edge_flow(\"Basin\", 1, \"Outlet\", 2)"
+    "plot_edge_flow(\"Basin\", 1, \"Outlet\", 2)\n",
+    "ax.set_ylabel(\"flow [m³s⁻¹]\");"
    ]
   }
  ],

--- a/docs/guide/examples.ipynb
+++ b/docs/guide/examples.ipynb
@@ -398,7 +398,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now run the model. You can open a terminal and run it from there::\n",
+    "## Running a model\n",
+    "Now run the model. You can open a terminal and run it from there:\n",
     "\n",
     "```bash\n",
     "ribasim basic/ribasim.toml\n",
@@ -712,8 +713,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now run the model with `ribasim level_range/ribasim.toml`.\n",
-    "After running the model, read back the results:\n"
+    "Now run the model (for running instructions see [here](#running-a-model)).\n",
+    "After running the model, read back the results:"
    ]
   },
   {
@@ -993,7 +994,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now run the model with `ribasim pid_control/ribasim.toml`.\n",
+    "Now run the model (for running instructions see [here](#running-a-model)).\n",
     "After running the model, read back the results:\n"
    ]
   },
@@ -1274,7 +1275,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now run the model with `ribasim allocation_example/ribasim.toml`.\n",
+    "Now run the model (for running instructions see [here](#running-a-model)).\n",
     "After running the model, read back the results:\n"
    ]
   },
@@ -1561,7 +1562,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now run the model with `ribasim level_demand/ribasim.toml`.\n",
+    "Now run the model (for running instructions see [here](#running-a-model)).\n",
     "After running the model, read back the results:\n"
    ]
   },
@@ -1957,6 +1958,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Now run the model (for running instructions see [here](#running-a-model)).\n",
     "After running the model, read back the result to plot the flow of each polder basin."
    ]
   },
@@ -2292,7 +2294,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now run the model with `ribasim outlet_continuous_control/ribasim.toml`.\n",
+    "Now run the model (for running instructions see [here](#running-a-model)).\n",
     "After running the model, read back the results:"
    ]
   },

--- a/docs/guide/examples.ipynb
+++ b/docs/guide/examples.ipynb
@@ -399,7 +399,7 @@
    "metadata": {},
    "source": [
     "## Running a model\n",
-    "Now run the model. You can open a terminal and run it from there:\n",
+    "Now run the model. You can open a terminal and run it from there. For example, to run the basic model, input:\n",
     "\n",
     "```bash\n",
     "ribasim basic/ribasim.toml\n",


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/1365.

In addition to the issue description I noticed that in the examples notebook only the first section contains elaborate running instructions. So I decided to create a link to there in all other sections.
