### PR TITLE
Add `Basin / subgrid_time` table

### DIFF
--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -65,6 +65,7 @@ using PreallocationTools: LazyBufferCache
 # basin profiles and TabulatedRatingCurve. See also the node
 # references in the docs.
 using DataInterpolations:
+    ConstantInterpolation,
     LinearInterpolation,
     LinearInterpolationIntInv,
     invert_integral,

--- a/core/src/callback.jl
+++ b/core/src/callback.jl
@@ -676,18 +676,23 @@ function update_subgrid_level!(integrator)::Nothing
     basin_level = p.basin.current_properties.current_level[parent(du)]
     subgrid = integrator.p.subgrid
 
-    i = 0
     # First update the all the subgrids with static h(h) relations
-    for (index, hh_itp) in zip(subgrid.basin_index, subgrid.interpolations)
-        i += 1
-        subgrid.level[i] = hh_itp(basin_level[index])
+    for (level_index, basin_index, hh_itp) in zip(
+        subgrid.level_index_static,
+        subgrid.basin_index_static,
+        subgrid.interpolations_static,
+    )
+        subgrid.level[level_index] = hh_itp(basin_level[basin_index])
     end
     # Then update the subgrids with dynamic h(h) relations
-    for (index, lookup) in zip(subgrid.basin_index_time, current_interpolation_index)
-        i += 1
+    for (level_index, basin_index, lookup) in zip(
+        subgrid.level_index_time,
+        subgrid.basin_index_time,
+        subgrid.current_interpolation_index,
+    )
         itp_index = lookup(t)
         hh_itp = subgrid.interpolations_time[itp_index]
-        subgrid.level[i] = hh_itp(basin_level[index])
+        subgrid.level[level_index] = hh_itp(basin_level[basin_index])
     end
 end
 

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -115,7 +115,7 @@ const ScalarInterpolation = LinearInterpolation{
     (1,),
 }
 
-"ConstantInterpolation from a Float64 to an Int, used to look up indices"
+"ConstantInterpolation from a Float64 to an Int, used to look up indices over time"
 const IndexLookup =
     ConstantInterpolation{Vector{Int64}, Vector{Float64}, Vector{Float64}, Int64, (1,)}
 
@@ -881,9 +881,11 @@ end
 
 "Subgrid linearly interpolates basin levels."
 @kwdef struct Subgrid
-    # level of each subgrid (static and dynamic) ordered by subgrid_id
+    # current level of each subgrid (static and dynamic) ordered by subgrid_id
     level::Vector{Float64}
-    # static
+
+    # Static part
+    # Static subgrid ids
     subgrid_id_static::Vector{Int32}
     # index into the basin.current_level vector for each static subgrid_id
     basin_index_static::Vector{Int}
@@ -891,7 +893,9 @@ end
     level_index_static::Vector{Int}
     # per subgrid one relation
     interpolations_static::Vector{ScalarInterpolation}
-    # dynamic
+
+    # Dynamic part
+    # Dynamic subgrid ids
     subgrid_id_time::Vector{Int32}
     # index into the basin.current_level vector for each dynamic subgrid_id
     basin_index_time::Vector{Int}

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -881,16 +881,22 @@ end
 
 "Subgrid linearly interpolates basin levels."
 @kwdef struct Subgrid
-    # cache the current level for static subgrids followed by dynamic subgrids
+    # level of each subgrid (static and dynamic) ordered by subgrid_id
     level::Vector{Float64}
     # static
-    subgrid_id::Vector{Int32}
-    basin_index::Vector{Int32}
+    subgrid_id_static::Vector{Int32}
+    # index into the basin.current_level vector for each static subgrid_id
+    basin_index_static::Vector{Int}
+    # index into the subgrid.level vector for each static subgrid_id
+    level_index_static::Vector{Int}
     # per subgrid one relation
