### PR TITLE
Simplify "Pre-commit auto update"

### DIFF
--- a/.github/workflows/pre-commit_auto_update.yml
+++ b/.github/workflows/pre-commit_auto_update.yml
@@ -9,18 +9,9 @@ jobs:
   auto-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: browniebroke/pre-commit-autoupdate-action@v1
+        secrets:
+          gh_pat: ${{ secrets.CI_PR_PAT }}
         with:
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - uses: browniebroke/pre-commit-autoupdate-action@main
-      - uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.CI_PR_PAT }}
-          branch: update/pre-commit-hooks
-          title: Update pre-commit hooks
-          commit-message: "Update pre-commit hooks"
-          body: Update versions of pre-commit hooks to latest version.
-          author: "GitHub <noreply@github.com>"
+          pull_request_title: Update pre-commit hooks
+          commit_message: Update pre-commit hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         exclude: '.teamcity'
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.2
+    rev: v0.11.1
     hooks:
       - id: ruff
         types_or: [python, pyi, jupyter]

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -1,4 +1,4 @@
-import datetime
+import  datetime
 import logging
 import shutil
 import warnings


### PR DESCRIPTION
Using the current docs:
https://github.com/browniebroke/github-actions#pre-commit-auto-update
All these other steps are already part of 
https://github.com/browniebroke/github-actions/blob/bcdb59e937d32c481e5ea2233aff21f8053a934a/.github/workflows/pre-commit-autoupdate.yml

I also added a commit that sets the hook version back and ruins some formatting so we can test if it fixes this automatically. Because the main problem with this Action was that a new e.g. ruff version would change the formatting, and this got rejected by the new pre-commit. That caused the auto update job to fail and never appear.