### PR TITLE
Fix internal link to component overview

### DIFF
--- a/docs/concept/core.qmd
+++ b/docs/concept/core.qmd
@@ -13,7 +13,7 @@ can be found in the [Ribasim repository](https://github.com/Deltares/Ribasim) un
 `core/` folder. For developers we also advise to read the
 [developer documentation](/dev/core.qmd). Information on coupling can be found [here](/guide/coupling.qmd).
 
-An overview of all components is given in the [Get Started](/tutorial/index.qmd#sec-components) section.
+An overview of all components is given in the [installation](/install.qmd#sec-components) section.
 
 # The simulation loop {#sec-simulationloop}
 

--- a/docs/dev/core.qmd
+++ b/docs/dev/core.qmd
@@ -4,7 +4,7 @@ title: "Julia core development"
 
 # Julia core overview
 
-The computational core is one of the components of Ribasim as illustrated in the [component overview](/tutorial/index.qmd#sec-components).
+The computational core is one of the components of Ribasim as illustrated in the [component overview](/install.qmd#sec-components).
 
 The computational process can be divided in three phases:
 


### PR DESCRIPTION
Saw this in a warning of `pixi run quarto-render`.
