### PR TITLE
Replace \n by newline in Mermaid diagram labels

### DIFF
--- a/docs/install.qmd
+++ b/docs/install.qmd
@@ -13,25 +13,30 @@ The figure below illustrates the relation between the various components of Riba
 flowchart TB
 modeler([Modeler]):::user
 
-api["Ribasim Python\n[python]"]
+api["Ribasim Python
+    [python]"]
 modeler-->|prepare model|api
 
-ribasim["Ribasim\n[julia]"]
+ribasim["Ribasim
+        [julia]"]
 modeler-->|start|ribasim
 
 subgraph qgisBoundary[QGIS]
     QGIS[QGIS Application]:::system_ext
-    qgisPlugin["Ribasim QGIS plugin\n[python]"]
+    qgisPlugin["Ribasim QGIS plugin
+               [python]"]
     QGIS-->qgisPlugin
 end
 modeler-->|prepare model|qgisBoundary
 
-model[("input model data\n[toml + geopackage + arrow]")]
+model[("input model data
+        [toml + geopackage + arrow]")]
 qgisPlugin-->|read/write|model
 api-->|read/write|model
 ribasim-->|simulate|model
 
-output[("simulation results\n[arrow]")]
+output[("simulation results
+         [arrow]")]
 ribasim-->|write|output
 
 class qgisBoundary boundary


### PR DESCRIPTION
This seems to fix #2179, and is the initial way newlines are introduced: https://mermaid.js.org/syntax/flowchart.html
If this doesn't work, `<br>` is another option.