### PR TITLE
Modify QGIS style symlinking

### DIFF
--- a/ribasim_qgis/scripts/install_ribasim_qgis.py
+++ b/ribasim_qgis/scripts/install_ribasim_qgis.py
@@ -6,14 +6,16 @@ target_path = Path("ribasim_qgis").absolute()
 plugins_path = Path(".pixi/qgis_env/profiles/default/python/plugins")
 source_path = plugins_path / "ribasim_qgis"
 
-styles_source_path = source_path / "core" / "styles"
+styles_source_path = target_path / "core" / "styles"
 styles_target_path = Path("python/ribasim/ribasim/styles").absolute()
 
+# Symlink ribasim_qgis styles to ribasim styles
+styles_source_path.unlink(missing_ok=True)
+styles_source_path.symlink_to(styles_target_path, target_is_directory=True)
+
+# Symlink qgis_env to ribasim_qgis, and hence qgis_env styles to ribasim styles
 plugins_path.mkdir(parents=True, exist_ok=True)
 source_path.unlink(missing_ok=True)
 source_path.symlink_to(target_path, target_is_directory=True)
-
-styles_source_path.unlink(missing_ok=True)
-styles_source_path.symlink_to(styles_target_path, target_is_directory=True)
 
 enable_plugin("ribasim_qgis")


### PR DESCRIPTION
This changes the style symlinking a bit from how it it was implemented in #1713.
I ran into permission denied errors locally on `styles_source_path.unlink` and this fixes them for me.

There are 3 places for styles:
1. ribasim python has them in the repo and uses them for adding styles on model.write
2. ribasim_qgis expects them as a default style fallback and has them in gitignore
3. qgis_env is such that `pixi run qgis` directly starts with the important plugins loaded

With this PR, 3 points to 2, and 2 points to 1.

After this is merged we need to double check if ribasim_qgis.zip still contains the styles under core/styles.
