### PR TITLE
Update to OteraEngine v1.1

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1850,10 +1850,10 @@ uuid = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 version = "1.1.0"
 
 [[deps.OteraEngine]]
-deps = ["Markdown", "Pkg", "TOML"]
-git-tree-sha1 = "13ddb53617c492c9d63c7336a553b0b60b6c7e1a"
+deps = ["Markdown", "TOML"]
+git-tree-sha1 = "9e0a1f6d31570bba27b502b0e62080b3a4f7a1cb"
 uuid = "b2d7f28f-acd6-4007-8b26-bc27716e5513"
-version = "1.0.0"
+version = "1.1.0"
 
 [[deps.PCRE2_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/utils/gen_python.jl
+++ b/utils/gen_python.jl
@@ -54,31 +54,21 @@ function get_connectivity()
     ]
 end
 
-config = Dict(
-    "trim_blocks" => true,
-    "lstrip_blocks" => true,
-    "autoescape" => false,
-    "newline" => "\n",
-)
+# Don't automatically escape expression blocks
+config = Dict("autoescape" => false)
 
-# Setup template with whitespace settings that mainly strips whitespace.
-# See schemas.py.jinja for the layout of the template.
-MODEL_TEMPLATE = Template(normpath(@__DIR__, "templates", "schemas.py.jinja"); config)
-CONNECTION_TEMPLATE =
-    Template(normpath(@__DIR__, "templates", "validation.py.jinja"); config)
+MODEL_TEMPLATE = Template(normpath(@__DIR__, "templates/schemas.py.jinja"); config)
+CONNECTION_TEMPLATE = Template(normpath(@__DIR__, "templates/validation.py.jinja"); config)
 
 function (@main)(_)::Cint
     # Write schemas.py
-    open(normpath(@__DIR__, "..", "python", "ribasim", "ribasim", "schemas.py"), "w") do io
+    open(normpath(@__DIR__, "../python/ribasim/ribasim/schemas.py"), "w") do io
         init = Dict(:models => get_models())
         println(io, MODEL_TEMPLATE(; init = init))
     end
 
     # Write validation.py
-    open(
-        normpath(@__DIR__, "..", "python", "ribasim", "ribasim", "validation.py"),
-        "w",
-    ) do io
+    open(normpath(@__DIR__, "../python/ribasim/ribasim/validation.py"), "w") do io
         init = Dict(:nodes => get_connectivity())
         println(io, CONNECTION_TEMPLATE(; init = init))
     end


### PR DESCRIPTION
This removes the newline option, either CRLF or LF works.

This leaves out the other default options and shortens the paths.
Better fix than #2054.