### PR TITLE
Fix test_version during release process and simplify versions in README.md

### DIFF
--- a/build/build.jl
+++ b/build/build.jl
@@ -39,16 +39,15 @@ Usage: `ribasim path/to/model/ribasim.toml`
 Documentation: https://ribasim.org/
 """
 
-function set_version(filename, version; group = nothing)
+"Use the git tag for `ribasim --version`,
+so dev builds can be identified by <tag>-g<short-commit>"
+function set_version(filename::String, tag::String)::Nothing
     data = TOML.parsefile(filename)
-    if !isnothing(group)
-        data[group]["version"] = version
-    else
-        data["version"] = version
-    end
+    data["package"]["version"] = tag
     open(filename, "w") do io
         TOML.print(io, data)
     end
+    return nothing
 end
 
 """
@@ -119,7 +118,7 @@ function add_metadata(project_dir, license_file, output_dir, git_repo, readme)
     end
 
     # Override the Cargo.toml file with the git version
-    set_version("cli/Cargo.toml", tag; group = "package")
+    set_version("cli/Cargo.toml", tag)
 end
 
 main()

--- a/build/build.jl
+++ b/build/build.jl
@@ -82,15 +82,6 @@ function add_metadata(project_dir, license_file, output_dir, git_repo, readme)
         force = true,
     )
 
-    # since the exact Ribasim version may be hard to find in the Manifest.toml file
-    # we can also extract that information, and add it to the README.md
-    manifest = TOML.parsefile(normpath(git_repo, "Manifest.toml"))
-    if !haskey(manifest, "manifest_format")
-        error("Manifest.toml is in the old format, run Pkg.upgrade_manifest()")
-    end
-    julia_version = manifest["julia_version"]
-    ribasim_entry = only(manifest["deps"]["Ribasim"])
-    version = ribasim_entry["version"]
     repo = GitRepo(git_repo)
     branch = LibGit2.head(repo)
     commit = LibGit2.peel(LibGit2.GitCommit, branch)
@@ -120,11 +111,9 @@ function add_metadata(project_dir, license_file, output_dir, git_repo, readme)
         This build uses the Ribasim version mentioned below.
 
         ```toml
-        release = "$tag"
+        version = "$tag"
         commit = "$url/$short_commit"
         branch = "$url/$short_name"
-        julia_version = "$julia_version"
-        core_version = "$version"
         ```"""
         println(io, version_info)
     end

--- a/build/tests/test_cli.py
+++ b/build/tests/test_cli.py
@@ -33,7 +33,7 @@ def test_version():
 
     # ribasim --version is based on the git tag so can be different from
     # ribasim.__version__ during development
-    version_pattern = r"ribasim \d{4,}\.\d{1,}\.\d{1,}"
+    version_pattern = r"ribasim \d{4,}\.\d+\.\d+"
     assert re.match(version_pattern, result.stdout)
 
 

--- a/build/tests/test_cli.py
+++ b/build/tests/test_cli.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 from pathlib import Path
 
@@ -30,7 +31,10 @@ def test_version():
         [executable, "--version"], check=True, capture_output=True, text=True
     )
 
-    assert ribasim.__version__ in result.stdout
+    # ribasim --version is based on the git tag so can be different from
+    # ribasim.__version__ during development
+    version_pattern = r"ribasim \d{4,}\.\d{1,}\.\d{1,}"
+    assert re.match(version_pattern, result.stdout)
 
 
 def test_help():


### PR DESCRIPTION
In the README.md we had version info like this:

```md
release = "$tag"
commit = "$url/$short_commit"
branch = "$url/$short_name"
julia_version = "$julia_version"
core_version = "$version"
```

This cuts it down to just this:

```md
version = "$tag"
commit = "$url/$short_commit"
branch = "$url/$short_name"
```

Where `tag` is of the form `2024.10.0-128-ge09eeb5` if it is after tag v2024.10.0, otherwise just `2024.10.0`
The `test_version` just checks the form, because we bump the versions before doing a git tag, so they can be off by one version temporarily. I think that's simpler than introducing more difficult logic in `set_version` to handle this.

Fixes #1655
