### PR TITLE
Bump schema version to 3

### DIFF
--- a/python/ribasim/ribasim/__init__.py
+++ b/python/ribasim/ribasim/__init__.py
@@ -1,5 +1,6 @@
 __version__ = "2024.11.0"
-__schema_version__ = 2
+# Keep synced write_schema_version in ribasim_qgis/core/geopackage.py
+__schema_version__ = 3
 
 from ribasim.config import Allocation, Logging, Node, Solver
 from ribasim.geometry.edge import EdgeTable

--- a/python/ribasim/ribasim/migrations.py
+++ b/python/ribasim/ribasim/migrations.py
@@ -8,7 +8,7 @@ from pandas import DataFrame
 
 
 def nodeschema_migration(gdf: GeoDataFrame, schema_version: int) -> GeoDataFrame:
-    if "node_id" in gdf.columns and schema_version == 0:
+    if schema_version == 0 and "node_id" in gdf.columns:
         warnings.warn("Migrating outdated Node table.", UserWarning)
         assert gdf["node_id"].is_unique, "Node IDs have to be unique."
         gdf.set_index("node_id", inplace=True)
@@ -27,7 +27,7 @@ def edgeschema_migration(gdf: GeoDataFrame, schema_version: int) -> GeoDataFrame
         warnings.warn("Migrating outdated Edge table.", UserWarning)
         assert gdf["edge_id"].is_unique, "Edge IDs have to be unique."
         gdf.set_index("edge_id", inplace=True)
-    if "subnetwork_id" in gdf.columns:
+    if schema_version < 3 and "subnetwork_id" in gdf.columns:
         warnings.warn("Migrating outdated Edge table.", UserWarning)
         gdf.drop(columns="subnetwork_id", inplace=True, errors="ignore")
 

--- a/ribasim_qgis/core/geopackage.py
+++ b/ribasim_qgis/core/geopackage.py
@@ -51,7 +51,8 @@ def layers(path: Path) -> list[str]:
     return layers
 
 
-def write_schema_version(path: Path, version: int = 2) -> None:
+# Keep version synced __schema_version__ in ribasim/__init__.py
+def write_schema_version(path: Path, version: int = 3) -> None:
     """Write the schema version to the geopackage."""
     with sqlite3_cursor(path) as cursor:
         cursor.execute(


### PR DESCRIPTION
Fixes #1978
In #1956 we forgot to update the schema version. Due to this line: https://github.com/Deltares/Ribasim/blob/18217f0a0065e93c076ee663db4f6f2057c139b1/python/ribasim/ribasim/input_base.py#L177
That means migration functions aren't called. This fixes that. I also added some extra comments on keeping them synced, and make the schema version checks a bit more consistent.