### PR TITLE
Allow max 1 outflow neighbour for FlowBoundary

### DIFF
--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -584,7 +584,7 @@ end
 
 """
 node_id: node ID of the FlowBoundary node
-outflow_links: The outgoing flow link metadata
+outflow_link: The outgoing flow link metadata
 active: whether this node is active and thus contributes flow
 cumulative_flow: The exactly integrated cumulative boundary flow since the start of the simulation
 cumulative_flow_saveat: The exactly integrated cumulative boundary flow since the last saveat
@@ -594,7 +594,7 @@ concentration_time: Data source for concentration updates
 """
 @kwdef struct FlowBoundary{C} <: AbstractParameterNode
     node_id::Vector{NodeID}
-    outflow_links::Vector{Vector{LinkMetadata}}
+    outflow_link::Vector{LinkMetadata} = []
     active::Vector{Bool}
     cumulative_flow::Vector{Float64} = zeros(length(node_id))
     cumulative_flow_saveat::Vector{Float64} = zeros(length(node_id))

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -701,7 +701,7 @@ function FlowBoundary(db::DB, config::Config, graph::MetaGraph)::FlowBoundary
 
     return FlowBoundary(;
         node_id = node_ids,
-        outflow_links = outflow_links.(Ref(graph), node_ids),
+        outflow_link = outflow_link.(Ref(graph), node_id),
         parsed_parameters.active,
         parsed_parameters.flow_rate,
         concentration,

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -131,9 +131,9 @@ function formulate_storage!(
     t::Number,
     flow_boundary::FlowBoundary,
 )
-    for (flow_rate, outflow_links, active, cumulative_flow) in zip(
+    for (flow_rate, outflow_link, active, cumulative_flow) in zip(
         flow_boundary.flow_rate,
-        flow_boundary.outflow_links,
+        flow_boundary.outflow_link,
         flow_boundary.active,
         flow_boundary.cumulative_flow,
     )
@@ -141,11 +141,9 @@ function formulate_storage!(
         if active
             volume += integral(flow_rate, tprev, t)
         end
-        for outflow_link in outflow_links
-            outflow_id = outflow_link.link[2]
-            if outflow_id.type == NodeType.Basin
-                current_storage[outflow_id.idx] += volume
-            end
+        outflow_id = outflow_link.link[2]
+        if outflow_id.type == NodeType.Basin
+            current_storage[outflow_id.idx] += volume
         end
     end
 end

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -48,7 +48,7 @@ n_neighbor_bounds_flow(::Val{:ManningResistance}) = n_neighbor_bounds(1, 1, 1, 1
 n_neighbor_bounds_flow(::Val{:TabulatedRatingCurve}) = n_neighbor_bounds(1, 1, 1, 1)
 n_neighbor_bounds_flow(::Val{:LevelBoundary}) =
     n_neighbor_bounds(0, typemax(Int), 0, typemax(Int))
-n_neighbor_bounds_flow(::Val{:FlowBoundary}) = n_neighbor_bounds(0, 0, 1, typemax(Int))
+n_neighbor_bounds_flow(::Val{:FlowBoundary}) = n_neighbor_bounds(0, 0, 1, 1)
 n_neighbor_bounds_flow(::Val{:Pump}) = n_neighbor_bounds(1, 1, 1, 1)
 n_neighbor_bounds_flow(::Val{:Outlet}) = n_neighbor_bounds(1, 1, 1, 1)
 n_neighbor_bounds_flow(::Val{:Terminal}) = n_neighbor_bounds(1, typemax(Int), 0, 0)

--- a/python/ribasim/ribasim/validation.py
+++ b/python/ribasim/ribasim/validation.py
@@ -93,7 +93,7 @@ flow_link_neighbor_amount: dict[str, list[int]] = {
     "UserDemand": [1, 1, 1, 1],
     "TabulatedRatingCurve": [1, 1, 1, 1],
     "FlowDemand": [0, 0, 0, 0],
-    "FlowBoundary": [0, 0, 1, 9223372036854775807],
+    "FlowBoundary": [0, 0, 1, 1],
     "Basin": [0, 9223372036854775807, 0, 9223372036854775807],
     "ManningResistance": [1, 1, 1, 1],
     "LevelDemand": [0, 0, 0, 0],


### PR DESCRIPTION
Fixes #2072. It was possible to let one FlowBoundary flow into multiple Basins. This is no longer allowed, so this is a breaking change. As far as I know it wasn't used though. It is quite confusing to have multiple outflow neighbours, because a Q at the FlowBoundary that goes to n Basins then becomes a nQ total inflow. And usually a FlowBoundary represents a single physical inflow point, that should always go to one point only.

The LevelBoundary can still be connected via resistance nodes to multiple Basins, but this makes sense when representing e.g. the sea.