### PR TITLE
Don't write `use_validation` to TOML

### DIFF
--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -104,7 +104,7 @@ class Model(FileModel):
     user_demand: UserDemand = Field(default_factory=UserDemand)
 
     edge: EdgeTable = Field(default_factory=EdgeTable)
-    use_validation: bool = Field(default=True)
+    use_validation: bool = Field(default=True, exclude=True)
 
     _used_node_ids: UsedIDs = PrivateAttr(default_factory=UsedIDs)
 

--- a/python/ribasim_testmodels/ribasim_testmodels/trivial.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/trivial.py
@@ -12,6 +12,7 @@ def trivial_model() -> Model:
         endtime="2021-01-01",
         crs="EPSG:28992",
         results=Results(subgrid=True, compression=False),
+        use_validation=True,
     )
 
     # Convert steady forcing to m/s


### PR DESCRIPTION
Fixes #1862.

This adds the default to a test model to ensure it doesn't end up that and hence make the model not runnable in CI.
