### PR TITLE
Use interpolations to update forcing in Basin

### DIFF
--- a/core/src/callback.jl
+++ b/core/src/callback.jl
@@ -36,7 +36,7 @@ function create_callbacks(
 
     # Update Basin forcings
     # All variables are given at the same time, so just precipitation works
-    times = [itp.t for itp in basin.precipitation]
+    times = [itp.t for itp in basin.forcing.precipitation]
     tstops = Float64[]
     for t in times
         append!(tstops, t)
@@ -728,13 +728,13 @@ function update_basin!(integrator)::Nothing
 end
 
 function update_basin!(basin::Basin, t)::Nothing
-    (; vertical_flux, precipitation, potential_evaporation, infiltration, drainage) = basin
+    (; vertical_flux, forcing) = basin
     for id in basin.node_id
         i = id.idx
-        set_flux!(vertical_flux.precipitation, precipitation, i, t)
-        set_flux!(vertical_flux.potential_evaporation, potential_evaporation, i, t)
-        set_flux!(vertical_flux.infiltration, infiltration, i, t)
-        set_flux!(vertical_flux.drainage, drainage, i, t)
+        set_flux!(vertical_flux.precipitation, forcing.precipitation, i, t)
+        set_flux!(vertical_flux.potential_evaporation, forcing.potential_evaporation, i, t)
+        set_flux!(vertical_flux.infiltration, forcing.infiltration, i, t)
+        set_flux!(vertical_flux.drainage, forcing.drainage, i, t)
     end
 
     return nothing

--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -83,6 +83,7 @@ function Model(config::Config)::Model
         # tell the solver to stop when new data comes in
         tstops = Vector{Float64}[]
         for schema_version in [
+            BasinTimeV1,
             FlowBoundaryTimeV1,
             LevelBoundaryTimeV1,
             UserDemandTimeV1,

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -108,6 +108,10 @@ Base.isless(id_1::NodeID, id_2::NodeID)::Bool = id_1.value < id_2.value
 Base.isless(id_1::Integer, id_2::NodeID)::Bool = id_1 < id_2.value
 Base.isless(id_1::NodeID, id_2::Integer)::Bool = id_1.value < id_2
 
+"ConstantInterpolation from a Float64 to a Float64"
+const ScalarConstantInterpolation =
+    ConstantInterpolation{Vector{Float64}, Vector{Float64}, Vector{Float64}, Float64, (1,)}
+
 "LinearInterpolation from a Float64 to a Float64"
 const ScalarInterpolation = LinearInterpolation{
     Vector{Float64},
@@ -389,7 +393,7 @@ else
     T = Vector{Float64}
 end
 """
-@kwdef struct Basin{V, C, CD, D} <: AbstractParameterNode
+@kwdef struct Basin{V, CD, D} <: AbstractParameterNode
     node_id::Vector{NodeID}
     inflow_ids::Vector{Vector{NodeID}} = [NodeID[]]
     outflow_ids::Vector{Vector{NodeID}} = [NodeID[]]
@@ -421,7 +425,11 @@ end
     demand::Vector{Float64} = zeros(length(node_id))
     allocated::Vector{Float64} = zeros(length(node_id))
     # Data source for parameter updates
-    time::StructVector{BasinTimeV1, C, Int}
+    precipitation::Vector{ScalarConstantInterpolation} = ScalarConstantInterpolation[]
+    potential_evaporation::Vector{ScalarConstantInterpolation} =
+        ScalarConstantInterpolation[]
+    drainage::Vector{ScalarConstantInterpolation} = ScalarConstantInterpolation[]
+    infiltration::Vector{ScalarConstantInterpolation} = ScalarConstantInterpolation[]
     # Storage for each Basin at the previous time step
     storage_prev::Vector{Float64} = zeros(length(node_id))
     # Level for each Basin at the previous time step
@@ -929,11 +937,11 @@ const ModelGraph = MetaGraph{
     Float64,
 }
 
-@kwdef mutable struct Parameters{C1, C2, C3, C4, C6, C7, C8, C9, C10, C11}
+@kwdef mutable struct Parameters{C1, C3, C4, C6, C7, C8, C9, C10, C11}
     const starttime::DateTime
     const graph::ModelGraph
     const allocation::Allocation
-    const basin::Basin{C1, C2, C3, C4}
+    const basin::Basin{C1, C3, C4}
     const linear_resistance::LinearResistance
     const manning_resistance::ManningResistance
     const tabulated_rating_curve::TabulatedRatingCurve

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -378,6 +378,20 @@ end
 end
 
 """
+Data source for Basin parameter updates over time
+
+This is used for both static and dynamic values,
+the length of each Vector is the number of Basins.
+"""
+@kwdef struct BasinForcing
+    precipitation::Vector{ScalarConstantInterpolation} = ScalarConstantInterpolation[]
+    potential_evaporation::Vector{ScalarConstantInterpolation} =
+        ScalarConstantInterpolation[]
+    drainage::Vector{ScalarConstantInterpolation} = ScalarConstantInterpolation[]
+    infiltration::Vector{ScalarConstantInterpolation} = ScalarConstantInterpolation[]
+end
+
+"""
 Requirements:
 
 * Must be positive: precipitation, evaporation, infiltration, drainage
@@ -424,12 +438,7 @@ end
     # Values for allocation if applicable
     demand::Vector{Float64} = zeros(length(node_id))
     allocated::Vector{Float64} = zeros(length(node_id))
-    # Data source for parameter updates
-    precipitation::Vector{ScalarConstantInterpolation} = ScalarConstantInterpolation[]
-    potential_evaporation::Vector{ScalarConstantInterpolation} =
-        ScalarConstantInterpolation[]
-    drainage::Vector{ScalarConstantInterpolation} = ScalarConstantInterpolation[]
-    infiltration::Vector{ScalarConstantInterpolation} = ScalarConstantInterpolation[]
+    forcing::BasinForcing = BasinForcing()
     # Storage for each Basin at the previous time step
     storage_prev::Vector{Float64} = zeros(length(node_id))
     # Level for each Basin at the previous time step

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -781,7 +781,7 @@ function Basin(db::DB, config::Config, graph::MetaGraph)::Basin
     )
 
     # Ensure the initial data is loaded at t0 for BMI
-    set_vertical_flux!(basin, 0.0)
+    update_basin!(basin, 0.0)
 
     storage0 = get_storages_from_levels(basin, state.level)
     @assert length(storage0) == n "Basin / state length differs from number of Basins"

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -738,6 +738,13 @@ function Basin(db::DB, config::Config, graph::MetaGraph)::Basin
         is_complete = false,
     )
 
+    forcing = BasinForcing(;
+        parsed_parameters.precipitation,
+        parsed_parameters.potential_evaporation,
+        parsed_parameters.drainage,
+        parsed_parameters.infiltration,
+    )
+
     # Current forcing is stored as separate array for BMI access
     # These are updated from the interpolation objects at runtime
     n = length(node_id)
@@ -772,10 +779,7 @@ function Basin(db::DB, config::Config, graph::MetaGraph)::Basin
         vertical_flux,
         storage_to_level,
         level_to_area,
-        parsed_parameters.precipitation,
-        parsed_parameters.potential_evaporation,
-        parsed_parameters.drainage,
-        parsed_parameters.infiltration,
+        forcing,
         concentration_data,
         concentration_time,
     )

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -15,6 +15,8 @@ function parse_static_and_time(
     time::Union{StructVector, Nothing} = nothing,
     defaults::NamedTuple = (; active = true),
     time_interpolatables::Vector{Symbol} = Symbol[],
+    interpolation_type::Type{<:AbstractInterpolation} = LinearInterpolation,
+    is_complete::Bool = true,
 )::Tuple{NamedTuple, Bool}
     # E.g. `PumpStatic`
     static_type = eltype(static)
