### PR TITLE
Quiet datacompy

### DIFF
--- a/python/ribasim/ribasim/__init__.py
+++ b/python/ribasim/ribasim/__init__.py
@@ -2,8 +2,12 @@ __version__ = "2025.1.0"
 # Keep synced write_schema_version in ribasim_qgis/core/geopackage.py
 __schema_version__ = 5
 
-from ribasim.config import Allocation, Logging, Node, Solver
-from ribasim.geometry.link import LinkTable
-from ribasim.model import Model
+import logging
+
+logging.getLogger("datacompy").setLevel(logging.ERROR)
+
+from ribasim.config import Allocation, Logging, Node, Solver  # noqa: E402
+from ribasim.geometry.link import LinkTable  # noqa: E402
+from ribasim.model import Model  # noqa: E402
 
 __all__ = ["LinkTable", "Allocation", "Logging", "Model", "Solver", "Node"]

--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -1,5 +1,6 @@
 import operator
 import re
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator
 from contextlib import closing
@@ -13,7 +14,10 @@ from typing import (
     cast,
 )
 
-import datacompy
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    import datacompy
+
 import geopandas as gpd
 import numpy as np
 import pandas as pd


### PR DESCRIPTION
Fixes #2084
The 5 warnings shown on `import ribasim` were either logging warnings or UserWarnings, so both need to be suppressed.

I had to add `noqa: E402` because we now have logging code above our imports. But if I move that line down it is too late and the warnings are logged.