### PR TITLE
Add default UserDemand boundary concentrations.

### DIFF
--- a/python/ribasim/ribasim/delwaq/template/B5_bounddata.inc.j2
+++ b/python/ribasim/ribasim/delwaq/template/B5_bounddata.inc.j2
@@ -18,6 +18,10 @@ ITEM 'Precipitation'
 CONCENTRATIONS 'Continuity' 'Precipitation'
 DATA 1 1
 
+ITEM 'UserDemand'
+CONCENTRATIONS 'Continuity' 'UserDemand'
+DATA 1 1
+
 {% for boundary in boundaries -%}
 ITEM '{{ boundary.name }}'
 CONCENTRATIONS {{ boundary.substances | join(' ') | safe }}


### PR DESCRIPTION
Fixes #1841

The fix is indeed to UserDemand, and @visr's hunch about the concentration not being set on the boundary turned out to be right.

Seems we're in business now 🎉:
<img width="954" alt="Screenshot 2024-09-23 at 17 38 26" src="https://github.com/user-attachments/assets/5d964a55-6e91-48c0-9cff-b5470462c68c">
