### PR TITLE
SparseConnectivityTracer v0.6.5 ⇒ v0.6.4

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1509,9 +1509,9 @@ version = "1.10.0"
 
 [[deps.SparseConnectivityTracer]]
 deps = ["ADTypes", "DocStringExtensions", "FillArrays", "LinearAlgebra", "Random", "Requires", "SparseArrays"]
-git-tree-sha1 = "d60da13a3f752dd5f3cc7f25d03621b243c98614"
+git-tree-sha1 = "5cecac368ad938c6fed636c8e28d206291c84b50"
 uuid = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
-version = "0.6.5"
+version = "0.6.4"
 
     [deps.SparseConnectivityTracer.extensions]
     SparseConnectivityTracerDataInterpolationsExt = "DataInterpolations"


### PR DESCRIPTION
Alternative to #1884, that brings us back to before #1860.
https://github.com/adrhill/SparseConnectivityTracer.jl/releases/tag/v0.6.5 doesn't seem to contain anything relevant for us though, so I'd be surprised if this would help.