### PR TITLE
Get rid of specifying sources in allocation by edges

### DIFF
--- a/core/src/allocation_init.jl
+++ b/core/src/allocation_init.jl
@@ -268,18 +268,19 @@ function add_constraints_user_source!(
 end
 
 """
-Add the source constraints to the allocation problem.
+Add the boundary source constraints to the allocation problem.
 The actual threshold values will be set before each allocation solve.
 The constraint indices are (edge_source_id, edge_dst_id).
 
 Constraint:
-flow over source edge <= source flow in subnetwork
+flow over source edge <= source flow in physical layer
 """
 function add_constraints_boundary_source!(
     problem::JuMP.Model,
     p::Parameters,
     subnetwork_id::Int32,
 )::Nothing
+    # Source edges (without the basins)
     edges_source =
         [edge for edge in source_edges_subnetwork(p, subnetwork_id) if edge[1] != edge[2]]
     F = problem[:F]
@@ -293,6 +294,14 @@ function add_constraints_boundary_source!(
     return nothing
 end
 
+"""
+Add main network source constraints to the allocation problem.
+The actual threshold values will be set before each allocation solve.
+The constraint indices are (edge_source_id, edge_dst_id).
+
+Constraint:
+flow over main network to subnetwork connection edge <= either 0 or allocated amount from the main network
+"""
 function add_constraints_main_network_source!(
     problem::JuMP.Model,
     p::Parameters,

--- a/core/src/allocation_optim.jl
+++ b/core/src/allocation_optim.jl
@@ -202,8 +202,6 @@ function set_initial_capacities_source!(
     p::Parameters,
 )::Nothing
     (; sources) = allocation_model
-    (; allocation) = p
-    (; mean_input_flows) = allocation
     (; subnetwork_id) = allocation_model
 
     mean_input_flows_subnetwork_ = mean_input_flows_subnetwork(p, subnetwork_id)

--- a/core/src/allocation_optim.jl
+++ b/core/src/allocation_optim.jl
@@ -203,21 +203,18 @@ function set_initial_capacities_source!(
     p::Parameters,
 )::Nothing
     (; sources) = allocation_model
-    (; graph, allocation) = p
+    (; allocation) = p
     (; mean_input_flows) = allocation
     (; subnetwork_id) = allocation_model
     main_network_source_edges = get_main_network_connections(p, subnetwork_id)
 
-    for edge_metadata in values(graph.edge_data)
-        (; edge) = edge_metadata
-        if graph[edge...].subnetwork_id_source == subnetwork_id
-            # If it is a source edge for this allocation problem
-            if edge ∉ main_network_source_edges
-                # Reset the source to the averaged flow over the last allocation period
-                source = sources[edge]
-                @assert source.type == AllocationSourceType.edge
-                source.capacity[] = mean_input_flows[edge][]
-            end
+    for edge in keys(p.allocation.mean_input_flows[subnetwork_id])
+        # If it is a source edge for this allocation problem
+        if edge ∉ main_network_source_edges
+            # Reset the source to the averaged flow over the last allocation period
+            source = sources[edge]
+            @assert source.type == AllocationSourceType.edge
+            source.capacity[] = mean_input_flows[edge][]
         end
     end
     return nothing

--- a/core/src/callback.jl
+++ b/core/src/callback.jl
@@ -802,10 +802,13 @@ function update_allocation!(integrator)::Nothing
     end
 
     # Reset the mean flows
-    for mean_flows in (mean_input_flows..., mean_realized_flows)
+    for mean_flows in mean_input_flows
         for edge in keys(mean_flows)
             mean_flows[edge] = 0.0
         end
+    end
+    for edge in keys(mean_realized_flows)
+        mean_realized_flows[edge] = 0.0
     end
 end
 

--- a/core/src/callback.jl
+++ b/core/src/callback.jl
@@ -153,8 +153,11 @@ function update_cumulative_flows!(u, t, integrator)::Nothing
     end
 
     # Update realized flows for allocation input
-    for edge in keys(allocation.mean_input_flows)
-        allocation.mean_input_flows[edge] += flow_update_on_edge(integrator, edge)
+    for subnetwork_id in allocation.subnetwork_ids
+        mean_input_flows_subnetwork_ = mean_input_flows_subnetwork(p, subnetwork_id)
+        for edge in keys(mean_input_flows_subnetwork_)
+            mean_input_flows_subnetwork_[edge] += flow_update_on_edge(integrator, edge)
+        end
     end
 
     # Update realized flows for allocation output
@@ -773,8 +776,10 @@ function update_allocation!(integrator)::Nothing
 
     # Divide by the allocation Δt to get the mean input flows from the cumulative flows
     (; Δt_allocation) = allocation_models[1]
-    for edge in keys(mean_input_flows)
-        mean_input_flows[edge] /= Δt_allocation
+    for mean_input_flows_subnetwork in values(mean_input_flows)
+        for edge in keys(mean_input_flows_subnetwork)
+            mean_input_flows_subnetwork[edge] /= Δt_allocation
+        end
     end
 
     # Divide by the allocation Δt to get the mean realized flows from the cumulative flows
@@ -797,7 +802,7 @@ function update_allocation!(integrator)::Nothing
     end
 
     # Reset the mean flows
-    for mean_flows in (mean_input_flows, mean_realized_flows)
+    for mean_flows in (mean_input_flows..., mean_realized_flows)
         for edge in keys(mean_flows)
             mean_flows[edge] = 0.0
         end

--- a/core/src/graph.jl
+++ b/core/src/graph.jl
@@ -56,15 +56,8 @@ function create_graph(db::DB, config::Config)::MetaGraph
     end
 
     errors = false
-    for (;
-        edge_id,
-        from_node_type,
-        from_node_id,
-        to_node_type,
-        to_node_id,
-        edge_type,
-        subnetwork_id,
-    ) in edge_rows
+    for (; edge_id, from_node_type, from_node_id, to_node_type, to_node_id, edge_type) in
+        edge_rows
         try
             # hasfield does not work
             edge_type = getfield(EdgeType, Symbol(edge_type))
@@ -73,13 +66,6 @@ function create_graph(db::DB, config::Config)::MetaGraph
         end
         id_src = NodeID(from_node_type, from_node_id, db)
         id_dst = NodeID(to_node_type, to_node_id, db)
-        if !ismissing(subnetwork_id)
-            Base.depwarn(
-                "Sources for allocation are automatically inferred and no longer have to be specified in the `Edge` table.",
-                :create_graph;
-                force = true,
-            )
-        end
         edge_metadata =
             EdgeMetadata(; id = edge_id, type = edge_type, edge = (id_src, id_dst))
         if edge_type == EdgeType.flow

--- a/core/src/graph.jl
+++ b/core/src/graph.jl
@@ -74,6 +74,13 @@ function create_graph(db::DB, config::Config)::MetaGraph
         end
         id_src = NodeID(from_node_type, from_node_id, db)
         id_dst = NodeID(to_node_type, to_node_id, db)
+        if !ismissing(subnetwork_id)
+            Base.depwarn(
+                "Sources for allocation are automatically inferred and no longer have to be specified in the `Edge` table.",
+                :create_graph;
+                force = true,
+            )
+        end
         if ismissing(subnetwork_id)
             subnetwork_id = 0
         end
@@ -101,6 +108,12 @@ function create_graph(db::DB, config::Config)::MetaGraph
     if errors
         error("Invalid edges found")
     end
+    # if edge_depwarn
+    #     Base.depwarn(
+    #         "Sources for allocation are automatically inferred and no longer have to be specified in the `Edge` table.",
+    #         :create_graph,
+    #     )
+    # end
 
     if incomplete_subnetwork(graph, node_ids)
         error("Incomplete connectivity in subnetwork")

--- a/core/src/graph.jl
+++ b/core/src/graph.jl
@@ -19,8 +19,7 @@ function create_graph(db::DB, config::Config)::MetaGraph
             FromNode.node_type AS from_node_type,
             ToNode.node_id AS to_node_id,
             ToNode.node_type AS to_node_type,
-            Edge.edge_type,
-            Edge.subnetwork_id
+            Edge.edge_type
         FROM Edge
         LEFT JOIN Node AS FromNode ON FromNode.node_id = Edge.from_node_id
         LEFT JOIN Node AS ToNode ON ToNode.node_id = Edge.to_node_id

--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -47,6 +47,7 @@ function Model(config::Config)::Model
     # so we can directly close it again.
     db = SQLite.DB(db_path)
 
+    database_warning(db)
     if !valid_nodes(db)
         error("Invalid nodes found.")
     end

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -128,7 +128,7 @@ The caches are always initialized with zeros
 """
 cache(len::Int)::Cache = LazyBufferCache(Returns(len); initializer! = set_zero!)
 
-@enumx AllocationSourceType edge basin main_to_sub user_return buffer
+@enumx AllocationSourceType boundary_node basin main_to_sub user_return buffer
 
 """
 Data structure for a single source within an allocation subnetwork.
@@ -177,7 +177,7 @@ main_network_connections: (from_id, to_id) from the main network to the subnetwo
 priorities: All used priority values.
 subnetwork_demands: The demand of an edge from the main network to a subnetwork
 subnetwork_allocateds: The allocated flow of an edge from the main network to a subnetwork
-mean_input_flows: Flows averaged over Δt_allocation over edges that are allocation sources
+mean_input_flows: Per subnetwork, flows averaged over Δt_allocation over edges that are allocation sources
 mean_realized_flows: Flows averaged over Δt_allocation over edges that realize a demand
 record_demand: A record of demands and allocated flows for nodes that have these
 record_flow: A record of all flows computed by allocation optimization, eventually saved to
@@ -190,7 +190,7 @@ record_flow: A record of all flows computed by allocation optimization, eventual
     priorities::Vector{Int32}
     subnetwork_demands::Dict{Tuple{NodeID, NodeID}, Vector{Float64}} = Dict()
     subnetwork_allocateds::Dict{Tuple{NodeID, NodeID}, Vector{Float64}} = Dict()
-    mean_input_flows::Dict{Tuple{NodeID, NodeID}, Float64}
+    mean_input_flows::Dict{Int32, Dict{Tuple{NodeID, NodeID}, Float64}}
     mean_realized_flows::Dict{Tuple{NodeID, NodeID}, Float64}
     record_demand::@NamedTuple{
         time::Vector{Float64},
@@ -252,14 +252,11 @@ end
 Type for storing metadata of edges in the graph:
 id: ID of the edge (only used for labeling flow output)
 type: type of the edge
-subnetwork_id_source: ID of subnetwork where this edge is a source
-  (0 if not a source)
 edge: (from node ID, to node ID)
 """
 @kwdef struct EdgeMetadata
     id::Int32
     type::EdgeType.T
-    subnetwork_id_source::Int32
     edge::Tuple{NodeID, NodeID}
 end
 
@@ -899,7 +896,6 @@ const ModelGraph = MetaGraph{
     EdgeMetadata,
     @NamedTuple{
         node_ids::Dict{Int32, Set{NodeID}},
-        edges_source::Dict{Int32, Set{EdgeMetadata}},
         flow_edges::Vector{EdgeMetadata},
         saveat::Float64,
     },

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -184,13 +184,14 @@ record_flow: A record of all flows computed by allocation optimization, eventual
     output file
 """
 @kwdef struct Allocation
-    subnetwork_ids::Vector{Int32} = []
-    allocation_models::Vector{AllocationModel} = []
-    main_network_connections::Vector{Vector{Tuple{NodeID, NodeID}}} = []
+    subnetwork_ids::Vector{Int32} = Int32[]
+    allocation_models::Vector{AllocationModel} = AllocationModel[]
+    main_network_connections::Vector{Vector{Tuple{NodeID, NodeID}}} =
+        Vector{Tuple{NodeID, NodeID}}[]
     priorities::Vector{Int32}
     subnetwork_demands::Dict{Tuple{NodeID, NodeID}, Vector{Float64}} = Dict()
     subnetwork_allocateds::Dict{Tuple{NodeID, NodeID}, Vector{Float64}} = Dict()
-    mean_input_flows::Dict{Int32, Dict{Tuple{NodeID, NodeID}, Float64}}
+    mean_input_flows::Vector{Dict{Tuple{NodeID, NodeID}, Float64}}
     mean_realized_flows::Dict{Tuple{NodeID, NodeID}, Float64}
     record_demand::@NamedTuple{
         time::Vector{Float64},

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -1283,8 +1283,11 @@ function Allocation(db::DB, config::Config, graph::MetaGraph)::Allocation
             id_source, _ = edge
             if id_source.type in boundary_source_nodetypes
                 (; subnetwork_id) = graph[id_source]
-                subnetwork_idx = searchsortedfirst(subnetwork_ids, subnetwork_id)
-                mean_input_flows[subnetwork_idx][edge] = 0.0
+                # Check whether the source node is part of a subnetwork
+                if subnetwork_id ≠ 0
+                    subnetwork_idx = searchsortedfirst(subnetwork_ids, subnetwork_id)
+                    mean_input_flows[subnetwork_idx][edge] = 0.0
+                end
             end
         end
 

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -1268,13 +1268,18 @@ function Subgrid(db::DB, config::Config, basin::Basin)::Subgrid
 end
 
 function Allocation(db::DB, config::Config, graph::MetaGraph)::Allocation
-    mean_input_flows = Dict{Tuple{NodeID, NodeID}, Float64}()
+    mean_input_flows = Dict{Int32, Dict{Tuple{NodeID, NodeID}, Float64}}()
 
     # Find edges which serve as sources in allocation
     for edge_metadata in values(graph.edge_data)
-        (; subnetwork_id_source, edge) = edge_metadata
-        if subnetwork_id_source != 0
-            mean_input_flows[edge] = 0.0
+        (; edge) = edge_metadata
+        id_source, _ = edge
+        if id_source in allocation_source_nodetypes
+            (; subnetwork_id) = graph[id_source]
+            if !haskey(mean_input_flows, subnetwork_id)
+                mean_input_flows[subnetwork_id] = Dict{Tuple{NodeID, NodeID}, Float64}()
+            end
+            mean_input_flows[subnetwork_id][edge] = 0.0
         end
     end
 

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -587,15 +587,17 @@ function set_initial_allocation_mean_flows!(integrator)::Nothing
     du = get_du(integrator)
     water_balance!(du, u, p, t)
 
-    for edge in keys(mean_input_flows)
-        if edge[1] == edge[2]
-            q = get_influx(du, edge[1], p)
-        else
-            q = get_flow(du, p, t, edge)
+    for mean_input_flows_subnetwork in values(mean_input_flows)
+        for edge in keys(mean_input_flows_subnetwork)
+            if edge[1] == edge[2]
+                q = get_influx(du, edge[1], p)
+            else
+                q = get_flow(du, p, t, edge)
+            end
+            # Multiply by Δt_allocation as averaging divides by this factor
+            # in update_allocation!
+            mean_input_flows_subnetwork[edge] = q * Δt_allocation
         end
-        # Multiply by Δt_allocation as averaging divides by this factor
-        # in update_allocation!
-        mean_input_flows[edge] = q * Δt_allocation
     end
 
     # Mean realized demands for basins are calculated as Δstorage/Δt
@@ -1168,3 +1170,12 @@ function min_low_user_demand_level_factor(
         one(T)
     end
 end
+
+function mean_input_flows_subnetwork(p::Parameters, subnetwork_id::Int32)
+    (; mean_input_flows, subnetwork_ids) = p.allocation
+    subnetwork_idx = searchsortedfirst(subnetwork_ids, subnetwork_id)
+    return mean_input_flows[subnetwork_idx]
+end
+
+source_edges_subnetwork(p::Parameters, subnetwork_id::Int32) =
+    keys(mean_input_flows_subnetwork(p, subnetwork_id))

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -1004,12 +1004,8 @@ function set_state_flow_edges(p::Parameters, u0::ComponentVector)::Parameters
     state_inflow_edges = Vector{EdgeMetadata}[]
     state_outflow_edges = Vector{EdgeMetadata}[]
 
-    placeholder_edge = EdgeMetadata(
-        0,
-        EdgeType.flow,
-        0,
-        (NodeID(:Terminal, 0, 0), NodeID(:Terminal, 0, 0)),
-    )
+    placeholder_edge =
+        EdgeMetadata(0, EdgeType.flow, (NodeID(:Terminal, 0, 0), NodeID(:Terminal, 0, 0)))
 
     for node_name in keys(u0)
         if hasfield(Parameters, node_name)

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -182,6 +182,14 @@ function valid_nodes(db::DB)::Bool
     return !errors
 end
 
+function database_warning(db::DB)::Nothing
+    cols = SQLite.columns(db, "Edge")
+    if "subnetwork_id" in cols.name
+        @warn "The 'subnetwork_id' column in the 'Edge' table is deprecated since ribasim v2024.12."
+    end
+    return nothing
+end
+
 """
 Test for each node given its node type whether the nodes that
 # are downstream ('down-edge') of this node are of an allowed type

--- a/core/test/allocation_test.jl
+++ b/core/test/allocation_test.jl
@@ -14,7 +14,8 @@
 
     (; graph, allocation) = p
 
-    allocation.mean_input_flows[(NodeID(:FlowBoundary, 1, p), NodeID(:Basin, 2, p))] = 4.5
+    allocation.mean_input_flows[1][(NodeID(:FlowBoundary, 1, p), NodeID(:Basin, 2, p))] =
+        4.5
     allocation_model = p.allocation.allocation_models[1]
     (; flow) = allocation_model
     u = ComponentVector(; storage = zeros(length(p.basin.node_id)))
@@ -105,11 +106,11 @@ end
 
     # In each subnetwork, the connection from the main network to the subnetwork is
     # interpreted as a source
-    @test Ribasim.get_allocation_model(p, Int32(3)).problem[:source].axes[1] ==
+    @test Ribasim.get_allocation_model(p, Int32(3)).problem[:source_main_network].axes[1] ==
           [(NodeID(:Basin, 2, p), NodeID(:Pump, 11, p))]
-    @test Ribasim.get_allocation_model(p, Int32(5)).problem[:source].axes[1] ==
+    @test Ribasim.get_allocation_model(p, Int32(5)).problem[:source_main_network].axes[1] ==
           [(NodeID(:Basin, 6, p), NodeID(:Pump, 24, p))]
-    @test Ribasim.get_allocation_model(p, Int32(7)).problem[:source].axes[1] ==
+    @test Ribasim.get_allocation_model(p, Int32(7)).problem[:source_main_network].axes[1] ==
           [(NodeID(:Basin, 10, p), NodeID(:Pump, 38, p))]
 end
 
@@ -174,7 +175,7 @@ end
 
     # Running full allocation algorithm
     (; Δt_allocation) = allocation_models[1]
-    mean_input_flows[(NodeID(:FlowBoundary, 1, p), NodeID(:Basin, 2, p))] =
+    mean_input_flows[1][(NodeID(:FlowBoundary, 1, p), NodeID(:Basin, 2, p))] =
         4.5 * Δt_allocation
     Ribasim.update_allocation!(model.integrator)
 
@@ -224,9 +225,9 @@ end
         allocation
     t = 0.0
 
-    # Set flows of sources in
-    mean_input_flows[(NodeID(:FlowBoundary, 58, p), NodeID(:Basin, 16, p))] = 1.0
-    mean_input_flows[(NodeID(:FlowBoundary, 59, p), NodeID(:Basin, 44, p))] = 1e-3
+    # Set flows of sources in subnetworks
+    mean_input_flows[2][(NodeID(:FlowBoundary, 58, p), NodeID(:Basin, 16, p))] = 1.0
+    mean_input_flows[4][(NodeID(:FlowBoundary, 59, p), NodeID(:Basin, 44, p))] = 1e-3
 
     # Collecting demands
     u = ComponentVector(; storage = zeros(length(basin.node_id)))
@@ -251,24 +252,24 @@ end
     du = get_du(model.integrator)
     Ribasim.formulate_storages!(current_storage, du, u, p, t)
 
-    current_storage ≈ Float32[
-        1.0346e6,
-        1.0346e6,
-        1.0346e6,
-        1.0346e6,
-        1.0346e6,
-        13.83,
-        40.10,
-        6.029e5,
-        4641,
-        2402,
-        6.03995,
-        928.8,
-        8.017,
-        10417,
-        5.619,
-        10417,
-        4.057,
+    @test current_storage ≈ Float32[
+        1.0346908f6,
+        1.03469f6,
+        1.0346894f6,
+        1.034689f6,
+        1.0346888f6,
+        13.833241,
+        40.109993,
+        187761.73,
+        4641.365,
+        2402.6687,
+        6.039952,
+        928.84283,
+        8.0175905,
+        10419.247,
+        5.619053,
+        10419.156,
+        4.057502,
     ]
 end
 
@@ -287,7 +288,7 @@ end
     (; user_demand, graph, allocation, basin, level_demand) = p
 
     # Initial "integrated" vertical flux
-    @test allocation.mean_input_flows[(NodeID(:Basin, 2, p), NodeID(:Basin, 2, p))] ≈ 1e2
+    @test allocation.mean_input_flows[1][(NodeID(:Basin, 2, p), NodeID(:Basin, 2, p))] ≈ 1e2
 
     Ribasim.solve!(model)
 
@@ -614,5 +615,5 @@ end
     # Given a max_level of Inf, the basin capacity is 0.0 because it is not possible for the basin level to be > Inf
     @test Ribasim.get_basin_capacity(allocation_models[1], u, p, t, basin.node_id[1]) == 0.0
     @test Ribasim.get_basin_capacity(allocation_models[1], u, p, t, basin.node_id[2]) == 0.0
-    @test Ribasim.get_basin_capacity(allocation_models[1], u, p, t, basin.node_id[3]) == 0.0
+    @test Ribasim.get_basin_capacity(allocation_models[2], u, p, t, basin.node_id[3]) == 0.0
 end

--- a/core/test/validation_test.jl
+++ b/core/test/validation_test.jl
@@ -86,12 +86,7 @@ end
     graph[NodeID(:Pump, 6, 1)] = NodeMetadata(:pump, 9)
 
     function set_edge_metadata!(id_1, id_2, edge_type)
-        graph[id_1, id_2] = EdgeMetadata(;
-            id = 0,
-            type = edge_type,
-            subnetwork_id_source = 0,
-            edge = (id_1, id_2),
-        )
+        graph[id_1, id_2] = EdgeMetadata(; id = 0, type = edge_type, edge = (id_1, id_2))
         return nothing
     end
 
@@ -148,12 +143,7 @@ end
     graph[NodeID(:Basin, 7, 1)] = NodeMetadata(:basin, 0)
 
     function set_edge_metadata!(id_1, id_2, edge_type)
-        graph[id_1, id_2] = EdgeMetadata(;
-            id = 0,
-            type = edge_type,
-            subnetwork_id_source = 0,
-            edge = (id_1, id_2),
-        )
+        graph[id_1, id_2] = EdgeMetadata(; id = 0, type = edge_type, edge = (id_1, id_2))
         return nothing
     end
 

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+- The Edge table no longer supports `subnetwork_id`; this is automatically inferred. [#1956](https://github.com/Deltares/Ribasim/pull/1956)
+
 ## [v2024.11.0] - 2024-10-08
 
 This major new release contains many improvements.

--- a/docs/concept/allocation.qmd
+++ b/docs/concept/allocation.qmd
@@ -42,9 +42,9 @@ The allocation problem is solved per subnetwork, which is given by a subset $S \
 
 Sources are indicated by a set of edges in the subnetwork
 $$
-E_S^\text{source} \subset E.
+E_S^\text{source} \subset E,
 $$
-That is, if $(i,j) \in E_S^\text{source}$, then the average over the last allocation interval $\Delta t_{\text{alloc}}$ of the of the flow over this edge
+which are automatically inferred as all edges that point out of LevelBoundary or FlowBoundary nodes. That is, if $(i,j) \in E_S^\text{source}$, then the average over the last allocation interval $\Delta t_{\text{alloc}}$ of the of the flow over this edge
 $$
     \frac{1}{\Delta t_{\text{alloc}}}\int_{t - \Delta t_{\text{alloc}}}^tQ_{ij}(t') dt'
 $$

--- a/docs/dev/callstacks.qmd
+++ b/docs/dev/callstacks.qmd
@@ -74,10 +74,12 @@ toml_path = normpath(
     @__DIR__,
     "../../generated_testmodels/main_network_with_subnetworks/ribasim.toml",
 )
-config = Ribasim.Config(toml_path; allocation_use_allocation = false)
+config = Ribasim.Config(toml_path)
 db_path = Ribasim.database_path(config)
 db = SQLite.DB(db_path)
 p = Ribasim.Parameters(db, config)
+empty!(p.allocation.subnetwork_ids)
+empty!(p.allocation.main_network_connections)
 graph, verts = tracecall((Ribasim,), Ribasim.initialize_allocation!, (p, config))
 plot_graph(graph)
 ```

--- a/docs/guide/examples.ipynb
+++ b/docs/guide/examples.ipynb
@@ -1203,7 +1203,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.edge.add(model.flow_boundary[1], model.basin[2], subnetwork_id=1)\n",
+    "model.edge.add(model.flow_boundary[1], model.basin[2])\n",
     "model.edge.add(model.basin[2], model.user_demand[3])\n",
     "model.edge.add(model.basin[2], model.linear_resistance[4])\n",
     "model.edge.add(model.linear_resistance[4], model.basin[5])\n",
@@ -1499,7 +1499,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.edge.add(model.flow_boundary[1], model.basin[2], subnetwork_id=2)\n",
+    "model.edge.add(model.flow_boundary[1], model.basin[2])\n",
     "model.edge.add(model.basin[2], model.user_demand[3])\n",
     "model.edge.add(model.level_demand[4], model.basin[2])\n",
     "model.edge.add(model.user_demand[3], model.basin[5])\n",

--- a/docs/reference/usage.qmd
+++ b/docs/reference/usage.qmd
@@ -199,7 +199,7 @@ to_node_type  | String                        | -
 to_node_id    | Int32                         | -
 edge_type     | String                        | must be "flow" or "control"
 geom          | LineString or MultiLineString | (optional)
-name          | String                        | (optional, does not have to be unique)
+name          | String                        | (deprecated)
 subnetwork_id | Int32                         | (optional, denotes source in allocation network)
 
 Similarly to the node table, you can use a geometry to visualize the connections between the

--- a/docs/reference/usage.qmd
+++ b/docs/reference/usage.qmd
@@ -199,8 +199,7 @@ to_node_type  | String                        | -
 to_node_id    | Int32                         | -
 edge_type     | String                        | must be "flow" or "control"
 geom          | LineString or MultiLineString | (optional)
-name          | String                        | (deprecated)
-subnetwork_id | Int32                         | (optional, denotes source in allocation network)
+name          | String                        | (optional, does not have to be unique)
 
 Similarly to the node table, you can use a geometry to visualize the connections between the
 nodes in QGIS. For instance, you can draw a line connecting the two node coordinates.

--- a/python/ribasim/ribasim/geometry/edge.py
+++ b/python/ribasim/ribasim/geometry/edge.py
@@ -91,8 +91,7 @@ class EdgeTable(SpatialTableModel[EdgeSchema]):
         name : str
             An optional name for the edge.
         subnetwork_id : int | None
-            An optional subnetwork id for the edge. This edge indicates a source for
-            the allocation algorithm, and should thus not be set for every edge in a subnetwork.
+            Deprecated: Sources for allocation are automatically inferred and no longer have to be specified in the `Edge` table.
         **kwargs : Dict
         """
         if not can_connect(from_node.node_type, to_node.node_type):

--- a/python/ribasim/ribasim/geometry/edge.py
+++ b/python/ribasim/ribasim/geometry/edge.py
@@ -90,8 +90,6 @@ class EdgeTable(SpatialTableModel[EdgeSchema]):
             The geometry of a line. If not supplied, it creates a straight line between the nodes.
         name : str
             An optional name for the edge.
-        subnetwork_id : int | None
-            Deprecated: Sources for allocation are automatically inferred and no longer have to be specified in the `Edge` table.
         **kwargs : Dict
         """
         if not can_connect(from_node.node_type, to_node.node_type):

--- a/python/ribasim/ribasim/geometry/edge.py
+++ b/python/ribasim/ribasim/geometry/edge.py
@@ -47,7 +47,6 @@ class EdgeSchema(_GeoBaseSchema):
     from_node_id: Series[Int32] = pa.Field(default=0)
     to_node_id: Series[Int32] = pa.Field(default=0)
     edge_type: Series[str] = pa.Field(default="flow")
-    subnetwork_id: Series[pd.Int32Dtype] = pa.Field(default=pd.NA, nullable=True)
     geometry: GeoSeries[LineString] = pa.Field(default=None, nullable=True)
 
     @classmethod
@@ -73,7 +72,6 @@ class EdgeTable(SpatialTableModel[EdgeSchema]):
         to_node: NodeData,
         geometry: LineString | MultiLineString | None = None,
         name: str = "",
-        subnetwork_id: int | None = None,
         edge_id: Optional[NonNegativeInt] = None,
         **kwargs,
     ):
@@ -90,6 +88,8 @@ class EdgeTable(SpatialTableModel[EdgeSchema]):
             The geometry of a line. If not supplied, it creates a straight line between the nodes.
         name : str
             An optional name for the edge.
+        id : int
+            An optional non-negative edge ID. If not supplied, it will be automatically generated.
         **kwargs : Dict
         """
         if not can_connect(from_node.node_type, to_node.node_type):
@@ -120,7 +120,6 @@ class EdgeTable(SpatialTableModel[EdgeSchema]):
                 "to_node_id": [to_node.node_id],
                 "edge_type": [edge_type],
                 "name": [name],
-                "subnetwork_id": [subnetwork_id],
                 **kwargs,
             },
             geometry=geometry_to_append,

--- a/python/ribasim/ribasim/migrations.py
+++ b/python/ribasim/ribasim/migrations.py
@@ -27,6 +27,9 @@ def edgeschema_migration(gdf: GeoDataFrame, schema_version: int) -> GeoDataFrame
         warnings.warn("Migrating outdated Edge table.", UserWarning)
         assert gdf["edge_id"].is_unique, "Edge IDs have to be unique."
         gdf.set_index("edge_id", inplace=True)
+    if "subnetwork_id" in gdf.columns and schema_version == 0:
+        warnings.warn("Migrating outdated Edge table.", UserWarning)
+        gdf.drop(columns="subnetwork_id", inplace = True, errors = "ignore")
 
     return gdf
 

--- a/python/ribasim/ribasim/migrations.py
+++ b/python/ribasim/ribasim/migrations.py
@@ -27,7 +27,7 @@ def edgeschema_migration(gdf: GeoDataFrame, schema_version: int) -> GeoDataFrame
         warnings.warn("Migrating outdated Edge table.", UserWarning)
         assert gdf["edge_id"].is_unique, "Edge IDs have to be unique."
         gdf.set_index("edge_id", inplace=True)
-    if "subnetwork_id" in gdf.columns and schema_version == 0:
+    if "subnetwork_id" in gdf.columns:
         warnings.warn("Migrating outdated Edge table.", UserWarning)
         gdf.drop(columns="subnetwork_id", inplace=True, errors="ignore")
 

--- a/python/ribasim/ribasim/migrations.py
+++ b/python/ribasim/ribasim/migrations.py
@@ -29,7 +29,7 @@ def edgeschema_migration(gdf: GeoDataFrame, schema_version: int) -> GeoDataFrame
         gdf.set_index("edge_id", inplace=True)
     if "subnetwork_id" in gdf.columns and schema_version == 0:
         warnings.warn("Migrating outdated Edge table.", UserWarning)
-        gdf.drop(columns="subnetwork_id", inplace = True, errors = "ignore")
+        gdf.drop(columns="subnetwork_id", inplace=True, errors="ignore")
 
     return gdf
 

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -307,7 +307,7 @@ class Model(FileModel):
         if self.use_validation:
             self._validate_model()
 
-        if self.edge.df.subnetwork_id.notna().any():
+        if self.edge.df is not None and self.edge.df["subnetwork_id"].notna().any():
             warnings.warn(
                 "Sources for allocation are automatically inferred and no longer have to be specified in the `Edge` table.",
                 DeprecationWarning,

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -1,7 +1,6 @@
 import datetime
 import logging
 import shutil
-import warnings
 from collections.abc import Generator
 from os import PathLike
 from pathlib import Path

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import shutil
+import warnings
 from collections.abc import Generator
 from os import PathLike
 from pathlib import Path
@@ -69,6 +70,8 @@ try:
     import xugrid
 except ImportError:
     xugrid = MissingOptionalModule("xugrid")
+
+warnings.simplefilter("always", DeprecationWarning)
 
 
 class Model(FileModel):
@@ -303,6 +306,12 @@ class Model(FileModel):
 
         if self.use_validation:
             self._validate_model()
+
+        if self.edge.df.subnetwork_id.notna().any():
+            warnings.warn(
+                "Sources for allocation are automatically inferred and no longer have to be specified in the `Edge` table.",
+                DeprecationWarning,
+            )
 
         filepath = Path(filepath)
         self.filepath = filepath

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -71,8 +71,6 @@ try:
 except ImportError:
     xugrid = MissingOptionalModule("xugrid")
 
-warnings.simplefilter("always", DeprecationWarning)
-
 
 class Model(FileModel):
     """A model of inland water resources systems."""
@@ -306,12 +304,6 @@ class Model(FileModel):
 
         if self.use_validation:
             self._validate_model()
-
-        if self.edge.df is not None and self.edge.df["subnetwork_id"].notna().any():
-            warnings.warn(
-                "Sources for allocation are automatically inferred and no longer have to be specified in the `Edge` table.",
-                DeprecationWarning,
-            )
 
         filepath = Path(filepath)
         self.filepath = filepath

--- a/python/ribasim/tests/test_model.py
+++ b/python/ribasim/tests/test_model.py
@@ -145,7 +145,6 @@ def test_edge_table(basic):
     df = model.edge.df
     assert df.geometry.is_unique
     assert df.from_node_id.dtype == np.int32
-    assert df.subnetwork_id.dtype == pd.Int32Dtype()
     assert df.crs == CRS.from_epsg(28992)
 
 

--- a/python/ribasim_testmodels/ribasim_testmodels/allocation.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/allocation.py
@@ -154,7 +154,7 @@ def subnetwork_model() -> Model:
     )
     model.outlet.add(Node(13, Point(2, 4), subnetwork_id=2), outlet_data)
 
-    model.edge.add(model.flow_boundary[1], model.basin[2], subnetwork_id=2)
+    model.edge.add(model.flow_boundary[1], model.basin[2])
     model.edge.add(model.basin[2], model.outlet[3])
     model.edge.add(model.outlet[3], model.terminal[4])
     model.edge.add(model.basin[2], model.user_demand[10])
@@ -269,7 +269,7 @@ def looped_subnetwork_model() -> Model:
         ],
     )
 
-    model.edge.add(model.flow_boundary[5], model.basin[2], subnetwork_id=2)
+    model.edge.add(model.flow_boundary[5], model.basin[2])
     model.edge.add(model.basin[2], model.outlet[3])
     model.edge.add(model.outlet[3], model.terminal[4])
     model.edge.add(model.basin[2], model.user_demand[1])
@@ -348,7 +348,7 @@ def minimal_subnetwork_model() -> Model:
         ],
     )
 
-    model.edge.add(model.flow_boundary[1], model.basin[2], subnetwork_id=2)
+    model.edge.add(model.flow_boundary[1], model.basin[2])
     model.edge.add(model.basin[2], model.pump[3])
     model.edge.add(model.pump[3], model.basin[4])
     model.edge.add(model.basin[4], model.user_demand[5])
@@ -409,7 +409,7 @@ def allocation_example_model() -> Model:
     )
     model.terminal.add(Node(8, Point(5, 0), subnetwork_id=2))
 
