### PR TITLE
Remove unused outstate config option

### DIFF
--- a/core/src/config.jl
+++ b/core/src/config.jl
@@ -119,7 +119,6 @@ end
 
 # Separate struct, as basin clashes with nodetype
 @option struct Results <: TableOption
-    outstate::Union{String, Nothing} = nothing
     compression::Bool = true
     compression_level::Int = 6
     subgrid::Bool = false

--- a/core/test/docs.toml
+++ b/core/test/docs.toml
@@ -45,9 +45,9 @@ evaporate_mass = true  # optional, default true to simulate a correct mass balan
 verbosity = "info" # optional, default "info", can otherwise be "debug", "warn" or "error"
 
 [results]
-# These results files are always written
-compression = true  # optional, default true, using zstd compression
+compression = true    # optional, default true, using zstd compression
 compression_level = 6 # optional, default 6
+subgrid = false       # optional, default false
 
 [experimental]
 # Experimental features, disabled by default

--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -71,7 +71,6 @@ class Allocation(ChildModel):
 
 
 class Results(ChildModel):
-    outstate: str | None = None
     compression: bool = True
     compression_level: int = 6
     subgrid: bool = False


### PR DESCRIPTION
Also the `subgrid` option was missing in the `docs.toml`. It is documented though, `outstate` was not.