### PR TITLE
Configurable interpolation types

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -461,9 +461,9 @@ version = "1.7.0"
 
 [[deps.DataInterpolations]]
 deps = ["FindFirstFunctions", "ForwardDiff", "LinearAlgebra", "PrettyTables", "RecipesBase", "Reexport"]
-git-tree-sha1 = "3d81cd1fcba530122a5d6c725aa53521d869816a"
+git-tree-sha1 = "78d06458ec13b53b3b0016daebe53f832d42ff44"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "6.5.2"
+version = "6.6.0"
 
     [deps.DataInterpolations.extensions]
     DataInterpolationsChainRulesCoreExt = "ChainRulesCore"

--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -67,6 +67,7 @@ using PreallocationTools: LazyBufferCache
 using DataInterpolations:
     LinearInterpolation,
     LinearInterpolationIntInv,
+    PCHIPInterpolation,
     invert_integral,
     derivative,
     integral,

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -405,8 +405,10 @@ interpolation in between. Relation can be updated in time, which is done by movi
 the `time` field into the `tables`, which is done in the `update_tabulated_rating_curve`
 callback.
 
-Type parameter C indicates the content backing the StructVector, which can be a NamedTuple
-of Vectors or Arrow Primitives, and is added to avoid type instabilities.
+Type parameters to avoid type instabilities:
+- C indicates the content backing the StructVector, which can be a NamedTuple
+of Vectors or Arrow Primitives;
+- I indicates the configured type of the interpolation objects for the Q(h) relationships
 
 node_id: node ID of the TabulatedRatingCurve node
 inflow_edge: incoming flow edge metadata
@@ -419,13 +421,13 @@ table: The current Q(h) relationships
 time: The time table used for updating the tables
 control_mapping: dictionary from (node_id, control_state) to Q(h) and/or active state
 """
-@kwdef struct TabulatedRatingCurve{C} <: AbstractParameterNode
+@kwdef struct TabulatedRatingCurve{C, I} <: AbstractParameterNode
     node_id::Vector{NodeID}
     inflow_edge::Vector{EdgeMetadata}
     outflow_edge::Vector{EdgeMetadata}
     active::Vector{Bool}
     max_downstream_level::Vector{Float64} = fill(Inf, length(node_id))
-    table::Vector{ScalarInterpolation}
+    table::Vector{I}
     time::StructVector{TabulatedRatingCurveTimeV1, C, Int}
     control_mapping::Dict{Tuple{NodeID, String}, ControlStateUpdate}
 end
@@ -880,14 +882,14 @@ const ModelGraph = MetaGraph{
     Float64,
 }
 
-@kwdef struct Parameters{C1, C2, C3, C4, C5, C6, C7, C8, C9, V}
+@kwdef struct Parameters{C1, C2, C3, C4, C5, C6, C7, C8, C9, V, I_TRC}
     starttime::DateTime
     graph::ModelGraph
     allocation::Allocation
     basin::Basin{C1, C2, V}
     linear_resistance::LinearResistance
     manning_resistance::ManningResistance
-    tabulated_rating_curve::TabulatedRatingCurve{C3}
+    tabulated_rating_curve::TabulatedRatingCurve{C3, I_TRC}
     level_boundary::LevelBoundary{C4}
     flow_boundary::FlowBoundary{C5}
     pump::Pump

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -121,20 +121,21 @@ end
 
 """
 From a table with columns node_id, flow_rate (Q) and level (h),
-create a ScalarInterpolation from level to flow rate for a given node_id.
+create an interpolation of given type from level to flow rate for a given node_id.
 """
 function qh_interpolation(
     table::StructVector,
     rowrange::UnitRange{Int},
-)::ScalarInterpolation
+    interpolation_type,
+)::AbstractInterpolation
     level = table.level[rowrange]
     flow_rate = table.flow_rate[rowrange]
 
     # Ensure that that Q stays 0 below the first level
     pushfirst!(level, first(level) - 1)
-    pushfirst!(flow_rate, first(flow_rate))
+    pushfirst!(flow_rate, 0)
 
-    return LinearInterpolation(
+    return interpolation_type.constructor(
         flow_rate,
         level;
         extrapolate = true,

--- a/core/test/docs.toml
+++ b/core/test/docs.toml
@@ -40,6 +40,11 @@ sparse = true       # optional, default true
 autodiff = false    # optional, default false
 evaporate_mass = true  # optional, default true to simulate a correct mass balance
 
+[interpolation]
+# Defines which interpolation types are used for which data
+# TODO: add supported interpolation types
+tabulated_rating_curve = "LinearInterpolation"
+
 [logging]
 # defines the logging level of Ribasim
 verbosity = "info" # optional, default "info", can otherwise be "debug", "warn" or "error"

--- a/docs/reference/usage.qmd
+++ b/docs/reference/usage.qmd
@@ -80,6 +80,14 @@ entry             | type   | description
 ----------------- | ------ | -----------
 verbosity         | String | Verbosity level: debug, info, warn, or error.
 
+## Interpolation settings
+
+The following can be set in the configuration in the `[interpolation]` section. The supported interpolation types are: ...
+
+entry                  | type   | description
+---------------------- | ------ | -----------
+tabulated_rating_curve | String | one of the supported interpolation types
+
 ## Experimental features
 
 ::: {.callout-important}

--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -144,6 +144,19 @@ class Logging(ChildModel):
     verbosity: Verbosity = Verbosity.info
 
 
+class Interpolation(ChildModel):
+    """
+    Defines the interpolation types used in the core
+
+    Attributes
+    ----------
+    tabulated_rating_curve : str
+        The interpolation type used for Q(h) relationships
+    """
+
+    tabulated_rating_curve: str = "LinearInterpolation"
+
+
 class Experimental(ChildModel):
     """
     Defines experimental features.

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -29,6 +29,7 @@ from ribasim.config import (
     Experimental,
     FlowBoundary,
     FlowDemand,
+    Interpolation,
     LevelBoundary,
     LevelDemand,
     LinearResistance,
@@ -82,6 +83,7 @@ class Model(FileModel):
     results_dir: Path = Field(default=Path("results"))
 
     logging: Logging = Field(default_factory=Logging)
+    interpolation: Interpolation = Field(default_factory=Interpolation)
     solver: Solver = Field(default_factory=Solver)
     results: Results = Field(default_factory=Results)
 


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/1919.

Inspired by ongoing discussions with @Huite and @visr on smoothness (see also https://github.com/Deltares/Ribasim/issues/1918, https://github.com/Deltares/Ribasim/issues/1920) I started looking into making the type of interpolation configurable in the several places in the core where interpolation is used. For this PR I am focussing on $Q(h)$ relationships.

We require of the $Q(h)$ interpolation that the flow is $0$ below and at the lowest supplied level. That's trivial to achieve for linear interpolation, but not for non-linear (generally piecewise polynomial of degree >1) interpolation types. This requires a special approach for each method.

The question is which methods to support (and even whether this should be configurable for $Q(h)$ relationships at all). I now experiment with [PCHIP Interpolation](https://docs.sciml.ai/DataInterpolations/stable/methods/#PCHIP-Interpolation) because of its smoothness and non-overshooting properties.

Another point of attention is extrapolation. For linear interpolation extrapolation makes sense, but for higher order interpolation methods extrapolation gets out of hand quick. We could make our own wrapper of interpolation types from `DataInterpolation`, but I also made an issue there to pick it up internally:

https://github.com/SciML/DataInterpolations.jl/issues/355