### PR TITLE
Revert to old tolerances for level control.

### DIFF
--- a/docs/guide/examples.ipynb
+++ b/docs/guide/examples.ipynb
@@ -41,7 +41,7 @@
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "from ribasim import Allocation, Model, Node\n",
+    "from ribasim import Allocation, Model, Node, Solver\n",
     "from ribasim.nodes import (\n",
     "    basin,\n",
     "    continuous_control,\n",
@@ -462,7 +462,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = Model(starttime=\"2020-01-01\", endtime=\"2021-01-01\", crs=\"EPSG:4326\")"
+    "model = Model(\n",
+    "    starttime=\"2020-01-01\",\n",
+    "    endtime=\"2021-01-01\",\n",
+    "    crs=\"EPSG:4326\",\n",
+    "    solver=Solver(abstol=1e-6, reltol=1e-5),\n",
+    ")"
    ]
   },
   {

--- a/python/ribasim_testmodels/ribasim_testmodels/discrete_control.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/discrete_control.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 from ribasim.config import Node
-from ribasim.model import Model
+from ribasim.model import Model, Solver
 from ribasim.nodes import (
     basin,
     discrete_control,
@@ -388,6 +388,7 @@ def level_range_model() -> Model:
         starttime="2020-01-01",
         endtime="2021-01-01",
         crs="EPSG:28992",
+        solver=Solver(abstol=1e-6, reltol=1e-5),
     )
 
     model.basin.add(


### PR DESCRIPTION
Fixes #1892 for now to speed up our CI. We should further investigate why the new tolerances (#1874) have slowed this model down so much. This also again stresses the need for a good benchmark suite, which should've caught it.