### PR TITLE
Use pixi to fix julia package permissions on Windows

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -21,8 +21,13 @@ test-ribasim-api = "pytest --basetemp=python/ribasim_api/tests/temp --junitxml=r
 [feature.dev.tasks]
 # Installation
 install-julia = "juliaup add 1.10.4 && juliaup override unset && juliaup override set 1.10.4"
+fix-julia-dir = "icacls $homedrive/$homepath/.julia/artifacts /q /c /t /reset;exit" # ignore errors (on non-Windows platforms)
 install-pre-commit = "pre-commit install"
-install-ci = { depends_on = ["install-julia", "update-registry-julia"] }
+install-ci = { depends_on = [
+    "fix-julia-dir",
+    "install-julia",
+    "update-registry-julia",
+] }
 install = { depends_on = [
     "install-ci",
     "install-qgis-plugins",
@@ -77,7 +82,7 @@ lint = { depends_on = [
 build = { "cmd" = "julia --project build.jl", cwd = "build", depends_on = [
     "generate-testmodels",
     "initialize-julia",
-], env = {JULIA_SSL_CA_ROOTS_PATH = ""} }
+], env = { JULIA_SSL_CA_ROOTS_PATH = "" } }
 remove-artifacts = "julia --eval 'rm(joinpath(Base.DEPOT_PATH[1], \"artifacts\"), force=true, recursive=true)'"
 # Tests
 test-ribasim-cli = "pytest --numprocesses=4 --basetemp=build/tests/temp --junitxml=report.xml build/tests"

--- a/pixi.toml
+++ b/pixi.toml
@@ -21,10 +21,12 @@ test-ribasim-api = "pytest --basetemp=python/ribasim_api/tests/temp --junitxml=r
 [feature.dev.tasks]
 # Installation
 install-julia = "juliaup add 1.10.4 && juliaup override unset && juliaup override set 1.10.4"
-fix-julia-dir = "icacls $homedrive/$homepath/.julia/artifacts /q /c /t /reset;exit 0" # ignore errors (on non-Windows platforms)
+# Workaround rare issue, only on Windows, hence uses exit 0 to ignore errors
+# Upstream issue: https://github.com/JuliaLang/julia/issues/52272
+reset-artifact-permissions = "icacls $homedrive/$homepath/.julia/artifacts /q /c /t /reset;exit 0"
 install-pre-commit = "pre-commit install"
 install-ci = { depends_on = [
-    "fix-julia-dir",
+    "reset-artifact-permissions",
     "install-julia",
     "update-registry-julia",
 ] }

--- a/pixi.toml
+++ b/pixi.toml
@@ -21,7 +21,7 @@ test-ribasim-api = "pytest --basetemp=python/ribasim_api/tests/temp --junitxml=r
 [feature.dev.tasks]
 # Installation
 install-julia = "juliaup add 1.10.4 && juliaup override unset && juliaup override set 1.10.4"
-fix-julia-dir = "icacls $homedrive/$homepath/.julia/artifacts /q /c /t /reset;exit" # ignore errors (on non-Windows platforms)
+fix-julia-dir = "icacls $homedrive/$homepath/.julia/artifacts /q /c /t /reset;exit 0" # ignore errors (on non-Windows platforms)
 install-pre-commit = "pre-commit install"
 install-ci = { depends_on = [
     "fix-julia-dir",


### PR DESCRIPTION
Fixes #1603

Given the recent changes in Teamcity, the original project is lost-ish https://dpcbuild.deltares.nl/buildConfiguration/Ribasim_Ribasim_Windows_FixJuliaArtifactPermissions?branch=continuous_control&buildTypeTab=overview&mode=builds? As in automatic (?), greyed-out, no build steps or builds visible. Furthermore, the new Template(s) used is/are platform-agnostic, so harder to integrate a Windows specific fix.

So the easier way is just to integrate it into pixi, and always running it at CI time, also useful when it irrevocably happens on Windows laptops. However, there seems to be no way to have platform specific tasks (@Hofer-Julian is that correct and maybe worth an issue? I know you proposed the deno shell 😉), so I now just append an `exit`, ignoring any exit code of the previous command.



