### PR TITLE
Write concentration.nc to Delft-FEWS

### DIFF
--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -844,8 +844,26 @@ class Model(FileModel):
 
         ds_basin = basin_df.set_index(["time", "node_id"]).to_xarray()
         _add_cf_attributes(ds_basin, timeseries_id="node_id")
+        ds_basin["level"].attrs.update({"units": "m"})
+        ds_basin["storage"].attrs.update({"units": "m3"})
+        ds_basin["relative_error"].attrs.update({"units": "1"})
+
+        flow_rate_variables = [
+            "inflow_rate",
+            "outflow_rate",
+            "storage_rate",
+            "precipitation",
+            "evaporation",
+            "drainage",
+            "infiltration",
+            "balance_error",
+        ]
+        for var in flow_rate_variables:
+            ds_basin[var].attrs.update({"units": "m3 s-1"})
+
         ds_flow = flow_df.set_index(["time", "link_id"]).to_xarray()
         _add_cf_attributes(ds_flow, timeseries_id="link_id")
+        ds_flow["flow_rate"].attrs.update({"units": "m3 s-1"})
 
         results_dir = region_home / "Modules/ribasim/{ModelId}/work/results"
         results_dir.mkdir(parents=True, exist_ok=True)
@@ -856,4 +874,5 @@ class Model(FileModel):
             df = pd.read_feather(concentration_path)
             ds = df.set_index(["time", "node_id", "substance"]).to_xarray()
             _add_cf_attributes(ds, timeseries_id="node_id", realization="substance")
+            ds["concentration"].attrs.update({"units": "g m-3"})
             ds.to_netcdf(results_dir / "concentration.nc")

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -842,12 +842,10 @@ class Model(FileModel):
         basin_df = pd.read_feather(basin_path)
         flow_df = pd.read_feather(flow_path)
 
-        ds_basin = _add_cf_attributes(
-            basin_df.set_index(["time", "node_id"]).to_xarray(), "node_id"
-        )
-        ds_flow = _add_cf_attributes(
-            flow_df.set_index(["time", "link_id"]).to_xarray(), "link_id"
-        )
+        ds_basin = basin_df.set_index(["time", "node_id"]).to_xarray()
+        _add_cf_attributes(ds_basin, timeseries_id="node_id")
+        ds_flow = flow_df.set_index(["time", "link_id"]).to_xarray()
+        _add_cf_attributes(ds_flow, timeseries_id="link_id")
 
         results_dir = region_home / "Modules/ribasim/{ModelId}/work/results"
         results_dir.mkdir(parents=True, exist_ok=True)
@@ -856,7 +854,6 @@ class Model(FileModel):
 
         if concentration_path.is_file():
             df = pd.read_feather(concentration_path)
-            ds = _add_cf_attributes(
-                df.set_index(["time", "node_id", "substance"]).to_xarray(), "node_id"
-            )
+            ds = df.set_index(["time", "node_id", "substance"]).to_xarray()
+            _add_cf_attributes(ds, timeseries_id="node_id", realization="substance")
             ds.to_netcdf(results_dir / "concentration.nc")

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -699,8 +699,8 @@ class Model(FileModel):
     def _add_flow(self, uds, node_lookup):
         basin_path = self.results_path / "basin.arrow"
         flow_path = self.results_path / "flow.arrow"
-        basin_df = pd.read_feather(basin_path, dtype_backend="pyarrow")
-        flow_df = pd.read_feather(flow_path, dtype_backend="pyarrow")
+        basin_df = pd.read_feather(basin_path)
+        flow_df = pd.read_feather(flow_path)
 
         # add the xugrid dimension indices to the dataframes
         link_dim = uds.grid.edge_dimension
@@ -741,7 +741,6 @@ class Model(FileModel):
                 "optimization_type",
                 "demand_priority",
             ],
-            dtype_backend="pyarrow",
         )
 
         # add the xugrid link dimension index to the dataframe

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -837,6 +837,7 @@ class Model(FileModel):
 
         basin_path = self.results_path / "basin.arrow"
         flow_path = self.results_path / "flow.arrow"
+        concentration_path = self.results_path / "concentration.arrow"
 
         basin_df = pd.read_feather(basin_path)
         flow_df = pd.read_feather(flow_path)
@@ -852,3 +853,10 @@ class Model(FileModel):
         results_dir.mkdir(parents=True, exist_ok=True)
         ds_basin.to_netcdf(results_dir / "basin.nc")
         ds_flow.to_netcdf(results_dir / "flow.nc")
+
+        if concentration_path.is_file():
+            df = pd.read_feather(concentration_path)
+            ds = _add_cf_attributes(
+                df.set_index(["time", "node_id", "substance"]).to_xarray(), "node_id"
+            )
+            ds.to_netcdf(results_dir / "concentration.nc")

--- a/python/ribasim/ribasim/utils.py
+++ b/python/ribasim/ribasim/utils.py
@@ -80,7 +80,7 @@ def _concat(dfs, **kwargs):
         return pd.concat(dfs, **kwargs)
 
 
