### PR TITLE
Refactor `get_area_and_level` for performance

### DIFF
--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -88,10 +88,9 @@ function set_current_basin_properties!(
 
     for i in eachindex(du.storage)
         s = storage[i]
-        area, level = get_area_and_level(basin, i, s)
-
-        current_area[i] = area
+        level = get_level_from_storage(basin, i, s)
         current_level[i] = level
+        current_area[i] = basin.level_to_area[i](current_level[i])
     end
 end
 

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -86,10 +86,8 @@ function set_current_basin_properties!(
 
     storage = u.storage
 
-    for i in eachindex(du.storage)
-        s = storage[i]
-        level = get_level_from_storage(basin, i, s)
-        current_level[i] = level
+    for (i, s) in enumerate(storage)
+        current_level[i] = get_level_from_storage(basin, i, s)
         current_area[i] = basin.level_to_area[i](current_level[i])
     end
 end

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -50,22 +50,19 @@ function get_storages_from_levels(basin::Basin, levels::AbstractVector)::Vector{
 end
 
 """
-Compute the area and level of a basin given its storage.
+Compute the level of a basin given its storage.
 """
-function get_area_and_level(basin::Basin, state_idx::Int, storage::T)::Tuple{T, T} where {T}
+function get_level_from_storage(basin::Basin, state_idx::Int, storage)
     storage_to_level = basin.storage_to_level[state_idx]
-    level_to_area = basin.level_to_area[state_idx]
     if storage >= 0
-        level = storage_to_level(storage)
+        return storage_to_level(storage)
     else
         # Negative storage is not feasible and this yields a level
         # below the basin bottom, but this does yield usable gradients
         # for the non-linear solver
-        bottom = first(level_to_area.t)
-        level = bottom + derivative(storage_to_level, 0.0) * storage
+        bottom = first(storage_to_level.u)
+        return bottom + derivative(storage_to_level, 0.0) * storage
     end
-    area = level_to_area(level)
-    return area, level
 end
 
 """
@@ -896,7 +893,7 @@ end
 (A::AbstractInterpolation)(t::GradientTracer) = t
 reduction_factor(x::GradientTracer, threshold::Real) = x
 relaxed_root(x::GradientTracer, threshold::Real) = x
-get_area_and_level(basin::Basin, state_idx::Int, storage::GradientTracer) = storage, storage
+get_level_from_storage(basin::Basin, state_idx::Int, storage::GradientTracer) = storage
 stop_declining_negative_storage!(du, u::ComponentVector{<:GradientTracer}) = nothing
 
 @kwdef struct MonitoredBackTracking{B, V}

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -83,7 +83,7 @@ function get_storages_and_levels(
     level = zero(storage)
     for (i, basin_storage) in enumerate(eachrow(storage))
         level[i, :] =
-            [get_area_and_level(p.basin, i, storage)[2] for storage in basin_storage]
+            [get_level_from_storage(p.basin, i, storage) for storage in basin_storage]
     end
 
     return (; time = tsteps, node_id, storage, level)

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -299,7 +299,6 @@ end
     import Tables
     using DataInterpolations: LinearInterpolation, integral, invert_integral
 
-    "Shorthand for Ribasim.get_area_and_level"
     function lookup(profile, S)
         level_to_area = LinearInterpolation(profile.A, profile.h; extrapolate = true)
         storage_to_level = invert_integral(level_to_area)

--- a/core/test/time_test.jl
+++ b/core/test/time_test.jl
@@ -39,10 +39,15 @@ end
     t_end = time_table.time[end]
     filter!(:time => t -> t !== t_end, time_table)
 
+    function get_area(basin, idx, storage)
+        level = Ribasim.get_level_from_storage(basin, idx, storage)
+        basin.level_to_area[idx](level)
+    end
+
     time_table[!, "basin_idx"] =
         [node_id.idx for node_id in Ribasim.NodeID.(:Basin, time_table.node_id, Ref(p))]
     time_table[!, "area"] = [
-        Ribasim.get_area_and_level(basin, idx, storage)[1] for
+        get_area(basin, idx, storage) for
         (idx, storage) in zip(time_table.basin_idx, basin_table.storage)
     ]
     # Mean areas are sufficient to compute the mean flows

--- a/core/test/utils_test.jl
+++ b/core/test/utils_test.jl
@@ -93,7 +93,7 @@ end
 
     # Converting from storages to levels and back should return the same storages
     storages = range(0.0, 2 * storage_to_level.t[end], 50)
-    levels = [Ribasim.get_storage_from_level(basin, 1, s) for s in storages]
+    levels = [Ribasim.get_level_from_storage(basin, 1, s) for s in storages]
     storages_ = [Ribasim.get_storage_from_level(basin, 1, l) for l in levels]
     @test storages ≈ storages_
 

--- a/core/test/utils_test.jl
+++ b/core/test/utils_test.jl
@@ -93,7 +93,7 @@ end
 
     # Converting from storages to levels and back should return the same storages
     storages = range(0.0, 2 * storage_to_level.t[end], 50)
-    levels = [Ribasim.get_area_and_level(basin, 1, s)[2] for s in storages]
+    levels = [Ribasim.get_storage_from_level(basin, 1, s) for s in storages]
     storages_ = [Ribasim.get_storage_from_level(basin, 1, l) for l in levels]
     @test storages ≈ storages_
 


### PR DESCRIPTION
For some reason `storage_to_level` introduces type instability. I haven't looked into why that is, but with this refactor the type instability doesn't propagate as far as before.

Profile before:
![image](https://github.com/user-attachments/assets/91a623e5-bc68-49f6-84c6-77fc2d71e51e)

Profile after:
![image](https://github.com/user-attachments/assets/62c08ecf-0135-4b42-907f-f80943f393b0)
