### PR TITLE
Convert autodiff Boolean to ADTypes

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.3"
 manifest_format = "2.0"
-project_hash = "921c2f0c042509feb4a1950ec24084c1ad561dd0"
+project_hash = "728a3147f36fe80499c0ee10fefc8d0d614823e8"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "fb97701c117c8162e84dfcf80215caa904aef44f"
@@ -2137,7 +2137,7 @@ weakdeps = ["Distributed"]
     DistributedExt = "Distributed"
 
 [[deps.Ribasim]]
-deps = ["Accessors", "Arrow", "BasicModelInterface", "CodecZstd", "ComponentArrays", "Configurations", "DBInterface", "DataInterpolations", "DataStructures", "Dates", "DiffEqBase", "DiffEqCallbacks", "EnumX", "FiniteDiff", "Graphs", "HiGHS", "IterTools", "JuMP", "Legolas", "LineSearches", "LinearAlgebra", "LinearSolve", "Logging", "LoggingExtras", "MetaGraphsNext", "OrdinaryDiffEqBDF", "OrdinaryDiffEqCore", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqTsit5", "PreallocationTools", "SQLite", "SciMLBase", "SparseArrays", "SparseConnectivityTracer", "StructArrays", "Tables", "TerminalLoggers", "TranscodingStreams"]
+deps = ["ADTypes", "Accessors", "Arrow", "BasicModelInterface", "CodecZstd", "ComponentArrays", "Configurations", "DBInterface", "DataInterpolations", "DataStructures", "Dates", "DiffEqBase", "DiffEqCallbacks", "EnumX", "FiniteDiff", "Graphs", "HiGHS", "IterTools", "JuMP", "Legolas", "LineSearches", "LinearAlgebra", "LinearSolve", "Logging", "LoggingExtras", "MetaGraphsNext", "OrdinaryDiffEqBDF", "OrdinaryDiffEqCore", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqTsit5", "PreallocationTools", "SQLite", "SciMLBase", "SparseArrays", "SparseConnectivityTracer", "StructArrays", "Tables", "TerminalLoggers", "TranscodingStreams"]
 path = "core"
 uuid = "aac5e3d9-0b8f-4d4f-8241-b1a7a9632635"
 version = "2025.1.0"

--- a/core/Project.toml
+++ b/core/Project.toml
@@ -5,6 +5,7 @@ manifest = "../Manifest.toml"
 version = "2025.1.0"
 
 [deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
 BasicModelInterface = "59605e27-edc0-445a-b93d-c09a3a50b330"
@@ -55,6 +56,7 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 RibasimMakieExt = ["Makie", "DataFrames"]
 
 [compat]
+ADTypes = "1.13"
 Accessors = "0.1"
 Aqua = "0.8"
 Arrow = "2.3"

--- a/core/src/callback.jl
+++ b/core/src/callback.jl
@@ -614,7 +614,7 @@ function get_value(subvariable::NamedTuple, p::Parameters, du::AbstractVector, t
             basin.concentration_data.concentration_external[listen_node_id.idx][variable](t)
     elseif startswith(variable, "concentration.")
         substance = Symbol(last(split(variable, ".")))
-        var_idx = findfirst(==(substance), basin.concentration_data.substances)
+        var_idx = find_index(substance, basin.concentration_data.substances)
         value = basin.concentration_data.concentration_state[listen_node_id.idx, var_idx]
     else
         error("Unsupported condition variable $variable.")
@@ -753,7 +753,7 @@ function update_basin_conc!(integrator)::Nothing
 
     for row in timeblock
         i = searchsortedfirst(node_id, NodeID(NodeType.Basin, row.node_id, 0))
-        j = findfirst(==(Symbol(row.substance)), substances)
+        j = find_index(Symbol(row.substance), substances)
         ismissing(row.drainage) || (concentration[1, i, j] = row.drainage)
         ismissing(row.precipitation) || (concentration[2, i, j] = row.precipitation)
     end
@@ -774,7 +774,7 @@ function update_conc!(integrator, parameter, nodetype)::Nothing
 
     for row in timeblock
         i = searchsortedfirst(node_id, NodeID(nodetype, row.node_id, 0))
-        j = findfirst(==(Symbol(row.substance)), substances)
+        j = find_index(Symbol(row.substance), substances)
         ismissing(row.concentration) || (concentration[i, j] = row.concentration)
     end
     return nothing

--- a/core/src/config.jl
+++ b/core/src/config.jl
@@ -13,6 +13,7 @@ using DataStructures: DefaultDict
 using Dates: DateTime
 using Logging: LogLevel, Debug, Info, Warn, Error
 using ..Ribasim: Ribasim, isnode, nodetype
+using ADTypes: AutoForwardDiff, AutoFiniteDiff
 using OrdinaryDiffEqCore: OrdinaryDiffEqAlgorithm, OrdinaryDiffEqNewtonAdaptiveAlgorithm
 using OrdinaryDiffEqNonlinearSolve: NLNewton
 using OrdinaryDiffEqLowOrderRK: Euler, RK4
@@ -305,7 +306,7 @@ function algorithm(solver::Solver; u0 = [])::OrdinaryDiffEqAlgorithm
     end
 
     if function_accepts_kwarg(algotype, :autodiff)
-        kwargs[:autodiff] = solver.autodiff
+        kwargs[:autodiff] = solver.autodiff ? AutoForwardDiff() : AutoFiniteDiff()
     end
 
     algotype(; kwargs...)

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -1876,7 +1876,7 @@ function set_concentrations!(
 )
     for substance in unique(concentration_data.substance)
         data_sub = filter(row -> row.substance == substance, concentration_data)
-        sub_idx = findfirst(==(Symbol(substance)), substances)
+        sub_idx = find_index(Symbol(substance), substances)
         for group in IterTools.groupby(row -> row.node_id, data_sub)
             first_row = first(group)
             value = getproperty(first_row, concentration_column)

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -1138,3 +1138,16 @@ function unsafe_array(
 )::Vector{Float64}
     GC.@preserve A unsafe_wrap(Array, pointer(A), length(A))
 end
+
+"""
+Find the index of a symbol in an ordered set using iteration.
+
+This replaces `findfirst(==(x), s)` which triggered this depwarn:
+> indexing is deprecated for OrderedSet, please rewrite your code to use iteration
+"""
+function find_index(x::Symbol, s::OrderedSet{Symbol})
+    for (i, s) in enumerate(s)
+        s === x && return i
+    end
+    error(lazy"$x not found in $s.")
+end

--- a/core/test/utils_test.jl
+++ b/core/test/utils_test.jl
@@ -411,3 +411,12 @@ end
     x.b[2] = 10.0
     @test y[2] === 10.0
 end
+
+@testitem "find_index" begin
+    using Ribasim: find_index
+    using DataStructures: OrderedSet
+    s = OrderedSet([:a, :b, :c])
+    @test find_index(:a, s) === 1
+    @test find_index(:c, s) === 3
+    @test_throws "not found" find_index(:d, s)
+end


### PR DESCRIPTION
This should fix the deprecation warning, that does this as well:

https://github.com/SciML/OrdinaryDiffEq.jl/blob/5e78c0ac9403e5c9110905ac87c66670832abfd4/lib/OrdinaryDiffEqCore/src/misc_utils.jl#L134-L148

Fixes #2029.
