### PR TITLE
Migrate min_crest_level from v0 as well

### DIFF
--- a/python/ribasim/ribasim/migrations.py
+++ b/python/ribasim/ribasim/migrations.py
@@ -80,7 +80,7 @@ def pidcontrolstaticschema_migration(df: DataFrame, schema_version: int) -> Data
 
 
 def outletstaticschema_migration(df: DataFrame, schema_version: int) -> DataFrame:
-    if schema_version == 1:
+    if schema_version < 2:
         warnings.warn("Migrating outdated Outlet / static table.", UserWarning)
         # First remove automatically added empty column.
         df.drop(columns="min_upstream_level", inplace=True, errors="ignore")


### PR DESCRIPTION
Many of the current Ribasim NL models have schema version 0, and `min_crest_level`. Those currently fail to migrate, but do with this patch.
