### PR TITLE
Prepare release v2025.1.0

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2101,7 +2101,7 @@ version = "3.6.5"
 deps = ["Accessors", "Arrow", "BasicModelInterface", "CodecZstd", "ComponentArrays", "Configurations", "DBInterface", "DataInterpolations", "DataStructures", "Dates", "DiffEqBase", "DiffEqCallbacks", "EnumX", "FiniteDiff", "Graphs", "HiGHS", "IterTools", "JuMP", "Legolas", "LineSearches", "LinearAlgebra", "LinearSolve", "Logging", "LoggingExtras", "MetaGraphsNext", "OrdinaryDiffEqBDF", "OrdinaryDiffEqCore", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqTsit5", "PreallocationTools", "SQLite", "SciMLBase", "SparseArrays", "SparseConnectivityTracer", "StructArrays", "Tables", "TerminalLoggers", "TranscodingStreams"]
 path = "core"
 uuid = "aac5e3d9-0b8f-4d4f-8241-b1a7a9632635"
-version = "2024.11.0"
+version = "2025.1.0"
 weakdeps = ["DataFrames", "Makie"]
 
     [deps.Ribasim.extensions]

--- a/build/cli/Cargo.lock
+++ b/build/cli/Cargo.lock
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "ribasim"
-version = "2024.11.0"
+version = "2025.1.0"
 dependencies = [
  "clap",
  "libc",

--- a/build/cli/Cargo.toml
+++ b/build/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ribasim"
-version = "2024.11.0"
+version = "2025.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/core/Project.toml
+++ b/core/Project.toml
@@ -2,7 +2,7 @@ name = "Ribasim"
 uuid = "aac5e3d9-0b8f-4d4f-8241-b1a7a9632635"
 authors = ["Deltares and contributors <ribasim.info@deltares.nl>"]
 manifest = "../Manifest.toml"
-version = "2024.11.0"
+version = "2025.1.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/core/test/data/config_test.toml
+++ b/core/test/data/config_test.toml
@@ -3,7 +3,7 @@ endtime = 2019-12-31
 crs = "EPSG:28992"
 input_dir = "../../generated_testmodels/lhm"
 results_dir = "../../generated_testmodels/lhm"
-ribasim_version = "2024.11.0"
+ribasim_version = "2025.1.0"
 
 [basin]
 time = "basin/time.arrow"

--- a/core/test/data/logging_test_loglevel_debug.toml
+++ b/core/test/data/logging_test_loglevel_debug.toml
@@ -3,7 +3,7 @@ endtime = 2019-12-31
 crs = "EPSG:28992"
 input_dir = "."
 results_dir = "results"
-ribasim_version = "2024.11.0"
+ribasim_version = "2025.1.0"
 
 [logging]
 verbosity = "debug"

--- a/core/test/data/logging_test_no_loglevel.toml
+++ b/core/test/data/logging_test_no_loglevel.toml
@@ -3,4 +3,4 @@ endtime = 2019-12-31
 crs = "EPSG:28992"
 input_dir = "."
 results_dir = "results"
-ribasim_version = "2024.11.0"
+ribasim_version = "2025.1.0"

--- a/core/test/docs.toml
+++ b/core/test/docs.toml
@@ -12,7 +12,7 @@ crs = "EPSG:4326"      # required
 input_dir = "."         # required
 results_dir = "results" # required
 
-ribasim_version = "2024.11.0" # required
+ribasim_version = "2025.1.0" # required
 
 # Specific tables can also go into Arrow files rather than the database.
 # For large tables this can benefit from better compressed file sizes.

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -5,8 +5,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [v2025.1.0] - 2025-01-17
+
+The first release of 2025 makes the Ribasim core more robust and stable, and speeds up
+initialization for large models. The biggest new feature is the experimental support for
+calculating tracers in Ribasim directly, which will hopefully make it easier to track where
+the water resources are heading.
+
+### Added
+- Remove Z coordinate on constructing Node in Python. [#1986](https://github.com/Deltares/Ribasim/pull/1986)
+- Add "Basin / subgrid_time" table. [#1975](https://github.com/Deltares/Ribasim/pull/1975)
+- Sign Ribasim binaries. [#2007](https://github.com/Deltares/Ribasim/pull/2007)
+- Experimental: Calculate tracer concentrations internally. [#1849](https://github.com/Deltares/Ribasim/pull/1849)
+- Document [parsing Delwaq results](https://ribasim.org/guide/delwaq). [#1845](https://github.com/Deltares/Ribasim/pull/1845)
+
+### Removed
+- Drop Python 3.10 support. [#2012](https://github.com/Deltares/Ribasim/pull/2012)
+
 ### Changed
+- Allocation: optimize per source. [#1927](https://github.com/Deltares/Ribasim/pull/1927)
 - The Edge table no longer supports `subnetwork_id`; this is automatically inferred. [#1956](https://github.com/Deltares/Ribasim/pull/1956)
+
+### Fixed
+- ManningResistance is more stable around Δh=0. [#1896](https://github.com/Deltares/Ribasim/pull/1896)
+- Fixes to Delwaq model generation. [#1903](https://github.com/Deltares/Ribasim/pull/1903) [#1917](https://github.com/Deltares/Ribasim/pull/1917) [#1948](https://github.com/Deltares/Ribasim/pull/1948)
+- Add step limiter to avoid negative flows or too large flows. [#1911](https://github.com/Deltares/Ribasim/pull/1911) [#1912](https://github.com/Deltares/Ribasim/pull/1912)
+- Fix README.md in builds. [#1935](https://github.com/Deltares/Ribasim/pull/1935) [#1938](https://github.com/Deltares/Ribasim/pull/1938)
+- Speed up initialization. [#1977](https://github.com/Deltares/Ribasim/pull/1977)
+- Automatically name index in Python. [#1974](https://github.com/Deltares/Ribasim/pull/1974)
+- Table sorting related fixes. [#2003](https://github.com/Deltares/Ribasim/pull/2003)
 
 ## [v2024.11.0] - 2024-10-08
 

--- a/docs/dev/release.qmd
+++ b/docs/dev/release.qmd
@@ -17,6 +17,20 @@ This section provides a guide for developers to follow when preparing a new rele
 
 Before starting the release process, ensure that all tests are passing and that all features intended for the release are complete and merged into the main branch.
 
+## QGIS manual testing
+
+Our continuous integration (CI) should have caught most issues.
+A current weak spot in our testing is the QGIS plugin, so a manual test plan is in place.
+Start with running the automated task to see if it can be correctly installed.
+
+```sh
+# This test might give a fatal error on the first run, this is most likely a timing issue.
+# Try to run it again when that happens.
+pixi run test-ribasim-qgis-ui
+```
+
+Then follow the instructions as described in the [QGIS manual test plan](/dev/qgis_test_plan.qmd).
+
 ## Update version numbers of the components
 
 Determine the new version number like `2023.1.0`, filling in the current year, a bumped `MINOR` number for normal releases and a bumped `MICRO` number for non-breaking, hotfix releases.
@@ -83,20 +97,6 @@ In order to publish Ribasim Python or Ribasim API follow the following steps:
 1) Open a terminal and run `pixi run publish-ribasim-python`
 
 2) Open a terminal and run `pixi run publish-ribasim-api`
-
-## QGIS manual testing
-
-Our continuous integration (CI) should have caught most issues.
-A current weak spot in our testing is the QGIS plugin, so a manual test plan is in place.
-Start with running the automated task to see if it can be correctly installed.
-
-```sh
-# This test might give a fatal error on the first run, this is most likely a timing issue.
-# Try to run it again when that happens.
-pixi run test-ribasim-qgis-ui
-```
-
-Then follow the instructions as described in the [QGIS manual test plan](/dev/qgis_test_plan.qmd).
 
 ## Announce release
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -21908,7 +21908,7 @@ packages:
   timestamp: 1598024297745
 - pypi: python/ribasim
   name: ribasim
-  version: 2024.11.0
+  version: 2025.1.0
   sha256: bc76f0d6b28e203efbaa6ced5c6e7c542e2304e784989ec6c3152a516cd1c041
   requires_dist:
   - geopandas>=1.0
@@ -21943,7 +21943,7 @@ packages:
   editable: true
 - pypi: python/ribasim_api
   name: ribasim-api
-  version: 2024.11.0
+  version: 2025.1.0
   sha256: 73658444714bf6027302b5bf1ec3da2cad1a265d8d1e3c0f4dcb9a17c02b704c
   requires_dist:
   - xmipy>=1.3

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Ribasim"
-version = "2024.11.0"
+version = "2025.1.0"
 description = "Water resources modeling"
 authors = ["Deltares and contributors <ribasim.info@deltares.nl>"]
 channels = ["conda-forge"]

--- a/python/ribasim/ribasim/__init__.py
+++ b/python/ribasim/ribasim/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2024.11.0"
+__version__ = "2025.1.0"
 # Keep synced write_schema_version in ribasim_qgis/core/geopackage.py
 __schema_version__ = 3
 

--- a/python/ribasim_api/ribasim_api/__init__.py
+++ b/python/ribasim_api/ribasim_api/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2024.11.0"
+__version__ = "2025.1.0"
 
 from ribasim_api.ribasim_api import RibasimApi
 

--- a/ribasim_qgis/core/nodes.py
+++ b/ribasim_qgis/core/nodes.py
@@ -609,6 +609,25 @@ class LevelBoundaryTime(Input):
         ]
 
 
+class LevelBoundaryConcentration(Input):
+    @classmethod
+    def input_type(cls) -> str:
+        return "LevelBoundary / concentration"
+
+    @classmethod
+    def geometry_type(cls) -> str:
+        return "No Geometry"
+
+    @classmethod
+    def attributes(cls) -> list[QgsField]:
+        return [
+            QgsField("node_id", QVariant.Int),
+            QgsField("time", QVariant.DateTime),
+            QgsField("substance", QVariant.String),
+            QgsField("concentration", QVariant.Double),
+        ]
+
+
 class PumpStatic(Input):
     @classmethod
     def input_type(cls) -> str:
@@ -685,6 +704,25 @@ class FlowBoundaryTime(Input):
             QgsField("node_id", QVariant.Int),
             QgsField("time", QVariant.DateTime),
             QgsField("flow_rate", QVariant.Double),
+        ]
+
+
+class FlowBoundaryConcentration(Input):
+    @classmethod
+    def input_type(cls) -> str:
+        return "FlowBoundary / concentration"
+
+    @classmethod
+    def geometry_type(cls) -> str:
+        return "No Geometry"
+
+    @classmethod
+    def attributes(cls) -> list[QgsField]:
+        return [
+            QgsField("node_id", QVariant.Int),
+            QgsField("time", QVariant.DateTime),
+            QgsField("substance", QVariant.String),
+            QgsField("concentration", QVariant.Double),
         ]
 
 
@@ -865,6 +903,25 @@ class UserDemandTime(Input):
             QgsField("demand", QVariant.Double),
             QgsField("return_factor", QVariant.Double),
             QgsField("priority", QVariant.Int),
+        ]
+
+
+class UserDemandConcentration(Input):
+    @classmethod
+    def input_type(cls) -> str:
+        return "UserDemand / concentration"
+
+    @classmethod
+    def geometry_type(cls) -> str:
+        return "No Geometry"
+
+    @classmethod
+    def attributes(cls) -> list[QgsField]:
+        return [
+            QgsField("node_id", QVariant.Int),
+            QgsField("time", QVariant.DateTime),
+            QgsField("substance", QVariant.String),
+            QgsField("concentration", QVariant.Double),
         ]
 
 

--- a/ribasim_qgis/metadata.txt
+++ b/ribasim_qgis/metadata.txt
@@ -7,7 +7,7 @@
 name=Ribasim
 qgisMinimumVersion=3.34
 description=QGIS plugin to setup Ribasim models
-version=2024.11.0
+version=2025.1.0
 author=Deltares and contributors
 email=ribasim.info@deltares.nl
 

--- a/ribasim_qgis/tests/data/simple_valid.toml
+++ b/ribasim_qgis/tests/data/simple_valid.toml
@@ -3,4 +3,4 @@ endtime = 2021-01-01 00:00:00
 crs = "EPSG:28992"
 input_dir = "."
 results_dir = "results"
-ribasim_version = "2024.11.0"
+ribasim_version = "2025.1.0"

--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -337,7 +337,7 @@ class DatasetWidget(QWidget):
                     f'crs = "{self.ribasim_widget.crs.authid()}"\n',
                     'input_dir = "."\n',
                     'results_dir = "results"\n',
-                    'ribasim_version = "2024.11.0"\n',
+                    'ribasim_version = "2025.1.0"\n',
                 ]
             )
 

--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -77,7 +77,7 @@ class DatasetTreeWidget(QTreeWidget):
         selection = self.selectedItems()
 
         # Warn before deletion
-        message = "\n".join([f"- {item.text(1)}" for item in selection])
+        message = "\n".join([f"- {item.text(0)}" for item in selection])
         reply = QMessageBox.question(
             self,
             "Deleting from Geopackage",


### PR DESCRIPTION
The first release of 2025 makes the Ribasim core more robust and stable, and speeds up
initialization for large models. The biggest new feature is the experimental support for
calculating tracers in Ribasim directly, which will hopefully make it easier to track where
the water resources are heading.

Note that I also pushed a few separate commits with fixes I found during the release process.