### PR TITLE
Use `autodiff = True` as the default again

### DIFF
--- a/core/src/config.jl
+++ b/core/src/config.jl
@@ -115,7 +115,7 @@ const nodetypes = collect(keys(nodekinds))
     water_balance_reltol::Float64 = 1e-2
     maxiters::Int = 1e9
     sparse::Bool = true
-    autodiff::Bool = false
+    autodiff::Bool = true
     evaporate_mass::Bool = true
 end
 

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -835,6 +835,7 @@ function OrdinaryDiffEqNonlinearSolve.relax!(
     if resid_after > resid_before
         @. dz = dz_tmp
     end
+    return dz
 end
 
 "Create a NamedTuple of the node IDs per state component in the state order"

--- a/core/test/config_test.jl
+++ b/core/test/config_test.jl
@@ -60,7 +60,8 @@ end
           AutoForwardDiff(; tag = :Ribasim)
     @test alg_autodiff(algorithm(Solver(; algorithm = "QNDF", autodiff = false))) ==
           AutoFiniteDiff()
-    @test alg_autodiff(algorithm(Solver(; algorithm = "QNDF"))) == AutoFiniteDiff()
+    @test alg_autodiff(algorithm(Solver(; algorithm = "QNDF"))) ==
+          AutoForwardDiff(; tag = :Ribasim)
     # autodiff is not a kwargs for explicit algorithms, but we use try-catch to bypass
     algorithm(Solver(; algorithm = "Euler", autodiff = true))
 

--- a/core/test/config_test.jl
+++ b/core/test/config_test.jl
@@ -32,7 +32,7 @@
     @testset "docs" begin
         config = Ribasim.Config(normpath(@__DIR__, "docs.toml"))
         @test config isa Ribasim.Config
-        @test !config.solver.autodiff
+        @test config.solver.autodiff
     end
 end
 

--- a/core/test/docs.toml
+++ b/core/test/docs.toml
@@ -43,7 +43,7 @@ water_balance_abstol = 1e-3 # optional, default 1e-3
 water_balance_reltol = 1e-2 # optional, default 1e-2
 maxiters = 1e9      # optional, default 1e9
 sparse = true       # optional, default true
-autodiff = false    # optional, default false
+autodiff = true     # optional, default true
 evaporate_mass = true  # optional, default true to simulate a correct mass balance
 
 [logging]

--- a/dvc.lock
+++ b/dvc.lock
@@ -17,7 +17,7 @@ stages:
       models/integration.toml:
         solver.abstol: 1e-07
         solver.algorithm: QNDF
-        solver.autodiff: false
+        solver.autodiff: true
         solver.reltol: 1e-07
     outs:
     - path: data/integration.toml

--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -139,7 +139,7 @@ class Solver(ChildModel):
     reltol: float = 1e-05
     maxiters: int = 1000000000
     sparse: bool = True
-    autodiff: bool = False
+    autodiff: bool = True
     evaporate_mass: bool = True
 
 


### PR DESCRIPTION
After https://github.com/Deltares/Ribasim/issues/2134 I wanted to check if https://github.com/Deltares/Ribasim/issues/1834 was fixed, and it was, so this essentially reverts https://github.com/Deltares/Ribasim/issues/1832.

Making it the default since it is noticably faster and should be more accurate as well. I've seen it do better with convergence bottlenecks as well.

```julia
# hws_2025_3_0
# autodiff=false
# 57.718218 seconds (15.07 M allocations: 10.536 GiB, 2.00% gc time, 2 lock conflicts)
# autodiff=true
# 51.234467 seconds (14.27 M allocations: 10.210 GiB, 1.76% gc time, 2 lock conflicts)

# AmstelGooienVecht_parameterized_2025_3_4
# autodiff=false
# 7.283102 seconds (2.52 M allocations: 1.033 GiB, 2.59% gc time, 6 lock conflicts)
# autodiff=true
# 5.603329 seconds (951.18 k allocations: 847.611 MiB, 2.76% gc time, 5 lock conflicts)
```