### PR TITLE
List `optimization_type` in `allocation_flow.arrow`

### DIFF
--- a/docs/reference/usage.qmd
+++ b/docs/reference/usage.qmd
@@ -323,21 +323,25 @@ Currently the stored demand and abstraction rate are those at the allocation tim
 ## Allocation flow - `allocation_flow.arrow`
 
 The allocation flow table contains results of the optimized allocation flow on every link in the model that is part of a subnetwork, for each time an optimization problem is solved (see also [here](/concept/allocation.qmd#the-high-level-algorithm)).
-If in the model a main network and subnetwork(s) are specified, there are 2 different
-types of optimization for the subnetwork: collecting its total demand per priority (for allocating flow from the main network to the subnetwork), and allocating flow within the subnetwork. The column `collect_demands` provides the distinction between these two optimization types.
+If in the model a main network and subnetwork(s) are specified, there are 3 different types of optimization for the subnetwork:
+The column `optimization_type` provides the distinction between these optimization types.
 
-column          | type
-----------------| -----
-time            | DateTime
-link_id         | Int32
-from_node_type  | String
-from_node_id    | Int32
-to_node_type    | String
-to_node_id      | Int32
-subnetwork_id   | Int32
-priority        | Int32
-flow_rate       | Float64
-collect_demands | Bool
+- `internal_sources`: first it will try using local sources internal to the subnetwork
+- `collect_demands`: collecting its total demand per priority (for allocating flow from the main network to the subnetwork)
+- `allocate`: allocating flow within the subnetwork
+
+column            | type
+----------------- | -----
+time              | DateTime
+link_id           | Int32
+from_node_type    | String
+from_node_id      | Int32
+to_node_type      | String
+to_node_id        | Int32
+subnetwork_id     | Int32
+priority          | Int32
+flow_rate         | Float64
+optimization_type | String
 
 ## Concentration - `concentration.arrow`
 


### PR DESCRIPTION
The docs still had the old `collect_demands::Bool` column.