### PR TITLE
Update Julia manifest

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -5,9 +5,9 @@ manifest_format = "2.0"
 project_hash = "08df9cf37f934d9c54c355f731e7bb06c158c106"
 
 [[deps.ADTypes]]
-git-tree-sha1 = "fb97701c117c8162e84dfcf80215caa904aef44f"
+git-tree-sha1 = "e2478490447631aedba0823d4d7a80b2cc8cdb32"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
-version = "1.13.0"
+version = "1.14.0"
 weakdeps = ["ChainRulesCore", "ConstructionBase", "EnzymeCore"]
 
     [deps.ADTypes.extensions]
@@ -57,9 +57,9 @@ version = "0.1.42"
 
 [[deps.Adapt]]
 deps = ["LinearAlgebra", "Requires"]
-git-tree-sha1 = "cd8b948862abee8f3d3e9b73a102a9ca924debb0"
+git-tree-sha1 = "f7817e2e585aa6d924fd714df1e2a84be7896c60"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "4.2.0"
+version = "4.3.0"
 weakdeps = ["SparseArrays", "StaticArrays"]
 
     [deps.Adapt.extensions]
@@ -84,9 +84,9 @@ uuid = "27a7e980-b3e6-11e9-2bcd-0b925532e340"
 version = "0.4.2"
 
 [[deps.ArgCheck]]
-git-tree-sha1 = "680b3b8759bd4c54052ada14e52355ab69e07876"
+git-tree-sha1 = "f9e9a66c9b7be1ad7372bbd9b062d9230c30c5ce"
 uuid = "dce04be8-c92d-5529-be00-80e4d2c0e197"
-version = "2.4.0"
+version = "2.5.0"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -191,9 +191,9 @@ version = "1.6.0"
 
 [[deps.BitIntegers]]
 deps = ["Random"]
-git-tree-sha1 = "6158239ac409f960abbc232a9b24c00f5cce3108"
+git-tree-sha1 = "f98cfeaba814d9746617822032d50a31c9926604"
 uuid = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
-version = "0.3.2"
+version = "0.3.5"
 
 [[deps.BitTwiddlingConvenienceFunctions]]
 deps = ["Static"]