-    model.edge.add(model.flow_boundary[1], model.basin[2], subnetwork_id=2)
+    model.edge.add(model.flow_boundary[1], model.basin[2])
     model.edge.add(model.basin[2], model.user_demand[3])
     model.edge.add(model.basin[2], model.linear_resistance[4])
     model.edge.add(model.linear_resistance[4], model.basin[5])
@@ -632,7 +632,7 @@ def main_network_with_subnetworks_model() -> Model:
         [user_demand.Static(return_factor=[0.9], priority=2, min_level=0.0)],
     )
 
-    model.edge.add(model.flow_boundary[1], model.basin[2], subnetwork_id=1)
+    model.edge.add(model.flow_boundary[1], model.basin[2])
     model.edge.add(model.basin[2], model.linear_resistance[3])
     model.edge.add(model.linear_resistance[3], model.basin[4])
     model.edge.add(model.basin[4], model.linear_resistance[5])
@@ -690,9 +690,9 @@ def main_network_with_subnetworks_model() -> Model:
     model.edge.add(model.user_demand[53], model.basin[50])
     model.edge.add(model.basin[44], model.user_demand[57])
     model.edge.add(model.user_demand[57], model.basin[44])
-    model.edge.add(model.basin[2], model.pump[11], subnetwork_id=3)
-    model.edge.add(model.basin[6], model.pump[24], subnetwork_id=5)
-    model.edge.add(model.basin[10], model.pump[38], subnetwork_id=7)
+    model.edge.add(model.basin[2], model.pump[11])
+    model.edge.add(model.basin[6], model.pump[24])
+    model.edge.add(model.basin[10], model.pump[38])
     model.edge.add(model.basin[8], model.user_demand[60])
     model.edge.add(model.user_demand[60], model.basin[8])
 
