### PR TITLE
Update GitHub action for updating lockfiles

### DIFF
--- a/.github/workflows/pixi_auto_update.yml
+++ b/.github/workflows/pixi_auto_update.yml
@@ -1,4 +1,8 @@
-name: Pixi auto update
+name: Update Pixi lockfile
+
+permissions:
+  contents: write
+  pull-requests: write
 
 on:
   schedule:
@@ -8,23 +12,26 @@ on:
   workflow_dispatch:
 
 jobs:
-  auto-update:
+  pixi-update:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - uses: prefix-dev/setup-pixi@v0.8.1
-        with:
-          pixi-version: "latest"
-          cache: false
-      - name: Update pixi lock file
-        run: pixi update
-      - uses: peter-evans/create-pull-request@v6
+          run-install: false
+      - name: Update lockfiles
+        run: |
+          set -o pipefail
+          pixi update --json --no-install | pixi exec pixi-diff-to-markdown >> diff.md
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: update/pixi-lock
-          title: Update pixi lock file
-          commit-message: "Update `pixi.lock`"
-          body: Update pixi dependencies to the latest version.
-          author: "GitHub <noreply@github.com>"
+          commit-message: Update pixi lockfile
+          title: Update pixi lockfile
+          body-path: diff.md
+          branch: update-pixi
+          base: main
+          delete-branch: true
+          add-paths: pixi.lock

--- a/.github/workflows/pixi_auto_update.yml
+++ b/.github/workflows/pixi_auto_update.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Update lockfiles
         run: |
           set -o pipefail
-          pixi update --json --no-install | pixi exec pixi-diff-to-markdown >> diff.md
+          pixi update --json | pixi exec pixi-diff-to-markdown >> diff.md
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:


### PR DESCRIPTION
This now uses the newly documented way to do this: https://pixi.sh/latest/advanced/updates_github_actions/

The main benefit for us is that it outputs a human readable diff.
