### PR TITLE
Make node_id globally unique (again)

### DIFF
--- a/core/src/graph.jl
+++ b/core/src/graph.jl
@@ -15,15 +15,15 @@ function create_graph(db::DB, config::Config, chunk_sizes::Vector{Int})::MetaGra
         """
         SELECT
             Edge.fid,
-            FNode.node_id AS from_node_id,
-            FNode.node_type AS from_node_type,
-            TNode.node_id AS to_node_id,
-            TNode.node_type AS to_node_type,
+            FromNode.node_id AS from_node_id,
+            FromNode.node_type AS from_node_type,
+            ToNode.node_id AS to_node_id,
+            ToNode.node_type AS to_node_type,
             Edge.edge_type,
             Edge.subnetwork_id
         FROM Edge
-        LEFT JOIN Node AS FNode ON FNode.node_id = Edge.from_node_id
-        LEFT JOIN Node AS TNode ON TNode.node_id = Edge.to_node_id
+        LEFT JOIN Node AS FromNode ON FromNode.node_id = Edge.from_node_id
+        LEFT JOIN Node AS ToNode ON ToNode.node_id = Edge.to_node_id
         """,
     )
     # Node IDs per subnetwork

--- a/core/src/graph.jl
+++ b/core/src/graph.jl
@@ -12,7 +12,19 @@ function create_graph(db::DB, config::Config, chunk_sizes::Vector{Int})::MetaGra
     )
     edge_rows = execute(
         db,
-        "SELECT fid, from_node_type, from_node_id, to_node_type, to_node_id, edge_type, subnetwork_id FROM Edge ORDER BY fid",
+        """
+        SELECT
+            Edge.fid,
+            FNode.node_id AS from_node_id,
+            FNode.node_type AS from_node_type,
+            TNode.node_id AS to_node_id,
+            TNode.node_type AS to_node_type,
+            Edge.edge_type,
+            Edge.subnetwork_id
+        FROM Edge
+        LEFT JOIN Node AS FNode ON FNode.node_id = Edge.from_node_id
+        LEFT JOIN Node AS TNode ON TNode.node_id = Edge.to_node_id
+        """,
     )
     # Node IDs per subnetwork
     node_ids = Dict{Int32, Set{NodeID}}()

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -72,8 +72,8 @@ function NodeID(value::Integer, db::DB)::NodeID
         db,
         "SELECT COUNT(*), node_type FROM Node WHERE node_type == (SELECT node_type FROM Node WHERE node_id == $value) AND node_id <= $value",
     )
-    @assert idx[1] > 0
-    return NodeID(type[1], value, idx[1])
+    @assert only(idx) > 0
+    return NodeID(only(type), value, only(idx))
 end
 
 Base.Int32(id::NodeID) = id.value

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -66,6 +66,16 @@ function NodeID(type::NodeType.T, value::Integer, db::DB)::NodeID
     return NodeID(type, value, idx)
 end
 
+function NodeID(value::Integer, db::DB)::NodeID
+    (idx, type) = execute(
+        columntable,
+        db,
+        "SELECT COUNT(*), node_type FROM Node WHERE node_type == (SELECT node_type FROM Node WHERE node_id == $value) AND node_id <= $value",
+    )
+    @assert idx[1] > 0
+    return NodeID(type[1], value, idx[1])
+end
+
 Base.Int32(id::NodeID) = id.value
 Base.convert(::Type{Int32}, id::NodeID) = id.value
 Base.broadcastable(id::NodeID) = Ref(id)

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -661,7 +661,7 @@ function CompoundVariable(
     }[]
     # Each row defines a subvariable
     for row in compound_variable_data
-        listen_node_id = NodeID(row.listen_node_type, row.listen_node_id, db)
+        listen_node_id = NodeID(row.listen_node_id, db)
         # Placeholder until actual ref is known
         variable_ref = PreallocationRef(placeholder_vector, 0)
         variable = row.variable
