### PR TITLE
Make it easier to review Julia manifest updates

### DIFF
--- a/.github/workflows/julia_auto_update.yml
+++ b/.github/workflows/julia_auto_update.yml
@@ -27,5 +27,5 @@ jobs:
           branch: update/julia-manifest
           title: Update Julia manifest
           commit-message: "Update Julia manifest"
-          body-path: .pixi/update-manifest-julia.md.md
+          body-path: .pixi/update-manifest-julia.md
           author: "GitHub <noreply@github.com>"

--- a/.github/workflows/julia_auto_update.yml
+++ b/.github/workflows/julia_auto_update.yml
@@ -19,9 +19,9 @@ jobs:
         run: |
           pixi run install-julia
           pixi run update-manifest-julia
-      - uses: peter-evans/create-pull-request@v7
         env:
           JULIA_PKG_PRECOMPILE_AUTO: "0"
+      - uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.CI_PR_PAT }}
           branch: update/julia-manifest

--- a/.github/workflows/julia_auto_update.yml
+++ b/.github/workflows/julia_auto_update.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Update Julia manifest file
         run: |
           pixi run install-julia
-          pixi run update-manifest-julia.md
+          pixi run update-manifest-julia
       - uses: peter-evans/create-pull-request@v7
         env:
           JULIA_PKG_PRECOMPILE_AUTO: "0"

--- a/.github/workflows/julia_auto_update.yml
+++ b/.github/workflows/julia_auto_update.yml
@@ -18,12 +18,14 @@ jobs:
       - name: Update Julia manifest file
         run: |
           pixi run install-julia
-          pixi run update-manifest-julia
+          pixi run update-manifest-julia.md
       - uses: peter-evans/create-pull-request@v7
+        env:
+          JULIA_PKG_PRECOMPILE_AUTO: "0"
         with:
           token: ${{ secrets.CI_PR_PAT }}
           branch: update/julia-manifest
           title: Update Julia manifest
           commit-message: "Update Julia manifest"
-          body: Update Julia dependencies to the latest version.
+          body-path: .pixi/update-manifest-julia.md.md
           author: "GitHub <noreply@github.com>"

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,7 +31,7 @@ install = { depends-on = [
 # Julia
 # Clear SSL_CERT_DIR to avoid Julia warnings, see https://github.com/JuliaLang/Downloads.jl/issues/244
 update-registry-julia = { cmd = "julia --eval='using Pkg; Registry.update()'", env = { SSL_CERT_DIR = "" } }
-update-manifest-julia = { cmd = "julia --project --eval='using Pkg; Pkg.update()'", env = { SSL_CERT_DIR = "" } }
+update-manifest-julia = { cmd = "julia --project utils/update-manifest.jl", env = { SSL_CERT_DIR = "", JULIA_SSL_CA_ROOTS_PATH = "" } }
 instantiate-julia = { cmd = "julia --project --eval='using Pkg; Pkg.instantiate()'", env = { SSL_CERT_DIR = "", JULIA_SSL_CA_ROOTS_PATH = "" } }
 initialize-julia = { depends-on = [
     "update-registry-julia",

--- a/utils/update-manifest.jl
+++ b/utils/update-manifest.jl
@@ -7,6 +7,7 @@ const DETAILS_BEGIN = """
 All package versions
 </summary>
 
+```
 """
 
 """
@@ -17,9 +18,9 @@ function (@main)(_)
     path = normpath(@__DIR__, "../.pixi/update-manifest-julia.md")
     redirect_stdio(; stdout = path, stderr = path) do
         println("Update the Julia Manifest.toml to get the latest dependencies.\n")
-        println("__Changed packages__`\n```")
+        println("__Changed packages__\n```")
         Pkg.update()
-        println("```\n\n__Packages still outdated after update__`\n```")
+        println("```\n\n__Packages still outdated after update__\n```")
         Pkg.status(; outdated = true)
         println("```")
     end
@@ -41,6 +42,6 @@ function (@main)(_)
         println(io, DETAILS_BEGIN)
         sort!(installed_lines)
         foreach(line -> println(io, line), installed_lines)
-        println("\n\n</details>")
+        println("```\n\n</details>")
     end
 end

--- a/utils/update-manifest.jl
+++ b/utils/update-manifest.jl
@@ -1,0 +1,17 @@
+import Pkg
+
+"""
+Update the Julia Manifest.toml and show the changes as well as outdated packages.
+The output is written to a file that can be used as the body of a pull request.
+"""
+function (@main)(_)
+    path = normpath(@__DIR__, "../.pixi/update-manifest-julia.md")
+    redirect_stdio(; stdout = path, stderr = path) do
+        println("Update the Julia Manifest.toml to get the latest dependencies.\n")
+        println("Output of `Pkg.update()`\n```")
+        Pkg.update()
+        println("```\n\nOutput of `Pkg.status(; outdated=true)`\n```")
+        Pkg.status(; outdated = true)
+        println("```")
+    end
+end

--- a/utils/update-manifest.jl
+++ b/utils/update-manifest.jl
@@ -1,5 +1,14 @@
 import Pkg
 
+const IS_INSTALLED = r"\s*Installed (.+)"
+const DETAILS_BEGIN = """
+<details>
+<summary>
+All package versions
+</summary>
+
+"""
+
 """
 Update the Julia Manifest.toml and show the changes as well as outdated packages.
 The output is written to a file that can be used as the body of a pull request.
@@ -8,10 +17,30 @@ function (@main)(_)
     path = normpath(@__DIR__, "../.pixi/update-manifest-julia.md")
     redirect_stdio(; stdout = path, stderr = path) do
         println("Update the Julia Manifest.toml to get the latest dependencies.\n")
-        println("Output of `Pkg.update()`\n```")
+        println("__Changed packages__`\n```")
         Pkg.update()
-        println("```\n\nOutput of `Pkg.status(; outdated=true)`\n```")
+        println("```\n\n__Packages still outdated after update__`\n```")
         Pkg.status(; outdated = true)
         println("```")
+    end
+
+    # The Pkg.update output first prints all installed package versions.
+    # This is a lot, strip it out, sort it, and put it in a details tag at the end.
+    installed_lines = String[]
+    lines = readlines(path)
+    open(path, "w") do io
+        for line in lines
+            m = match(IS_INSTALLED, line)
+            if m === nothing
+                println(io, line)
+            else
+                push!(installed_lines, only(m.captures))
+            end
+        end
+
+        println(io, DETAILS_BEGIN)
+        sort!(installed_lines)
+        foreach(line -> println(io, line), installed_lines)
+        println("\n\n</details>")
     end
 end


### PR DESCRIPTION
This should put the output of `] update` and `status --outdated` in the PR body, so we can easily see what changed and what is stuck.

Without this it looks like #1990.
With this it looks like [#2070](https://github.com/Deltares/Ribasim/pull/2070).