### PR TITLE
Write results also on an interrupt or crash

### DIFF
--- a/core/src/main.jl
+++ b/core/src/main.jl
@@ -43,7 +43,13 @@ function main(toml_path::AbstractString)::Cint
                 end
 
                 try
-                    model = run(config)
+                    model = Model(config)
+                    try
+                        solve!(model)
+                    finally
+                        @warn "Simulation crashed or interrupted. Writing results."
+                        write_results(model)
+                    end
 
                     if successful_retcode(model)
                         log_bottlenecks(model; converged = true)


### PR DESCRIPTION
See https://github.com/Deltares/Ribasim/issues/2177#issuecomment-2765619875

Instead of calling `run(config)` this replaces it with the contents of that function:

https://github.com/Deltares/Ribasim/blob/e81fa39ca54374067e4880f0f06e4c4e8afa6957/core/src/main.jl#L10-L15

Such that we can `solve!` in a try and call `write_results` whether it crashes or not.
I don't know how we can easily test it. Perhaps not worth the effort? I tested it on a model that hangs, which I killed with ctrl+c. This works great for that, allowing you to inspect results right up to the hang.