-    interpolations::Vector{ScalarInterpolation}
+    interpolations_static::Vector{ScalarInterpolation}
     # dynamic
     subgrid_id_time::Vector{Int32}
-    basin_index_time::Vector{Int32}
+    # index into the basin.current_level vector for each dynamic subgrid_id
+    basin_index_time::Vector{Int}
+    # index into the subgrid.level vector for each dynamic subgrid_id
+    level_index_time::Vector{Int}
     # per subgrid n relations, n being the number of timesteps for that subgrid
     interpolations_time::Vector{ScalarInterpolation}
     # per subgrid 1 lookup from t to an index in interpolations_time

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -105,6 +105,7 @@ end
 
 Base.to_index(id::NodeID) = Int(id.value)
 
+"LinearInterpolation from a Float64 to a Float64"
 const ScalarInterpolation = LinearInterpolation{
     Vector{Float64},
     Vector{Float64},
@@ -113,6 +114,10 @@ const ScalarInterpolation = LinearInterpolation{
     Float64,
     (1,),
 }
+
+"ConstantInterpolation from a Float64 to an Int, used to look up indices"
+const IndexLookup =
+    ConstantInterpolation{Vector{Int64}, Vector{Float64}, Vector{Float64}, Int64, (1,)}
 
 set_zero!(v) = v .= zero(eltype(v))
 const Cache = LazyBufferCache{Returns{Int}, typeof(set_zero!)}
@@ -876,10 +881,20 @@ end
 
 "Subgrid linearly interpolates basin levels."
 @kwdef struct Subgrid
+    # cache the current level for static subgrids followed by dynamic subgrids
+    level::Vector{Float64}
+    # static
     subgrid_id::Vector{Int32}
     basin_index::Vector{Int32}
+    # per subgrid one relation
     interpolations::Vector{ScalarInterpolation}
-    level::Vector{Float64}
+    # dynamic
+    subgrid_id_time::Vector{Int32}
+    basin_index_time::Vector{Int32}
+    # per subgrid n relations, n being the number of timesteps for that subgrid
+    interpolations_time::Vector{ScalarInterpolation}
+    # per subgrid 1 lookup from t to an index in interpolations_time
+    current_interpolation_index::Vector{IndexLookup}
 end
 
 """

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -201,7 +201,7 @@ function static_and_time_node_ids(
     db::DB,
     static::StructVector,
     time::StructVector,
-    node_type::NodeType.T,
+    node_type::NodeType.T;
     is_complete::Bool = true,
 )::Tuple{Set{NodeID}, Set{NodeID}, Vector{NodeID}, Bool}
     node_ids = get_node_ids(db, node_type)

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -188,7 +188,7 @@ function parse_static_and_time(
 end
 
 """
-Validate the split of node IDs between static and time tables.
+Retrieve and validate the split of node IDs between static and time tables.
 
 For node types that can have a part of the parameters defined statically and a part dynamically,
 this checks if each ID is defined exactly once in either table.

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -1258,7 +1258,7 @@ function Subgrid(db::DB, config::Config, basin::Basin)::Subgrid
 
     # Since not all Basins need to have subgrids, don't enforce completeness.
     _, _, _, valid =
-        static_and_time_node_ids(db, static, time, "Basin"; is_complete = false)
+        static_and_time_node_ids(db, static, time, NodeType.Basin; is_complete = false)
     if !valid
         error("Problems encountered when parsing Subgrid static and time node IDs.")
     end

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -1351,7 +1351,6 @@ function Subgrid(db::DB, config::Config, basin::Basin)::Subgrid
         push_lookup!(current_interpolation_index, lookup_index, lookup_time)
     end
 
-    has_error && error("Invalid Basin / subgrid_time table.")
     level = fill(NaN, length(subgrid_id_static) + length(subgrid_id_time))
 
     # Find the level indices

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -187,6 +187,12 @@ function parse_static_and_time(
     return out, !errors
 end
 
+"""
+Validate the split of node IDs between static and time tables.
+
+For node types that can have a part of the parameters defined statically and a part dynamically,
+this checks if each ID is defined exactly once in either table.
+"""
 function static_and_time_node_ids(
     db::DB,
     static::StructVector,

--- a/core/src/schema.jl
+++ b/core/src/schema.jl
@@ -10,6 +10,7 @@
 @schema "ribasim.basin.profile" BasinProfile
 @schema "ribasim.basin.state" BasinState
 @schema "ribasim.basin.subgrid" BasinSubgrid
+@schema "ribasim.basin.subgridtime" BasinSubgridTime
 @schema "ribasim.basin.concentration" BasinConcentration
 @schema "ribasim.basin.concentrationexternal" BasinConcentrationExternal
 @schema "ribasim.basin.concentrationstate" BasinConcentrationState
@@ -58,8 +59,12 @@ function nodetype(
     type_string = string(T)
     elements = split(type_string, '.'; limit = 3)
     last_element = last(elements)
+    # Special case last elements that need an underscore
     if startswith(last_element, "concentration") && length(last_element) > 13
         elements[end] = "concentration_$(last_element[14:end])"
+    end
+    if last_element == "subgridtime"
+        elements[end] = "subgrid_time"
     end
     if isnode(sv)
         n = elements[2]
@@ -146,6 +151,14 @@ end
 @version BasinSubgridV1 begin
     subgrid_id::Int32
     node_id::Int32
+    basin_level::Float64
+    subgrid_level::Float64
+end
+
+@version BasinSubgridTimeV1 begin
+    subgrid_id::Int32
+    node_id::Int32
+    time::DateTime
     basin_level::Float64
     subgrid_level::Float64
 end

--- a/core/src/schema.jl
+++ b/core/src/schema.jl
@@ -62,8 +62,7 @@ function nodetype(
     # Special case last elements that need an underscore
     if startswith(last_element, "concentration") && length(last_element) > 13
         elements[end] = "concentration_$(last_element[14:end])"
-    end
-    if last_element == "subgridtime"
+    elseif last_element == "subgridtime"
         elements[end] = "subgrid_time"
     end
     if isnode(sv)

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -321,8 +321,8 @@ Validate the entries for a single subgrid element.
 """
 function valid_subgrid(
     subgrid_id::Int32,
-    node_id::NodeID,
-    node_to_basin::Dict{NodeID, Int},
+    node_id::Int32,
+    node_to_basin::Dict{Int32, Int},
     basin_level::Vector{Float64},
     subgrid_level::Vector{Float64},
 )::Bool

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -376,11 +376,14 @@ function subgrid_level_table(
     (; t, saveval) = saved.subgrid_level
     subgrid = integrator.p.subgrid
 
-    nelem = length(subgrid.subgrid_id)
+    nelem = length(subgrid.level)
     ntsteps = length(t)
 
     time = repeat(datetime_since.(t, config.starttime); inner = nelem)
-    subgrid_id = repeat(subgrid.subgrid_id; outer = ntsteps)
+    subgrid_id = repeat(
+        sort(vcat(subgrid.subgrid_id_static, subgrid.subgrid_id_time));
+        outer = ntsteps,
+    )
     subgrid_level = FlatVector(saveval)
     return (; time, subgrid_id, subgrid_level)
 end
@@ -412,9 +415,9 @@ function write_arrow(
     mkpath(dirname(path))
     try
         Arrow.write(path, table; compress, metadata)
-    catch
+    catch e
         @error "Failed to write results, file may be locked." path
-        error("Failed to write results.")
+        rethrow(e)
     end
     return nothing
 end

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -607,4 +607,5 @@ end
     basin_level = copy(BMI.get_value_ptr(model, "basin.level"))
     basin_level[2] += 1
     @test basin_level ≈ df.subgrid_level[(end - 1):end]
+    @test basin_level ≈ model.integrator.p.subgrid.level
 end

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -597,6 +597,7 @@ end
     @test nrow(df) == ntime * 2
     @test df.subgrid_id == repeat(1:2; outer = ntime)
     @test extrema(df.time) == (DateTime(2020), DateTime(2021))
+    @test allunique(df.time[1:2:(end - 1)])
     @test all(df.subgrid_level[1:2] .== 0.01)
 
     # After a month the h(h) of subgrid_id 2 increases by a meter

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -583,3 +583,28 @@ end
     @test all(isapprox.(Δinf[1:2:end], 25.0; atol = 1e-10))
     @test all(Δinf[2:2:end] .== 0.0)
 end
+
+@testitem "two_basin" begin
+    using DataFrames: DataFrame, nrow
+    using Dates: DateTime
+    import BasicModelInterface as BMI
+
+    toml_path = normpath(@__DIR__, "../../generated_testmodels/two_basin/ribasim.toml")
+    model = Ribasim.run(toml_path)
+    df = DataFrame(Ribasim.subgrid_level_table(model))
+
+    ntime = 367
+    @test nrow(df) == ntime * 2
+    @test df.subgrid_id == repeat(1:2; outer = ntime)
+    @test extrema(df.time) == (DateTime(2020), DateTime(2021))
+    @test all(df.subgrid_level[1:2] .== 0.01)
+
+    # After a month the h(h) of subgrid_id 2 increases by a meter
+    i_change = searchsortedfirst(df.time, DateTime(2020, 2))
+    @test df.subgrid_level[i_change + 1] - df.subgrid_level[i_change - 1] ≈ 1.0f0
+
+    # Besides the 1 meter shift the h(h) relations are 1:1
+    basin_level = copy(BMI.get_value_ptr(model, "basin.level"))
+    basin_level[2] += 1
+    @test basin_level ≈ df.subgrid_level[(end - 1):end]
+end

--- a/core/test/validation_test.jl
+++ b/core/test/validation_test.jl
@@ -285,30 +285,24 @@ end
     using Ribasim: valid_subgrid, NodeID
     using Logging
 
-    node_to_basin = Dict(NodeID(:Basin, 9, 1) => 1)
+    node_to_basin = Dict(Int32(9) => 1)
 
     logger = TestLogger()
     with_logger(logger) do
-        @test !valid_subgrid(
-            Int32(1),
-            NodeID(:Basin, 10, 1),
-            node_to_basin,
-            [-1.0, 0.0],
-            [-1.0, 0.0],
-        )
+        @test !valid_subgrid(Int32(1), Int32(10), node_to_basin, [-1.0, 0.0], [-1.0, 0.0])
     end
 
     @test length(logger.logs) == 1
     @test logger.logs[1].level == Error
     @test logger.logs[1].message == "The node_id of the Basin / subgrid does not exist."
-    @test logger.logs[1].kwargs[:node_id] == NodeID(:Basin, 10, 1)
+    @test logger.logs[1].kwargs[:node_id] == Int32(10)
     @test logger.logs[1].kwargs[:subgrid_id] == 1
 
     logger = TestLogger()
     with_logger(logger) do
         @test !valid_subgrid(
             Int32(1),
-            NodeID(:Basin, 9, 1),
+            Int32(9),
             node_to_basin,
             [-1.0, 0.0, 0.0],
             [-1.0, 0.0, 0.0],

--- a/docs/reference/node/basin.qmd
+++ b/docs/reference/node/basin.qmd
@@ -395,7 +395,7 @@ Generally, to create physically meaningful subgrid water levels, the subgrid tab
 
 This table is the transient form of the Subgrid table.
 The only difference is that a time column is added.
-The table must by sorted by time, and per time it must be sorted by `subgrid_id`.
+The table must by sorted by `subgrid_id`, and per `subgrid_id` it must be sorted by `time`.
 With this the subgrid relations can be updated over time.
 Note that a `node_id` can be either in this table or in the static one, but not both.
 That means for each Basin all subgrid relations are either static or dynamic.

--- a/docs/reference/node/basin.qmd
+++ b/docs/reference/node/basin.qmd
@@ -228,7 +228,7 @@ ax.legend()
 
 for converting the initial state in terms of levels to an initial state in terms of storages used in the core.
 
-#### Interactive basin example
+#### Interactive Basin example
 
 The profile data is not detailed enough to create a full 3D picture of the basin. However, if we assume the profile data is for a stretch of canal of given length, the following plot shows a cross section of the basin.
 ```{python}
@@ -391,6 +391,15 @@ Water levels beyond the last `basin_level` are linearly extrapolated.
 Note that the interpolation to subgrid water level is not constrained by any water balance within Ribasim.
 Generally, to create physically meaningful subgrid water levels, the subgrid table must be parametrized properly such that the spatially integrated water volume of the subgrid elements agrees with the total storage volume of the basin.
 
+## Subgrid time
+
+This table is the transient form of the Subgrid table.
+The only difference is that a time column is added.
+The table must by sorted by time, and per time it must be sorted by `subgrid_id`.
+With this the subgrid relations can be updated over time.
+Note that a `node_id` can be either in this table or in the static one, but not both.
+That means for each Basin all subgrid relations are either static or dynamic.
+
 ## Concentration {#sec-basin-conc}
 This table defines the concentration of substances for the inflow boundaries of a Basin node.
 
@@ -402,7 +411,7 @@ substance     | String   |                          | can correspond to known De
 drainage      | Float64  | $\text{g}/\text{m}^3$    | (optional)
 precipitation | Float64  | $\text{g}/\text{m}^3$    | (optional)
 
-## ConcentrationState {#sec-basin-conc-state}
+## Concentration state {#sec-basin-conc-state}
 This table defines the concentration of substances in the Basin at the start of the simulation.
 
 column         | type     | unit                     | restriction
@@ -411,7 +420,7 @@ node_id        | Int32    | -                        | sorted
 substance      | String   | -                        | can correspond to known Delwaq substances
 concentration  | Float64  | $\text{g}/\text{m}^3$    |
 
-## ConcentrationExternal
+## Concentration external
 This table is used for (external) concentrations, that can be used for Control lookups.
 
 column         | type     | unit                     | restriction

--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -23,6 +23,7 @@ from ribasim.schemas import (
     BasinStateSchema,
     BasinStaticSchema,
     BasinSubgridSchema,
+    BasinSubgridTimeSchema,
     BasinTimeSchema,
     ContinuousControlFunctionSchema,
     ContinuousControlVariableSchema,
@@ -404,6 +405,10 @@ class Basin(MultiNodeModel):
     subgrid: TableModel[BasinSubgridSchema] = Field(
         default_factory=TableModel[BasinSubgridSchema],
         json_schema_extra={"sort_keys": ["subgrid_id", "basin_level"]},
+    )
+    subgrid_time: TableModel[BasinSubgridTimeSchema] = Field(
+        default_factory=TableModel[BasinSubgridTimeSchema],
+        json_schema_extra={"sort_keys": ["subgrid_id", "time", "basin_level"]},
     )
     area: SpatialTableModel[BasinAreaSchema] = Field(
         default_factory=SpatialTableModel[BasinAreaSchema],

--- a/python/ribasim/ribasim/nodes/basin.py
+++ b/python/ribasim/ribasim/nodes/basin.py
@@ -8,6 +8,7 @@ from ribasim.schemas import (
     BasinStateSchema,
     BasinStaticSchema,
     BasinSubgridSchema,
+    BasinSubgridTimeSchema,
     BasinTimeSchema,
 )
 
@@ -18,6 +19,7 @@ __all__ = [
     "State",
     "Static",
     "Subgrid",
+    "SubgridTime",
     "Time",
 ]
 
@@ -39,6 +41,10 @@ class Profile(TableModel[BasinProfileSchema]):
 
 
 class Subgrid(TableModel[BasinSubgridSchema]):
+    pass
+
+
+class SubgridTime(TableModel[BasinSubgridTimeSchema]):
     pass
 
 

--- a/python/ribasim/ribasim/schemas.py
+++ b/python/ribasim/ribasim/schemas.py
@@ -116,6 +116,25 @@ class BasinStaticSchema(_BaseSchema):
     )
 
 
+class BasinSubgridTimeSchema(_BaseSchema):
+    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    subgrid_id: Series[Annotated[pd.ArrowDtype, pyarrow.int32()]] = pa.Field(
+        nullable=False
+    )
+    node_id: Series[Annotated[pd.ArrowDtype, pyarrow.int32()]] = pa.Field(
+        nullable=False, default=0
+    )
+    time: Series[Annotated[pd.ArrowDtype, pyarrow.timestamp("ms")]] = pa.Field(
+        nullable=False
+    )
+    basin_level: Series[Annotated[pd.ArrowDtype, pyarrow.float64()]] = pa.Field(
+        nullable=False
+    )
+    subgrid_level: Series[Annotated[pd.ArrowDtype, pyarrow.float64()]] = pa.Field(
+        nullable=False
+    )
+
+
 class BasinSubgridSchema(_BaseSchema):
     fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
     subgrid_id: Series[Annotated[pd.ArrowDtype, pyarrow.int32()]] = pa.Field(

--- a/python/ribasim_testmodels/ribasim_testmodels/two_basin.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/two_basin.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from ribasim.config import Node
+from ribasim.config import Node, Results
 from ribasim.input_base import TableModel
 from ribasim.model import Model
 from ribasim.nodes import basin, flow_boundary, tabulated_rating_curve
@@ -18,7 +18,12 @@ def two_basin_model() -> Model:
     infiltrates in the left basin, and exfiltrates in the right basin.
     The right basin fills up and discharges over the rating curve.
     """
-    model = Model(starttime="2020-01-01", endtime="2021-01-01", crs="EPSG:28992")
+    model = Model(
+        starttime="2020-01-01",
+        endtime="2021-01-01",
+        crs="EPSG:28992",
+        results=Results(subgrid=True),
+    )
 
     model.flow_boundary.add(
         Node(1, Point(0, 0)), [flow_boundary.Static(flow_rate=[1e-2])]

--- a/python/ribasim_testmodels/ribasim_testmodels/two_basin.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/two_basin.py
@@ -44,10 +44,12 @@ def two_basin_model() -> Model:
         Node(3, Point(750, 0)),
         [
             *basin_shared,
-            basin.Subgrid(
+            # Raise the subgrid levels by a meter after a month
+            basin.SubgridTime(
                 subgrid_id=2,
-                basin_level=[0.0, 1.0],
-                subgrid_level=[0.0, 1.0],
+                time=["2020-01-01", "2020-01-01", "2020-02-01", "2020-02-01"],
+                basin_level=[0.0, 1.0, 0.0, 1.0],
+                subgrid_level=[0.0, 1.0, 1.0, 2.0],
                 meta_x=750.0,
                 meta_y=0.0,
             ),

--- a/ribasim_qgis/core/nodes.py
+++ b/ribasim_qgis/core/nodes.py
@@ -348,8 +348,8 @@ class BasinTime(Input):
     @classmethod
     def attributes(cls) -> list[QgsField]:
         return [
-            QgsField("time", QVariant.DateTime),
             QgsField("node_id", QVariant.Int),
+            QgsField("time", QVariant.DateTime),
             QgsField("drainage", QVariant.Double),
             QgsField("potential_evaporation", QVariant.Double),
             QgsField("infiltration", QVariant.Double),
@@ -369,8 +369,8 @@ class BasinConcentrationExternal(Input):
     @classmethod
     def attributes(cls) -> list[QgsField]:
         return [
-            QgsField("time", QVariant.DateTime),
             QgsField("node_id", QVariant.Int),
+            QgsField("time", QVariant.DateTime),
             QgsField("substance", QVariant.String),
             QgsField("concentration", QVariant.Double),
         ]
@@ -388,8 +388,8 @@ class BasinConcentrationState(Input):
     @classmethod
     def attributes(cls) -> list[QgsField]:
         return [
-            QgsField("time", QVariant.DateTime),
             QgsField("node_id", QVariant.Int),
+            QgsField("time", QVariant.DateTime),
             QgsField("substance", QVariant.String),
             QgsField("concentration", QVariant.Double),
         ]
@@ -407,15 +407,15 @@ class BasinConcentration(Input):
     @classmethod
     def attributes(cls) -> list[QgsField]:
         return [
-            QgsField("time", QVariant.DateTime),
             QgsField("node_id", QVariant.Int),
+            QgsField("time", QVariant.DateTime),
             QgsField("substance", QVariant.String),
             QgsField("drainage", QVariant.Double),
             QgsField("precipitation", QVariant.Double),
         ]
 
 
-class BasinSubgridLevel(Input):
+class BasinSubgrid(Input):
     @classmethod
     def input_type(cls) -> str:
         return "Basin / subgrid"
@@ -429,6 +429,26 @@ class BasinSubgridLevel(Input):
         return [
             QgsField("subgrid_id", QVariant.Int),
             QgsField("node_id", QVariant.Int),
+            QgsField("basin_level", QVariant.Double),
+            QgsField("subgrid_level", QVariant.Double),
+        ]
+
+
+class BasinSubgridTime(Input):
+    @classmethod
+    def input_type(cls) -> str:
+        return "Basin / subgrid_time"
+
+    @classmethod
+    def geometry_type(cls) -> str:
+        return "No Geometry"
+
+    @classmethod
+    def attributes(cls) -> list[QgsField]:
+        return [
+            QgsField("subgrid_id", QVariant.Int),
+            QgsField("node_id", QVariant.Int),
+            QgsField("time", QVariant.DateTime),
             QgsField("basin_level", QVariant.Double),
             QgsField("subgrid_level", QVariant.Double),
         ]
@@ -505,8 +525,8 @@ class TabulatedRatingCurveTime(Input):
     @classmethod
     def attributes(cls) -> list[QgsField]:
         return [
-            QgsField("time", QVariant.DateTime),
             QgsField("node_id", QVariant.Int),
+            QgsField("time", QVariant.DateTime),
             QgsField("level", QVariant.Double),
             QgsField("flow_rate", QVariant.Double),
         ]
@@ -583,7 +603,6 @@ class LevelBoundaryTime(Input):
     @classmethod
     def attributes(cls) -> list[QgsField]:
         return [
-            QgsField("time", QVariant.DateTime),
             QgsField("node_id", QVariant.Int),
             QgsField("time", QVariant.DateTime),
             QgsField("level", QVariant.Double),
@@ -663,8 +682,8 @@ class FlowBoundaryTime(Input):
     @classmethod
     def attributes(cls) -> list[QgsField]:
         return [
-            QgsField("time", QVariant.DateTime),
             QgsField("node_id", QVariant.Int),
+            QgsField("time", QVariant.DateTime),
             QgsField("flow_rate", QVariant.Double),
         ]
 


### PR DESCRIPTION
Fixes #1010

This adds `Basin / subgrid_time`. So far the only relation we could update over time was `Q(h)` (`TabulatedRatingCurve / time`), and that is implemented differently. I wrote #1976 to get those more in line. It's good to read that since it explains the implementation here.

Things I dislike:
- Need a special case to allow an underscore in `Basin / subgrid_time`, just like `Basin / concentration_`.
- Other dynamic tables are just named time and have a static counterpart like `Basin / static`, `Basin / time`. Since we already have `Basin / subgrid` we cannot do that.
