### PR TITLE
VSCode parallel tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
         "editor.formatOnSave": true
     },
     "julia.executablePath": "julia +1.11.3",
+    "julia.numTestProcesses": 6,
     "notebook.formatOnSave.enabled": true,
     "notebook.codeActionsOnSave": {
         "notebook.source.fixAll": "explicit",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,32 +2,14 @@
     "[julia]": {
         "editor.formatOnSave": true
     },
-    "julia.executablePath": "julia +1.11.3",
-    "julia.numTestProcesses": 6,
-    "notebook.formatOnSave.enabled": true,
-    "notebook.codeActionsOnSave": {
-        "notebook.source.fixAll": "explicit",
-        "notebook.source.organizeImports": "explicit"
-    },
     "[python]": {
-        "editor.defaultFormatter": "charliermarsh.ruff",
-        "editor.formatOnSave": true,
         "editor.codeActionsOnSave": {
             "source.fixAll": "explicit",
             "source.organizeImports": "explicit"
-        }
+        },
+        "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.formatOnSave": true
     },
-    "mypy-type-checker.importStrategy": "fromEnvironment",
-    "python.testing.pytestArgs": [
-        "."
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true,
-    "julia.lint.disabledDirs": [
-        ".pixi"
-    ],
-    "julia.lint.run": true,
-    "files.insertFinalNewline": true,
     "cSpell.enabledLanguageIds": [
         "asciidoc",
         "c",
@@ -79,5 +61,23 @@
         "qgis",
         "quartodoc",
         "Ribasim"
-    ]
+    ],
+    "files.insertFinalNewline": true,
+    "julia.executablePath": "julia +1.11.3",
+    "julia.lint.disabledDirs": [
+        ".pixi"
+    ],
+    "julia.lint.run": true,
+    "julia.numTestProcesses": 6,
+    "mypy-type-checker.importStrategy": "fromEnvironment",
+    "notebook.codeActionsOnSave": {
+        "notebook.source.fixAll": "explicit",
+        "notebook.source.organizeImports": "explicit"
+    },
+    "notebook.formatOnSave.enabled": true,
+    "python.testing.pytestArgs": [
+        "."
+    ],
+    "python.testing.pytestEnabled": true,
+    "python.testing.unittestEnabled": false
 }


### PR DESCRIPTION
This adds `"julia.numTestProcesses": 6` and sorts the settings.
This makes VSCode run the tests in parallel. I did some quick checks before and around 6 seemed optimal for my hardware.
Probably few people will have hardware that would cause this to be slower.