### PR TITLE
Put level as the first column in basin.arrow

### DIFF
--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -119,8 +119,8 @@ function basin_table(
 )::@NamedTuple{
     time::Vector{DateTime},
     node_id::Vector{Int32},
-    storage::Vector{Float64},
     level::Vector{Float64},
+    storage::Vector{Float64},
     inflow_rate::Vector{Float64},
     outflow_rate::Vector{Float64},
     storage_rate::Vector{Float64},
@@ -167,8 +167,8 @@ function basin_table(
     return (;
         time,
         node_id,
-        storage,
         level,
+        storage,
         inflow_rate,
         outflow_rate,
         storage_rate,

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -45,8 +45,8 @@
             (
                 :time,
                 :node_id,
-                :storage,
                 :level,
+                :storage,
                 :inflow_rate,
                 :outflow_rate,
                 :storage_rate,

--- a/docs/reference/usage.qmd
+++ b/docs/reference/usage.qmd
@@ -230,8 +230,8 @@ column         | type     | unit
 -------------- | ---------| ----
 time           | DateTime | -
 node_id        | Int32    | -
-storage        | Float64  | $\text{m}^3$
 level          | Float64  | $\text{m}$
+storage        | Float64  | $\text{m}^3$
 inflow_rate    | Float64  | $\text{m}^3/\text{s}$
 outflow_rate   | Float64  | $\text{m}^3/\text{s}$
 storage_rate   | Float64  | $\text{m}^3/\text{s}$


### PR DESCRIPTION
The iMOD timeseries plugin shows the first column by default. That is storage. Most users want to view level first, and have to switch manually. So this simply puts level first, such that we get:

![image](https://github.com/user-attachments/assets/92e5ae0e-a704-45fd-bf5a-09c35008f8a7)