### PR TITLE
Empty default point

### DIFF
--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -170,7 +170,7 @@ class Node(pydantic.BaseModel):
     def __init__(
         self,
         node_id: Optional[NonNegativeInt] = None,
-        geometry: Point = Point("nan", "nan"),
+        geometry: Point = Point(),
         **kwargs,
     ) -> None:
         if is_empty(geometry):


### PR DESCRIPTION
`Point("nan", "nan").is_empty` is False in the new GEOS/Shapely.

Fixes #1866.