@@ -203,9 +203,9 @@ version = "0.1.6"
 
 [[deps.BracketingNonlinearSolve]]
 deps = ["CommonSolve", "ConcreteStructs", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase"]
-git-tree-sha1 = "95cb19c37ea427617e9795655667712f03058d98"
+git-tree-sha1 = "1d2a0c173ccdb01d7c30b541aeae01f077cb8df2"
 uuid = "70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
-version = "1.1.0"
+version = "1.1.2"
 weakdeps = ["ForwardDiff"]
 
     [deps.BracketingNonlinearSolve.extensions]
@@ -252,9 +252,9 @@ version = "0.13.2"
 
 [[deps.Cairo_jll]]
 deps = ["Artifacts", "Bzip2_jll", "CompilerSupportLibraries_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "LZO_jll", "Libdl", "Pixman_jll", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
-git-tree-sha1 = "009060c9a6168704143100f36ab08f06c2af4642"
+git-tree-sha1 = "2ac646d71d0d24b44f3f8c84da8c9f4d70fb67df"
 uuid = "83423d85-b0ee-5818-9007-b63ccbeb887a"
-version = "1.18.2+1"
+version = "1.18.4+0"
 
 [[deps.ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra"]
@@ -467,9 +467,9 @@ version = "8.0.0"
 
 [[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "1d0a14036acb104d9e89698bd408f63ab58cdc82"
+git-tree-sha1 = "4e1fe97fdaed23e9dc21d4d664bea76b65fc50a0"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.20"
+version = "0.18.22"
 
 [[deps.DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -489,9 +489,9 @@ version = "1.6.4"
 
 [[deps.DiffEqBase]]
 deps = ["ArrayInterface", "ConcreteStructs", "DataStructures", "DocStringExtensions", "EnumX", "EnzymeCore", "FastBroadcast", "FastClosures", "FastPower", "FunctionWrappers", "FunctionWrappersWrappers", "LinearAlgebra", "Logging", "Markdown", "MuladdMacro", "Parameters", "PrecompileTools", "Printf", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLOperators", "SciMLStructures", "Setfield", "Static", "StaticArraysCore", "Statistics", "TruncatedStacktraces"]
-git-tree-sha1 = "df4954f297a09f05e1f84a049566ae93d5304477"
+git-tree-sha1 = "edd2e4d2c0833bed404b2a3d66207e95d3a2f6ba"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
-version = "6.164.1"
+version = "6.167.1"
 
     [deps.DiffEqBase.extensions]
     DiffEqBaseCUDAExt = "CUDA"
@@ -545,9 +545,9 @@ version = "1.15.1"
 
 [[deps.DifferentiationInterface]]
 deps = ["ADTypes", "LinearAlgebra"]
-git-tree-sha1 = "cf6dcb4b21bdd893fd45be70791d6dc89ca16506"
+git-tree-sha1 = "e31cedb046c74ddb1872b32c57e3a11e4ecc432a"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
-version = "0.6.48"
+version = "0.6.49"
 
     [deps.DifferentiationInterface.extensions]
     DifferentiationInterfaceChainRulesCoreExt = "ChainRulesCore"
@@ -603,9 +603,9 @@ version = "1.11.0"
 
 [[deps.Distributions]]
 deps = ["AliasTables", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
-git-tree-sha1 = "03aa5d44647eaec98e1920635cdfed5d5560a8b9"
+git-tree-sha1 = "0b4190661e8a4e51a842070e7dd4fae440ddb7f4"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
-version = "0.25.117"
+version = "0.25.118"
 
     [deps.Distributions.extensions]
     DistributionsChainRulesCoreExt = "ChainRulesCore"
@@ -635,9 +635,9 @@ uuid = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"
 version = "2.2.4+0"
 
 [[deps.EnumX]]
-git-tree-sha1 = "bdb1942cd4c45e3c678fd11569d5cccd80976237"
+git-tree-sha1 = "bddad79635af6aec424f53ed8aad5d7555dc6f00"
 uuid = "4e289a0a-7415-4d19-859d-a7e5c4648b56"
-version = "1.0.4"
+version = "1.0.5"
 
 [[deps.EnzymeCore]]
 git-tree-sha1 = "0cdb7af5c39e92d78a0ee8d0a447d32f7593137e"
@@ -745,9 +745,9 @@ version = "0.8.3"
 
 [[deps.FilePathsBase]]
 deps = ["Compat", "Dates"]
-git-tree-sha1 = "2ec417fc319faa2d768621085cc1feebbdee686b"
+git-tree-sha1 = "3bab2c5aa25e7840a4b065805c0cdfc01f3068d2"
 uuid = "48062228-2e41-5def-b9a4-89aafe57970f"
-version = "0.9.23"
+version = "0.9.24"
 weakdeps = ["Mmap", "Test"]
 
     [deps.FilePathsBase.extensions]
@@ -885,9 +885,9 @@ version = "1.4.1"
 
 [[deps.GeometryBasics]]
 deps = ["EarCut_jll", "Extents", "GeoInterface", "IterTools", "LinearAlgebra", "PrecompileTools", "Random", "StaticArrays"]
-git-tree-sha1 = "3ba0e2818cc2ff79a5989d4dca4bc63120a98bd9"
+git-tree-sha1 = "f08692959aa8346272de501d1ddfbc8ea0ab0d31"
 uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
-version = "0.5.5"
+version = "0.5.6"
 
 [[deps.Gettext_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "XML2_jll"]
@@ -949,21 +949,21 @@ version = "8.5.0+0"
 
 [[deps.HiGHS]]
 deps = ["HiGHS_jll", "MathOptInterface", "PrecompileTools", "SparseArrays"]
-git-tree-sha1 = "b07cf87cb3bcbd65d1d3fcf4143d4a44abe33d20"
+git-tree-sha1 = "219becee955e18b349be83d74bdd2e5ad4804d0f"
 uuid = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
-version = "1.13.0"
+version = "1.15.0"
 
 [[deps.HiGHS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
-git-tree-sha1 = "26694f04567e584b054b9f33a810cec52adafa38"
+git-tree-sha1 = "72bceb63d4ae3683f091f812b6958a199c494a1b"
 uuid = "8fd58aa0-07eb-5a78-9b36-339c94fd15ea"
-version = "1.9.0+0"
+version = "1.10.0+0"
 
 [[deps.HypergeometricFunctions]]
 deps = ["LinearAlgebra", "OpenLibm_jll", "SpecialFunctions"]
-git-tree-sha1 = "2bd56245074fab4015b9174f24ceba8293209053"
+git-tree-sha1 = "68c173f4f449de5b438ee67ed0c9c748dc31a2ec"
 uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
-version = "0.3.27"
+version = "0.3.28"
 
 [[deps.IJulia]]
 deps = ["Base64", "Conda", "Dates", "InteractiveUtils", "JSON", "Libdl", "Logging", "Markdown", "MbedTLS", "Pkg", "Printf", "REPL", "Random", "SoftGlobalScope", "Test", "UUIDs", "ZMQ"]
@@ -1066,10 +1066,10 @@ weakdeps = ["Unitful"]
     InterpolationsUnitfulExt = "Unitful"
 
 [[deps.IntervalArithmetic]]
-deps = ["CRlibm_jll", "LinearAlgebra", "MacroTools", "RoundingEmulator"]
-git-tree-sha1 = "0fcf2079f918f68c6412cab5f2679822cbd7357f"
+deps = ["CRlibm_jll", "LinearAlgebra", "MacroTools", "OpenBLASConsistentFPCSR_jll", "RoundingEmulator"]
+git-tree-sha1 = "dfbf101df925acf1caa3b15a00b574887cd8472d"
 uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
-version = "0.22.23"
+version = "0.22.26"
 weakdeps = ["DiffRules", "ForwardDiff", "IntervalSets", "RecipesBase"]
 
     [deps.IntervalArithmetic.extensions]
@@ -1127,9 +1127,9 @@ version = "1.0.0"
 
 [[deps.JLD2]]
 deps = ["FileIO", "MacroTools", "Mmap", "OrderedCollections", "PrecompileTools", "Requires", "TranscodingStreams"]
-git-tree-sha1 = "91d501cb908df6f134352ad73cde5efc50138279"
+git-tree-sha1 = "1059c071429b4753c0c869b75c859c44ba09a526"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.5.11"
+version = "0.5.12"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
@@ -1161,9 +1161,9 @@ version = "0.2.1"
 
 [[deps.JpegTurbo]]
 deps = ["CEnum", "FileIO", "ImageCore", "JpegTurbo_jll", "TOML"]
-git-tree-sha1 = "fa6d0bcff8583bac20f1ffa708c3913ca605c611"
+git-tree-sha1 = "9496de8fb52c224a2e3f9ff403947674517317d9"
 uuid = "b835a17e-a41a-41e7-81f0-2f016b05efe0"
-version = "0.1.5"
+version = "0.1.6"
 
 [[deps.JpegTurbo_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -1173,9 +1173,9 @@ version = "3.1.1+0"
 
 [[deps.JuMP]]
 deps = ["LinearAlgebra", "MacroTools", "MathOptInterface", "MutableArithmetics", "OrderedCollections", "PrecompileTools", "Printf", "SparseArrays"]
-git-tree-sha1 = "cf832644f225dbe721bb9b97bf432007765fc695"
+git-tree-sha1 = "c9ace86360c1dc0635de5f9e2ce5143b86c53311"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
-version = "1.24.0"
+version = "1.25.0"
 
     [deps.JuMP.extensions]
     JuMPDimensionalDataExt = "DimensionalData"
@@ -1380,9 +1380,9 @@ version = "1.11.0"
 
 [[deps.LinearSolve]]
 deps = ["ArrayInterface", "ChainRulesCore", "ConcreteStructs", "DocStringExtensions", "EnumX", "GPUArraysCore", "InteractiveUtils", "Krylov", "LazyArrays", "Libdl", "LinearAlgebra", "MKL_jll", "Markdown", "PrecompileTools", "Preferences", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLOperators", "Setfield", "StaticArraysCore", "UnPack"]
-git-tree-sha1 = "6e975dea0fc1825ef3bc83c11281fdf745a69a43"
+git-tree-sha1 = "c64ec326eeeb20c065afd6aa5add4fad458e460a"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "3.4.0"
+version = "3.7.0"
 
     [deps.LinearSolve.extensions]
     LinearSolveBandedMatricesExt = "BandedMatrices"
@@ -1504,9 +1504,9 @@ version = "1.1.0"
 
 [[deps.MathOptInterface]]
 deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "DataStructures", "ForwardDiff", "JSON3", "LinearAlgebra", "MutableArithmetics", "NaNMath", "OrderedCollections", "PrecompileTools", "Printf", "SparseArrays", "SpecialFunctions", "Test"]
-git-tree-sha1 = "098fafb5e7eb6ad99b7b2c9464323759183aa0f3"
+git-tree-sha1 = "6723502b2135aa492a65be9633e694482a340ee7"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.37.0"
+version = "1.38.0"
 
 [[deps.MathTeXEngine]]
 deps = ["AbstractTrees", "Automa", "DataStructures", "FreeTypeAbstraction", "GeometryBasics", "LaTeXStrings", "REPL", "RelocatableFolders", "UnicodeFun"]
@@ -1537,9 +1537,9 @@ version = "2.28.6+0"
 
 [[deps.MetaGraphsNext]]
 deps = ["Graphs", "JLD2", "SimpleTraits"]
-git-tree-sha1 = "d2ecf4a20f4ac694987dd08ac489b7f7ff805f35"
+git-tree-sha1 = "86da17f3e953b3b8e64200fb24fd85cdaa63eb36"
 uuid = "fa8bd995-216d-47f1-8a91-f3b68fbeb377"
-version = "0.7.1"
+version = "0.7.2"
 
 [[deps.Missings]]
 deps = ["DataAPI"]
@@ -1585,10 +1585,10 @@ uuid = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
 version = "1.6.4"
 
 [[deps.NLSolversBase]]
-deps = ["DiffResults", "Distributed", "FiniteDiff", "ForwardDiff"]
-git-tree-sha1 = "a0b464d183da839699f4c79e7606d9d186ec172c"
+deps = ["ADTypes", "DifferentiationInterface", "Distributed", "FiniteDiff", "ForwardDiff"]
+git-tree-sha1 = "1f78293864c5e48ecf97269b0e23d7be28eb1958"
 uuid = "d41bc354-129a-5804-8e4c-c37616107c6c"
-version = "7.8.3"
+version = "7.9.0"
 
 [[deps.NaNMath]]
 deps = ["OpenLibm_jll"]
@@ -1608,9 +1608,9 @@ version = "1.2.0"
 
 [[deps.NonlinearSolve]]
 deps = ["ADTypes", "ArrayInterface", "BracketingNonlinearSolve", "CommonSolve", "ConcreteStructs", "DiffEqBase", "DifferentiationInterface", "FastClosures", "FiniteDiff", "ForwardDiff", "LineSearch", "LinearAlgebra", "LinearSolve", "NonlinearSolveBase", "NonlinearSolveFirstOrder", "NonlinearSolveQuasiNewton", "NonlinearSolveSpectralMethods", "PrecompileTools", "Preferences", "Reexport", "SciMLBase", "SimpleNonlinearSolve", "SparseArrays", "SparseMatrixColorings", "StaticArraysCore", "SymbolicIndexingInterface"]
-git-tree-sha1 = "95def4e218a6832d158feafb9963be0337ea432c"
+git-tree-sha1 = "eb1007ce104fc6704ac346859bc53976c44edc38"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "4.4.0"
+version = "4.5.0"
 
     [deps.NonlinearSolve.extensions]
     NonlinearSolveFastLevenbergMarquardtExt = "FastLevenbergMarquardt"
@@ -1640,9 +1640,9 @@ version = "4.4.0"
 
 [[deps.NonlinearSolveBase]]
 deps = ["ADTypes", "Adapt", "ArrayInterface", "CommonSolve", "Compat", "ConcreteStructs", "DifferentiationInterface", "EnzymeCore", "FastClosures", "LinearAlgebra", "Markdown", "MaybeInplace", "Preferences", "Printf", "RecursiveArrayTools", "SciMLBase", "SciMLJacobianOperators", "SciMLOperators", "StaticArraysCore", "SymbolicIndexingInterface", "TimerOutputs"]
-git-tree-sha1 = "8a2437b5ead050301b6a6258f226e5137e511000"
+git-tree-sha1 = "369acf69870d75c47db9622dad7b98cae9f1f083"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "1.5.0"
+version = "1.5.1"
 
     [deps.NonlinearSolveBase.extensions]
     NonlinearSolveBaseBandedMatricesExt = "BandedMatrices"
@@ -1694,9 +1694,9 @@ uuid = "510215fc-4207-5dde-b226-833fc4488ee2"
 version = "0.5.5"
 
 [[deps.OffsetArrays]]
-git-tree-sha1 = "5e1897147d1ff8d98883cda2be2187dcf57d8f0c"
+git-tree-sha1 = "a414039192a155fb38c4599a60110f0018c6ec82"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.15.0"
+version = "1.16.0"
 weakdeps = ["Adapt"]
 
     [deps.OffsetArrays.extensions]
@@ -1707,6 +1707,12 @@ deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "887579a3eb005446d514ab7aeac5d1d027658b8f"
 uuid = "e7412a2a-1a6e-54c0-be00-318e2571c051"
 version = "1.3.5+1"
+
+[[deps.OpenBLASConsistentFPCSR_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "567515ca155d0020a45b05175449b499c63e7015"
+uuid = "6cdc7f73-28fd-5e50-80fb-958a8875b1af"
+version = "0.3.29+0"
 
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
@@ -1755,15 +1761,15 @@ version = "1.8.0"
 
 [[deps.OrdinaryDiffEqBDF]]
 deps = ["ADTypes", "ArrayInterface", "DiffEqBase", "FastBroadcast", "LinearAlgebra", "MacroTools", "MuladdMacro", "OrdinaryDiffEqCore", "OrdinaryDiffEqDifferentiation", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqSDIRK", "PrecompileTools", "Preferences", "RecursiveArrayTools", "Reexport", "StaticArrays", "TruncatedStacktraces"]
-git-tree-sha1 = "86ccea2bd0fdfa5570172a9717061f6417e21dea"
+git-tree-sha1 = "970ac761ae1c4249fc70d75760c328269a518585"
 uuid = "6ad6398a-0878-4a85-9266-38940aa047c8"
-version = "1.2.0"
+version = "1.3.0"
 
 [[deps.OrdinaryDiffEqCore]]
 deps = ["ADTypes", "Accessors", "Adapt", "ArrayInterface", "DataStructures", "DiffEqBase", "DocStringExtensions", "EnumX", "FastBroadcast", "FastClosures", "FastPower", "FillArrays", "FunctionWrappersWrappers", "InteractiveUtils", "LinearAlgebra", "Logging", "MacroTools", "MuladdMacro", "Polyester", "PrecompileTools", "Preferences", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLOperators", "SciMLStructures", "SimpleUnPack", "Static", "StaticArrayInterface", "StaticArraysCore", "SymbolicIndexingInterface", "TruncatedStacktraces"]
-git-tree-sha1 = "2f31fd2e015223f7e196f6d0e8a2a9c34b6a1bdc"
+git-tree-sha1 = "67d6b00d29c9e08948ba5d313519c82fa2d2b443"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
-version = "1.18.1"
+version = "1.20.0"
 weakdeps = ["EnzymeCore"]
 
     [deps.OrdinaryDiffEqCore.extensions]
@@ -1789,15 +1795,15 @@ version = "1.5.0"
 
 [[deps.OrdinaryDiffEqRosenbrock]]
 deps = ["ADTypes", "DiffEqBase", "FastBroadcast", "FiniteDiff", "ForwardDiff", "LinearAlgebra", "LinearSolve", "MacroTools", "MuladdMacro", "OrdinaryDiffEqCore", "OrdinaryDiffEqDifferentiation", "Polyester", "PrecompileTools", "Preferences", "RecursiveArrayTools", "Reexport", "Static"]
-git-tree-sha1 = "2c79566a08201524bad4a11ab32c621e185c5ead"
+git-tree-sha1 = "bede3226fd485741e364239e23236e07ace77639"
 uuid = "43230ef6-c299-4910-a778-202eb28ce4ce"
-version = "1.6.0"
+version = "1.8.0"
 
 [[deps.OrdinaryDiffEqSDIRK]]
 deps = ["ADTypes", "DiffEqBase", "FastBroadcast", "LinearAlgebra", "MacroTools", "MuladdMacro", "OrdinaryDiffEqCore", "OrdinaryDiffEqDifferentiation", "OrdinaryDiffEqNonlinearSolve", "RecursiveArrayTools", "Reexport", "SciMLBase", "TruncatedStacktraces"]
-git-tree-sha1 = "45eed1444fbfa510e1806d4153f83bd862d2d035"
+git-tree-sha1 = "b3a7e3a2f355d837c823b435630f035aef446b45"
 uuid = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
-version = "1.2.0"
+version = "1.3.0"
 
 [[deps.OrdinaryDiffEqTsit5]]
 deps = ["DiffEqBase", "FastBroadcast", "LinearAlgebra", "MuladdMacro", "OrdinaryDiffEqCore", "PrecompileTools", "Preferences", "RecursiveArrayTools", "Reexport", "Static", "TruncatedStacktraces"]
@@ -1872,9 +1878,9 @@ version = "2.8.1"
 
 [[deps.Pixman_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LLVMOpenMP_jll", "Libdl"]
-git-tree-sha1 = "35621f10a7531bc8fa58f74610b1bfb70a3cfc6b"
+git-tree-sha1 = "db76b1ecd5e9715f3d043cec13b2ec93ce015d53"
 uuid = "30392449-352a-5448-841d-b1acce4e97dc"
-version = "0.43.4+0"
+version = "0.44.2+0"
 
 [[deps.Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
@@ -2029,9 +2035,9 @@ version = "1.3.4"
 
 [[deps.RecursiveArrayTools]]
 deps = ["Adapt", "ArrayInterface", "DocStringExtensions", "GPUArraysCore", "IteratorInterfaceExtensions", "LinearAlgebra", "RecipesBase", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface", "Tables"]
-git-tree-sha1 = "e96b644f7bfbf1015f8e42a7c7abfae2a48fafbf"
+git-tree-sha1 = "112c876cee36a5784df19098b55db2b238afc36a"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
-version = "3.31.0"
+version = "3.31.2"
 
     [deps.RecursiveArrayTools.extensions]
     RecursiveArrayToolsFastBroadcastExt = "FastBroadcast"
@@ -2074,9 +2080,9 @@ version = "1.3.1"
 
 [[deps.Revise]]
 deps = ["CodeTracking", "FileWatching", "JuliaInterpreter", "LibGit2", "LoweredCodeUtils", "OrderedCollections", "REPL", "Requires", "UUIDs", "Unicode"]
-git-tree-sha1 = "9bb80533cb9769933954ea4ffbecb3025a783198"
+git-tree-sha1 = "5cf59106f9b47014c58c5053a1ce09c0a2e0333c"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.7.2"
+version = "3.7.3"
 weakdeps = ["Distributed"]
 
     [deps.Revise.extensions]
@@ -2140,9 +2146,9 @@ version = "3.48.0+0"
 
 [[deps.SciMLBase]]
 deps = ["ADTypes", "Accessors", "ArrayInterface", "CommonSolve", "ConstructionBase", "Distributed", "DocStringExtensions", "EnumX", "FunctionWrappersWrappers", "IteratorInterfaceExtensions", "LinearAlgebra", "Logging", "Markdown", "Moshi", "PrecompileTools", "Preferences", "Printf", "RecipesBase", "RecursiveArrayTools", "Reexport", "RuntimeGeneratedFunctions", "SciMLOperators", "SciMLStructures", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface"]
-git-tree-sha1 = "ee305515b0946db5f56af699e8b5804fee04146c"
+git-tree-sha1 = "b774e82af5c068939e1085d4ec058aadb79c5483"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "2.75.1"
+version = "2.79.0"
 
     [deps.SciMLBase.extensions]
     SciMLBaseChainRulesCoreExt = "ChainRulesCore"
@@ -2152,7 +2158,7 @@ version = "2.75.1"
     SciMLBasePyCallExt = "PyCall"
     SciMLBasePythonCallExt = "PythonCall"
     SciMLBaseRCallExt = "RCall"
-    SciMLBaseZygoteExt = "Zygote"
+    SciMLBaseZygoteExt = ["Zygote", "ChainRulesCore"]
 
     [deps.SciMLBase.weakdeps]
     ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
@@ -2173,9 +2179,9 @@ version = "0.1.1"
 
 [[deps.SciMLOperators]]
 deps = ["Accessors", "ArrayInterface", "DocStringExtensions", "LinearAlgebra", "MacroTools"]
-git-tree-sha1 = "6149620767866d4b0f0f7028639b6e661b6a1e44"
+git-tree-sha1 = "1c4b7f6c3e14e6de0af66e66b86d525cae10ecb4"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
-version = "0.3.12"
+version = "0.3.13"
 weakdeps = ["SparseArrays", "StaticArraysCore"]
 
     [deps.SciMLOperators.extensions]
@@ -2184,9 +2190,9 @@ weakdeps = ["SparseArrays", "StaticArraysCore"]
 
 [[deps.SciMLStructures]]
 deps = ["ArrayInterface"]
-git-tree-sha1 = "0444a37a25fab98adbd90baa806ee492a3af133a"
+git-tree-sha1 = "566c4ed301ccb2a44cbd5a27da5f885e0ed1d5df"
 uuid = "53ae85a6-f571-4167-b2af-e1d143709226"
-version = "1.6.1"
+version = "1.7.0"
 
 [[deps.Scratch]]
 deps = ["Dates"]
@@ -2235,9 +2241,9 @@ version = "0.4.0"
 
 [[deps.SimpleNonlinearSolve]]
 deps = ["ADTypes", "ArrayInterface", "BracketingNonlinearSolve", "CommonSolve", "ConcreteStructs", "DifferentiationInterface", "FastClosures", "FiniteDiff", "ForwardDiff", "LineSearch", "LinearAlgebra", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "Setfield", "StaticArraysCore"]
-git-tree-sha1 = "a3868a6add9f5989d1f4bd21de0333ef89fb9d9f"
+git-tree-sha1 = "f42f8b8b728812e485ad099ee5e959d9b49cdb3d"
 uuid = "727e6d20-b764-4bd8-a329-72de5adea6c7"
-version = "2.1.0"
+version = "2.2.0"
 
     [deps.SimpleNonlinearSolve.extensions]
     SimpleNonlinearSolveChainRulesCoreExt = "ChainRulesCore"
@@ -2313,9 +2319,9 @@ version = "0.6.15"
 
 [[deps.SparseDiffTools]]
 deps = ["ADTypes", "Adapt", "ArrayInterface", "Compat", "DataStructures", "FiniteDiff", "ForwardDiff", "Graphs", "LinearAlgebra", "PackageExtensionCompat", "Random", "Reexport", "SciMLOperators", "Setfield", "SparseArrays", "StaticArrayInterface", "StaticArrays", "UnPack", "VertexSafeGraphs"]
-git-tree-sha1 = "d79802152d958607f414f5447cb25e314db979c0"
+git-tree-sha1 = "59bad850b1fc622051bf80a2be86c95b487e0243"
 uuid = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
-version = "2.23.1"
+version = "2.24.0"
 
     [deps.SparseDiffTools.extensions]
     SparseDiffToolsEnzymeExt = "Enzyme"
@@ -2365,9 +2371,9 @@ version = "0.1.1"
 
 [[deps.Static]]
 deps = ["CommonWorldInvalidations", "IfElse", "PrecompileTools"]
-git-tree-sha1 = "87d51a3ee9a4b0d2fe054bdd3fc2436258db2603"
+git-tree-sha1 = "f737d444cb0ad07e61b3c1bef8eb91203c321eff"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-version = "1.1.1"
+version = "1.2.0"
 
 [[deps.StaticArrayInterface]]
 deps = ["ArrayInterface", "Compat", "IfElse", "LinearAlgebra", "PrecompileTools", "Static"]
@@ -2499,9 +2505,9 @@ version = "1.0.3"
 
 [[deps.TZJData]]
 deps = ["Artifacts"]
-git-tree-sha1 = "7def47e953a91cdcebd08fbe76d69d2715499a7d"
+git-tree-sha1 = "72df96b3a595b7aab1e101eb07d2a435963a97e2"
 uuid = "dc5dba14-91b3-4cab-a142-028a31da12f7"
-version = "1.4.0+2025a"
+version = "1.5.0+2025b"
 
 [[deps.TableTraits]]
 deps = ["IteratorInterfaceExtensions"]
@@ -2568,9 +2574,9 @@ version = "0.11.3"
 
 [[deps.TimeZones]]
 deps = ["Artifacts", "Dates", "Downloads", "InlineStrings", "Mocking", "Printf", "Scratch", "TZJData", "Unicode", "p7zip_jll"]
-git-tree-sha1 = "38bb1023fb94bfbaf2a29e1e0de4bbba6fe0bf6d"
+git-tree-sha1 = "2c705e96825b66c4a3f25031a683c06518256dd3"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
-version = "1.21.2"
+version = "1.21.3"
 weakdeps = ["RecipesBase"]
 
     [deps.TimeZones.extensions]
@@ -2738,9 +2744,9 @@ version = "1.4.0"
 
 [[deps.ZeroMQ_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "libsodium_jll"]
-git-tree-sha1 = "f02ce8f0fda1ed40f4d0d59a2ad05e35e8ac9b0e"
+git-tree-sha1 = "766d90db2817565b667c1cc9cc420d668f2e8dba"
 uuid = "8f1865be-045e-5c20-9c9f-bfbfb0764568"
-version = "4.3.5+3"
+version = "4.3.6+0"
 
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
@@ -2784,9 +2790,9 @@ version = "2.0.3+0"
 
 [[deps.libpng_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Zlib_jll"]
-git-tree-sha1 = "055a96774f383318750a1a5e10fd4151f04c29c5"
+git-tree-sha1 = "068dfe202b0a05b8332f1e8e6b4080684b9c7700"
 uuid = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
-version = "1.6.46+0"
+version = "1.6.47+0"
 
 [[deps.libsixel_jll]]
 deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "Libdl", "libpng_jll"]
@@ -2795,10 +2801,10 @@ uuid = "075b6546-f08a-558a-be8f-8157d0f608a5"
 version = "1.10.5+0"
 
 [[deps.libsodium_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "f76d682d87eefadd3f165d8d9fda436464213142"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "011b0a7331b41c25524b64dc42afc9683ee89026"
 uuid = "a9144af2-ca23-56d9-984f-0d03f7b5ccf8"
-version = "1.0.20+3"
+version = "1.0.21+0"
 
 [[deps.libvorbis_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Ogg_jll", "Pkg"]


### PR DESCRIPTION
Update the Julia Manifest.toml to get the latest dependencies.

__Changed packages__
```
  Installing known registries into `~/.julia`
       Added `General` registry to ~/.julia/registries
    Updating registry at `~/.julia/registries/General.toml`
     Cloning git-repo `https://github.com/visr/SparseConnectivityTracer.jl`
    Updating git-repo `https://github.com/visr/SparseConnectivityTracer.jl`
    Updating `~/work/Ribasim/Ribasim/Project.toml`
  [864edb3b] ↑ DataStructures v0.18.20 ⇒ v0.18.22
  [2b5f629d] ↑ DiffEqBase v6.164.1 ⇒ v6.167.1
  [a0c0ee7d] ↑ DifferentiationInterface v0.6.48 ⇒ v0.6.49
  [4e289a0a] ↑ EnumX v1.0.4 ⇒ v1.0.5
  [87dc4568] ↑ HiGHS v1.13.0 ⇒ v1.15.0
  [4076af6c] ↑ JuMP v1.24.0 ⇒ v1.25.0
  [7ed4a6bd] ↑ LinearSolve v3.4.0 ⇒ v3.7.0
  [fa8bd995] ↑ MetaGraphsNext v0.7.1 ⇒ v0.7.2
  [6ad6398a] ↑ OrdinaryDiffEqBDF v1.2.0 ⇒ v1.3.0
  [bbf590c4] ↑ OrdinaryDiffEqCore v1.18.1 ⇒ v1.20.0
  [43230ef6] ↑ OrdinaryDiffEqRosenbrock v1.6.0 ⇒ v1.8.0
  [2d112036] ↑ OrdinaryDiffEqSDIRK v1.2.0 ⇒ v1.3.0
  [295af30f] ↑ Revise v3.7.2 ⇒ v3.7.3
  [0bca4576] ↑ SciMLBase v2.75.1 ⇒ v2.79.0
    Updating `~/work/Ribasim/Ribasim/Manifest.toml`
  [47edcb42] ↑ ADTypes v1.13.0 ⇒ v1.14.0
  [79e6a3ab] ↑ Adapt v4.2.0 ⇒ v4.3.0
  [dce04be8] ↑ ArgCheck v2.4.0 ⇒ v2.5.0
  [c3b6d118] ↑ BitIntegers v0.3.2 ⇒ v0.3.5
  [70df07ce] ↑ BracketingNonlinearSolve v1.1.0 ⇒ v1.1.2
  [864edb3b] ↑ DataStructures v0.18.20 ⇒ v0.18.22
  [2b5f629d] ↑ DiffEqBase v6.164.1 ⇒ v6.167.1
  [a0c0ee7d] ↑ DifferentiationInterface v0.6.48 ⇒ v0.6.49
  [31c24e10] ↑ Distributions v0.25.117 ⇒ v0.25.118
  [4e289a0a] ↑ EnumX v1.0.4 ⇒ v1.0.5
  [48062228] ↑ FilePathsBase v0.9.23 ⇒ v0.9.24
  [5c1252a2] ↑ GeometryBasics v0.5.5 ⇒ v0.5.6
  [87dc4568] ↑ HiGHS v1.13.0 ⇒ v1.15.0
  [34004b35] ↑ HypergeometricFunctions v0.3.27 ⇒ v0.3.28
  [d1acc4aa] ↑ IntervalArithmetic v0.22.23 ⇒ v0.22.26
  [033835bb] ↑ JLD2 v0.5.11 ⇒ v0.5.12
  [b835a17e] ↑ JpegTurbo v0.1.5 ⇒ v0.1.6
  [4076af6c] ↑ JuMP v1.24.0 ⇒ v1.25.0
  [7ed4a6bd] ↑ LinearSolve v3.4.0 ⇒ v3.7.0
  [b8f27783] ↑ MathOptInterface v1.37.0 ⇒ v1.38.0
  [fa8bd995] ↑ MetaGraphsNext v0.7.1 ⇒ v0.7.2
  [d41bc354] ↑ NLSolversBase v7.8.3 ⇒ v7.9.0
  [8913a72c] ↑ NonlinearSolve v4.4.0 ⇒ v4.5.0
  [be0214bd] ↑ NonlinearSolveBase v1.5.0 ⇒ v1.5.1
  [6fe1bfb0] ↑ OffsetArrays v1.15.0 ⇒ v1.16.0
  [6ad6398a] ↑ OrdinaryDiffEqBDF v1.2.0 ⇒ v1.3.0
  [bbf590c4] ↑ OrdinaryDiffEqCore v1.18.1 ⇒ v1.20.0
  [43230ef6] ↑ OrdinaryDiffEqRosenbrock v1.6.0 ⇒ v1.8.0
  [2d112036] ↑ OrdinaryDiffEqSDIRK v1.2.0 ⇒ v1.3.0
  [731186ca] ↑ RecursiveArrayTools v3.31.0 ⇒ v3.31.2
  [295af30f] ↑ Revise v3.7.2 ⇒ v3.7.3
  [0bca4576] ↑ SciMLBase v2.75.1 ⇒ v2.79.0
  [c0aeaf25] ↑ SciMLOperators v0.3.12 ⇒ v0.3.13
  [53ae85a6] ↑ SciMLStructures v1.6.1 ⇒ v1.7.0
  [727e6d20] ↑ SimpleNonlinearSolve v2.1.0 ⇒ v2.2.0
  [47a9eef4] ↑ SparseDiffTools v2.23.1 ⇒ v2.24.0
  [aedffcd0] ↑ Static v1.1.1 ⇒ v1.2.0
  [dc5dba14] ↑ TZJData v1.4.0+2025a ⇒ v1.5.0+2025b
  [f269a46b] ↑ TimeZones v1.21.2 ⇒ v1.21.3
  [83423d85] ↑ Cairo_jll v1.18.2+1 ⇒ v1.18.4+0
  [8fd58aa0] ↑ HiGHS_jll v1.9.0+0 ⇒ v1.10.0+0
  [6cdc7f73] + OpenBLASConsistentFPCSR_jll v0.3.29+0
  [30392449] ↑ Pixman_jll v0.43.4+0 ⇒ v0.44.2+0
  [8f1865be] ↑ ZeroMQ_jll v4.3.5+3 ⇒ v4.3.6+0
  [b53b4c65] ↑ libpng_jll v1.6.46+0 ⇒ v1.6.47+0
  [a9144af2] ↑ libsodium_jll v1.0.20+3 ⇒ v1.0.21+0
    Building Conda ─→ `~/.julia/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/b19db3927f0db4151cb86d073689f2428e524576/build.log`
    Building IJulia → `~/.julia/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/1b1299f7d6617291f3d260e9f5b0250afdaac8c0/build.log`
        Info We haven't cleaned this depot up for a bit, running Pkg.gc()...
      Active manifest files: 1 found
      Active artifact files: 70 found
      Active scratchspaces: 2 found
     Deleted no artifacts, repos, packages or scratchspaces
```

__Packages still outdated after update__
```
Status `~/work/Ribasim/Ribasim/Project.toml`
```
<details>
<summary>
All package versions
</summary>

```

ADTypes ────────────────────────── v1.14.0
AbstractFFTs ───────────────────── v1.5.0
AbstractTrees ──────────────────── v0.4.5
Accessors ──────────────────────── v0.1.42
Adapt ──────────────────────────── v4.3.0
AdaptivePredicates ─────────────── v1.2.0
AliasTables ────────────────────── v1.1.3
Animations ─────────────────────── v0.4.2
ArgCheck ───────────────────────── v2.5.0
ArnoldiMethod ──────────────────── v0.4.0
ArrayInterface ─────────────────── v7.18.0
ArrayLayouts ───────────────────── v1.11.1
Arrow ──────────────────────────── v2.8.0
ArrowTypes ─────────────────────── v2.3.0
Automa ─────────────────────────── v1.1.0
AxisAlgorithms ─────────────────── v1.1.0
AxisArrays ─────────────────────── v0.4.7
BasicModelInterface ────────────── v0.1.1
BenchmarkTools ─────────────────── v1.6.0
BitIntegers ────────────────────── v0.3.5
BitTwiddlingConvenienceFunctions ─ v0.1.6
BracketingNonlinearSolve ───────── v1.1.2
Bzip2_jll ──────────────────────── v1.0.9+0
CEnum ──────────────────────────── v0.5.0
CPUSummary ─────────────────────── v0.2.6
CRlibm_jll ─────────────────────── v1.0.1+0
Cairo ──────────────────────────── v1.1.1
CairoMakie ─────────────────────── v0.13.2
Cairo_jll ──────────────────────── v1.18.4+0
ChainRulesCore ─────────────────── v1.25.1
CloseOpenIntervals ─────────────── v0.1.13
CodeTracking ───────────────────── v1.3.6
CodecBzip2 ─────────────────────── v0.8.5
CodecLz4 ───────────────────────── v0.4.5
CodecZlib ──────────────────────── v0.7.8
CodecZstd ──────────────────────── v0.8.6
ColorBrewer ────────────────────── v0.4.1
ColorSchemes ───────────────────── v3.29.0
ColorTypes ─────────────────────── v0.12.0
ColorVectorSpace ───────────────── v0.11.0
Colors ─────────────────────────── v0.13.0
CommonSolve ────────────────────── v0.2.4
CommonSubexpressions ───────────── v0.3.1
CommonWorldInvalidations ───────── v1.0.0
Compat ─────────────────────────── v4.16.0
CompositionsBase ───────────────── v0.1.2
ConcreteStructs ────────────────── v0.2.3
ConcurrentUtilities ────────────── v2.5.0
Conda ──────────────────────────── v1.10.2
Configurations ─────────────────── v0.17.6
ConstructionBase ───────────────── v1.5.8
Contour ────────────────────────── v0.6.3
CpuId ──────────────────────────── v0.3.1
Crayons ────────────────────────── v4.1.1
DBInterface ────────────────────── v2.6.1
DataAPI ────────────────────────── v1.16.0
DataFrames ─────────────────────── v1.7.0
DataInterpolations ─────────────── v8.0.0
DataStructures ─────────────────── v0.18.22
DataValueInterfaces ────────────── v1.0.0
DelaunayTriangulation ──────────── v1.6.4
DiffEqBase ─────────────────────── v6.167.1
DiffEqCallbacks ────────────────── v4.3.0
DiffResults ────────────────────── v1.1.0
DiffRules ──────────────────────── v1.15.1
DifferentiationInterface ───────── v0.6.49
DisplayAs ──────────────────────── v0.1.6
Distributions ──────────────────── v0.25.118
DocStringExtensions ────────────── v0.9.3
EarCut_jll ─────────────────────── v2.2.4+0
EnumX ──────────────────────────── v1.0.5
EnzymeCore ─────────────────────── v0.8.8
ExactPredicates ────────────────── v2.2.8
Expat_jll ──────────────────────── v2.6.5+0
ExprTools ──────────────────────── v0.1.10
ExproniconLite ─────────────────── v0.10.14
Extents ────────────────────────── v0.1.5
FFMPEG_jll ─────────────────────── v6.1.2+0
FFTW ───────────────────────────── v1.8.1
FFTW_jll ───────────────────────── v3.3.10+3
FastBroadcast ──────────────────── v0.3.5
FastClosures ───────────────────── v0.3.2
FastPower ──────────────────────── v1.1.1
FileIO ─────────────────────────── v1.17.0
FilePaths ──────────────────────── v0.8.3
FilePathsBase ──────────────────── v0.9.24
FillArrays ─────────────────────── v1.13.0
FindFirstFunctions ─────────────── v1.4.1
FiniteDiff ─────────────────────── v2.27.0
FixedPointNumbers ──────────────── v0.8.5
Fontconfig_jll ─────────────────── v2.15.0+0
Format ─────────────────────────── v1.3.7
ForwardDiff ────────────────────── v0.10.38
FreeType ───────────────────────── v4.1.1
FreeType2_jll ──────────────────── v2.13.3+1
FreeTypeAbstraction ────────────── v0.10.6
FriBidi_jll ────────────────────── v1.0.16+0
FunctionWrappers ───────────────── v1.1.3
FunctionWrappersWrappers ───────── v0.1.3
Functors ───────────────────────── v0.5.2
GPUArraysCore ──────────────────── v0.2.0
GeoFormatTypes ─────────────────── v0.4.4
GeoInterface ───────────────────── v1.4.1
GeometryBasics ─────────────────── v0.5.6
Gettext_jll ────────────────────── v0.21.0+0
Giflib_jll ─────────────────────── v5.2.3+0
Glib_jll ───────────────────────── v2.82.4+0
Glob ───────────────────────────── v1.3.1
Graphics ───────────────────────── v1.1.3
Graphite2_jll ──────────────────── v1.3.14+1
Graphs ─────────────────────────── v1.12.0
GridLayoutBase ─────────────────── v0.11.1
Grisu ──────────────────────────── v1.0.2
HarfBuzz_jll ───────────────────── v8.5.0+0
HiGHS ──────────────────────────── v1.15.0
HiGHS_jll ──────────────────────── v1.10.0+0
HypergeometricFunctions ────────── v0.3.28
IJulia ─────────────────────────── v1.26.0
IOCapture ──────────────────────── v0.2.5
IfElse ─────────────────────────── v0.1.1
ImageAxes ──────────────────────── v0.6.12
ImageBase ──────────────────────── v0.1.7
ImageCore ──────────────────────── v0.10.5
ImageIO ────────────────────────── v0.6.9
ImageMetadata ──────────────────── v0.9.10
Imath_jll ──────────────────────── v3.1.11+0
IndirectArrays ─────────────────── v1.0.0
Infiltrator ────────────────────── v1.8.6
Inflate ────────────────────────── v0.1.5
InlineStrings ──────────────────── v1.4.3
IntelOpenMP_jll ────────────────── v2025.0.4+0
Interpolations ─────────────────── v0.15.1
IntervalArithmetic ─────────────── v0.22.26
IntervalSets ───────────────────── v0.7.10
InverseFunctions ───────────────── v0.1.17
InvertedIndices ────────────────── v1.3.1
IrrationalConstants ────────────── v0.2.4
Isoband ────────────────────────── v0.1.1
IterTools ──────────────────────── v1.10.0
IteratorInterfaceExtensions ────── v1.0.0
JLD2 ───────────────────────────── v0.5.12
JLLWrappers ────────────────────── v1.7.0
JSON ───────────────────────────── v0.21.4
JSON3 ──────────────────────────── v1.14.1
Jieko ──────────────────────────── v0.2.1
JpegTurbo ──────────────────────── v0.1.6
JpegTurbo_jll ──────────────────── v3.1.1+0
JuMP ───────────────────────────── v1.25.0
JuliaInterpreter ───────────────── v0.9.42
KernelDensity ──────────────────── v0.6.9
Krylov ─────────────────────────── v0.9.10
LAME_jll ───────────────────────── v3.100.2+0
LERC_jll ───────────────────────── v4.0.1+0
LLVMOpenMP_jll ─────────────────── v18.1.7+0
LZO_jll ────────────────────────── v2.10.3+0
LaTeXStrings ───────────────────── v1.4.0
LayoutPointers ─────────────────── v0.1.17
LazyArrays ─────────────────────── v2.6.1
LazyModules ────────────────────── v0.3.1
LeftChildRightSiblingTrees ─────── v0.2.0
Legolas ────────────────────────── v0.5.23
Libffi_jll ─────────────────────── v3.2.2+2
Libgcrypt_jll ──────────────────── v1.11.0+0
Libglvnd_jll ───────────────────── v1.7.0+0
Libgpg_error_jll ───────────────── v1.51.1+0
Libiconv_jll ───────────────────── v1.18.0+0
Libmount_jll ───────────────────── v2.40.3+0
Libtiff_jll ────────────────────── v4.7.1+0
Libuuid_jll ────────────────────── v2.40.3+0
LineSearch ─────────────────────── v0.1.4
LineSearches ───────────────────── v7.3.0
LinearSolve ────────────────────── v3.7.0
LogExpFunctions ────────────────── v0.3.29
LoggingExtras ──────────────────── v1.1.0
LoweredCodeUtils ───────────────── v3.1.0
Lz4_jll ────────────────────────── v1.10.1+0
MKL_jll ────────────────────────── v2025.0.1+1
MacroTools ─────────────────────── v0.5.15
Makie ──────────────────────────── v0.22.2
MakieCore ──────────────────────── v0.9.1
ManualMemory ───────────────────── v0.1.8
MappedArrays ───────────────────── v0.4.2
MarkdownTables ─────────────────── v1.1.0
MathOptInterface ───────────────── v1.38.0
MathTeXEngine ──────────────────── v0.6.2
MaybeInplace ───────────────────── v0.1.4
MbedTLS ────────────────────────── v1.1.9
MetaGraphsNext ─────────────────── v0.7.2
Missings ───────────────────────── v1.2.0
Mocking ────────────────────────── v0.8.1
MosaicViews ────────────────────── v0.3.4
Moshi ──────────────────────────── v0.3.5
MuladdMacro ────────────────────── v0.2.4
MutableArithmetics ─────────────── v1.6.4
NLSolversBase ──────────────────── v7.9.0
NaNMath ────────────────────────── v1.1.2
Netpbm ─────────────────────────── v1.1.1
NonlinearSolve ─────────────────── v4.5.0
NonlinearSolveBase ─────────────── v1.5.1
NonlinearSolveFirstOrder ───────── v1.3.0
NonlinearSolveQuasiNewton ──────── v1.2.0
NonlinearSolveSpectralMethods ──── v1.1.0
Observables ────────────────────── v0.5.5
OffsetArrays ───────────────────── v1.16.0
Ogg_jll ────────────────────────── v1.3.5+1
OpenBLASConsistentFPCSR_jll ────── v0.3.29+0
OpenEXR ────────────────────────── v0.3.3
OpenEXR_jll ────────────────────── v3.2.4+0
OpenSSL_jll ────────────────────── v3.0.16+0
OpenSpecFun_jll ────────────────── v0.5.6+0
Opus_jll ───────────────────────── v1.3.3+0
OrderedCollections ─────────────── v1.8.0
OrdinaryDiffEqBDF ──────────────── v1.3.0
OrdinaryDiffEqCore ─────────────── v1.20.0
OrdinaryDiffEqDifferentiation ──── v1.4.0
OrdinaryDiffEqLowOrderRK ───────── v1.2.0
OrdinaryDiffEqNonlinearSolve ───── v1.5.0
OrdinaryDiffEqRosenbrock ───────── v1.8.0
OrdinaryDiffEqSDIRK ────────────── v1.3.0
OrdinaryDiffEqTsit5 ────────────── v1.1.0
OteraEngine ────────────────────── v1.1.1
PDMats ─────────────────────────── v0.11.32
PNGFiles ───────────────────────── v0.4.4
PackageCompiler ────────────────── v2.2.0
PackageExtensionCompat ─────────── v1.0.2
Packing ────────────────────────── v0.5.1
PaddedViews ────────────────────── v0.5.12
Pango_jll ──────────────────────── v1.56.1+0
Parameters ─────────────────────── v0.12.3
Parsers ────────────────────────── v2.8.1
Pixman_jll ─────────────────────── v0.44.2+0
PkgVersion ─────────────────────── v0.3.3
PlotUtils ──────────────────────── v1.4.3
Polyester ──────────────────────── v0.7.16
PolyesterWeave ─────────────────── v0.2.2
PolygonOps ─────────────────────── v0.1.2
PooledArrays ───────────────────── v1.4.3
PreallocationTools ─────────────── v0.4.25
PrecompileTools ────────────────── v1.2.1
Preferences ────────────────────── v1.4.3
PrettyTables ───────────────────── v2.4.0
ProgressLogging ────────────────── v0.1.4
ProgressMeter ──────────────────── v1.10.2
PtrArrays ──────────────────────── v1.3.0
QOI ────────────────────────────── v1.0.1
QuadGK ─────────────────────────── v2.11.2
RangeArrays ────────────────────── v0.3.2
Ratios ─────────────────────────── v0.4.5
RecipesBase ────────────────────── v1.3.4
RecursiveArrayTools ────────────── v3.31.2
Reexport ───────────────────────── v1.2.2
RelocatableFolders ─────────────── v1.0.1
Requires ───────────────────────── v1.3.1
Revise ─────────────────────────── v3.7.3
Rmath ──────────────────────────── v0.8.0
Rmath_jll ──────────────────────── v0.5.1+0
RoundingEmulator ───────────────── v0.2.1
RuntimeGeneratedFunctions ──────── v0.5.13
SIMD ───────────────────────────── v3.7.1
SIMDTypes ──────────────────────── v0.1.0
SQLite ─────────────────────────── v1.6.1
SQLite_jll ─────────────────────── v3.48.0+0
SciMLBase ──────────────────────── v2.79.0
SciMLJacobianOperators ─────────── v0.1.1
SciMLOperators ─────────────────── v0.3.13
SciMLStructures ────────────────── v1.7.0
Scratch ────────────────────────── v1.2.1
SentinelArrays ─────────────────── v1.4.8
Setfield ───────────────────────── v1.1.2
ShaderAbstractions ─────────────── v0.5.0
Showoff ────────────────────────── v1.0.3
SignedDistanceFields ───────────── v0.4.0
SimpleNonlinearSolve ───────────── v2.2.0
SimpleTraits ───────────────────── v0.9.4
SimpleUnPack ───────────────────── v1.1.0
Sixel ──────────────────────────── v0.1.3
SoftGlobalScope ────────────────── v1.1.0
SortingAlgorithms ──────────────── v1.2.1
SparseDiffTools ────────────────── v2.24.0
SparseMatrixColorings ──────────── v0.4.14
SpecialFunctions ───────────────── v2.5.0
StableRNGs ─────────────────────── v1.0.2
StackViews ─────────────────────── v0.1.1
Static ─────────────────────────── v1.2.0
StaticArrayInterface ───────────── v1.8.0
StaticArrays ───────────────────── v1.9.13
StaticArraysCore ───────────────── v1.4.3
Statistics ─────────────────────── v1.11.1
StatsAPI ───────────────────────── v1.7.0
StatsBase ──────────────────────── v0.34.4
StatsFuns ──────────────────────── v1.3.2
StrideArraysCore ───────────────── v0.5.7
StringManipulation ─────────────── v0.4.1
StringViews ────────────────────── v1.3.4
StructArrays ───────────────────── v0.7.0
StructTypes ────────────────────── v1.11.0
SymbolicIndexingInterface ──────── v0.3.38
TZJData ────────────────────────── v1.5.0+2025b
TableTraits ────────────────────── v1.0.1
Tables ─────────────────────────── v1.12.0
TensorCore ─────────────────────── v0.1.1
TerminalLoggers ────────────────── v0.1.7
TestEnv ────────────────────────── v1.102.0
TestItemRunner ─────────────────── v1.1.0
TestItems ──────────────────────── v1.0.0
ThreadingUtilities ─────────────── v0.5.2
TiffImages ─────────────────────── v0.11.3
TimeZones ──────────────────────── v1.21.3
TimerOutputs ───────────────────── v0.5.28
TranscodingStreams ─────────────── v0.11.3
TriplotBase ────────────────────── v0.1.0
TruncatedStacktraces ───────────── v1.4.0
UnPack ─────────────────────────── v1.0.2
UnicodeFun ─────────────────────── v0.4.1
Unitful ────────────────────────── v1.22.0
VersionParsing ─────────────────── v1.3.0
VertexSafeGraphs ───────────────── v0.2.0
WeakRefStrings ─────────────────── v1.4.2
WebP ───────────────────────────── v0.1.3
WoodburyMatrices ───────────────── v1.0.0
XML2_jll ───────────────────────── v2.13.6+1
XSLT_jll ───────────────────────── v1.1.42+0
XZ_jll ─────────────────────────── v5.6.4+1
Xorg_libX11_jll ────────────────── v1.8.6+3
Xorg_libXau_jll ────────────────── v1.0.12+0
Xorg_libXdmcp_jll ──────────────── v1.1.5+0
Xorg_libXext_jll ───────────────── v1.3.6+3
Xorg_libXrender_jll ────────────── v0.9.11+1
Xorg_libpthread_stubs_jll ──────── v0.1.2+0
Xorg_libxcb_jll ────────────────── v1.17.0+3
Xorg_xtrans_jll ────────────────── v1.5.1+0
ZMQ ────────────────────────────── v1.4.0
ZeroMQ_jll ─────────────────────── v4.3.6+0
Zstd_jll ───────────────────────── v1.5.7+1
isoband_jll ────────────────────── v0.2.3+0
libaom_jll ─────────────────────── v3.11.0+0
libass_jll ─────────────────────── v0.15.2+0
libfdk_aac_jll ─────────────────── v2.0.3+0
libpng_jll ─────────────────────── v1.6.47+0
libsixel_jll ───────────────────── v1.10.5+0
libsodium_jll ──────────────────── v1.0.21+0
libvorbis_jll ──────────────────── v1.3.7+2
libwebp_jll ────────────────────── v1.5.0+0
oneTBB_jll ─────────────────────── v2022.0.0+0
x264_jll ───────────────────────── v10164.0.1+0
x265_jll ───────────────────────── v3.6.0+0