@@ -713,8 +713,8 @@ def subnetworks_with_sources_model() -> Model:
         [flow_boundary.Static(flow_rate=[0.003])],
     )
 
-    model.edge.add(model.flow_boundary[58], model.basin[16], subnetwork_id=3)
-    model.edge.add(model.flow_boundary[59], model.basin[44], subnetwork_id=7)
+    model.edge.add(model.flow_boundary[58], model.basin[16])
+    model.edge.add(model.flow_boundary[59], model.basin[44])
 
     return model
 
@@ -769,7 +769,7 @@ def level_demand_model() -> Model:
         [basin.Profile(area=1000.0, level=[0.0, 1.0]), basin.State(level=[2.0])],
     )
 
-    model.edge.add(model.flow_boundary[1], model.basin[2], subnetwork_id=2)
+    model.edge.add(model.flow_boundary[1], model.basin[2])
     model.edge.add(model.basin[2], model.user_demand[3])
     model.edge.add(model.level_demand[4], model.basin[2])
     model.edge.add(model.user_demand[3], model.basin[5])
@@ -842,7 +842,6 @@ def flow_demand_model() -> Model:
     model.edge.add(
         model.level_boundary[1],
         model.tabulated_rating_curve[2],
-        subnetwork_id=2,
     )
     model.edge.add(model.tabulated_rating_curve[2], model.basin[3])
     model.edge.add(model.basin[3], model.user_demand[4])
