### PR TITLE
Fix README.md in builds

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -7,3 +7,38 @@ pixi run build
 ```
 
 > :warning: If the build is failing, because it cannot find certain files, chances are high that you need to enable long paths in Windows.
+
+## Ribasim CLI
+
+In order to find out about it's usage call `ribasim --help`
+
+## Libribasim
+
+Libribasim is a shared library that exposes Ribasim functionality to external (non-Julian)
+programs. It can be compiled using [PackageCompiler's
+create_lib](https://julialang.github.io/PackageCompiler.jl/stable/libs.html), which is set
+up in this directory. The C API that is offered to control Ribasim is the C API of the
+[Basic Model Interface](https://bmi.readthedocs.io/en/latest/), also known as BMI.
+
+Not all BMI functions are implemented yet.
+Couplings to other models are implemented in [`imod_coupler`](https://github.com/Deltares/imod_coupler).
+
+Here is an example of using libribasim from Python:
+
+```python
+In [1]: from ctypes import CDLL, c_int, c_char_p, create_string_buffer, byref
+
+In [2]: c_dll = CDLL("libribasim", winmode=0x08)  # winmode for Windows
+
+In [3]: argument = create_string_buffer(0)
+   ...: c_dll.init_julia(c_int(0), byref(argument))
+Out[3]: 1
+
+In [4]: config_path = "ribasim.toml"
+
+In [5]: c_dll.initialize(c_char_p(config_path.encode()))
+Out[5]: 0
+
+In [6]: c_dll.update()
+Out[6]: 0
+```

--- a/build/build.jl
+++ b/build/build.jl
@@ -3,44 +3,6 @@ using PackageCompiler
 using TOML
 using LibGit2
 
-"""
-# Ribasim CLI
-
-In order to find out about it's usage call `ribasim --help`
-
-# Libribasim
-
-Libribasim is a shared library that exposes Ribasim functionality to external (non-Julian)
-programs. It can be compiled using [PackageCompiler's
-create_lib](https://julialang.github.io/PackageCompiler.jl/stable/libs.html), which is set
-up in this directory. The C API that is offered to control Ribasim is the C API of the
-[Basic Model Interface](https://bmi.readthedocs.io/en/latest/), also known as BMI.
-
-Not all BMI functions are implemented yet, this has been set up as a proof of concept to
-demonstrate that we can use other software such as
-[`imod_coupler`](https://github.com/Deltares/imod_coupler) to control Ribasim and couple it to
-other models.
-
-Here is an example of using libribasim from Python:
-
-```python
-In [1]: from ctypes import CDLL, c_int, c_char_p, create_string_buffer, byref
-
-In [2]: c_dll = CDLL("libribasim", winmode=0x08)  # winmode for Windows
-
-In [3]: argument = create_string_buffer(0)
-   ...: c_dll.init_julia(c_int(0), byref(argument))
-Out[3]: 1
-
-In [4]: config_path = "ribasim.toml"
-
-In [5]: c_dll.initialize(c_char_p(config_path.encode()))
-Out[5]: 0
-
-In [6]: c_dll.update()
-Out[6]: 0
-```
-"""
 function main()
     project_dir = "../core"
     license_file = "../LICENSE"
@@ -61,12 +23,21 @@ function main()
         force = true,
     )
 
-    readme = @doc(build_app)
-    add_metadata(project_dir, license_file, output_dir, git_repo, readme)
+    add_metadata(project_dir, license_file, output_dir, git_repo, readme_start)
     run(Cmd(`cargo build --release`; dir = "cli"))
     ribasim = Sys.iswindows() ? "ribasim.exe" : "ribasim"
     cp("cli/target/release/$ribasim", "ribasim/$ribasim"; force = true)
 end
+
+readme_start = """
+# Ribasim
+
+Ribasim is a water resources model to simulate the physical behavior of a managed open water system
+based on a set of control rules and a prioritized water allocation strategy.
+
+Usage: `ribasim path/to/model/ribasim.toml`
+Documentation: https://ribasim.org/
+"""
 
 function set_version(filename, version; group = nothing)
     data = TOML.parsefile(filename)


### PR DESCRIPTION
I used the shorter readme text from #1930, and moved the longer text to the README.md in https://github.com/Deltares/Ribasim/tree/main/build.

Fixes #1930.
