### PR TITLE
Don't remove or reset artifacts anymore

### DIFF
--- a/.teamcity/Templates/Build.kt
+++ b/.teamcity/Templates/Build.kt
@@ -46,7 +46,6 @@ open class Build(platformOs: String) : Template() {
                 workingDir = "ribasim"
                 scriptContent = header +
                 """
-                pixi run remove-artifacts
                 pixi run build
                 """.trimIndent()
             }

--- a/pixi.toml
+++ b/pixi.toml
@@ -70,7 +70,6 @@ build = { "cmd" = "julia --project build.jl", cwd = "build", depends-on = [
     "generate-testmodels",
     "initialize-julia",
 ], env = { SSL_CERT_DIR = "", JULIA_SSL_CA_ROOTS_PATH = "" } }
-remove-artifacts = "julia --eval 'rm(joinpath(Base.DEPOT_PATH[1], \"artifacts\"), force=true, recursive=true)'"
 # Tests
 test-ribasim-cli = "pytest --numprocesses=4 --basetemp=build/tests/temp --junitxml=report.xml build/tests"
 test-ribasim-core = { cmd = "julia --project=core --eval 'using Pkg; Pkg.test()'", depends-on = [
@@ -154,11 +153,7 @@ github-release = "python utils/github-release.py"
 
 [target.win.tasks]
 add-ribasim-icon = { cmd = "rcedit build/ribasim/ribasim.exe --set-icon docs/assets/ribasim.ico" }
-# Workaround rare issue on Windows where the permissions of the artifacts directory are incorrect
-# Upstream issue: https://github.com/JuliaLang/julia/issues/52272
-reset-artifact-permissions = "icacls $homedrive/$homepath/.julia/artifacts /q /c /t /reset"
 install-ci = { depends-on = [
-    # "reset-artifact-permissions",  # see #1972
     "install-julia",
     "update-registry-julia",
 ] }


### PR DESCRIPTION
Fixes #1972.
This problem doesn't seem to be happening anymore, possibly since moving to Windows 11.