@@ -885,7 +884,7 @@ def linear_resistance_demand_model():
         [flow_demand.Static(priority=[1], demand=2.0)],
     )
 
-    model.edge.add(model.basin[1], model.linear_resistance[2], subnetwork_id=1)
+    model.edge.add(model.basin[1], model.linear_resistance[2])
     model.edge.add(model.linear_resistance[2], model.basin[3])
     model.edge.add(model.flow_demand[4], model.linear_resistance[2])
 
@@ -978,7 +977,7 @@ def fair_distribution_model():
         ],
     )
 
-    model.edge.add(model.level_boundary[1], model.pump[2], subnetwork_id=1)
+    model.edge.add(model.level_boundary[1], model.pump[2])
     model.edge.add(model.pump[2], model.basin[3])
     model.edge.add(model.basin[3], model.linear_resistance[4])
     model.edge.add(model.linear_resistance[4], model.basin[5])

--- a/python/ribasim_testmodels/ribasim_testmodels/invalid.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/invalid.py
@@ -216,7 +216,6 @@ def invalid_priorities_model() -> Model:
     model.edge.add(
         model.level_boundary[1],
         model.tabulated_rating_curve[2],
-        subnetwork_id=2,
     )
     model.edge.add(model.tabulated_rating_curve[2], model.basin[3])
     model.edge.add(model.basin[3], model.user_demand[4])

--- a/ribasim_qgis/core/nodes.py
+++ b/ribasim_qgis/core/nodes.py
@@ -253,7 +253,6 @@ class Edge(Input):
             QgsField("from_node_id", QVariant.Int),
             QgsField("to_node_id", QVariant.Int),
             QgsField("edge_type", QVariant.String),
-            QgsField("subnetwork_id", QVariant.Int),
         ]
 
     @classmethod


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/1953.

To do: come up with a unified way to handle deprecation, and incorporate this in the developer docs and release process. Maybe also use a 'deprecation' label instead of a 'breaking' label? 