### PR TITLE
Fix extra newlines in codegen output on Windows

### DIFF
--- a/utils/gen_python.jl
+++ b/utils/gen_python.jl
@@ -54,17 +54,18 @@ function get_connectivity()
     ]
 end
 
-# Setup template with whitespace settings that mainly strips whitespace.
-# See schemas.py.jinja for the layout of the template.
-MODEL_TEMPLATE = Template(
-    normpath(@__DIR__, "templates", "schemas.py.jinja");
-    config = Dict("trim_blocks" => true, "lstrip_blocks" => true, "autoescape" => false),
+config = Dict(
+    "trim_blocks" => true,
+    "lstrip_blocks" => true,
+    "autoescape" => false,
+    "newline" => "\n",
 )
 
-CONNECTION_TEMPLATE = Template(
-    normpath(@__DIR__, "templates", "validation.py.jinja");
-    config = Dict("trim_blocks" => true, "lstrip_blocks" => true, "autoescape" => false),
-)
+# Setup template with whitespace settings that mainly strips whitespace.
+# See schemas.py.jinja for the layout of the template.
+MODEL_TEMPLATE = Template(normpath(@__DIR__, "templates", "schemas.py.jinja"); config)
+CONNECTION_TEMPLATE =
+    Template(normpath(@__DIR__, "templates", "validation.py.jinja"); config)
 
 function (@main)(_)::Cint
     # Write schemas.py


### PR DESCRIPTION
By setting `"newline" => "\n"` in the OteraEngine Template config.

This means that the input, e.g. `schemas.py.jinja` will be assumed to have LF line endings instead of the assumed CRLF line endings on Windows. In our .gitattributes file, we have `*.py text eol=lf` which means that the file will be checked out with LF line endings on Windows.

Fixes #2048