### PR TITLE
Revert "Make min_upstream_level and max_downstream_level controllable…

### DIFF
--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -86,10 +86,8 @@ controllablefields(nodetype::Symbol) = controllablefields(Val(nodetype))
 controllablefields(::Val{:LinearResistance}) = Set((:active, :resistance))
 controllablefields(::Val{:ManningResistance}) = Set((:active, :manning_n))
 controllablefields(::Val{:TabulatedRatingCurve}) = Set((:active, :table))
-controllablefields(::Val{:Pump}) =
-    Set((:active, :flow_rate, :min_upstream_level, :max_downstream_level))
-controllablefields(::Val{:Outlet}) =
-    Set((:active, :flow_rate, :min_upstream_level, :max_downstream_level))
+controllablefields(::Val{:Pump}) = Set((:active, :flow_rate))
+controllablefields(::Val{:Outlet}) = Set((:active, :flow_rate))
 controllablefields(::Val{:PidControl}) =
     Set((:active, :target, :proportional, :integral, :derivative))
 controllablefields(nodetype) = Set{Symbol}()
@@ -287,8 +285,8 @@ function valid_flow_rates(
     for (key, control_state_update) in pairs(control_mapping)
         id_controlled = key[1]
         push!(ids_controlled, id_controlled)
-        i = findfirst(x -> x.name === :flow_rate, control_state_update.scalar_update)
-        flow_rate_update = control_state_update.scalar_update[i]
+        flow_rate_update = only(control_state_update.scalar_update)
+        @assert flow_rate_update.name == :flow_rate
         flow_rate_ = flow_rate_update.value
 
         if flow_rate_ < 0.0

--- a/core/test/control_test.jl
+++ b/core/test/control_test.jl
@@ -14,12 +14,9 @@
 
     # Control input(flow rates)
     pump_control_mapping = p.pump.control_mapping
-    control_state_update = pump_control_mapping[(NodeID(:Pump, 4, p), "off")]
-    i = findfirst(x -> x.name === :flow_rate, control_state_update.scalar_update)
-    @test control_state_update.scalar_update[i].value == 0
-    control_state_update = pump_control_mapping[(NodeID(:Pump, 4, p), "on")]
-    i = findfirst(x -> x.name === :flow_rate, control_state_update.scalar_update)
-    @test control_state_update.scalar_update[i].value == 1.0e-5
+    @test only(pump_control_mapping[(NodeID(:Pump, 4, p), "off")].scalar_update).value == 0
+    @test only(pump_control_mapping[(NodeID(:Pump, 4, p), "on")].scalar_update).value ==
+          1.0e-5
 
     logic_mapping::Vector{Dict{Vector{Bool}, String}} = [
         Dict(


### PR DESCRIPTION
… (#2088)"

This reverts commit c87c70f9674ad7332510c839f7677b79a95a9b29.

This caused a considerable slowdown of the HWS model. I think it is just because parameter updates are slow, and this does 3 instead of 1.

Related to https://github.com/Deltares/Ribasim/issues/2122