### PR TITLE
CI: Force rebuilding on tags

### DIFF
--- a/.teamcity/Ribasim/buildTypes/GenerateTestmodels.kt
+++ b/.teamcity/Ribasim/buildTypes/GenerateTestmodels.kt
@@ -1,5 +1,6 @@
 package Ribasim.buildTypes
 
+import Templates.*
 import Templates.GithubCommitStatusIntegration
 import jetbrains.buildServer.configs.kotlin.*
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
@@ -8,6 +9,8 @@ import jetbrains.buildServer.configs.kotlin.triggers.vcs
 object GenerateTestmodels : BuildType({
     templates(GithubCommitStatusIntegration)
     name = "Generate Testmodels"
+
+    templates(GithubPullRequestsIntegration)
 
     artifactRules = """ribasim\generated_testmodels => generated_testmodels.zip"""
     publishArtifacts = PublishMode.SUCCESSFUL
@@ -49,6 +52,8 @@ object GenerateTestmodels : BuildType({
     triggers {
         vcs {
             id = "TRIGGER_646"
+            branchFilter = "+:<default>"
+            triggerRules = "-:comment=^[skip ci]:**"
         }
     }
 

--- a/.teamcity/Ribasim/buildTypes/Ribasim_MakeGitHubRelease.kt
+++ b/.teamcity/Ribasim/buildTypes/Ribasim_MakeGitHubRelease.kt
@@ -1,5 +1,6 @@
 package Ribasim.buildTypes
 
+import Templates.*
 import Ribasim_Linux.Linux_BuildRibasim
 import Ribasim_Linux.Linux_TestRibasimBinaries
 import Ribasim_Windows.Windows_BuildRibasim
@@ -60,6 +61,7 @@ object Ribasim_MakeGitHubRelease : BuildType({
         }
         dependency(Linux_BuildRibasim) {
             snapshot {
+                reuseBuilds = ReuseBuilds.NO
                 onDependencyFailure = FailureAction.FAIL_TO_START
             }
 
@@ -83,6 +85,7 @@ object Ribasim_MakeGitHubRelease : BuildType({
         }
         dependency(AbsoluteId("SigningAndCertificates_Ribasim_SigningRibasimRelease")) {
             snapshot {
+                reuseBuilds = ReuseBuilds.NO
                 onDependencyFailure = FailureAction.FAIL_TO_START
             }
 

--- a/.teamcity/Ribasim/buildTypes/Ribasim_UploadToMinio.kt
+++ b/.teamcity/Ribasim/buildTypes/Ribasim_UploadToMinio.kt
@@ -50,6 +50,7 @@ object Ribasim_UploadToMinio : BuildType({
     triggers {
         vcs {
             id = "riba_main_minio_trigger"
+            triggerRules = "-:comment=^[skip ci]:**"
             branchFilter = """
                 +:<default>
             """.trimIndent()

--- a/.teamcity/Ribasim_Linux/RibasimLinuxProject.kt
+++ b/.teamcity/Ribasim_Linux/RibasimLinuxProject.kt
@@ -35,6 +35,9 @@ object Linux_Main : BuildType({
 
     triggers {
         vcs {
+            id = "TRIGGER_RIBA_SKIPL1"
+            branchFilter = "+:<default>"
+            triggerRules = "-:comment=^[skip ci]:**"
         }
     }
 

--- a/.teamcity/Ribasim_Windows/RibasimWindowsProject.kt
+++ b/.teamcity/Ribasim_Windows/RibasimWindowsProject.kt
@@ -39,6 +39,9 @@ object Windows_Main : BuildType({
 
     triggers {
         vcs {
+            id = "TRIGGER_RIBA_SKIPW1"
+            branchFilter = "+:<default>"
+            triggerRules = "-:comment=^[skip ci]:**"
         }
     }
 

--- a/docs/dev/ci.qmd
+++ b/docs/dev/ci.qmd
@@ -30,6 +30,10 @@ They include the following checks:
 * Ribasim Python tests: Runs Ribasim Python tests on multiple platforms and multiple Python versions
 * QGIS Tests: Runs QGIS unit tests
 
+The Github CI configuration is stored in version control,
+and can be found in the `.github` folder.
+
+One can [skip running the CI](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/skipping-workflow-runs) using `[skip ci]` in the git commit message.
 
 # TeamCity
 Ribasim has another cloud-based CI service based on [TeamCity](https://www.jetbrains.com/teamcity/).
@@ -40,6 +44,13 @@ graph LR
     A[TeamCity]-->|Monitoring|B[GitHub]
     A-->C(Release)
 ```
+
+The Teamcity CI configuration itself is also stored in version control, and can be found in the `.teamcity` folder.
+Note that changes are only applied once merged to the `main` branch.
+One can test the validity of their local configuration with `mvn teamcity-configs:generate`
+(requiring a local installation of [maven](https://maven.apache.org/)).
+
+Like Github, one can skip running the Teamcity CI by starting the git commit message with `[skip ci]`.
 
 ## Conditions of using TeamCity
 TeamCity only runs workflows with the following conditions:


### PR DESCRIPTION
Teamcity re-uses builds in a build chain when possible, so once the tag triggered the release chain, it re-used the previously build executable(s) for the commit of the tag. We can disable this by `reuseBuilds = ReuseBuilds.NO` in the specific snapshot builds.

This also enables us to skip builds on Teamcity (and already on Github) with a commit message that starts with `[skip ci]`. I've documented this as well.

Finally, I noted we create duplicate builds, once for a(ny) branch, and once for a created PR. This is bad (especially because I disabled some re-use above), so I've added some branchfilter to the default branch only (as [advised when using PR integration](https://www.jetbrains.com/help/teamcity/pull-requests.html#Interaction+with+VCS+Roots)). I also added this PR integration to the testmodel build which didn't have it yet.

Fixes #2040 
Fixes #2128 