### PR TITLE
Don't update concentrations if not opting in to feature

### DIFF
--- a/core/src/callback.jl
+++ b/core/src/callback.jl
@@ -34,25 +34,30 @@ function create_callbacks(
         FunctionCallingCallback(update_cumulative_flows!; func_start = false)
     push!(callbacks, cumulative_flows_cb)
 
-    # Update concentrations
-    concentrations_cb = FunctionCallingCallback(update_concentrations!; func_start = false)
-    push!(callbacks, concentrations_cb)
+    if config.experimental.concentration
+        # Update concentrations
+        concentrations_cb =
+            FunctionCallingCallback(update_concentrations!; func_start = false)
+        push!(callbacks, concentrations_cb)
+    end
 
     # Update Basin forcings
     tstops = get_tstops(basin.time.time, starttime)
     basin_cb = PresetTimeCallback(tstops, update_basin!; save_positions = (false, false))
     push!(callbacks, basin_cb)
 
-    # Update boundary concentrations
-    for (boundary, func) in (
-        (basin, update_basin_conc!),
-        (flow_boundary, update_flowb_conc!),
-        (level_boundary, update_levelb_conc!),
-        (user_demand, update_userd_conc!),
-    )
-        tstops = get_tstops(boundary.concentration_time.time, starttime)
-        conc_cb = PresetTimeCallback(tstops, func; save_positions = (false, false))
-        push!(callbacks, conc_cb)
+    if config.experimental.concentration
+        # Update boundary concentrations
+        for (boundary, func) in (
+            (basin, update_basin_conc!),
+            (flow_boundary, update_flowb_conc!),
+            (level_boundary, update_levelb_conc!),
+            (user_demand, update_userd_conc!),
+        )
+            tstops = get_tstops(boundary.concentration_time.time, starttime)
+            conc_cb = PresetTimeCallback(tstops, func; save_positions = (false, false))
+            push!(callbacks, conc_cb)
+        end
     end
 
     # Update TabulatedRatingCurve Q(h) relationships

--- a/python/ribasim_testmodels/ribasim_testmodels/allocation.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/allocation.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-from ribasim.config import Allocation, Node, Solver
+from ribasim.config import Allocation, Experimental, Node, Solver
 from ribasim.input_base import TableModel
 from ribasim.model import Model
 from ribasim.nodes import (
@@ -27,6 +27,7 @@ def user_demand_model() -> Model:
         endtime="2021-01-01",
         crs="EPSG:28992",
         solver=Solver(algorithm="Tsit5"),
+        experimental=Experimental(concentration=True),
     )
 
     model.basin.add(
@@ -97,6 +98,7 @@ def subnetwork_model() -> Model:
         endtime="2020-04-01",
         crs="EPSG:28992",
         allocation=Allocation(use_allocation=True, timestep=86400),
+        experimental=Experimental(concentration=True),
     )
 
     basin_data: list[TableModel[Any]] = [
@@ -182,6 +184,7 @@ def looped_subnetwork_model() -> Model:
         endtime="2021-01-01",
         crs="EPSG:28992",
         allocation=Allocation(use_allocation=True, timestep=86400),
+        experimental=Experimental(concentration=True),
     )
 
     basin_data: list[TableModel[Any]] = [
@@ -308,6 +311,7 @@ def minimal_subnetwork_model() -> Model:
         endtime="2021-01-01",
         crs="EPSG:28992",
         allocation=Allocation(use_allocation=True, timestep=86400),
+        experimental=Experimental(concentration=True),
     )
 
     basin_data: list[TableModel[Any]] = [
@@ -364,6 +368,7 @@ def allocation_example_model() -> Model:
         endtime="2020-01-20",
         crs="EPSG:28992",
         allocation=Allocation(use_allocation=True, timestep=86400),
+        experimental=Experimental(concentration=True),
     )
 
     basin_data: list[TableModel[Any]] = [
@@ -426,6 +431,7 @@ def main_network_with_subnetworks_model() -> Model:
         endtime="2020-03-01",
         crs="EPSG:28992",
         allocation=Allocation(use_allocation=True, timestep=86400),
+        experimental=Experimental(concentration=True),
     )
 
     basin_data: list[TableModel[Any]] = [
@@ -721,6 +727,7 @@ def level_demand_model() -> Model:
         endtime="2020-02-01",
         crs="EPSG:28992",
         allocation=Allocation(use_allocation=True, timestep=1e5),
+        experimental=Experimental(concentration=True),
     )
     model.flow_boundary.add(
         Node(1, Point(0, 0), subnetwork_id=2), [flow_boundary.Static(flow_rate=[1e-3])]
@@ -781,6 +788,7 @@ def flow_demand_model() -> Model:
         endtime="2021-01-01 00:00:00",
         crs="EPSG:28992",
         allocation=Allocation(use_allocation=True, timestep=1e5),
+        experimental=Experimental(concentration=True),
     )
 
     model.tabulated_rating_curve.add(
@@ -855,6 +863,7 @@ def linear_resistance_demand_model():
         endtime="2021-01-01 00:00:00",
         crs="EPSG:28992",
         allocation=Allocation(use_allocation=True),
+        experimental=Experimental(concentration=True),
     )
 
     model.basin.add(
@@ -890,6 +899,7 @@ def fair_distribution_model():
         endtime="2020-01-07 00:00:00",
         crs="EPSG:28992",
         allocation=Allocation(use_allocation=True),
+        experimental=Experimental(concentration=True),
     )
 
     model.level_boundary.add(
@@ -987,6 +997,7 @@ def allocation_training_model():
         endtime="2023-01-01",
         crs="EPSG:4326",
         allocation=Allocation(use_allocation=True),
+        experimental=Experimental(concentration=True),
     )
 
     flow_boundary_times = pd.date_range(start="2022-01-01", end="2023-01-01", freq="MS")

--- a/python/ribasim_testmodels/ribasim_testmodels/backwater.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/backwater.py
@@ -1,6 +1,6 @@
 import numpy as np
 import ribasim
-from ribasim.config import Node
+from ribasim.config import Experimental, Node
 from ribasim.nodes import (
     basin,
     flow_boundary,
@@ -23,6 +23,7 @@ def backwater_model():
         endtime="2021-01-01",
         crs="EPSG:28992",
         solver=ribasim.Solver(autodiff=True),
+        experimental=Experimental(concentration=True),
     )
 
     model.flow_boundary.add(

--- a/python/ribasim_testmodels/ribasim_testmodels/basic.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/basic.py
@@ -274,6 +274,7 @@ def tabulated_rating_curve_model() -> ribasim.Model:
         starttime="2020-01-01",
         endtime="2021-01-01",
         crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
 
     # Setup tabulated rating curve:
@@ -352,6 +353,7 @@ def outlet_model():
         starttime="2020-01-01",
         endtime="2021-01-01",
         crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
 
     # Set up the basins

--- a/python/ribasim_testmodels/ribasim_testmodels/bucket.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/bucket.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 import ribasim
-from ribasim.config import Node
+from ribasim.config import Experimental, Node
 from ribasim.nodes import (
     basin,
 )
@@ -14,6 +14,7 @@ def bucket_model() -> ribasim.Model:
         starttime="2020-01-01",
         endtime="2021-01-01",
         crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
 
     model.basin.add(
@@ -41,6 +42,7 @@ def leaky_bucket_model() -> ribasim.Model:
         starttime="2020-01-01",
         endtime="2020-01-05",
         crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
 
     model.basin.add(

--- a/python/ribasim_testmodels/ribasim_testmodels/continuous_control.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/continuous_control.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from ribasim.config import Node
+from ribasim.config import Experimental, Node
 from ribasim.model import Model
 from ribasim.nodes import (
     basin,
@@ -18,6 +18,7 @@ def outlet_continuous_control_model() -> Model:
         starttime="2020-01-01",
         endtime="2021-01-01",
         crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
 
     model.level_boundary.add(

--- a/python/ribasim_testmodels/ribasim_testmodels/discrete_control.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/discrete_control.py
@@ -25,6 +25,7 @@ def pump_discrete_control_model() -> Model:
         starttime="2020-01-01",
         endtime="2021-01-01",
         crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
 
     model.basin.add(
@@ -124,6 +125,7 @@ def flow_condition_model() -> Model:
         starttime="2020-01-01",
         endtime="2021-01-01",
         crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
 
     model.flow_boundary.add(
@@ -187,6 +189,7 @@ def level_boundary_condition_model() -> Model:
         starttime="2020-01-01",
         endtime="2021-01-01",
         crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
 
     model.level_boundary.add(
@@ -261,6 +264,7 @@ def tabulated_rating_curve_control_model() -> Model:
         starttime="2020-01-01",
         endtime="2021-01-01",
         crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
 
     model.basin.add(
@@ -323,6 +327,7 @@ def compound_variable_condition_model() -> Model:
         starttime="2020-01-01",
         endtime="2021-01-01",
         crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
 
     model.basin.add(
@@ -381,6 +386,7 @@ def level_range_model() -> Model:
         endtime="2021-01-01",
         crs="EPSG:28992",
         solver=Solver(abstol=1e-6, reltol=1e-5),
+        experimental=Experimental(concentration=True),
     )
 
     model.basin.add(
@@ -469,6 +475,7 @@ def connector_node_flow_condition_model() -> Model:
         starttime="2020-01-01",
         endtime="2021-01-01",
         crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
 
     model.basin.add(
@@ -519,6 +526,7 @@ def concentration_condition_model() -> Model:
         starttime="2020-01-01",
         endtime="2021-01-01",
         crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
 
     model.basin.add(

--- a/python/ribasim_testmodels/ribasim_testmodels/doc_example.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/doc_example.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 from ribasim import Model, Node
+from ribasim.config import Experimental
 from ribasim.nodes import (
     basin,
     outlet,
@@ -12,7 +13,12 @@ from shapely.geometry import Point
 
 def local_pidcontrolled_cascade_model():
     """Demonstrating model for the cascade polder project from our partner."""
-    model = Model(starttime="2020-01-01", endtime="2021-01-01", crs="EPSG:28992")
+    model = Model(
+        starttime="2020-01-01",
+        endtime="2021-01-01",
+        crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
+    )
 
     # Set up basins
     time = pd.date_range(model.starttime, model.endtime)

--- a/python/ribasim_testmodels/ribasim_testmodels/equations.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/equations.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import numpy as np
-from ribasim.config import Node, Solver
+from ribasim.config import Experimental, Node, Solver
 from ribasim.input_base import TableModel
 from ribasim.model import Model
 from ribasim.nodes import (
@@ -23,6 +23,7 @@ def linear_resistance_model() -> Model:
         starttime="2020-01-01",
         endtime="2021-01-01",
         crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
 
     model.basin.add(
@@ -53,6 +54,7 @@ def rating_curve_model() -> Model:
         starttime="2020-01-01",
         endtime="2021-01-01",
         crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
 
     model.basin.add(
@@ -91,6 +93,7 @@ def manning_resistance_model() -> Model:
         starttime="2020-01-01",
         endtime="2021-01-01",
         crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
 
     basin_profile = basin.Profile(area=[0.01, 100.0, 100.0], level=[0.0, 1.0, 2.0])
@@ -125,6 +128,7 @@ def misc_nodes_model() -> Model:
         endtime="2021-01-01",
         crs="EPSG:28992",
         solver=Solver(dt=24 * 60 * 60, algorithm="Euler"),
+        experimental=Experimental(concentration=True),
     )
 
     basin_shared: list[TableModel[Any]] = [
@@ -158,7 +162,10 @@ def misc_nodes_model() -> Model:
 def pid_control_equation_model() -> Model:
     """Set up a model with pid control for an analytical solution test."""
     model = Model(
-        starttime="2020-01-01", endtime="2020-01-01 00:05:00", crs="EPSG:28992"
+        starttime="2020-01-01",
+        endtime="2020-01-01 00:05:00",
+        crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
     model.basin.add(
         Node(1, Point(0, 0)),

--- a/python/ribasim_testmodels/ribasim_testmodels/pid_control.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/pid_control.py
@@ -1,4 +1,4 @@
-from ribasim.config import Node
+from ribasim.config import Experimental, Node
 from ribasim.model import Model
 from ribasim.nodes import (
     basin,
@@ -19,6 +19,7 @@ def pid_control_model() -> Model:
         starttime="2020-01-01",
         endtime="2020-12-01",
         crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
 
     model.flow_boundary.add(
@@ -90,6 +91,7 @@ def discrete_control_of_pid_control_model() -> Model:
         starttime="2020-01-01",
         endtime="2020-12-01",
         crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
 
     model.level_boundary.add(

--- a/python/ribasim_testmodels/ribasim_testmodels/time.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/time.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas as pd
-from ribasim.config import Node
+from ribasim.config import Experimental, Node
 from ribasim.model import Model
 from ribasim.nodes import basin, flow_boundary
 from shapely.geometry import Point
@@ -12,6 +12,7 @@ def flow_boundary_time_model() -> Model:
         starttime="2020-01-01",
         endtime="2021-01-01",
         crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
     )
 
     model.flow_boundary.add(

--- a/python/ribasim_testmodels/ribasim_testmodels/trivial.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/trivial.py
@@ -1,4 +1,4 @@
-from ribasim.config import Node, Results
+from ribasim.config import Experimental, Node, Results
 from ribasim.model import Model
 from ribasim.nodes import basin, tabulated_rating_curve
 from shapely.geometry import Point
@@ -12,6 +12,7 @@ def trivial_model() -> Model:
         crs="EPSG:28992",
         results=Results(subgrid=True, compression=False),
         use_validation=True,
+        experimental=Experimental(concentration=True),
     )
 
     # Convert steady forcing to m/s

--- a/python/ribasim_testmodels/ribasim_testmodels/two_basin.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/two_basin.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from ribasim.config import Node
+from ribasim.config import Experimental, Node
 from ribasim.input_base import TableModel
 from ribasim.model import Model
 from ribasim.nodes import basin, flow_boundary, tabulated_rating_curve
@@ -18,7 +18,12 @@ def two_basin_model() -> Model:
     infiltrates in the left basin, and exfiltrates in the right basin.
     The right basin fills up and discharges over the rating curve.
     """
-    model = Model(starttime="2020-01-01", endtime="2021-01-01", crs="EPSG:28992")
+    model = Model(
+        starttime="2020-01-01",
+        endtime="2021-01-01",
+        crs="EPSG:28992",
+        experimental=Experimental(concentration=True),
+    )
 
     model.flow_boundary.add(
         Node(1, Point(0, 0)), [flow_boundary.Static(flow_rate=[1e-2])]


### PR DESCRIPTION
I noticed these callbacks take 50% of computational time, for which I will create a separate issue. Currently we always compute, but only write out the results if the experimental feature flag was enabled. Since it is slowing down the model, let's turn off the computation as well.