### PR TITLE
[CI] Quote all branches with a /.

### DIFF
--- a/.github/workflows/core_testmodels.yml
+++ b/.github/workflows/core_testmodels.yml
@@ -1,7 +1,7 @@
 name: Julia Run Testmodels
 on:
   push:
-    branches: [main, update/pixi-lock, update/julia-manifest]
+    branches: [main, "update/pixi-lock", "update/julia-manifest"]
     paths-ignore: [".teamcity/**"]
     tags: ["*"]
   pull_request:

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -1,7 +1,7 @@
 name: Julia Tests
 on:
   push:
-    branches: [main, update/pixi-lock, update/julia-manifest]
+    branches: [main, "update/pixi-lock", "update/julia-manifest"]
     paths-ignore: [".teamcity/**"]
     tags: ["*"]
   pull_request:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Docs
 on:
   push:
-    branches: [main, update/pixi-lock, update/julia-manifest]
+    branches: [main, "update/pixi-lock", "update/julia-manifest"]
     paths-ignore: [".teamcity/**"]
   pull_request:
     paths-ignore: [".teamcity/**"]

--- a/.github/workflows/julia_auto_update.yml
+++ b/.github/workflows/julia_auto_update.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: update/julia-manifest
+          branch: "update/julia-manifest"
           title: Update Julia manifest
           commit-message: "Update Julia manifest"
           body: Update Julia dependencies to the latest version.

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,7 +1,7 @@
 name: Mypy Type Check
 on:
   push:
-    branches: [main, update/pixi-lock]
+    branches: [main, "update/pixi-lock"]
     paths-ignore: [".teamcity/**"]
     tags: ["*"]
   pull_request:

--- a/.github/workflows/pixi_auto_update.yml
+++ b/.github/workflows/pixi_auto_update.yml
@@ -32,7 +32,7 @@ jobs:
           commit-message: Update pixi lockfile
           title: Update pixi lockfile
           body-path: diff.md
-          branch: update/pixi-lock
+          branch: "update/pixi-lock"
           base: main
           delete-branch: true
           add-paths: pixi.lock

--- a/.github/workflows/pre-commit_auto_update.yml
+++ b/.github/workflows/pre-commit_auto_update.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: update/pre-commit-hooks
+          branch: "update/pre-commit-hooks"
           title: Update pre-commit hooks
           commit-message: "Update pre-commit hooks"
           body: Update versions of pre-commit hooks to latest version.

--- a/.github/workflows/pre-commit_check.yml
+++ b/.github/workflows/pre-commit_check.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   merge_group:
   push:
-    branches: [main, update/pre-commit-hooks, update/pixi-lock]
+    branches: [main, "update/pre-commit-hooks", "update/pixi-lock"]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/python_codegen.yml
+++ b/.github/workflows/python_codegen.yml
@@ -1,7 +1,7 @@
 name: Python Codegen
 on:
   push:
-    branches: [main, update/pixi-lock]
+    branches: [main, "update/pixi-lock"]
     paths-ignore: [".teamcity/**"]
     tags: ["*"]
   pull_request:

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -1,7 +1,7 @@
 name: Ribasim Python Tests
 on:
   push:
-    branches: [main, update/pixi-lock]
+    branches: [main, "update/pixi-lock"]
     paths-ignore: [".teamcity/**"]
     tags: ["*"]
   pull_request:


### PR DESCRIPTION
Fixes #1996 

I'm assuming this is the culprit, Github documents using quotes for branches with / in them: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet