### PR TITLE
Set pixi-version to v0.30.0

### DIFF
--- a/.github/workflows/core_testmodels.yml
+++ b/.github/workflows/core_testmodels.yml
@@ -36,7 +36,7 @@ jobs:
           cache-registries: "true"
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: "latest"
+          pixi-version: v0.30.0
       - name: Prepare pixi
         run: pixi run install-ci
       - name: Run testmodels with Ribasim Core

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -36,7 +36,7 @@ jobs:
           cache-registries: "true"
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: "latest"
+          pixi-version: v0.30.0
       - name: Test Ribasim Core
         run: |
           pixi run test-ribasim-core-cov

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
           cache-registries: "true"
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: "latest"
+          pixi-version: v0.30.0
       - name: Prepare pixi
         run: pixi run install-ci
 

--- a/.github/workflows/julia_auto_update.yml
+++ b/.github/workflows/julia_auto_update.yml
@@ -16,7 +16,7 @@ jobs:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: "latest"
+          pixi-version: v0.30.0
       - name: Update Julia manifest file
         run: |
           pixi run install-julia

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: "latest"
+          pixi-version: v0.30.0
       - name: Run mypy on python/ribasim
         run: |
           pixi run mypy-ribasim-python

--- a/.github/workflows/pixi_auto_update.yml
+++ b/.github/workflows/pixi_auto_update.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Set up pixi
         uses: prefix-dev/setup-pixi@v0.8.1
         with:
+          pixi-version: v0.30.0
           run-install: false
       - name: Update lockfiles
         run: |

--- a/.github/workflows/python_codegen.yml
+++ b/.github/workflows/python_codegen.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: "latest"
+          pixi-version: v0.30.0
       - name: Test if codegen runs without errors
         run: pixi run codegen
       - name: Ensure that no code has been generated

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: "latest"
+          pixi-version: v0.30.0
       - name: Test Ribasim Python
         run: pixi run --environment ${{ matrix.pixi-environment }} test-ribasim-python-cov
       - name: Upload coverage to Codecov

--- a/.github/workflows/qgis.yml
+++ b/.github/workflows/qgis.yml
@@ -19,7 +19,7 @@ jobs:
           - uses: actions/checkout@v4
           - uses: prefix-dev/setup-pixi@v0.8.1
             with:
-              pixi-version: "latest"
+              pixi-version: v0.30.0
           - name: Run tests
             run: pixi run test-ribasim-qgis-docker
           - name: Upload coverage to Codecov


### PR DESCRIPTION
Instead of latest. All PRs made since v0.31 came out seem to have pixi environment related issues. Checking if this will fix it.

#1867 green with v0.30
#1868 red with v0.31
#1869 red with v0.31

This is the error, that somewhat randomly appears during `pixi run`

```
  × /home/runner/work/Ribasim/Ribasim/.pixi/envs/dev/lib/gcc/x86_64-conda-
  │ linux-gnu/14.1.0/libhwasan.so: No such file or directory (os error 2)
```

The failing jobs share that they all run Julia code and are on Ubuntu, although there are also Julia and Ubuntu jobs that pass. `gcc_impl_linux-64` is a dependency of rust.