@@ -900,14 +900,12 @@ function PidControl(
     end
     controlled_basins = collect(controlled_basins)
 
+    listen_node_id = NodeID.(parsed_parameters.listen_node_id, Ref(db))
+
     return PidControl(;
         node_id = node_ids,
         parsed_parameters.active,
-        listen_node_id = NodeID.(
-            parsed_parameters.listen_node_type,
-            parsed_parameters.listen_node_id,
-            Ref(db),
-        ),
+        listen_node_id,
         parsed_parameters.target,
         target_ref,
         parsed_parameters.proportional,

--- a/core/src/schema.jl
+++ b/core/src/schema.jl
@@ -220,7 +220,6 @@ end
 @version DiscreteControlVariableV1 begin
     node_id::Int32
     compound_variable_id::Int32
-    listen_node_type::String
     listen_node_id::Int32
     variable::String
     weight::Union{Missing, Float64}
@@ -241,7 +240,6 @@ end
 
 @version ContinuousControlVariableV1 begin
     node_id::Int32
-    listen_node_type::String
     listen_node_id::Int32
     variable::String
     weight::Union{Missing, Float64}
@@ -258,7 +256,6 @@ end
 @version PidControlStaticV1 begin
     node_id::Int32
     active::Union{Missing, Bool}
-    listen_node_type::String
     listen_node_id::Int32
     target::Float64
     proportional::Float64
@@ -269,7 +266,6 @@ end
 
 @version PidControlTimeV1 begin
     node_id::Int32
-    listen_node_type::String
     listen_node_id::Int32
     time::DateTime
     target::Float64

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -110,8 +110,7 @@ sort_by_time_id_level(row) = (row.time, row.node_id, row.level)
 sort_by_priority(row) = (row.node_id, row.priority)
 sort_by_priority_time(row) = (row.node_id, row.priority, row.time)
 sort_by_subgrid_level(row) = (row.subgrid_id, row.basin_level)
-sort_by_variable(row) =
-    (row.node_id, row.listen_node_type, row.listen_node_id, row.variable)
+sort_by_variable(row) = (row.node_id, row.listen_node_id, row.variable)
 sort_by_condition(row) = (row.node_id, row.compound_variable_id, row.greater_than)
 sort_by_id_input(row) = (row.node_id, row.input)
 
@@ -174,13 +173,11 @@ end
 function valid_nodes(db::DB)::Bool
     errors = false
 
-    sql = "SELECT node_type, node_id FROM Node GROUP BY node_type, node_id HAVING COUNT(*) > 1"
-    node_type, node_id = execute(columntable, db, sql)
-
-    for (node_type, node_id) in zip(node_type, node_id)
+    sql = "SELECT node_id FROM Node GROUP BY node_id HAVING COUNT(*) > 1"
+    node_ids = only(execute(columntable, db, sql))
+    for node_id in node_ids
         errors = true
-        id = NodeID(node_type, node_id)
-        @error "Multiple occurrences of node $id found in Node table."
+        @error "Multiple occurrences of node_id $node_id found in Node table."
     end
 
     return !errors

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -217,9 +217,7 @@ function flow_table(
 )::@NamedTuple{
     time::Vector{DateTime},
     edge_id::Vector{Union{Int32, Missing}},
-    from_node_type::Vector{String},
     from_node_id::Vector{Int32},
-    to_node_type::Vector{String},
     to_node_id::Vector{Int32},
     flow_rate::FlatVector{Float64},
 }
@@ -228,9 +226,7 @@ function flow_table(
     (; graph) = integrator.p
     (; flow_dict) = graph[]
 
-    from_node_type = String[]
     from_node_id = Int32[]
-    to_node_type = String[]
     to_node_id = Int32[]
     unique_edge_ids_flow = Union{Int32, Missing}[]
 
@@ -240,9 +236,7 @@ function flow_table(
     end
 
     for (from_id, to_id) in flow_edge_ids
-        push!(from_node_type, string(from_id.type))
         push!(from_node_id, from_id.value)
-        push!(to_node_type, string(to_id.type))
         push!(to_node_id, to_id.value)
         push!(unique_edge_ids_flow, graph[from_id, to_id].id)
     end
@@ -257,21 +251,11 @@ function flow_table(
     end
     time = repeat(datetime_since.(t_starts, config.starttime); inner = nflow)
     edge_id = repeat(unique_edge_ids_flow; outer = ntsteps)
-    from_node_type = repeat(from_node_type; outer = ntsteps)
     from_node_id = repeat(from_node_id; outer = ntsteps)
-    to_node_type = repeat(to_node_type; outer = ntsteps)
     to_node_id = repeat(to_node_id; outer = ntsteps)
     flow_rate = FlatVector(saveval, :flow)
 
-    return (;
-        time,
-        edge_id,
-        from_node_type,
-        from_node_id,
-        to_node_type,
-        to_node_id,
-        flow_rate,
-    )
+    return (; time, edge_id, from_node_id, to_node_id, flow_rate)
 end
 
 "Create a discrete control result table from the saved data"

--- a/core/test/control_test.jl
+++ b/core/test/control_test.jl
@@ -262,24 +262,20 @@ end
     model = Ribasim.run(toml_path)
     flow_data = DataFrame(Ribasim.flow_table(model))
 
-    function get_edge_flow(from_node_type, from_node_id, to_node_type, to_node_id)
+    function get_edge_flow(from_node_id, to_node_id)
         data = filter(
-            [:from_node_type, :from_node_id, :to_node_type, :to_node_id] =>
-                (a, b, c, d) ->
-                    (a == from_node_type) &&
-                        (b == from_node_id) &&
-                        (c == to_node_type) &&
-                        (d == to_node_id),
+            [:from_node_id, :to_node_id] =>
+                (a, b) -> (a == from_node_id) && (b == to_node_id),
             flow_data,
         )
         return data.flow_rate
     end
 
-    inflow = get_edge_flow("LinearResistance", 1, "Basin", 1)
-    @test get_edge_flow("Basin", 1, "Outlet", 1) ≈ max.(0.6 .* inflow, 0) rtol = 1e-4
-    @test get_edge_flow("Outlet", 1, "Terminal", 1) ≈ max.(0.6 .* inflow, 0) rtol = 1e-4
-    @test get_edge_flow("Basin", 1, "Outlet", 2) ≈ max.(0.4 .* inflow, 0) rtol = 1e-4
-    @test get_edge_flow("Outlet", 2, "Terminal", 2) ≈ max.(0.4 .* inflow, 0) rtol = 1e-4
+    inflow = get_edge_flow(2, 3)
+    @test get_edge_flow(3, 4) ≈ max.(0.6 .* inflow, 0) rtol = 1e-4
+    @test get_edge_flow(4, 6) ≈ max.(0.6 .* inflow, 0) rtol = 1e-4
+    @test get_edge_flow(3, 5) ≈ max.(0.4 .* inflow, 0) rtol = 1e-4
+    @test get_edge_flow(5, 7) ≈ max.(0.4 .* inflow, 0) rtol = 1e-4
 end
 
 @testitem "Concentration discrete control" begin

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -38,16 +38,8 @@
 
     @testset "Schema" begin
         @test Tables.schema(flow) == Tables.Schema(
-            (
-                :time,
-                :edge_id,
-                :from_node_type,
-                :from_node_id,
-                :to_node_type,
-                :to_node_id,
-                :flow_rate,
-            ),
-            (DateTime, Union{Int32, Missing}, String, Int32, String, Int32, Float64),
+            (:time, :edge_id, :from_node_id, :to_node_id, :flow_rate),
+            (DateTime, Union{Int32, Missing}, Int32, Int32, Float64),
         )
         @test Tables.schema(basin) == Tables.Schema(
             (
@@ -103,8 +95,8 @@
     @testset "Results values" begin
         @test flow.time[1] == DateTime(2020)
         @test coalesce.(flow.edge_id[1:2], -1) == [0, 1]
-        @test flow.from_node_id[1:2] == [6, 6]
-        @test flow.to_node_id[1:2] == [6, 2147483647]
+        @test flow.from_node_id[1:2] == [6, 0]
+        @test flow.to_node_id[1:2] == [0, 2147483647]
 
         @test basin.storage[1] ≈ 1.0
         @test basin.level[1] ≈ 0.044711584

--- a/docs/guide/examples.ipynb
+++ b/docs/guide/examples.ipynb
@@ -1138,7 +1138,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.terminal.add(Node(1, Point(5.0, 0.0), subnetwork_id=1))"
+    "model.terminal.add(Node(8, Point(5.0, 0.0), subnetwork_id=1))"
    ]
   },
   {
@@ -1213,7 +1213,7 @@
     "model.edge.add(model.basin[5], model.tabulated_rating_curve[7])\n",
     "model.edge.add(model.user_demand[3], model.basin[2])\n",
     "model.edge.add(model.user_demand[6], model.basin[5])\n",
-    "model.edge.add(model.tabulated_rating_curve[7], model.terminal[1])"
+    "model.edge.add(model.tabulated_rating_curve[7], model.terminal[8])"
    ]
   },
   {
@@ -2094,7 +2094,7 @@
    "outputs": [],
    "source": [
     "model.linear_resistance.add(\n",
-    "    Node(1, Point(1, 0)), [linear_resistance.Static(resistance=[10.0])]\n",
+    "    Node(2, Point(1, 0)), [linear_resistance.Static(resistance=[10.0])]\n",
     ")"
    ]
   },
@@ -2112,7 +2112,7 @@
    "outputs": [],
    "source": [
     "model.basin.add(\n",
-    "    Node(1, Point(2, 0)),\n",
+    "    Node(3, Point(2, 0)),\n",
     "    [\n",
     "        basin.Profile(area=10000.0, level=[0.0, 1.0]),\n",
     "        basin.State(level=[10.0]),\n",
@@ -2133,8 +2133,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.outlet.add(Node(1, Point(3, 1)), [outlet.Static(flow_rate=[1.0])])\n",
-    "model.outlet.add(Node(2, Point(3, -1)), [outlet.Static(flow_rate=[1.0])])"
+    "model.outlet.add(Node(4, Point(3, 1)), [outlet.Static(flow_rate=[1.0])])\n",
+    "model.outlet.add(Node(5, Point(3, -1)), [outlet.Static(flow_rate=[1.0])])"
    ]
   },
   {
@@ -2150,8 +2150,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.terminal.add(Node(1, Point(4, 1)))\n",
-    "model.terminal.add(Node(2, Point(4, -1)))"
+    "model.terminal.add(Node(6, Point(4, 1)))\n",
+    "model.terminal.add(Node(7, Point(4, -1)))"
    ]
   },
   {
@@ -2168,10 +2168,10 @@
    "outputs": [],
    "source": [
     "model.continuous_control.add(\n",
-    "    Node(1, Point(2, 1)),\n",
+    "    Node(8, Point(2, 1)),\n",
     "    [\n",
     "        continuous_control.Variable(\n",
-    "            listen_node_id=[1],\n",
+    "            listen_node_id=[2],\n",
     "            variable=\"flow_rate\",\n",
     "        ),\n",
     "        continuous_control.Function(\n",
@@ -2182,10 +2182,10 @@
     "    ],\n",
     ")\n",
     "model.continuous_control.add(\n",
-    "    Node(2, Point(2, -1)),\n",
+    "    Node(9, Point(2, -1)),\n",
     "    [\n",
     "        continuous_control.Variable(\n",
-    "            listen_node_id=[1],\n",
+    "            listen_node_id=[2],\n",
     "            variable=\"flow_rate\",\n",
     "        ),\n",
     "        continuous_control.Function(\n",
@@ -2213,16 +2213,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.edge.add(model.level_boundary[1], model.linear_resistance[1])\n",
-    "model.edge.add(model.linear_resistance[1], model.basin[1])\n",
-    "model.edge.add(model.basin[1], model.outlet[1])\n",
-    "model.edge.add(model.basin[1], model.outlet[2])\n",
-    "model.edge.add(model.outlet[1], model.terminal[1])\n",
-    "model.edge.add(model.outlet[2], model.terminal[2])\n",
+    "model.edge.add(model.level_boundary[1], model.linear_resistance[2])\n",
+    "model.edge.add(model.linear_resistance[2], model.basin[3])\n",
+    "model.edge.add(model.basin[3], model.outlet[4])\n",
+    "model.edge.add(model.basin[3], model.outlet[5])\n",
+    "model.edge.add(model.outlet[4], model.terminal[6])\n",
+    "model.edge.add(model.outlet[5], model.terminal[7])\n",
     "\n",
     "# Define which node is controlled by each continuous control node\n",
-    "model.edge.add(model.continuous_control[1], model.outlet[1])\n",
-    "model.edge.add(model.continuous_control[2], model.outlet[2])"
+    "model.edge.add(model.continuous_control[8], model.outlet[4])\n",
+    "model.edge.add(model.continuous_control[9], model.outlet[5])"
    ]
   },
   {

--- a/docs/guide/examples.ipynb
+++ b/docs/guide/examples.ipynb
@@ -119,10 +119,10 @@
     "    basin.State(level=[1.4]),\n",
     "]\n",
     "\n",
-    "model.basin.add(Node(1, Point(0.0, 0.0)), basin_data)\n",
-    "model.basin.add(Node(3, Point(2.0, 0.0)), basin_data)\n",
-    "model.basin.add(Node(6, Point(3.0, 2.0)), basin_data)\n",
-    "model.basin.add(Node(9, Point(5.0, 0.0)), basin_data)"
+    "basin1 = model.basin.add(Node(1, Point(0.0, 0.0)), basin_data)\n",
+    "basin3 = model.basin.add(Node(3, Point(2.0, 0.0)), basin_data)\n",
+    "basin6 = model.basin.add(Node(6, Point(3.0, 2.0)), basin_data)\n",
+    "basin9 = model.basin.add(Node(9, Point(5.0, 0.0)), basin_data)"
    ]
   },
   {
@@ -139,11 +139,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.linear_resistance.add(\n",
+    "linear_resistance10 = model.linear_resistance.add(\n",
     "    Node(10, Point(6.0, 0.0)),\n",
     "    [linear_resistance.Static(resistance=[5e3])],\n",
     ")\n",
-    "model.linear_resistance.add(\n",
+    "linear_resistance12 = model.linear_resistance.add(\n",
     "    Node(12, Point(2.0, 1.0)),\n",
     "    [linear_resistance.Static(resistance=[3600.0 * 24.0 / 100.0])],\n",
     ")"
@@ -163,7 +163,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.manning_resistance.add(\n",
+    "manning_resistance2 = model.manning_resistance.add(\n",
     "    Node(2, Point(1.0, 0.0)),\n",
     "    [\n",
     "        manning_resistance.Static(\n",
@@ -188,8 +188,8 @@
    "outputs": [],
    "source": [
     "q = 10 / 86400  # 10 m³/day\n",
-    "model.tabulated_rating_curve.add(\n",
-    "    Node(6, Point(4.0, 0.0)),\n",
+    "tabulated_rating_curve4 = model.tabulated_rating_curve.add(\n",
+    "    Node(4, Point(4.0, 0.0)),\n",
     "    [\n",
     "        tabulated_rating_curve.Static(\n",
     "            level=[0.0, 1.0],\n",
@@ -197,8 +197,8 @@
     "        )\n",
     "    ],\n",
     ")\n",
-    "model.tabulated_rating_curve.add(\n",
-    "    Node(3, Point(3.0, 1.0)),\n",
+    "tabulated_rating_curve5 = model.tabulated_rating_curve.add(\n",
+    "    Node(5, Point(3.0, 1.0)),\n",
     "    [\n",
     "        tabulated_rating_curve.Static(\n",
     "            level=[0.0, 1.0],\n",
@@ -206,8 +206,8 @@
     "        )\n",
     "    ],\n",
     ")\n",
-    "model.tabulated_rating_curve.add(\n",
-    "    Node(1, Point(3.0, -1.0)),\n",
+    "tabulated_rating_curve8 = model.tabulated_rating_curve.add(\n",
+    "    Node(8, Point(3.0, -1.0)),\n",
     "    [\n",
     "        tabulated_rating_curve.Static(\n",
     "            level=[0.0, 1.0],\n",
@@ -231,7 +231,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.pump.add(Node(7, Point(4.0, 1.0)), [pump.Static(flow_rate=[0.5 / 3600])])"
+    "pump7 = model.pump.add(Node(7, Point(4.0, 1.0)), [pump.Static(flow_rate=[0.5 / 3600])])"
    ]
   },
   {
@@ -248,10 +248,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.level_boundary.add(\n",
+    "level_boundary11 = model.level_boundary.add(\n",
     "    Node(11, Point(2.0, 2.0)), [level_boundary.Static(level=[0.5])]\n",
     ")\n",
-    "model.level_boundary.add(\n",
+    "level_boundary17 = model.level_boundary.add(\n",
     "    Node(17, Point(6.0, 1.0)), [level_boundary.Static(level=[1.5])]\n",
     ")"
    ]
@@ -270,10 +270,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.flow_boundary.add(\n",
+    "flow_boundary15 = model.flow_boundary.add(\n",
     "    Node(15, Point(3.0, 3.0)), [flow_boundary.Static(flow_rate=[1e-4])]\n",
     ")\n",
-    "model.flow_boundary.add(\n",
+    "flow_boundary16 = model.flow_boundary.add(\n",
     "    Node(16, Point(0.0, 1.0)), [flow_boundary.Static(flow_rate=[1e-4])]\n",
     ")"
    ]
@@ -292,7 +292,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.terminal.add(Node(14, Point(3.0, -2.0)))"
+    "terminal14 = model.terminal.add(Node(14, Point(3.0, -2.0)))"
    ]
   },
   {
@@ -308,34 +308,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.edge.add(model.basin[1], model.manning_resistance[2])\n",
-    "model.edge.add(model.manning_resistance[2], model.basin[3])\n",
+    "model.edge.add(basin1, manning_resistance2)\n",
+    "model.edge.add(manning_resistance2, basin3)\n",
     "model.edge.add(\n",
-    "    model.basin[3],\n",
-    "    model.tabulated_rating_curve[6],\n",
+    "    basin3,\n",
+    "    tabulated_rating_curve8,\n",
     ")\n",
     "model.edge.add(\n",
-    "    model.basin[3],\n",
-    "    model.tabulated_rating_curve[3],\n",
+    "    basin3,\n",
+    "    tabulated_rating_curve5,\n",
     ")\n",
     "model.edge.add(\n",
-    "    model.basin[3],\n",
-    "    model.tabulated_rating_curve[1],\n",
+    "    basin3,\n",
+    "    tabulated_rating_curve4,\n",
     ")\n",
-    "model.edge.add(model.tabulated_rating_curve[3], model.basin[6])\n",
-    "model.edge.add(model.tabulated_rating_curve[6], model.basin[9])\n",
+    "model.edge.add(tabulated_rating_curve5, basin6)\n",
+    "model.edge.add(tabulated_rating_curve8, basin9)\n",
     "model.edge.add(\n",
-    "    model.tabulated_rating_curve[1],\n",
-    "    model.terminal[14],\n",
+    "    tabulated_rating_curve4,\n",
+    "    terminal14,\n",
     ")\n",
-    "model.edge.add(model.basin[6], model.pump[7])\n",
-    "model.edge.add(model.pump[7], model.basin[9])\n",
-    "model.edge.add(model.basin[9], model.linear_resistance[10])\n",
-    "model.edge.add(model.level_boundary[11], model.linear_resistance[12])\n",
-    "model.edge.add(model.linear_resistance[12], model.basin[3])\n",
-    "model.edge.add(model.flow_boundary[15], model.basin[6])\n",
-    "model.edge.add(model.flow_boundary[16], model.basin[1])\n",
-    "model.edge.add(model.linear_resistance[10], model.level_boundary[17])"
+    "model.edge.add(basin6, pump7)\n",
+    "model.edge.add(pump7, basin9)\n",
+    "model.edge.add(basin9, linear_resistance10)\n",
+    "model.edge.add(level_boundary11, linear_resistance12)\n",
+    "model.edge.add(linear_resistance12, basin3)\n",
+    "model.edge.add(flow_boundary15, basin6)\n",
+    "model.edge.add(flow_boundary16, basin1)\n",
+    "model.edge.add(linear_resistance10, level_boundary17)"
    ]
   },
   {
@@ -512,7 +512,6 @@
     "        discrete_control.Variable(\n",
     "            compound_variable_id=1,\n",
     "            listen_node_id=1,\n",
-    "            listen_node_type=[\"Basin\"],\n",
     "            variable=[\"level\"],\n",
     "        ),\n",
     "        discrete_control.Condition(\n",
@@ -898,7 +897,6 @@
     "                \"2020-12-01\",\n",
     "            ],\n",
     "            listen_node_id=2,\n",
-    "            listen_node_type=\"Basin\",\n",
     "            target=[5.0, 5.0, 7.5, 7.5],\n",
     "            proportional=proportional,\n",
     "            integral=integral,\n",
@@ -1847,7 +1845,6 @@
    "outputs": [],
    "source": [
     "pid_control_data = {\n",
-    "    \"listen_node_type\": \"Basin\",\n",
     "    \"proportional\": [0.05],\n",
     "    \"integral\": [0.00],\n",
     "    \"derivative\": [0.0],\n",
@@ -2174,7 +2171,6 @@
     "    Node(1, Point(2, 1)),\n",
     "    [\n",
     "        continuous_control.Variable(\n",
-    "            listen_node_type=\"LinearResistance\",\n",
     "            listen_node_id=[1],\n",
     "            variable=\"flow_rate\",\n",
     "        ),\n",
@@ -2189,7 +2185,6 @@
     "    Node(2, Point(2, -1)),\n",
     "    [\n",
     "        continuous_control.Variable(\n",
-    "            listen_node_type=\"LinearResistance\",\n",
     "            listen_node_id=[1],\n",
     "            variable=\"flow_rate\",\n",
     "        ),\n",
@@ -2310,9 +2305,7 @@
     "\n",
     "def plot_edge_flow(from_node_type, from_node_id, to_node_type, to_node_id):\n",
     "    df_flow_filtered = df_flow[\n",
-    "        (df_flow[\"from_node_type\"] == from_node_type)\n",
-    "        & (df_flow[\"from_node_id\"] == from_node_id)\n",
-    "        & (df_flow[\"to_node_type\"] == to_node_type)\n",
+    "        (df_flow[\"from_node_id\"] == from_node_id)\n",
     "        & (df_flow[\"to_node_id\"] == to_node_id)\n",
     "    ]\n",
     "    df_flow_filtered.plot(\n",

--- a/docs/guide/examples.ipynb
+++ b/docs/guide/examples.ipynb
@@ -189,7 +189,7 @@
    "source": [
     "q = 10 / 86400  # 10 m³/day\n",
     "tabulated_rating_curve4 = model.tabulated_rating_curve.add(\n",
-    "    Node(4, Point(4.0, 0.0)),\n",
+    "    Node(8, Point(4.0, 0.0)),\n",
     "    [\n",
     "        tabulated_rating_curve.Static(\n",
     "            level=[0.0, 1.0],\n",
@@ -207,7 +207,7 @@
     "    ],\n",
     ")\n",
     "tabulated_rating_curve8 = model.tabulated_rating_curve.add(\n",
-    "    Node(8, Point(3.0, -1.0)),\n",
+    "    Node(4, Point(3.0, -1.0)),\n",
     "    [\n",
     "        tabulated_rating_curve.Static(\n",
     "            level=[0.0, 1.0],\n",

--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -220,6 +220,11 @@ class MultiNodeModel(NodeModel):
 
         node_id = node.node_id
 
+        if self._parent is None:
+            raise ValueError(
+                f"You can only add to a {self._node_type} MultiNodeModel when attached to a Model."
+            )
+
         if node_id is None:
             node_id = self._parent.node_id.new_id()
         elif node_id in self._parent.node_id:

--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -195,7 +195,9 @@ class MultiNodeModel(NodeModel):
         self.node.filter(self.__class__.__name__)
         return self
 
-    def add(self, node: Node, tables: Sequence[TableModel[Any]] | None = None) -> None:
+    def add(
+        self, node: Node, tables: Sequence[TableModel[Any]] | None = None
+    ) -> NodeData:
         """Add a node and the associated data to the model.
 
         Parameters

--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -253,7 +253,7 @@ class MultiNodeModel(NodeModel):
             if self.node.df is None
             else pd.concat([self.node.df, node_table])
         )
-        self._parent.node_id.add(node_id)
+        self._parent.used_node_ids.add(node_id)
         return self[node_id]
 
     def __getitem__(self, index: int) -> NodeData:

--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -235,6 +235,7 @@ class MultiNodeModel(NodeModel):
             if self.node.df is None
             else pd.concat([self.node.df, node_table])
         )
+        return self[node_id]
 
     def __getitem__(self, index: int) -> NodeData:
         # Unlike TableModel, support only indexing single rows.
@@ -398,7 +399,6 @@ class DiscreteControl(MultiNodeModel):
         json_schema_extra={
             "sort_keys": [
                 "node_id",
-                "listen_node_type",
                 "listen_node_id",
                 "variable",
             ]

--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -153,7 +153,7 @@ class Node(pydantic.BaseModel):
     Attributes
     ----------
     node_id : Optional[NonNegativeInt]
-        Integer ID of the node. Must be unique within the same node type.
+        Integer ID of the node. Must be unique for the model.
     geometry : shapely.geometry.Point
         The coordinates of the node.
     name : str

--- a/python/ribasim/ribasim/delwaq/generate.py
+++ b/python/ribasim/ribasim/delwaq/generate.py
@@ -59,7 +59,7 @@ def generate(toml_path: Path) -> tuple[nx.DiGraph, set[str]]:
     for row in nodes.df.itertuples():
         if row.node_type not in ribasim.geometry.edge.SPATIALCONTROLNODETYPES:
             G.add_node(
-                f"{row.node_type} #{row.node_id}",
+                row.node_id,
                 type=row.node_type,
                 id=row.node_id,
                 x=row.geometry.x,
@@ -70,8 +70,8 @@ def generate(toml_path: Path) -> tuple[nx.DiGraph, set[str]]:
     for row in model.edge.df.itertuples():
         if row.edge_type == "flow":
             G.add_edge(
-                f"{row.from_node_type} #{row.from_node_id}",
-                f"{row.to_node_type} #{row.to_node_id}",
+                row.from_node_id,
+                row.to_node_id,
                 id=[row.Index],
                 duplicate=None,
             )
@@ -260,7 +260,7 @@ def generate(toml_path: Path) -> tuple[nx.DiGraph, set[str]]:
     nflows = flows.copy()
     nflows = flows.groupby(["time", "edge_id"]).sum().reset_index()
     nflows.drop(
-        columns=["from_node_id", "from_node_type", "to_node_id", "to_node_type"],
+        columns=["from_node_id", "to_node_id"],
         inplace=True,
     )
 

--- a/python/ribasim/ribasim/geometry/edge.py
+++ b/python/ribasim/ribasim/geometry/edge.py
@@ -33,9 +33,7 @@ class NodeData(NamedTuple):
 
 class EdgeSchema(pa.DataFrameModel):
     name: Series[str] = pa.Field(default="")
-    from_node_type: Series[str] = pa.Field(nullable=True)
     from_node_id: Series[Int32] = pa.Field(default=0, coerce=True)
-    to_node_type: Series[str] = pa.Field(nullable=True)
     to_node_id: Series[Int32] = pa.Field(default=0, coerce=True)
     edge_type: Series[str] = pa.Field(default="flow", coerce=True)
     subnetwork_id: Series[pd.Int32Dtype] = pa.Field(
@@ -89,9 +87,7 @@ class EdgeTable(SpatialTableModel[EdgeSchema]):
 
         table_to_append = GeoDataFrame[EdgeSchema](
             data={
-                "from_node_type": pd.Series([from_node.node_type], dtype=str),
                 "from_node_id": pd.Series([from_node.node_id], dtype=np.int32),
-                "to_node_type": pd.Series([to_node.node_type], dtype=str),
                 "to_node_id": pd.Series([to_node.node_id], dtype=np.int32),
                 "edge_type": pd.Series([edge_type], dtype=str),
                 "name": pd.Series([name], dtype=str),

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -467,7 +467,6 @@ class Model(FileModel):
 
         if not node_df.node_id.is_unique:
             raise ValueError("node_id must be unique")
-        node_df.sort_values("node_id", inplace=True)
 
         assert self.edge.df is not None
         edge_df = self.edge.df.copy()

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -340,8 +340,8 @@ class Model(FileModel):
         node = self.node_table().df
         control_nodes_geometry = df_listen_edge.merge(
             node,
-            left_on=["control_node_id", "control_node_type"],
-            right_on=["node_id", "node_type"],
+            left_on=["control_node_id"],
+            right_on=["node_id"],
             how="left",
         )["geometry"]
 

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -64,7 +64,14 @@ except ImportError:
     xugrid = MissingOptionalModule("xugrid")
 
 
-class NodeID(BaseModel):
+class UsedNodeIDs(BaseModel):
+    """A helper class to manage global unique node IDs.
+
+    We keep track of all node IDs in the model,
+    and keep track of the maximum to provide new IDs.
+    MultiNodeModels will check this instance on `add`.
+    """
+
     node_ids: set[int] = set()
     max_node_id: NonNegativeInt = 0
 
@@ -86,7 +93,7 @@ class Model(FileModel):
     endtime: datetime.datetime
     crs: str
 
-    node_id: NodeID = Field(default_factory=NodeID)
+    used_node_ids: UsedNodeIDs = Field(default_factory=UsedNodeIDs)
 
     input_dir: Path = Field(default=Path("."))
     results_dir: Path = Field(default=Path("results"))

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -52,6 +52,7 @@ from ribasim.utils import (
     MissingOptionalModule,
     _edge_lookup,
     _node_lookup,
+    _node_lookup_numpy,
     _time_in_ns,
 )
 
@@ -176,6 +177,13 @@ class Model(FileModel):
         context_file_loading.get()["database"] = db_path
         self.edge._save(directory, input_dir)
         node = self.node_table()
+
+        assert node.df is not None
+        if not node.df["node_id"].is_unique:
+            raise ValueError("node_id must be unique")
+        node.df.set_index("node_id", drop=False, inplace=True)
+        node.df.index.name = "fid"
+        node.df.sort_index(inplace=True)
         node._save(directory, input_dir)
 
         for sub in self._nodes():
@@ -300,9 +308,7 @@ class Model(FileModel):
         df_listen_edge = pd.DataFrame(
             data={
                 "control_node_id": pd.Series([], dtype=np.int32),
-                "control_node_type": pd.Series([], dtype=str),
                 "listen_node_id": pd.Series([], dtype=np.int32),
-                "listen_node_type": pd.Series([], dtype=str),
             }
         )
 
@@ -311,11 +317,8 @@ class Model(FileModel):
             if table is None:
                 continue
 
-            to_add = table[
-                ["node_id", "listen_node_id", "listen_node_type"]
-            ].drop_duplicates()
-            to_add.columns = ["control_node_id", "listen_node_id", "listen_node_type"]
-            to_add["control_node_type"] = "PidControl"
+            to_add = table[["node_id", "listen_node_id"]].drop_duplicates()
+            to_add.columns = ["control_node_id", "listen_node_id"]
             df_listen_edge = pd.concat([df_listen_edge, to_add])
 
         # Listen edges from ContinuousControl and DiscreteControl
@@ -326,15 +329,11 @@ class Model(FileModel):
             if table is None:
                 continue
 
-            to_add = table[
-                ["node_id", "listen_node_id", "listen_node_type"]
-            ].drop_duplicates()
+            to_add = table[["node_id", "listen_node_id"]].drop_duplicates()
             to_add.columns = [
                 "control_node_id",
                 "listen_node_id",
-                "listen_node_type",
             ]
-            to_add["control_node_type"] = name
             df_listen_edge = pd.concat([df_listen_edge, to_add])
 
         # Collect geometry data
@@ -348,7 +347,7 @@ class Model(FileModel):
 
         listen_nodes_geometry = df_listen_edge.merge(
             node,
-            left_on=["listen_node_id", "listen_node_type"],
+            left_on=["listen_node_id"],
             right_on=["node_id", "node_type"],
             how="left",
         )["geometry"]
@@ -447,6 +446,10 @@ class Model(FileModel):
         node_df = self.node_table().df
         assert node_df is not None
 
+        if not node_df.node_id.is_unique:
+            raise ValueError("node_id must be unique")
+        node_df.sort_values("node_id", inplace=True)
+
         assert self.edge.df is not None
         edge_df = self.edge.df.copy()
         # We assume only the flow network is of interest.
@@ -456,13 +459,7 @@ class Model(FileModel):
         edge_id = edge_df.index.to_numpy()
         from_node_id = edge_df.from_node_id.to_numpy()
         to_node_id = edge_df.to_node_id.to_numpy()
-        node_lookup = _node_lookup(node_df)
-        from_node_index = pd.MultiIndex.from_frame(
-            edge_df[["from_node_type", "from_node_id"]]
-        )
-        to_node_index = pd.MultiIndex.from_frame(
-            edge_df[["to_node_type", "to_node_id"]]
-        )
+        node_lookup = _node_lookup_numpy(node_id)
 
         grid = xugrid.Ugrid1d(
             node_x=node_df.geometry.x,
@@ -470,8 +467,8 @@ class Model(FileModel):
             fill_value=-1,
             edge_node_connectivity=np.column_stack(
                 (
-                    node_lookup.loc[from_node_index],
-                    node_lookup.loc[to_node_index],
+                    node_lookup.loc[from_node_id],
+                    node_lookup.loc[to_node_id],
                 )
             ),
             name="ribasim",
@@ -522,19 +519,17 @@ class Model(FileModel):
         # add the xugrid dimension indices to the dataframes
         edge_dim = uds.grid.edge_dimension
         node_dim = uds.grid.node_dimension
+        node_lookup = _node_lookup(uds)
         edge_lookup = _edge_lookup(uds)
         flow_df[edge_dim] = edge_lookup[flow_df["edge_id"]].to_numpy()
-        # Use a MultiIndex to ensure the lookup results is the same length as basin_df
-        basin_df["node_type"] = "Basin"
-        multi_index = pd.MultiIndex.from_frame(basin_df[["node_type", "node_id"]])
-        basin_df[node_dim] = node_lookup.loc[multi_index].to_numpy()
+        basin_df[node_dim] = node_lookup[basin_df["node_id"]].to_numpy()
 
         # add flow results to the UgridDataset
         flow_da = flow_df.set_index(["time", edge_dim])["flow_rate"].to_xarray()
         uds[flow_da.name] = flow_da
 
         # add basin results to the UgridDataset
-        basin_df.drop(columns=["node_type", "node_id"], inplace=True)
+        basin_df.drop(columns=["node_id"], inplace=True)
         basin_ds = basin_df.set_index(["time", node_dim]).to_xarray()
 
         for var_name, da in basin_ds.data_vars.items():

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -348,7 +348,7 @@ class Model(FileModel):
         listen_nodes_geometry = df_listen_edge.merge(
             node,
             left_on=["listen_node_id"],
-            right_on=["node_id", "node_type"],
+            right_on=["node_id"],
             how="left",
         )["geometry"]
 

--- a/python/ribasim/ribasim/schemas.py
+++ b/python/ribasim/ribasim/schemas.py
@@ -76,7 +76,6 @@ class ContinuousControlFunctionSchema(_BaseSchema):
 
 class ContinuousControlVariableSchema(_BaseSchema):
     node_id: Series[Int32] = pa.Field(nullable=False, default=0)
-    listen_node_type: Series[str] = pa.Field(nullable=False)
     listen_node_id: Series[Int32] = pa.Field(nullable=False, default=0)
     variable: Series[str] = pa.Field(nullable=False)
     weight: Series[float] = pa.Field(nullable=True)
@@ -98,7 +97,6 @@ class DiscreteControlLogicSchema(_BaseSchema):
 class DiscreteControlVariableSchema(_BaseSchema):
     node_id: Series[Int32] = pa.Field(nullable=False, default=0)
     compound_variable_id: Series[Int32] = pa.Field(nullable=False, default=0)
-    listen_node_type: Series[str] = pa.Field(nullable=False)
     listen_node_id: Series[Int32] = pa.Field(nullable=False, default=0)
     variable: Series[str] = pa.Field(nullable=False)
     weight: Series[float] = pa.Field(nullable=True)
@@ -202,7 +200,6 @@ class OutletStaticSchema(_BaseSchema):
 class PidControlStaticSchema(_BaseSchema):
     node_id: Series[Int32] = pa.Field(nullable=False, default=0)
     active: Series[pa.BOOL] = pa.Field(nullable=True)
-    listen_node_type: Series[str] = pa.Field(nullable=False)
     listen_node_id: Series[Int32] = pa.Field(nullable=False, default=0)
     target: Series[float] = pa.Field(nullable=False)
     proportional: Series[float] = pa.Field(nullable=False)
@@ -213,7 +210,6 @@ class PidControlStaticSchema(_BaseSchema):
 
 class PidControlTimeSchema(_BaseSchema):
     node_id: Series[Int32] = pa.Field(nullable=False, default=0)
-    listen_node_type: Series[str] = pa.Field(nullable=False)
     listen_node_id: Series[Int32] = pa.Field(nullable=False, default=0)
     time: Series[Timestamp] = pa.Field(nullable=False)
     target: Series[float] = pa.Field(nullable=False)

--- a/python/ribasim/ribasim/utils.py
+++ b/python/ribasim/ribasim/utils.py
@@ -1,5 +1,6 @@
 import re
 
+import numpy as np
 import pandas as pd
 from pandera.dtypes import Int32
 from pandera.typing import Series
@@ -27,14 +28,26 @@ class MissingOptionalModule:
         )
 
 
-def _node_lookup(df) -> Series[Int32]:
-    """Create a lookup table from from (node_type, node_id) to the node dimension index.
-
+def _node_lookup_numpy(node_id) -> Series[Int32]:
+    """Create a lookup table from from node_id to the node dimension index.
     Used when adding data onto the nodes of an xugrid dataset.
     """
-    return df.reset_index(names="node_index").set_index(["node_type", "node_id"])[
-        "node_index"
-    ]
+    return pd.Series(
+        index=node_id,
+        data=node_id.argsort().astype(np.int32),
+        name="node_index",
+    )
+
+
+def _node_lookup(uds) -> Series[Int32]:
+    """Create a lookup table from from node_id to the node dimension index.
+    Used when adding data onto the nodes of an xugrid dataset.
+    """
+    return pd.Series(
+        index=uds["node_id"],
+        data=uds[uds.grid.node_dimension],
+        name="node_index",
+    )
 
 
 def _edge_lookup(uds) -> Series[Int32]:

--- a/python/ribasim/tests/test_io.py
+++ b/python/ribasim/tests/test_io.py
@@ -145,7 +145,6 @@ def test_sort(level_range, tmp_path):
     assert table.df.iloc[0]["greater_than"] == 5.0
 
     # The edge table is not sorted
-    assert edge.df.iloc[1]["from_node_type"] == "Pump"
     assert edge.df.iloc[1]["from_node_id"] == 3
 
     # re-apply wrong sort, then check if it gets sorted on write
@@ -157,7 +156,6 @@ def test_sort(level_range, tmp_path):
     table_loaded = model_loaded.discrete_control.condition
     edge_loaded = model_loaded.edge
     assert table_loaded.df.iloc[0]["greater_than"] == 5.0
-    assert edge.df.iloc[1]["from_node_type"] == "Pump"
     assert edge.df.iloc[1]["from_node_id"] == 3
     __assert_equal(table.df, table_loaded.df)
     __assert_equal(edge.df, edge_loaded.df)

--- a/python/ribasim_testmodels/ribasim_testmodels/allocation.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/allocation.py
@@ -388,7 +388,7 @@ def allocation_example_model() -> Model:
             )
         ],
     )
-    model.terminal.add(Node(1, Point(5, 0), subnetwork_id=2))
+    model.terminal.add(Node(8, Point(5, 0), subnetwork_id=2))
 
     model.edge.add(model.flow_boundary[1], model.basin[2], subnetwork_id=2)
     model.edge.add(model.basin[2], model.user_demand[3])
@@ -396,7 +396,7 @@ def allocation_example_model() -> Model:
     model.edge.add(model.linear_resistance[4], model.basin[5])
     model.edge.add(model.basin[5], model.user_demand[6])
     model.edge.add(model.basin[5], model.tabulated_rating_curve[7])
-    model.edge.add(model.tabulated_rating_curve[7], model.terminal[1])
+    model.edge.add(model.tabulated_rating_curve[7], model.terminal[8])
     model.edge.add(model.user_demand[3], model.basin[2])
     model.edge.add(model.user_demand[6], model.basin[5])
 

--- a/python/ribasim_testmodels/ribasim_testmodels/basic.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/basic.py
@@ -91,7 +91,7 @@ def basic_model() -> ribasim.Model:
     # Setup TabulatedRatingCurve
     q = 10 / 86400  # 10 m³/day
     model.tabulated_rating_curve.add(
-        Node(6, Point(4.0, 0.0)),
+        Node(4, Point(4.0, 0.0)),
         [
             tabulated_rating_curve.Static(
                 level=[0.0, 1.0],
@@ -100,7 +100,7 @@ def basic_model() -> ribasim.Model:
         ],
     )
     model.tabulated_rating_curve.add(
-        Node(3, Point(3.0, 1.0)),
+        Node(5, Point(3.0, 1.0)),
         [
             tabulated_rating_curve.Static(
                 level=[0.0, 1.0],
@@ -109,7 +109,7 @@ def basic_model() -> ribasim.Model:
         ],
     )
     model.tabulated_rating_curve.add(
-        Node(1, Point(3.0, -1.0)),
+        Node(8, Point(3.0, -1.0)),
         [
             tabulated_rating_curve.Static(
                 level=[0.0, 1.0],
@@ -161,19 +161,19 @@ def basic_model() -> ribasim.Model:
     model.edge.add(model.manning_resistance[2], model.basin[3])
     model.edge.add(
         model.basin[3],
-        model.tabulated_rating_curve[6],
+        model.tabulated_rating_curve[8],
     )
     model.edge.add(
         model.basin[3],
-        model.tabulated_rating_curve[3],
+        model.tabulated_rating_curve[5],
     )
     model.edge.add(
         model.basin[3],
-        model.tabulated_rating_curve[1],
+        model.tabulated_rating_curve[4],
     )
-    model.edge.add(model.tabulated_rating_curve[3], model.basin[6])
+    model.edge.add(model.tabulated_rating_curve[5], model.basin[6])
     model.edge.add(model.basin[6], model.pump[7])
-    model.edge.add(model.tabulated_rating_curve[6], model.basin[9])
+    model.edge.add(model.tabulated_rating_curve[8], model.basin[9])
     model.edge.add(model.pump[7], model.basin[9])
     model.edge.add(model.basin[9], model.linear_resistance[10])
     model.edge.add(
@@ -185,7 +185,7 @@ def basic_model() -> ribasim.Model:
         model.basin[3],
     )
     model.edge.add(
-        model.tabulated_rating_curve[1],
+        model.tabulated_rating_curve[4],
         model.terminal[14],
     )
     model.edge.add(

--- a/python/ribasim_testmodels/ribasim_testmodels/basic.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/basic.py
@@ -91,7 +91,7 @@ def basic_model() -> ribasim.Model:
     # Setup TabulatedRatingCurve
     q = 10 / 86400  # 10 m³/day
     model.tabulated_rating_curve.add(
-        Node(4, Point(4.0, 0.0)),
+        Node(8, Point(4.0, 0.0)),
         [
             tabulated_rating_curve.Static(
                 level=[0.0, 1.0],
@@ -109,7 +109,7 @@ def basic_model() -> ribasim.Model:
         ],
     )
     model.tabulated_rating_curve.add(
-        Node(8, Point(3.0, -1.0)),
+        Node(4, Point(3.0, -1.0)),
         [
             tabulated_rating_curve.Static(
                 level=[0.0, 1.0],

--- a/python/ribasim_testmodels/ribasim_testmodels/continuous_control.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/continuous_control.py
@@ -32,29 +32,28 @@ def outlet_continuous_control_model() -> Model:
     )
 
     model.linear_resistance.add(
-        Node(1, Point(1, 0)), [linear_resistance.Static(resistance=[10.0])]
+        Node(2, Point(1, 0)), [linear_resistance.Static(resistance=[10.0])]
     )
 
     model.basin.add(
-        Node(1, Point(2, 0)),
+        Node(3, Point(2, 0)),
         [
             basin.Profile(area=10000.0, level=[0.0, 1.0]),
             basin.State(level=[10.0]),
         ],
     )
 
-    model.outlet.add(Node(1, Point(3, 1)), [outlet.Static(flow_rate=[1.0])])
-    model.outlet.add(Node(2, Point(3, -1)), [outlet.Static(flow_rate=[1.0])])
+    model.outlet.add(Node(4, Point(3, 1)), [outlet.Static(flow_rate=[1.0])])
+    model.outlet.add(Node(5, Point(3, -1)), [outlet.Static(flow_rate=[1.0])])
 
-    model.terminal.add(Node(1, Point(4, 1)))
-    model.terminal.add(Node(2, Point(4, -1)))
+    model.terminal.add(Node(6, Point(4, 1)))
+    model.terminal.add(Node(7, Point(4, -1)))
 
     model.continuous_control.add(
-        Node(1, Point(2, 1)),
+        Node(8, Point(2, 1)),
         [
             continuous_control.Variable(
-                listen_node_type="LinearResistance",
-                listen_node_id=[1],
+                listen_node_id=[2],
                 variable="flow_rate",
             ),
             continuous_control.Function(
@@ -65,11 +64,10 @@ def outlet_continuous_control_model() -> Model:
         ],
     )
     model.continuous_control.add(
-        Node(2, Point(2, -1)),
+        Node(9, Point(2, -1)),
         [
             continuous_control.Variable(
-                listen_node_type="LinearResistance",
-                listen_node_id=[1],
+                listen_node_id=[2],
                 variable="flow_rate",
             ),
             continuous_control.Function(
@@ -80,13 +78,13 @@ def outlet_continuous_control_model() -> Model:
         ],
     )
 
-    model.edge.add(model.level_boundary[1], model.linear_resistance[1])
-    model.edge.add(model.linear_resistance[1], model.basin[1])
-    model.edge.add(model.basin[1], model.outlet[1])
-    model.edge.add(model.basin[1], model.outlet[2])
-    model.edge.add(model.outlet[1], model.terminal[1])
-    model.edge.add(model.outlet[2], model.terminal[2])
-    model.edge.add(model.continuous_control[1], model.outlet[1])
-    model.edge.add(model.continuous_control[2], model.outlet[2])
+    model.edge.add(model.level_boundary[1], model.linear_resistance[2])
+    model.edge.add(model.linear_resistance[2], model.basin[3])
+    model.edge.add(model.basin[3], model.outlet[4])
+    model.edge.add(model.basin[3], model.outlet[5])
+    model.edge.add(model.outlet[4], model.terminal[6])
+    model.edge.add(model.outlet[5], model.terminal[7])
+    model.edge.add(model.continuous_control[8], model.outlet[4])
+    model.edge.add(model.continuous_control[9], model.outlet[5])
 
     return model

--- a/python/ribasim_testmodels/ribasim_testmodels/discrete_control.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/discrete_control.py
@@ -57,7 +57,6 @@ def pump_discrete_control_model() -> Model:
         Node(5, Point(1, 1)),
         [
             discrete_control.Variable(
-                listen_node_type="Basin",
                 listen_node_id=[1, 3],
                 variable="level",
                 compound_variable_id=[1, 2],
@@ -76,7 +75,6 @@ def pump_discrete_control_model() -> Model:
         Node(6, Point(2, -1)),
         [
             discrete_control.Variable(
-                listen_node_type="Basin",
                 listen_node_id=[3],
                 variable="level",
                 compound_variable_id=1,
@@ -151,7 +149,6 @@ def flow_condition_model() -> Model:
         Node(5, Point(1, 1)),
         [
             discrete_control.Variable(
-                listen_node_type="FlowBoundary",
                 listen_node_id=[1],
                 variable="flow_rate",
                 look_ahead=60 * 86400,
@@ -218,7 +215,6 @@ def level_boundary_condition_model() -> Model:
         Node(6, Point(1.5, 1)),
         [
             discrete_control.Variable(
-                listen_node_type="LevelBoundary",
                 listen_node_id=[1],
                 variable="level",
                 look_ahead=60 * 86400,
@@ -294,7 +290,6 @@ def tabulated_rating_curve_control_model() -> Model:
         Node(4, Point(1, 1)),
         [
             discrete_control.Variable(
-                listen_node_type="Basin",
                 listen_node_id=[1],
                 variable="level",
                 compound_variable_id=1,
@@ -360,7 +355,6 @@ def compound_variable_condition_model() -> Model:
         Node(6, Point(1, 1)),
         [
             discrete_control.Variable(
-                listen_node_type="FlowBoundary",
                 listen_node_id=[2, 3],
                 variable="flow_rate",
                 weight=0.5,
@@ -424,7 +418,6 @@ def level_range_model() -> Model:
         Node(7, Point(1, 0)),
         [
             discrete_control.Variable(
-                listen_node_type="Basin",
                 listen_node_id=[1],
                 variable="level",
                 compound_variable_id=1,
@@ -497,7 +490,7 @@ def connector_node_flow_condition_model() -> Model:
         ],
     )
     model.linear_resistance.add(
-        Node(1, Point(1, 0)),
+        Node(2, Point(1, 0)),
         [
             linear_resistance.Static(
                 control_state=["On", "Off"], resistance=1e4, active=[True, False]
@@ -505,18 +498,17 @@ def connector_node_flow_condition_model() -> Model:
         ],
     )
     model.basin.add(
-        Node(2, Point(2, 0)),
+        Node(3, Point(2, 0)),
         [
             basin.Profile(area=1000.0, level=[0.0, 1.0]),
             basin.State(level=[10.0]),
         ],
     )
     model.discrete_control.add(
-        Node(1, Point(0.5, 0.8660254037844386)),
+        Node(4, Point(0.5, 0.8660254037844386)),
         [
             discrete_control.Variable(
-                listen_node_type=["LinearResistance"],
-                listen_node_id=[1],
+                listen_node_id=[2],
                 variable=["flow_rate"],
                 compound_variable_id=1,
             ),
@@ -525,9 +517,9 @@ def connector_node_flow_condition_model() -> Model:
         ],
     )
 
-    model.edge.add(model.basin[1], model.linear_resistance[1])
-    model.edge.add(model.linear_resistance[1], model.basin[2])
-    model.edge.add(model.discrete_control[1], model.linear_resistance[1])
+    model.edge.add(model.basin[1], model.linear_resistance[2])
+    model.edge.add(model.linear_resistance[2], model.basin[3])
+    model.edge.add(model.discrete_control[4], model.linear_resistance[2])
 
     return model
 
@@ -558,7 +550,7 @@ def concentration_condition_model() -> Model:
     )
 
     model.pump.add(
-        Node(1, Point(1, 0)),
+        Node(2, Point(1, 0)),
         [
             pump.Static(
                 control_state=["On", "Off"], active=[True, False], flow_rate=1e-3
@@ -566,13 +558,12 @@ def concentration_condition_model() -> Model:
         ],
     )
 
-    model.terminal.add(Node(1, Point(2, 0)))
+    model.terminal.add(Node(3, Point(2, 0)))
 
     model.discrete_control.add(
-        Node(1, Point(1, 1)),
+        Node(4, Point(1, 1)),
         [
             discrete_control.Variable(
-                listen_node_type=["Basin"],
                 listen_node_id=[1],
                 variable=["concentration_external.kryptonite"],
                 compound_variable_id=1,
@@ -582,8 +573,8 @@ def concentration_condition_model() -> Model:
         ],
     )
 
-    model.edge.add(model.basin[1], model.pump[1])
-    model.edge.add(model.pump[1], model.terminal[1])
-    model.edge.add(model.discrete_control[1], model.pump[1])
+    model.edge.add(model.basin[1], model.pump[2])
+    model.edge.add(model.pump[2], model.terminal[3])
+    model.edge.add(model.discrete_control[4], model.pump[2])
 
     return model

--- a/python/ribasim_testmodels/ribasim_testmodels/doc_example.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/doc_example.py
@@ -104,7 +104,6 @@ def local_pidcontrolled_cascade_model():
 
     # Set up pid control
     pid_control_data = {
-        "listen_node_type": "Basin",
         "proportional": [0.1],
         "integral": [0.00],
         "derivative": [0.0],

--- a/python/ribasim_testmodels/ribasim_testmodels/equations.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/equations.py
@@ -179,7 +179,6 @@ def pid_control_equation_model() -> Model:
         Node(4, Point(0.5, 1)),
         [
             pid_control.Static(
-                listen_node_type="Basin",
                 listen_node_id=[1],
                 target=10.0,
                 proportional=-2.5,

--- a/python/ribasim_testmodels/ribasim_testmodels/invalid.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/invalid.py
@@ -67,7 +67,6 @@ def invalid_discrete_control_model() -> Model:
         Node(5, Point(1, 1)),
         [
             discrete_control.Variable(
-                listen_node_type=["Basin", "FlowBoundary", "FlowBoundary"],
                 listen_node_id=[1, 4, 4],
                 variable=["level", "flow_rate", "flow_rate"],
                 # Invalid: look_ahead can only be specified for timeseries variables.

--- a/python/ribasim_testmodels/ribasim_testmodels/pid_control.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/pid_control.py
@@ -44,7 +44,6 @@ def pid_control_model() -> Model:
                     "2020-07-01",
                     "2020-12-01",
                 ],
-                listen_node_type="Basin",
                 listen_node_id=2,
                 target=[5.0, 5.0, 7.5, 7.5],
                 proportional=-1e-3,
@@ -66,7 +65,6 @@ def pid_control_model() -> Model:
                     "2020-07-01",
                     "2020-12-01",
                 ],
-                listen_node_type="Basin",
                 listen_node_id=2,
                 target=[5.0, 5.0, 7.5, 7.5],
                 proportional=1e-3,
@@ -116,7 +114,6 @@ def discrete_control_of_pid_control_model() -> Model:
         Node(6, Point(1, 1)),
         [
             pid_control.Static(
-                listen_node_type="Basin",
                 listen_node_id=3,
                 control_state=["target_high", "target_low"],
                 target=[5.0, 3.0],
@@ -130,7 +127,6 @@ def discrete_control_of_pid_control_model() -> Model:
         Node(7, Point(0, 1)),
         [
             discrete_control.Variable(
-                listen_node_type="LevelBoundary",
                 listen_node_id=[1],
                 variable="level",
                 compound_variable_id=1,

--- a/python/ribasim_testmodels/ribasim_testmodels/trivial.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/trivial.py
@@ -23,7 +23,7 @@ def trivial_model() -> Model:
     # 22. start at -1.0
     # 11. start at 0.0
     # 33. start at 1.0
-    model.basin.add(
+    basin6 = model.basin.add(
         Node(6, Point(400, 200)),
         [
             basin.Static(
@@ -42,19 +42,16 @@ def trivial_model() -> Model:
 
     # TODO largest signed 32 bit integer, to check encoding
     terminal_id = 2147483647
-    model.terminal.add(Node(terminal_id, Point(500, 200)))
-    model.tabulated_rating_curve.add(
-        Node(6, Point(450, 200)),
+    term = model.terminal.add(Node(terminal_id, Point(500, 200)))
+    trc0 = model.tabulated_rating_curve.add(
+        Node(0, Point(450, 200)),
         [tabulated_rating_curve.Static(level=[0.0, 1.0], flow_rate=[0.0, 10 / 86400])],
     )
 
     model.edge.add(
-        model.basin[6],
-        model.tabulated_rating_curve[6],
+        basin6,
+        trc0,
     )
-    model.edge.add(
-        model.tabulated_rating_curve[6],
-        model.terminal[terminal_id],
-    )
+    model.edge.add(trc0, term)
 
     return model

--- a/ribasim_qgis/core/nodes.py
+++ b/ribasim_qgis/core/nodes.py
@@ -260,9 +260,7 @@ class Edge(Input):
     def attributes(cls) -> list[QgsField]:
         return [
             QgsField("name", QVariant.String),
-            QgsField("from_node_type", QVariant.String),
             QgsField("from_node_id", QVariant.Int),
-            QgsField("to_node_type", QVariant.String),
             QgsField("to_node_id", QVariant.Int),
             QgsField("edge_type", QVariant.String),
             QgsField("subnetwork_id", QVariant.Int),
@@ -284,8 +282,6 @@ class Edge(Input):
         layer = self.layer
 
         self.set_dropdown("edge_type", EDGETYPES)
-        self.set_dropdown("from_node_type", NONSPATIALNODETYPES)
-        self.set_dropdown("to_node_type", NONSPATIALNODETYPES)
 
         layer_form_config = layer.editFormConfig()
         layer.setEditFormConfig(layer_form_config)
@@ -668,7 +664,6 @@ class DiscreteControlVariable(Input):
         return [
             QgsField("node_id", QVariant.Int),
             QgsField("compound_variable_id", QVariant.Int),
-            QgsField("listen_node_type", QVariant.String),
             QgsField("listen_node_id", QVariant.Int),
             QgsField("variable", QVariant.String),
             QgsField("weight", QVariant.Double),
@@ -725,7 +720,6 @@ class ContinuousControlVariable(Input):
     def attributes(cls) -> list[QgsField]:
         return [
             QgsField("node_id", QVariant.Int),
-            QgsField("listen_node_type", QVariant.String),
             QgsField("listen_node_id", QVariant.Int),
             QgsField("variable", QVariant.String),
             QgsField("weight", QVariant.Double),
@@ -766,7 +760,6 @@ class PidControlStatic(Input):
         return [
             QgsField("node_id", QVariant.Int),
             QgsField("active", QVariant.Bool),
-            QgsField("listen_node_type", QVariant.String),
             QgsField("listen_node_id", QVariant.Int),
             QgsField("target", QVariant.Double),
             QgsField("proportional", QVariant.Double),
@@ -788,7 +781,6 @@ class PidControlTime(Input):
     def attributes(cls) -> list[QgsField]:
         return [
             QgsField("node_id", QVariant.Int),
-            QgsField("listen_node_type", QVariant.String),
             QgsField("listen_node_id", QVariant.Int),
             QgsField("time", QVariant.DateTime),
             QgsField("target", QVariant.Double),

--- a/ribasim_qgis/core/topology.py
+++ b/ribasim_qgis/core/topology.py
@@ -114,9 +114,7 @@ def set_edge_properties(node: QgsVectorLayer, edge: QgsVectorLayer) -> None:
     from_fid, to_fid = derive_connectivity(node_index, node_xy, edge_xy)
 
     edge_fields = edge.fields()
-    from_type_field = edge_fields.indexFromName("from_node_type")
     from_id_field = edge_fields.indexFromName("from_node_id")
-    to_type_field = edge_fields.indexFromName("to_node_type")
     to_id_field = edge_fields.indexFromName("to_node_id")
     edge_type_field = edge_fields.indexFromName("edge_type")
 
@@ -127,21 +125,11 @@ def set_edge_properties(node: QgsVectorLayer, edge: QgsVectorLayer) -> None:
             edge_iterator = cast(Iterable[QgsFeature], edge.getFeatures())
             for feature, fid1, fid2 in zip(edge_iterator, from_fid, to_fid):
                 type1, id1 = node_identifiers[fid1]
-                type2, id2 = node_identifiers[fid2]
+                _, id2 = node_identifiers[fid2]
                 edge_type = infer_edge_type(type1)
 
                 fid = feature.id()
-                edge.changeAttributeValue(
-                    fid,
-                    from_type_field,
-                    type1,
-                )
                 edge.changeAttributeValue(fid, from_id_field, id1)
-                edge.changeAttributeValue(
-                    fid,
-                    to_type_field,
-                    type2,
-                )
                 edge.changeAttributeValue(fid, to_id_field, id2)
                 edge.changeAttributeValue(fid, edge_type_field, edge_type)
 


### PR DESCRIPTION
Fixes #1690 as a 🎁 for @deltamarnix when he is back from holiday.

Triggered by #1648, which seems very hard to do in QGIS as it doesn't support compound indexes and we dislike a separate global unique id. In a discussion with @visr he mentioned most people don't use the non-global unique id feature (yet).

Reverts #1513. Partially reverts #1690 as the `NodeID` changes are not reverted, as it is quite useful to know the node_type in several parts of the code (instead of only a node_id). Therefore, I've added a new `NodeID` constructor and joined the Edge table with the Node table.

I had to change the node_ids of several new test models created by @SouthEndMusic, bit of a pain, but the tests seem to pass still.

Furthermore, I changed the `node.add` functionality to *return* the `NodeData`, which should make the `edge.add` more straightforward (and pave the way for automatic id numbering in the future). So this:

```julia
model.terminal.add(Node(terminal_id, Point(500, 200)))
model.tabulated_rating_curve.add(
    Node(6, Point(450, 200)),
    [tabulated_rating_curve.Static(level=[0.0, 1.0], flow_rate=[0.0, 10 / 86400])],
)

model.edge.add(
    model.basin[6],
    model.tabulated_rating_curve[6],
)
model.edge.add(
    model.tabulated_rating_curve[6],
    model.terminal[terminal_id],
)
```
becomes this:

```julia
term = model.terminal.add(Node(terminal_id, Point(500, 200)))
trc0 = model.tabulated_rating_curve.add(
    Node(0, Point(450, 200)),
    [tabulated_rating_curve.Static(level=[0.0, 1.0], flow_rate=[0.0, 10 / 86400])],
)

model.edge.add(
    basin6,
    trc0,
)
model.edge.add(trc0, term)
```

I've made this change in a single Python test model, and in the first model of the examples notebook. We could gradually change this further over time.