### PR TITLE
Use StateVector instead of ComponentVector

### DIFF
--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -99,7 +99,7 @@ using ComponentArrays: ComponentVector, ComponentArray, Axis, getaxes
 using Dates: Dates, DateTime, Millisecond, @dateformat_str
 
 # We customize broadcasting for our StateVector.
-using Base.Broadcast: Broadcasted, ArrayStyle
+using Base.Broadcast: Broadcasted, ArrayStyle, Extruded
 
 # Callbacks are used to trigger function calls at specific points in the similation.
 # E.g. after each timestep for discrete control,

--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -98,6 +98,9 @@ using ComponentArrays: ComponentVector, ComponentArray, Axis, getaxes
 # internally we use a Float64; seconds since the start of the simulation.
 using Dates: Dates, DateTime, Millisecond, @dateformat_str
 
+# We customize broadcasting for our StateVector.
+using Base.Broadcast: Broadcasted, ArrayStyle
+
 # Callbacks are used to trigger function calls at specific points in the similation.
 # E.g. after each timestep for discrete control,
 # or at each saveat for saving storage and flow results.

--- a/core/src/allocation_optim.jl
+++ b/core/src/allocation_optim.jl
@@ -29,7 +29,7 @@ Set the objective for the given demand priority.
 """
 function set_objective_demand_priority!(
     allocation_model::AllocationModel,
-    u::ComponentVector,
+    u::StateVector,
     p::Parameters,
     t::Float64,
     demand_priority_idx::Int,
@@ -331,7 +331,7 @@ Get several variables associated with a basin:
 function get_basin_data(
     allocation_model::AllocationModel,
     p::Parameters,
-    u::ComponentVector,
+    u::StateVector,
     node_id::NodeID,
 )
     (; graph, basin) = p
@@ -358,7 +358,7 @@ Storages are converted to flows by dividing by the allocation timestep.
 """
 function get_basin_capacity(
     allocation_model::AllocationModel,
-    u::ComponentVector,
+    u::StateVector,
     p::Parameters,
     t::Float64,
     node_id::NodeID,
@@ -388,7 +388,7 @@ Storages are converted to flows by dividing by the allocation timestep.
 """
 function get_basin_demand(
     allocation_model::AllocationModel,
-    u::ComponentVector,
+    u::StateVector,
     p::Parameters,
     t::Float64,
     node_id::NodeID,
@@ -412,7 +412,7 @@ vertical fluxes + the disk of storage above the maximum level / Δt_allocation
 """
 function set_initial_capacities_basin!(
     allocation_model::AllocationModel,
-    u::ComponentVector,
+    u::StateVector,
     p::Parameters,
     t::Float64,
 )::Nothing
@@ -460,7 +460,7 @@ Set the initial demand of each basin in the subnetwork as
 """
 function set_initial_demands_level!(
     allocation_model::AllocationModel,
-    u::ComponentVector,
+    u::StateVector,
     p::Parameters,
     t::Float64,
 )::Nothing
@@ -876,7 +876,7 @@ Solve the allocation problem for a single (demand_priority, source_priority) pai
 function optimize_per_source!(
     allocation_model::AllocationModel,
     demand_priority_idx::Integer,
-    u::ComponentVector,
+    u::StateVector,
     p::Parameters,
     t::AbstractFloat,
     optimization_type::OptimizationType.T,
@@ -970,7 +970,7 @@ end
 
 function optimize_demand_priority!(
     allocation_model::AllocationModel,
-    u::ComponentVector,
+    u::StateVector,
     p::Parameters,
     t::Float64,
     demand_priority_idx::Int,
@@ -1017,7 +1017,7 @@ Set the initial capacities and demands which are reduced by usage.
 """
 function set_initial_values!(
     allocation_model::AllocationModel,
-    u::ComponentVector,
+    u::StateVector,
     p::Parameters,
     t::Float64,
 )::Nothing
@@ -1066,7 +1066,7 @@ function collect_demands!(
     p::Parameters,
     allocation_model::AllocationModel,
     t::Float64,
-    u::ComponentVector,
+    u::StateVector,
 )::Nothing
     (; allocation) = p
     (; subnetwork_id) = allocation_model
@@ -1124,7 +1124,7 @@ function allocate_demands!(
     p::Parameters,
     allocation_model::AllocationModel,
     t::Float64,
-    u::ComponentVector,
+    u::StateVector,
 )::Nothing
     optimization_type = OptimizationType.allocate
     (; demand_priorities_all) = p.allocation

--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -49,7 +49,7 @@ function BMI.get_value_ptr(model::Model, name::String)::Vector{Float64}
     elseif name == "basin.drainage"
         p.basin.vertical_flux.drainage::Vector{Float64}
     elseif name == "basin.cumulative_infiltration"
-        unsafe_array(u.infiltration)::Vector{Float64}
+        unsafe_array(u, :infiltration)::Vector{Float64}
     elseif name == "basin.cumulative_drainage"
         p.basin.cumulative_drainage::Vector{Float64}
     elseif name == "basin.subgrid_level"
@@ -57,7 +57,7 @@ function BMI.get_value_ptr(model::Model, name::String)::Vector{Float64}
     elseif name == "user_demand.demand"
         vec(p.user_demand.demand)::Vector{Float64}
     elseif name == "user_demand.cumulative_inflow"
-        unsafe_array(u.user_demand_inflow)::Vector{Float64}
+        unsafe_array(u, :user_demand_inflow)::Vector{Float64}
     else
         error("Unknown variable $name")
     end

--- a/core/src/callback.jl
+++ b/core/src/callback.jl
@@ -7,7 +7,7 @@ Returns the CallbackSet and the SavedValues for flow.
 function create_callbacks(
     parameters::Parameters,
     config::Config,
-    u0::ComponentVector,
+    u0::StateVector,
     saveat,
 )::Tuple{CallbackSet, SavedResults}
     (; starttime, basin, flow_boundary, level_boundary, user_demand) = parameters

--- a/core/src/graph.jl
+++ b/core/src/graph.jl
@@ -227,7 +227,7 @@ the state vector, given an link (inflow_id, outflow_id).
 from the parameters, but integrated/averaged FlowBoundary flows must be provided via `boundary_flow`.
 """
 function get_flow(
-    flow::ComponentVector,
+    flow::StateVector,
     p::Parameters,
     t::Number,
     link::Tuple{NodeID, NodeID};
@@ -247,7 +247,7 @@ function get_flow(
     end
 end
 
-function get_influx(du::ComponentVector, id::NodeID, p::Parameters)
+function get_influx(du::StateVector, id::NodeID, p::Parameters)
     @assert id.type == NodeType.Basin
     (; basin) = p
     (; vertical_flux) = basin

--- a/core/src/logging.jl
+++ b/core/src/logging.jl
@@ -41,7 +41,7 @@ function log_bottlenecks(model; converged::Bool)
         max_errors = 5
         # Iterate over the errors in descending order
         for i in sortperm(flow_error; rev = true)
-            node_id = Symbol(id_from_state_index(p, u, i))
+            node_id = Symbol(u.node_id[i])
             error = flow_error[i]
             isnan(error) && continue  # NaN are sorted as largest
             # Stop reporting errors if they are too small or too many

--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -1,5 +1,5 @@
 struct SavedResults
-    flow::SavedValues{Float64, SavedFlow{StateVector{Float64}}}
+    flow::SavedValues{Float64, SavedFlow{StateVector{Float64, Float64}}}
     basin_state::SavedValues{Float64, SavedBasinState}
     subgrid_level::SavedValues{Float64, Vector{Float64}}
     solver_stats::SavedValues{Float64, SolverStats}

--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -1,5 +1,5 @@
-struct SavedResults{V <: ComponentVector{Float64}}
-    flow::SavedValues{Float64, SavedFlow{V}}
+struct SavedResults
+    flow::SavedValues{Float64, SavedFlow{StateVector{Float64}}}
     basin_state::SavedValues{Float64, SavedBasinState}
     subgrid_level::SavedValues{Float64, Vector{Float64}}
     solver_stats::SavedValues{Float64, SolverStats}
@@ -103,7 +103,7 @@ function Model(config::Config)::Model
     end
     @debug "Read database into memory."
 
-    u0 = build_state_vector(parameters)
+    u0 = StateVector(parameters)
     du0 = zero(u0)
 
     parameters = set_state_flow_links(parameters, u0)

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -1,12 +1,7 @@
 """
 The right hand side function of the system of ODEs set up by Ribasim.
 """
-function water_balance!(
-    du::ComponentVector,
-    u::ComponentVector,
-    p::Parameters,
-    t::Number,
-)::Nothing
+function water_balance!(du::StateVector, u::StateVector, p::Parameters, t::Number)::Nothing
     (; basin, pid_control) = p
     (; current_storage, current_low_storage_factor, current_level) =
         basin.current_properties
@@ -78,8 +73,8 @@ Compute the storages, levels and areas of all Basins given the
 state u and the time t.
 """
 function set_current_basin_properties!(
-    du::ComponentVector,
-    u::ComponentVector,
+    du::StateVector,
+    u::StateVector,
     p::Parameters,
     t::Number,
 )::Nothing
@@ -124,8 +119,8 @@ end
 
 function formulate_storages!(
     current_storage::AbstractVector,
-    du::ComponentVector,
-    u::ComponentVector,
+    du::StateVector,
+    u::StateVector,
     p::Parameters,
     t::Number;
     add_initial_storage::Bool = true,
@@ -148,11 +143,7 @@ end
 """
 The storage contributions of the forcings that are not part of the state.
 """
-function formulate_storage!(
-    current_storage::AbstractVector,
-    basin::Basin,
-    du::ComponentVector,
-)
+function formulate_storage!(current_storage::AbstractVector, basin::Basin, du::StateVector)
     (; current_cumulative_precipitation, current_cumulative_drainage) =
         basin.current_properties
 
@@ -218,7 +209,7 @@ function update_vertical_flux!(basin::Basin, du::AbstractVector)::Nothing
     return nothing
 end
 
-function set_error!(pid_control::PidControl, p::Parameters, du::ComponentVector, t::Number)
+function set_error!(pid_control::PidControl, p::Parameters, du::StateVector, t::Number)
     (; basin) = p
     (; listen_node_id, target, error) = pid_control
     error = error[parent(du)]
@@ -232,8 +223,8 @@ function set_error!(pid_control::PidControl, p::Parameters, du::ComponentVector,
 end
 
 function formulate_pid_control!(
-    u::ComponentVector,
-    du::ComponentVector,
+    u::StateVector,
+    du::StateVector,
     pid_control::PidControl,
     p::Parameters,
     t::Number,
@@ -300,7 +291,7 @@ end
 """
 Formulate the time derivative of the storage in a single Basin.
 """
-function formulate_dstorage(du::ComponentVector, p::Parameters, t::Number, node_id::NodeID)
+function formulate_dstorage(du::StateVector, p::Parameters, t::Number, node_id::NodeID)
     (; basin) = p
     (; inflow_ids, outflow_ids, vertical_flux) = basin
     @assert node_id.type == NodeType.Basin
@@ -322,7 +313,7 @@ function formulate_dstorage(du::ComponentVector, p::Parameters, t::Number, node_
 end
 
 function formulate_flow!(
-    du::ComponentVector,
+    du::StateVector,
     user_demand::UserDemand,
     p::Parameters,
     t::Number,
@@ -375,7 +366,7 @@ function formulate_flow!(
 end
 
 function formulate_flow!(
-    du::ComponentVector,
+    du::StateVector,
     linear_resistance::LinearResistance,
     p::Parameters,
     t::Number,
@@ -740,7 +731,7 @@ Clamp the cumulative flow states within the minimum and maximum
 flow rates for the last time step if these flow rate bounds are known.
 """
 function limit_flow!(
-    u::ComponentVector,
+    u::StateVector,
     integrator::DEIntegrator,
     p::Parameters,
     t::Number,

--- a/core/test/allocation_test.jl
+++ b/core/test/allocation_test.jl
@@ -1,6 +1,5 @@
 @testitem "Allocation solve" begin
-    using Ribasim: NodeID, OptimizationType
-    using ComponentArrays: ComponentVector
+    using Ribasim: NodeID, OptimizationType, StateVector
     import SQLite
     import JuMP
 
@@ -15,7 +14,7 @@
         4.5
     allocation_model = p.allocation.allocation_models[1]
     (; flow) = allocation_model
-    u = ComponentVector(; storage = zeros(length(p.basin.node_id)))
+    u = StateVector()
     t = 0.0
     Ribasim.allocate_demands!(p, allocation_model, t, u)
 
@@ -109,8 +108,7 @@ end
 
 @testitem "Allocation with main network optimization problem" begin
     using SQLite
-    using Ribasim: NodeID, NodeType, OptimizationType
-    using ComponentArrays: ComponentVector
+    using Ribasim: NodeID, NodeType, OptimizationType, StateVector
     using JuMP
     using DataFrames: DataFrame, ByRow, transform!
 
@@ -133,7 +131,7 @@ end
     t = 0.0
 
     # Collecting demands
-    u = ComponentVector(; storage = zeros(length(basin.node_id)))
+    u = StateVector()
     for allocation_model in allocation_models[2:end]
         Ribasim.collect_demands!(p, allocation_model, t, u)
     end
@@ -204,8 +202,7 @@ end
 
 @testitem "Subnetworks with sources" begin
     using SQLite
-    using Ribasim: NodeID, OptimizationType
-    using ComponentArrays: ComponentVector
+    using Ribasim: NodeID, OptimizationType, StateVector
     using OrdinaryDiffEqCore: get_du
     using JuMP
 
@@ -227,7 +224,7 @@ end
     mean_input_flows[4][(NodeID(:FlowBoundary, 59, p), NodeID(:Basin, 44, p))] = 1e-3
 
     # Collecting demands
-    u = ComponentVector(; storage = zeros(length(basin.node_id)))
+    u = StateVector()
     for allocation_model in allocation_models[2:end]
         Ribasim.collect_demands!(p, allocation_model, t, u)
     end

--- a/docs/concept/allocation.qmd
+++ b/docs/concept/allocation.qmd
@@ -241,7 +241,6 @@ The following is an example of an optimization problem for the example shown [he
 using Ribasim
 using Ribasim: NodeID
 using SQLite
-using ComponentArrays: ComponentVector
 
 toml_path = normpath(@__DIR__, "../../generated_testmodels/allocation_example/ribasim.toml")
 model = Ribasim.Model(toml_path)


### PR DESCRIPTION
This gets rid of our main use of ComponentArrays in favor of a minimal Ribasim state specific replacement called StateVector. ComponentArrays is a convenient package, but after recent breakage I wondered if it isn't better to make a more minimal and more static alternative for the state vector. IMO this leads to more readable code, and better stacktraces, at the cost of defining StateVector ourselves. Other ComponentArrays uses have mostly been replaced already by normal struct-of-arrays. The state needs to be an `AbstractVector{T}` and has clear components that all should be contiguous.

There are still a few other uses that need replacing.

This is a draft because I haven't managed to get SparseConnectivityTracer working with this properly. It already helped to support `similar(u, Int)`, but during tracing `du` stays a StateVector, but `u` becomes a Vector.

```jl
ERROR: MethodError: no method matching water_balance!(::StateVector{…}, ::Vector{…}, ::Ribasim.Parameters{…}, ::Float64)
The function `water_balance!` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  water_balance!(::StateVector, ::StateVector, ::Ribasim.Parameters, ::Number)
   @ Ribasim a:\repo\ribasim\Ribasim\core\src\solve.jl:4

Stacktrace:
 [1] (::Ribasim.var"#251#252"{…})(du::StateVector{…}, u::Vector{…})
   @ Ribasim a:\repo\ribasim\Ribasim\core\src\util.jl:795
 [2] trace_function(::Type{…}, f!::Ribasim.var"#251#252"{…}, y::StateVector{…}, x::StateVector{…})
   @ SparseConnectivityTracer a:\.julia\packages\SparseConnectivityTracer\aHOLr\src\trace_functions.jl:56
 [3] _jacobian_sparsity(f!::Function, y::StateVector{…}, x::StateVector{…}, ::Type{…})
   @ SparseConnectivityTracer a:\.julia\packages\SparseConnectivityTracer\aHOLr\src\trace_functions.jl:87
 [4] jacobian_sparsity
   @ a:\.julia\packages\SparseConnectivityTracer\aHOLr\src\adtypes_interface.jl:60 [inlined]
 [5] get_jac_prototype(du0::StateVector{…}, u0::StateVector{…}, p::Ribasim.Parameters{…}, t0::Float64)
   @ Ribasim a:\repo\ribasim\Ribasim\core\src\util.jl:794
 [6] Ribasim.Model(config::Ribasim.config.Config)
   @ Ribasim a:\repo\ribasim\Ribasim\core\src\model.jl:135
```