### PR TITLE
Coerce geometries to 2D

### DIFF
--- a/python/ribasim/ribasim/geometry/base.py
+++ b/python/ribasim/ribasim/geometry/base.py
@@ -2,7 +2,7 @@ from typing import Any, get_type_hints
 
 import pandera as pa
 from pandera.typing import Series
-from pandera.typing.geopandas import GeoSeries
+from pandera.typing.geopandas import GeoDataFrame, GeoSeries
 
 from ribasim.schemas import _BaseSchema
 
@@ -12,3 +12,8 @@ class _GeoBaseSchema(_BaseSchema):
     def is_correct_geometry_type(cls, geoseries: GeoSeries[Any]) -> Series[bool]:
         T = get_type_hints(cls)["geometry"].__args__[0]
         return geoseries.map(lambda geom: isinstance(geom, T))
+
+    @pa.check_types
+    def force_2d(cls, gdf: GeoDataFrame[Any]) -> GeoDataFrame[Any]:
+        gdf.geometry = gdf.geometry.force_2d()
+        return gdf

--- a/python/ribasim/tests/test_validation.py
+++ b/python/ribasim/tests/test_validation.py
@@ -186,3 +186,9 @@ def test_geometry_validation():
 
     with pytest.raises(ValueError):
         basin.Area(geometry=[point])
+
+    # Drop third dimension on geometry on initialization
+    threed = basinarea.df.geometry.force_3d()
+    assert threed.has_z.iloc[0]
+    basinarea = basin.Area(geometry=threed)
+    assert not basinarea.df.geometry.has_z.iloc[0]


### PR DESCRIPTION
Doesn't seem to be working yet. Handing over to @evetion.
Fixes #2103.

```py
import ribasim

m1 = ribasim.Model.read("a/ribasim.toml")
m1.discrete_control.node.df.geometry = m1.discrete_control.node.df.geometry.force_3d()
m1.write("b/ribasim.toml")
m2 = ribasim.Model.read("b/ribasim.toml")
m2.discrete_control.node.df  # still 3D :(
```

https://pandera.readthedocs.io/en/stable/data_format_conversion.html

edit: We want parse as documented [here](https://pandera.readthedocs.io/en/stable/parsers.html#parsers-in-dataframemodel).