-def _add_cf_attributes(ds, timeseries_id):
+def _add_cf_attributes(ds, timeseries_id: str, realization: str | None = None) -> None:
     """Add CF attributes to an xarray.Dataset."""
     ds.attrs.update(
         {
@@ -91,6 +91,9 @@ def _add_cf_attributes(ds, timeseries_id):
     )
     ds["time"].attrs.update({"standard_name": "time", "axis": "T"})
     ds[timeseries_id].attrs.update({"cf_role": "timeseries_id"})
+    if realization:
+        # https://confluence.ecmwf.int/display/COPSRV/Metadata+recommendations+for+encoding+NetCDF+products+based+on+CF+convention#MetadatarecommendationsforencodingNetCDFproductsbasedonCFconvention-3.4Realizationdiscretecoordinates
+        ds[realization].attrs.update({"standard_name": "realization", "axis": "E"})
     return ds
 
 

--- a/python/ribasim/ribasim/utils.py
+++ b/python/ribasim/ribasim/utils.py
@@ -81,7 +81,22 @@ def _concat(dfs, **kwargs):
 
 
 def _add_cf_attributes(ds, timeseries_id: str, realization: str | None = None) -> None:
-    """Add CF attributes to an xarray.Dataset."""
+    """
+    Add CF attributes to an xarray.Dataset.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        The dataset to which CF attributes will be added.
+    timeseries_id : str
+        The name of the variable that identifies the timeseries.
+    realization : str | None, optional
+        The name of the variable representing realizations (e.g., "substance"), if applicable.
+
+    Returns
+    -------
+    None
+    """
     ds.attrs.update(
         {
             "Conventions": "CF-1.8",
@@ -94,6 +109,8 @@ def _add_cf_attributes(ds, timeseries_id: str, realization: str | None = None) -
         {"cf_role": "timeseries_id", "long_name": "station identification code"}
     )
     if realization:
+        # Use realization as the standard name as recommended by ECMWF.
+        # axis = "E" is not currently enabled since it seemed to confuse Delft-FEWS.
         # https://confluence.ecmwf.int/display/COPSRV/Metadata+recommendations+for+encoding+NetCDF+products+based+on+CF+convention#MetadatarecommendationsforencodingNetCDFproductsbasedonCFconvention-3.4Realizationdiscretecoordinates
         ds[realization].attrs.update(
             {

--- a/python/ribasim/ribasim/utils.py
+++ b/python/ribasim/ribasim/utils.py
@@ -89,11 +89,19 @@ def _add_cf_attributes(ds, timeseries_id: str, realization: str | None = None) -
             "references": "https://ribasim.org",
         }
     )
-    ds["time"].attrs.update({"standard_name": "time", "axis": "T"})
-    ds[timeseries_id].attrs.update({"cf_role": "timeseries_id"})
+    ds["time"].attrs.update({"standard_name": "time", "axis": "T", "long_name": "time"})
+    ds[timeseries_id].attrs.update(
+        {"cf_role": "timeseries_id", "long_name": "station identification code"}
+    )
     if realization:
         # https://confluence.ecmwf.int/display/COPSRV/Metadata+recommendations+for+encoding+NetCDF+products+based+on+CF+convention#MetadatarecommendationsforencodingNetCDFproductsbasedonCFconvention-3.4Realizationdiscretecoordinates
-        ds[realization].attrs.update({"standard_name": "realization", "axis": "E"})
+        ds[realization].attrs.update(
+            {
+                "standard_name": "realization",
+                "units": "1",
+                "long_name": "substance name",
+            }
+        )
     return ds
 
 


### PR DESCRIPTION
Part of #2166. @gijsber do you think this 3D structure would work? The `to_fews` output for the basic testmodel on this branch is here:

[ugrid.zip](https://github.com/user-attachments/files/19426651/ugrid.zip)
[{ModelId}.zip](https://github.com/user-attachments/files/19420907/ModelId.zip)
[results.zip](https://github.com/user-attachments/files/19420864/results.zip)

```
netcdf concentration {
dimensions:
	time = 366 ;
	node_id = 4 ;
	substance = 9 ;
variables:
	double concentration(time, node_id, substance) ;
		concentration:_FillValue = NaN ;
		concentration:units = "g m-3" ;
	int64 time(time) ;
		time:standard_name = "time" ;
		time:axis = "T" ;
		time:long_name = "time" ;
		time:units = "days since 2020-01-01 00:00:00" ;
		time:calendar = "proleptic_gregorian" ;
	int node_id(node_id) ;
		node_id:cf_role = "timeseries_id" ;
		node_id:long_name = "station identification code" ;
	string substance(substance) ;
		substance:standard_name = "realization" ;
		substance:units = "1" ;
		substance:long_name = "substance name" ;

// global attributes:
		:Conventions = "CF-1.8" ;
		:title = "Ribasim model results" ;
		:references = "https://ribasim.org" ;
}
```
