### PR TITLE
Add `model.to_fews(region_dir)`

### DIFF
--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -754,7 +754,7 @@ class Model(FileModel):
         ** Warning: This method is experimental and is likely to change. **
 
         To run this method, the model needs to be written to disk, and have results.
-        The Node and Link tables are written to shapefiles in the Config directory.
+        The Node and Link tables are written to shapefiles in the REGION_HOME/Config directory.
         The results are written to NetCDF files in the Modules directory.
         The netCDF files are NetCDF4 with CF-conventions.
 

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -755,7 +755,7 @@ class Model(FileModel):
 
         To run this method, the model needs to be written to disk, and have results.
         The Node and Link tables are written to shapefiles in the REGION_HOME/Config directory.
-        The results are written to NetCDF files in the Modules directory.
+        The results are written to NetCDF files in the REGION_HOME/Modules directory.
         The netCDF files are NetCDF4 with CF-conventions.
 
         Parameters

--- a/python/ribasim/ribasim/utils.py
+++ b/python/ribasim/ribasim/utils.py
@@ -66,12 +66,6 @@ def _link_lookup(uds) -> Series[Int32]:
     )
 
 
-def _time_in_ns(df) -> None:
-    """Convert the time column to datetime64[ns] dtype."""
-    # datetime64[ms] gives trouble; https://github.com/pydata/xarray/issues/6318
-    df["time"] = df["time"].astype("datetime64[ns]")
-
-
 def _concat(dfs, **kwargs):
     """Concatenate DataFrames with a warning filter."""
     with catch_warnings():
@@ -84,6 +78,20 @@ def _concat(dfs, **kwargs):
             category=FutureWarning,
         )
         return pd.concat(dfs, **kwargs)
+
+
+def _add_cf_attributes(ds, timeseries_id):
+    """Add CF attributes to an xarray.Dataset."""
+    ds.attrs.update(
+        {
+            "Conventions": "CF-1.8",
+            "title": "Ribasim model results",
+            "references": "https://ribasim.org",
+        }
+    )
+    ds["time"].attrs.update({"standard_name": "time", "axis": "T"})
+    ds[timeseries_id].attrs.update({"cf_role": "timeseries_id"})
+    return ds
 
 
 class UsedIDs(BaseModel):


### PR DESCRIPTION
This adds a function `model.to_fews(region_dir)` that converts the network and results to files that Delft-FEWS can directly handle. It is marked as experimental for now.

@gijsber is working on a Delft-FEWS configuration that can be used to visualize model results, to complement our existing tools. We'll likely add this configuration to this monorepo since it is generic. #2159 also pertains to this work.

What is especially nice is the spatio-temporal support of Delft-FEWS, so we can make visualizations like this:

![image](https://github.com/user-attachments/assets/2e61bf82-0d7d-4558-a645-755d7e763b74)

In theory we can support similar functionality with QGIS, but looking at the plots in https://github.com/Deltares/Ribasim/pull/1369 this would likely need work in QGIS itself. So this is really a quick win to be able to inspect models better.