### PR TITLE
Use PrecompileTools to compile basic model on build.

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2112,7 +2112,7 @@ weakdeps = ["Distributed"]
     DistributedExt = "Distributed"
 
 [[deps.Ribasim]]
-deps = ["ADTypes", "Accessors", "Arrow", "BasicModelInterface", "CodecZstd", "ComponentArrays", "Configurations", "DBInterface", "DataInterpolations", "DataStructures", "Dates", "DiffEqBase", "DiffEqCallbacks", "EnumX", "FiniteDiff", "Graphs", "HiGHS", "IterTools", "JuMP", "Legolas", "LineSearches", "LinearAlgebra", "LinearSolve", "Logging", "LoggingExtras", "MetaGraphsNext", "OrdinaryDiffEqBDF", "OrdinaryDiffEqCore", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqTsit5", "PreallocationTools", "SQLite", "SciMLBase", "SparseArrays", "SparseConnectivityTracer", "StructArrays", "Tables", "TerminalLoggers", "TranscodingStreams"]
+deps = ["ADTypes", "Accessors", "Arrow", "BasicModelInterface", "CodecZstd", "ComponentArrays", "Configurations", "DBInterface", "DataInterpolations", "DataStructures", "Dates", "DiffEqBase", "DiffEqCallbacks", "EnumX", "FiniteDiff", "Graphs", "HiGHS", "IterTools", "JuMP", "Legolas", "LineSearches", "LinearAlgebra", "LinearSolve", "Logging", "LoggingExtras", "MetaGraphsNext", "OrdinaryDiffEqBDF", "OrdinaryDiffEqCore", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqTsit5", "PreallocationTools", "PrecompileTools", "Preferences", "SQLite", "SciMLBase", "SparseArrays", "SparseConnectivityTracer", "StructArrays", "Tables", "TerminalLoggers", "TranscodingStreams"]
 path = "core"
 uuid = "aac5e3d9-0b8f-4d4f-8241-b1a7a9632635"
 version = "2025.1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -68,3 +68,6 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [sources]
 Ribasim = {path = "core"}
+
+[preferences.Ribasim]
+precompile_workload = false

--- a/build/precompile.jl
+++ b/build/precompile.jl
@@ -1,7 +1,31 @@
 # Workflow that will compile a lot of the code we will need.
 # With the purpose of reducing the latency for compiled binaries.
 
+using Preferences, UUIDs
+set_preferences!(
+    UUID("0bca4576-84f4-4d90-8ffe-ffa030f20462"),  # SciMLBase
+    "SpecializationLevel" => "FullSpecialize";
+    force = true,
+)
+set_preferences!(
+    UUID("aac5e3d9-0b8f-4d4f-8241-b1a7a9632635"),  # Ribasim
+    "precompile_workload" => true;
+    force = true,
+)
 using Ribasim
 
 toml_path = normpath(@__DIR__, "../generated_testmodels/basic/ribasim.toml")
+# This should now only take a second or less
 @assert Ribasim.main(toml_path) == 0
+
+# Remove preferences to avoid affecting normal Ribasim usage
+set_preferences!(
+    UUID("0bca4576-84f4-4d90-8ffe-ffa030f20462"),  # SciMLBase
+    "SpecializationLevel" => missing;
+    force = true,
+)
+set_preferences!(
+    UUID("aac5e3d9-0b8f-4d4f-8241-b1a7a9632635"),  # Ribasim
+    "precompile_workload" => missing;
+    force = true,
+)

--- a/core/Project.toml
+++ b/core/Project.toml
@@ -39,6 +39,8 @@ OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 PreallocationTools = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -95,6 +97,8 @@ OrdinaryDiffEqRosenbrock = "1.1"
 OrdinaryDiffEqSDIRK = "1.1"
 OrdinaryDiffEqTsit5 = "1.1"
 PreallocationTools = "0.4"
+PrecompileTools = "1.2.1"
+Preferences = "1.4.3"
 SQLite = "1.5.1"
 SciMLBase = "2.36"
 SparseArrays = "1"
@@ -123,6 +127,9 @@ TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [preferences.LinearSolve]
 LoadMKL_JLL = false
+
+[preferences.Ribasim]
+precompile_workload = false
 
 [targets]
 test = ["Aqua", "CSV", "DataFrames", "IOCapture", "Logging", "Statistics", "TerminalLoggers", "Test", "TOML", "TestItemRunner"]

--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -14,6 +14,8 @@ For more granular access, see:
 """
 module Ribasim
 
+using PrecompileTools: @setup_workload, @compile_workload
+
 # Algorithms for solving ODEs.
 using OrdinaryDiffEqCore: OrdinaryDiffEqCore, get_du, AbstractNLSolver
 using DiffEqBase: DiffEqBase, calculate_residuals!
@@ -160,5 +162,13 @@ function plot_basin_data end
 function plot_basin_data! end
 function plot_flow end
 function plot_flow! end
+
+@setup_workload begin
+    toml_path = normpath(@__DIR__, "../../generated_testmodels/basic/ribasim.toml")
+    isfile(toml_path) || return
+    @compile_workload begin
+        Ribasim.main(toml_path)
+    end
+end
 
 end  # module Ribasim

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -21,15 +21,40 @@ const SolverStats = @NamedTuple{
     5 Drainage = 6 Precipitation = 7
 Base.to_index(id::Substance.T) = Int(id)  # used to index into concentration matrices
 
-@generated function config.snake_case(nt::NodeType.T)
-    ex = quote end
-    for (sym, _) in EnumX.symbol_map(NodeType.T)
-        sc = QuoteNode(config.snake_case(sym))
-        t = NodeType.T(sym)
-        push!(ex.args, :(nt === $t && return $sc))
+function config.snake_case(nt::NodeType.T)::Symbol
+    if nt == NodeType.Basin
+        return :basin
+    elseif nt == NodeType.TabulatedRatingCurve
+        return :tabulated_rating_curve
+    elseif nt == NodeType.Pump
+        return :pump
+    elseif nt == NodeType.Outlet
+        return :outlet
+    elseif nt == NodeType.UserDemand
+        return :user_demand
+    elseif nt == NodeType.FlowDemand
+        return :flow_demand
+    elseif nt == NodeType.LevelDemand
+        return :level_demand
+    elseif nt == NodeType.FlowBoundary
+        return :flow_boundary
+    elseif nt == NodeType.LevelBoundary
+        return :level_boundary
+    elseif nt == NodeType.LinearResistance
+        return :linear_resistance
+    elseif nt == NodeType.ManningResistance
+        return :manning_resistance
+    elseif nt == NodeType.Terminal
+        return :terminal
+    elseif nt == NodeType.DiscreteControl
+        return :discrete_control
+    elseif nt == NodeType.ContinuousControl
+        return :continuous_control
+    elseif nt == NodeType.PidControl
+        return :pid_control
+    else
+        error("Unknown node type: $nt")
     end
-    push!(ex.args, :(return :nothing))  # type stability
-    ex
 end
 
 # Support creating a NodeType enum instance from a symbol or string


### PR DESCRIPTION
Should help with latency (#1942) on our executables. The basic one will run in half a second, and models related to basic see improvements too (but much less).

This sets up a precompile workload using PrecompileTools, which also compiles the statements of *other* packages with our types, instead of just Ribasim. This also sets the [specialization level](https://docs.sciml.ai/SciMLBase/stable/interfaces/Problems/#Specialization-Levels) of SciML to full, which is recommended for simulations.

However, as both will significantly increase compile time (and the model printing progress during it), I've disabled it by default for developers.

I believe that if we fix the type explosion of our Parameters we will have a fast executable for all models, although we ideally should have a workload that includes *all* our functionality (arrow, alloc, etc.).