### PR TITLE
Use named function as weight function

### DIFF
--- a/core/src/graph.jl
+++ b/core/src/graph.jl
@@ -39,6 +39,7 @@ function create_graph(db::DB, config::Config)::MetaGraph
         vertex_data_type = NodeMetadata,
         edge_data_type = LinkMetadata,
         graph_data = nothing,
+        weight_function,
     )
     for row in node_rows
         node_id = NodeID(row.node_type, row.node_id, node_table)

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -981,6 +981,10 @@ end
     current_interpolation_index::Vector{IndexLookup}
 end
 
+# This function is the same as the MetaGraphsNext default anonymous function,
+# but has a stable type for the type alias below.
+weight_function(::Any) = 1.0
+
 """
 The metadata of the graph (the fields of the NamedTuple) can be accessed
     e.g. using graph[].flow.
@@ -1002,7 +1006,7 @@ const ModelGraph = MetaGraph{
         flow_links::Vector{LinkMetadata},
         saveat::Float64,
     },
-    MetaGraphsNext.var"#11#13",
+    typeof(weight_function),
     Float64,
 }
 


### PR DESCRIPTION
The generated `MetaGraphsNext.var"#11#13"` looked quite magical, and it changed in Julia 1.12. This way it will work in both 1.11 and 1.12. We don't use it anyway. This is all that's needed to get Ribasim to precompile on 1.12.