@@ -42,7 +44,16 @@ function parse_static_and_time(
         # If the type is a union, then the associated parameter is optional and
         # the type is of the form Union{Missing,ActualType}
         parameter_type = if parameter_name in time_interpolatables
-            ScalarInterpolation
+            # We need the concrete type to store in the parameters
+            # The interpolation_type is not concrete because they don't have the
+            # constructors we use
+            if interpolation_type == LinearInterpolation
+                ScalarInterpolation
+            elseif interpolation_type == ConstantInterpolation
+                ScalarConstantInterpolation
+            else
+                error("Unknown interpolation type.")
+            end
         elseif isa(parameter_type, Union)
             nonmissingtype(parameter_type)
         else
@@ -120,7 +131,7 @@ function parse_static_and_time(
                         val = defaults[parameter_name]
                     end
                     if parameter_name in time_interpolatables
-                        val = LinearInterpolation(
+                        val = interpolation_type(
                             [val, val],
                             trivial_timespan;
                             cache_parameters = true,
@@ -149,7 +160,7 @@ function parse_static_and_time(
             for parameter_name in parameter_names
                 # If the parameter is interpolatable, create an interpolation object
                 if parameter_name in time_interpolatables
-                    val, is_valid = get_scalar_interpolation(
+                    val = get_scalar_interpolation(
                         config.starttime,
                         t_end,
                         time,
@@ -157,11 +168,8 @@ function parse_static_and_time(
                         parameter_name;
                         default_value = hasproperty(defaults, parameter_name) ?
                                         defaults[parameter_name] : NaN,
+                        interpolation_type,
                     )
-                    if !is_valid
-                        errors = true
-                        @error "A $parameter_name time series for $node_id has repeated times, this can not be interpolated."
-                    end
                 else
                     # Activity of transient nodes is assumed to be true
                     if parameter_name == :active
@@ -170,6 +178,19 @@ function parse_static_and_time(
                         # If the parameter is not interpolatable, get the instance in the first row
                         val = getfield(time[time_first_idx], parameter_name)
                     end
+                end
+                getfield(out, parameter_name)[node_id.idx] = val
+            end
+        elseif !is_complete
+            # Apply the defaults just like if it was in static but missing
+            for parameter_name in parameter_names
+                val = defaults[parameter_name]
+                if parameter_name in time_interpolatables
+                    val = interpolation_type(
+                        [val, val],
+                        trivial_timespan;
+                        cache_parameters = true,
+                    )
                 end
                 getfield(out, parameter_name)[node_id.idx] = val
             end
@@ -651,23 +672,19 @@ function ConcentrationData(
         for group in IterTools.groupby(row -> row.substance, data_id)
             first_row = first(group)
             substance = first_row.substance
-            itp, no_duplication = get_scalar_interpolation(
+            itp = get_scalar_interpolation(
                 config.starttime,
                 t_end,
                 StructVector(group),
                 NodeID(:Basin, first_row.node_id, 0),
-                :concentration,
+                :concentration;
+                interpolation_type = LinearInterpolation,
             )
             concentration_external_id["concentration_external.$substance"] = itp
             if any(itp.u .< 0)
                 errors = true
                 @error "Found negative concentration(s) in `Basin / concentration_external`." node_id =
                     id, substance
-            end
-            if !no_duplication
-                errors = true
-                @error "There are repeated time values for in `Basin / concentration_external`." node_id =
-                    id substance
             end
         end
         push!(concentration_external, concentration_external_id)
@@ -691,26 +708,45 @@ function ConcentrationData(
 end
 
 function Basin(db::DB, config::Config, graph::MetaGraph)::Basin
-    node_id = get_node_ids(db, NodeType.Basin)
-    n = length(node_id)
-
     # both static and time are optional, but we need fallback defaults
     static = load_structvector(db, config, BasinStaticV1)
     time = load_structvector(db, config, BasinTimeV1)
     state = load_structvector(db, config, BasinStateV1)
 
-    # Forcing
-    precipitation = zeros(n)
-    potential_evaporation = zeros(n)
-    drainage = zeros(n)
-    infiltration = zeros(n)
-    table = (; precipitation, potential_evaporation, drainage, infiltration)
+    _, _, node_id, valid =
+        static_and_time_node_ids(db, static, time, NodeType.Basin; is_complete = false)
+    if !valid
+        error("Problems encountered when parsing Basin static and time node IDs.")
+    end
 
-    set_static_value!(table, node_id, static)
-    set_current_value!(table, node_id, time, config.starttime)
-    check_no_nans(table, "Basin")
+    time_interpolatables =
+        [:precipitation, :potential_evaporation, :drainage, :infiltration]
+    parsed_parameters, valid = parse_static_and_time(
+        db,
+        config,
+        Basin;
+        static,
+        time,
+        time_interpolatables,
+        interpolation_type = ConstantInterpolation,
+        defaults = (;
+            precipitation = NaN,
+            potential_evaporation = NaN,
+            drainage = NaN,
+            infiltration = NaN,
+        ),
+        is_complete = false,
+    )
 
-    vertical_flux = ComponentVector(; table...)
+    # Current forcing is stored as separate array for BMI access
+    # These are updated from the interpolation objects at runtime
+    n = length(node_id)
+    vertical_flux = ComponentVector(;
+        precipitation = zeros(n),
+        potential_evaporation = zeros(n),
+        drainage = zeros(n),
+        infiltration = zeros(n),
+    )
 
     # Profiles
     area, level = create_storage_tables(db, config)
@@ -736,10 +772,16 @@ function Basin(db::DB, config::Config, graph::MetaGraph)::Basin
         vertical_flux,
         storage_to_level,
         level_to_area,
-        time,
+        parsed_parameters.precipitation,
+        parsed_parameters.potential_evaporation,
+        parsed_parameters.drainage,
+        parsed_parameters.infiltration,
         concentration_data,
         concentration_time,
     )
+
+    # Ensure the initial data is loaded at t0 for BMI
+    set_vertical_flux!(basin, 0.0)
 
     storage0 = get_storages_from_levels(basin, state.level)
     @assert length(storage0) == n "Basin / state length differs from number of Basins"
@@ -1074,39 +1116,30 @@ function user_demand_time!(
 
         active[user_demand_idx] = true
         demand_from_timeseries[user_demand_idx] = true
-        return_factor_itp, is_valid_return = get_scalar_interpolation(
+        return_factor_itp = get_scalar_interpolation(
             config.starttime,
             t_end,
             StructVector(group),
             NodeID(:UserDemand, first_row.node_id, 0),
             :return_factor;
+            interpolation_type = LinearInterpolation,
         )
-        if is_valid_return
-            return_factor[user_demand_idx] = return_factor_itp
-        else
-            @error "The return_factor(t) relationship for UserDemand $(first_row.node_id) from the time table has repeated timestamps, this can not be interpolated."
-            errors = true
-        end
+        return_factor[user_demand_idx] = return_factor_itp
 
         min_level[user_demand_idx] = first_row.min_level
 
         priority_idx = findsorted(priorities, first_row.priority)
-        demand_p_itp, is_valid_demand = get_scalar_interpolation(
+        demand_p_itp = get_scalar_interpolation(
             config.starttime,
             t_end,
             StructVector(group),
             NodeID(:UserDemand, first_row.node_id, 0),
             :demand;
             default_value = 0.0,
+            interpolation_type = LinearInterpolation,
         )
         demand[user_demand_idx, priority_idx] = demand_p_itp(0.0)
-
-        if is_valid_demand
-            demand_itp[user_demand_idx][priority_idx] = demand_p_itp
-        else
-            @error "The demand(t) relationship for UserDemand $(first_row.node_id) of priority $(first_row.priority_idx) from the time table has repeated timestamps, this can not be interpolated."
-            errors = true
-        end
+        demand_itp[user_demand_idx][priority_idx] = demand_p_itp
     end
     return errors
 end

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -13,8 +13,6 @@ function water_balance!(
 
     du .= 0.0
 
-    set_vertical_flux!(basin, t)
-
     # Ensures current_* vectors are current
     set_current_basin_properties!(du, u, p, t)
 
@@ -190,35 +188,6 @@ function formulate_storage!(
             end
         end
     end
-end
-
-"Update a current vertical flux from an interpolation at time t."
-function set_flux!(
-    fluxes::AbstractVector{Float64},
-    interpolations::Vector{ScalarConstantInterpolation},
-    i::Int,
-    t,
-)::Nothing
-    val = interpolations[i](t)
-    # keep old value if new value is NaN
-    if !isnan(val)
-        fluxes[i] = val
-    end
-    return nothing
-end
-
-"Update all current vertical fluxes from an interpolation at time t."
-function set_vertical_flux!(basin::Basin, t)::Nothing
-    (; vertical_flux, precipitation, potential_evaporation, infiltration, drainage) = basin
-    for id in basin.node_id
-        i = id.idx
-        set_flux!(vertical_flux.precipitation, precipitation, i, t)
-        set_flux!(vertical_flux.potential_evaporation, potential_evaporation, i, t)
-        set_flux!(vertical_flux.infiltration, infiltration, i, t)
-        set_flux!(vertical_flux.drainage, drainage, i, t)
-    end
-
-    return nothing
 end
 
 """

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -79,6 +79,11 @@ function get_scalar_interpolation(
     parameter = getfield.(time, param)[rows]
     parameter = coalesce.(parameter, default_value)
     times = seconds_since.(time.time[rows], starttime)
+    # Add extra timestep at start for constant extrapolation
+    if times[1] > 0
+        pushfirst!(times, nextfloat(-Inf))
+        pushfirst!(parameter, parameter[1])
+    end
     # Add extra timestep at end for constant extrapolation
     if times[end] < t_end
         push!(times, t_end)

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -113,8 +113,7 @@ sort_by(::StructVector{BasinStateV1}) = x -> (x.node_id)
 sort_by(::StructVector{BasinStaticV1}) = x -> (x.node_id)
 sort_by(::StructVector{BasinSubgridV1}) = x -> (x.subgrid_id, x.basin_level)
 sort_by(::StructVector{BasinSubgridTimeV1}) = x -> (x.subgrid_id, x.time, x.basin_level)
-# TODO BasinTimeV1 (x.node_id, x.time), like in python
-sort_by(::StructVector{BasinTimeV1}) = x -> (x.time, x.node_id)
+sort_by(::StructVector{BasinTimeV1}) = x -> (x.node_id, x.time)
 
 sort_by(::StructVector{ContinuousControlFunctionV1}) = x -> (x.node_id, x.input)
 sort_by(::StructVector{ContinuousControlVariableV1}) =

--- a/core/test/io_test.jl
+++ b/core/test/io_test.jl
@@ -82,7 +82,7 @@ end
     table = Ribasim.load_structvector(db, config, Ribasim.BasinTimeV1)
     close(db)
     by = Ribasim.sort_by(table)
-    @test by((; node_id = 1, time = 2)) == (2, 1)
+    @test by((; node_id = 1, time = 2)) == (1, 2)
     # reverse it so it needs sorting
     reversed_table = sort(table; by, rev = true)
     @test issorted(table; by)

--- a/core/test/time_test.jl
+++ b/core/test/time_test.jl
@@ -40,10 +40,10 @@ end
 
     for (i, gb) in enumerate(groupby(basin_table, :node_id))
         area = basin.level_to_area[i](gb.level)
-        pot_evap = basin.potential_evaporation[i](seconds)
+        pot_evap = basin.forcing.potential_evaporation[i](seconds)
         # high tolerance since the area is only approximate
         @test gb.evaporation ≈ area .* pot_evap atol = 1e-5
-        prec = basin.precipitation[i](seconds)
+        prec = basin.forcing.precipitation[i](seconds)
         fixed_area = Ribasim.basin_areas(basin, i)[end]
         @test gb.precipitation ≈ fixed_area .* prec
     end

--- a/core/test/time_test.jl
+++ b/core/test/time_test.jl
@@ -24,7 +24,7 @@
 end
 
 @testitem "vertical_flux_means" begin
-    using DataFrames: DataFrame, transform!, ByRow
+    using DataFrames: DataFrame, groupby
 
     toml_path =
         normpath(@__DIR__, "../../generated_testmodels/basic_transient/ribasim.toml")
@@ -36,49 +36,17 @@ end
     n_basin = length(basin.node_id)
     basin_table = DataFrame(Ribasim.basin_table(model))
 
-    time_table = DataFrame(basin.time)
-    t_end = time_table.time[end]
-    filter!(:time => t -> t !== t_end, time_table)
+    seconds = Ribasim.seconds_since.(unique(basin_table.time), basin_table.time[1])
 
-    function get_area(basin, idx, storage)
-        level = Ribasim.get_level_from_storage(basin, idx, storage)
-        basin.level_to_area[idx](level)
+    for (i, gb) in enumerate(groupby(basin_table, :node_id))
+        area = basin.level_to_area[i](gb.level)
+        pot_evap = basin.potential_evaporation[i](seconds)
+        # high tolerance since the area is only approximate
+        @test gb.evaporation ≈ area .* pot_evap atol = 1e-5
+        prec = basin.precipitation[i](seconds)
+        fixed_area = Ribasim.basin_areas(basin, i)[end]
+        @test gb.precipitation ≈ fixed_area .* prec
     end
-
-    time_table[!, "basin_idx"] =
-        [node_id.idx for node_id in Ribasim.NodeID.(:Basin, time_table.node_id, Ref(p))]
-    time_table[!, "area"] = [
-        get_area(basin, idx, storage) for
-        (idx, storage) in zip(time_table.basin_idx, basin_table.storage)
-    ]
-    # Mean areas over the timestep are computed as an approximation of
-    # how the area changes over the timestep, affecting evaporation
-    time_table[!, "mean_area"] .= 0.0
-    n_basins = length(basin.node_id)
-    n_times = length(unique(time_table.time)) - 1
-    for basin_idx in 1:n_basins
-        for time_idx in 1:n_times
-            idx_1 = n_basins * (time_idx - 1) + basin_idx
-            idx_2 = n_basins * time_idx + basin_idx
-            mean_area = (time_table.area[idx_1] + time_table.area[idx_2]) / 2
-            time_table.mean_area[idx_1] = mean_area
-        end
-    end
-
-    @test all(
-        isapprox(
-            basin_table.evaporation,
-            time_table.mean_area .* time_table.potential_evaporation;
-            rtol = 1e-2,
-        ),
-    )
-
-    fixed_area =
-        Dict(id.value => Ribasim.basin_areas(basin, id.idx)[end] for id in basin.node_id)
-    transform!(time_table, :node_id => ByRow(id -> fixed_area[id]) => :fixed_area)
-    @test all(
-        basin_table.precipitation .≈ time_table.fixed_area .* time_table.precipitation,
-    )
 end
 
 @testitem "Integrate over discontinuity" begin

--- a/core/test/utils_test.jl
+++ b/core/test/utils_test.jl
@@ -27,7 +27,6 @@ end
         node_id = NodeID.(:Basin, [5, 7], [1, 2]),
         storage_to_level,
         level_to_area,
-        time = StructVector{Ribasim.BasinTimeV1}(undef, 0),
         concentration_time = StructVector{Ribasim.BasinConcentrationV1}(undef, 0),
     )
 
@@ -138,7 +137,6 @@ end
         node_id = NodeID.(:Basin, [1], 1),
         storage_to_level = [storage_to_level],
         level_to_area = [level_to_area],
-        time = StructVector{Ribasim.BasinTimeV1}(undef, 0),
         concentration_time = StructVector{Ribasim.BasinConcentrationV1}(undef, 0),
     )
 

--- a/python/ribasim_testmodels/ribasim_testmodels/basic.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/basic.py
@@ -255,6 +255,7 @@ def basic_transient_model() -> ribasim.Model:
             "level": 1.4,
         }
     )
+    model.basin.static.df = None  # A node cannot have both static and dynamic forcing
     model.basin.time = forcing  # type: ignore # TODO: Fix implicit typing from pydantic. See TableModel.check_dataframe
     model.basin.state = state  # type: ignore # TODO: Fix implicit typing from pydantic. See TableModel.check_dataframe
 


### PR DESCRIPTION
Fixes another bullet point from #601, namely:

- use interpolation objects instead of `update_basin`, which still relies on time being sorted first

Now we can also use `parse_static_and_time` for Basin, bringing our node types more in line with each other and more code reuse.  For this I had to extend it a bit to support other interpolation types, and support IDs not being in time nor static. We still add time of new data as tstops to ensure the solver knows about net data as it happens.

Labeling this as breaking since before this we allowed a node ID to be in both the static and time tables. In `parse_static_and_time` (the other node types) we specifically check for this with a clear error message. I had to update `basic_transient`, to remove the static table there.