### PR TITLE
Enforce aspect ratio bound and  limit figure size in docs

### DIFF
--- a/docs/reference/test-models.qmd
+++ b/docs/reference/test-models.qmd
@@ -14,11 +14,10 @@ for model_name, model_constructor in ribasim_testmodels.constructors.items():
         continue
 
     model = model_constructor()
-    fig, ax = plt.subplots()
+    fig, ax = plt.subplots(figsize = (6, 6))
     model.plot(ax)
     ax.set_title(label=model_name, loc="left")
     fig.text(0, 1, model_constructor.__doc__)
-    fig.tight_layout()
     plt.show()
     plt.close(fig)
 ```

--- a/docs/reference/test-models.qmd
+++ b/docs/reference/test-models.qmd
@@ -14,10 +14,11 @@ for model_name, model_constructor in ribasim_testmodels.constructors.items():
         continue
 
     model = model_constructor()
-    fig, ax = plt.subplots(figsize = (6, 6))
+    fig, ax = plt.subplots(figsize = (6, 4))
     model.plot(ax)
     ax.set_title(label=model_name, loc="left")
     fig.text(0, 1, model_constructor.__doc__)
+    ax.axis('off')
     plt.show()
     plt.close(fig)
 ```

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -366,7 +366,12 @@ class Model(FileModel):
             )
         return
 
-    def plot(self, ax=None, indicate_subnetworks: bool = True) -> Any:
+    def plot(
+        self,
+        ax=None,
+        indicate_subnetworks: bool = True,
+        aspect_ratio_bound: float = 0.33,
+    ) -> Any:
         """Plot the nodes, edges and allocation networks of the model.
 
         Parameters
@@ -375,6 +380,9 @@ class Model(FileModel):
             Axes on which to draw the plot.
         indicate_subnetworks : bool
             Whether to indicate subnetworks with a convex hull backdrop.
+        aspect_ratio_bound : float
+            The maximal aspect ratio in (0,1). The smaller this number, the further the figure
+            shape is allowed to be from a square
 
         Returns
         -------
@@ -401,6 +409,21 @@ class Model(FileModel):
             labels += labels_subnetworks
 
         ax.legend(handles, labels, loc="lower left", bbox_to_anchor=(1, 0.5))
+
+        # Enforce aspect ratio bound
+        xlim = ax.get_xlim()
+        ylim = ax.get_ylim()
+        xsize = xlim[1] - xlim[0]
+        ysize = ylim[1] - ylim[0]
+
+        if ysize < aspect_ratio_bound * xsize:
+            y_mid = (ylim[0] + ylim[1]) / 2
+            ysize_new = aspect_ratio_bound * xsize
+            ax.set_ylim(y_mid - ysize_new / 2, y_mid + ysize_new / 2)
+        elif xsize < aspect_ratio_bound * ysize:
+            x_mid = (xlim[0] + xlim[1]) / 2
+            xsize_new = aspect_ratio_bound * ysize
+            ax.set_xlim(x_mid - xsize_new / 2, x_mid + xsize_new / 2)
 
         return ax
 


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/1463.

`two_basin` now looks like this:


![cell-2-output-38](https://github.com/user-attachments/assets/078f2c52-8c7b-44f2-8591-6fa0ab985c24)
