### PR TITLE
Implement success

### DIFF
--- a/core/integration_test/hws_integration_test.jl
+++ b/core/integration_test/hws_integration_test.jl
@@ -1,5 +1,4 @@
 @testitem "HWS model integration test" begin
-    using SciMLBase: successful_retcode
     using Dates
     using Statistics
     using Arrow
@@ -10,7 +9,7 @@
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
     @test model isa Ribasim.Model
-    @test successful_retcode(model)
+    @test success(model)
 
     basin_bytes_bench =
         read(normpath(@__DIR__, "../../models/hws_2024_7_0/benchmark/basin_state.arrow"))

--- a/core/regression_test/regression_test.jl
+++ b/core/regression_test/regression_test.jl
@@ -1,5 +1,4 @@
 @testitem "regression_ode_solvers_trivial" begin
-    using SciMLBase: successful_retcode
     import Arrow
     using Ribasim
 
@@ -24,7 +23,7 @@
                 )
                 model = Ribasim.run(config)
                 @test model isa Ribasim.Model
-                @test successful_retcode(model)
+                @test success(model)
                 (; p) = model.integrator
 
                 # read all results as bytes first to avoid memory mapping
@@ -52,7 +51,6 @@
 end
 
 @testitem "regression_ode_solvers_basic" begin
-    using SciMLBase: successful_retcode
     import Arrow
     using Ribasim
     using Statistics
@@ -83,7 +81,7 @@ end
                 )
                 model = Ribasim.run(config)
                 @test model isa Ribasim.Model
-                @test successful_retcode(model)
+                @test success(model)
                 (; p) = model.integrator
 
                 # read all results as bytes first to avoid memory mapping
@@ -122,7 +120,6 @@ end
 end
 
 @testitem "regression_ode_solvers_pid_control" begin
-    using SciMLBase: successful_retcode
     import Arrow
     using Ribasim
 
@@ -154,7 +151,7 @@ end
                 )
                 model = Ribasim.run(config)
                 @test model isa Ribasim.Model
-                @test successful_retcode(model)
+                @test success(model)
                 (; p) = model.integrator
 
                 # read all results as bytes first to avoid memory mapping
@@ -184,7 +181,6 @@ end
 end
 
 @testitem "regression_ode_solvers_allocation" begin
-    using SciMLBase: successful_retcode
     import Arrow
     using Ribasim
 
@@ -221,7 +217,7 @@ end
                 )
                 model = Ribasim.run(config)
                 @test model isa Ribasim.Model
-                @test successful_retcode(model)
+                @test success(model)
                 (; p) = model.integrator
 
                 # read all results as bytes first to avoid memory mapping

--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -32,11 +32,9 @@ using LineSearches: BackTracking
 
 # Interface for defining and solving the ODE problem of the physical layer.
 using SciMLBase:
-    init,
-    solve!,
-    step!,
-    check_error!,
     SciMLBase,
+    init,
+    check_error!,
     successful_retcode,
     CallbackSet,
     ODEFunction,

--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -16,7 +16,7 @@ function BMI.finalize(model::Model)::Nothing
 end
 
 function BMI.update(model::Model)::Nothing
-    step!(model.integrator)
+    SciMLBase.step!(model.integrator)
     return nothing
 end
 

--- a/core/src/main.jl
+++ b/core/src/main.jl
@@ -46,12 +46,18 @@ function main(toml_path::AbstractString)::Cint
                     model = Model(config)
                     try
                         solve!(model)
-                    finally
-                        @warn "Simulation crashed or interrupted. Writing results."
+                    catch
+                        # Catch errors thrown during simulation.
+                        @warn "Simulation crashed or interrupted."
+                        log_bottlenecks(model; converged = false)
                         write_results(model)
+                        display_error(io)
+                        return 1
                     end
 
-                    if successful_retcode(model)
+                    write_results(model)
+
+                    if success(model)
                         log_bottlenecks(model; converged = true)
                         @info "The model finished successfully."
                         return 0
@@ -67,19 +73,27 @@ function main(toml_path::AbstractString)::Cint
                     end
 
                 catch
+                    # Catch errors thrown before the model is initialized.
                     # Both validation errors that we throw and unhandled exceptions are caught here.
-                    # To make it easier to find the cause, log the stacktrace to the terminal and log file.
-                    stack = current_exceptions()
-                    Base.invokelatest(Base.display_error, stack)
-                    Base.invokelatest(Base.display_error, io, stack)
+                    display_error(io)
                     return 1
                 end
             end
         end
     catch
-        # If it fails before we get to setup the logger, we can't log to a file.
+        # Catch errors thrown before the logger is initialized.
         # This happens if e.g. the config is invalid.
-        Base.invokelatest(Base.display_error, current_exceptions())
+        display_error()
         return 1
     end
+end
+
+"Print a stacktrace to the terminal and optionally a log file."
+function display_error(io::Union{IOStream, Nothing} = nothing)::Nothing
+    stack = current_exceptions()
+    Base.invokelatest(Base.display_error, stack)
+    if io !== nothing
+        Base.invokelatest(Base.display_error, io, stack)
+    end
+    return nothing
 end

--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -345,8 +345,7 @@ function solve!(model::Model)::Model
     (; tspan) = integrator.sol.prob
     if config.allocation.use_allocation
         (; timestep) = config.allocation
-        allocation_times = 0:timestep:(tspan[end] - timestep)
-        n_allocation_times = length(allocation_times)
+        n_allocation_times = floor(Int, tspan[end] / timestep)
         for _ in 1:n_allocation_times
             update_allocation!(integrator)
             SciMLBase.step!(integrator, timestep, true)

--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -342,7 +342,8 @@ Solve a Model until the configured `endtime`.
 """
 function SciMLBase.solve!(model::Model)::Model
     (; config, integrator) = model
-    (; tspan) = integrator.sol.prob
+    (; t, sol) = integrator
+    (; tspan) = sol.prob
     if config.allocation.use_allocation
         (; timestep) = config.allocation
         allocation_times = 0:timestep:(tspan[end] - timestep)
@@ -352,7 +353,10 @@ function SciMLBase.solve!(model::Model)::Model
             step!(integrator, timestep, true)
         end
     else
-        step!(integrator, tspan[end], true)
+        tspan_left = tspan[end] - t
+        if tspan_left > 0
+            step!(integrator, tspan_left, true)
+        end
     end
     check_error!(integrator)
     return model

--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -296,8 +296,24 @@ function Base.show(io::IO, model::Model)
     println(io, "Model(ts: $nsaved, t: $t)")
 end
 
-function SciMLBase.successful_retcode(model::Model)::Bool
-    return SciMLBase.successful_retcode(model.integrator.sol)
+"""
+    Base.success(model::Model)::Bool
+
+Returns true if the model has finished successfully.
+"""
+function Base.success(model::Model)::Bool
+    return successful_retcode(model.integrator.sol) && is_finished(model)
+end
+
+"""
+    is_finished(model::Model)::Bool
+
+Returns true if the model has reached the configured `endtime`.
+"""
+function is_finished(model::Model)::Bool
+    (; starttime, endtime) = model.config
+    t = datetime_since(model.integrator.t, starttime)
+    return t >= endtime
 end
 
 """

--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -358,8 +358,7 @@ function solve!(model::Model)::Model
             SciMLBase.step!(integrator, dt, true)
         end
     else
-        dt = tspan[end] - integrator.t
-        dt > 0 && SciMLBase.step!(integrator, dt, true)
+        SciMLBase.solve!(integrator)
     end
     check_error!(integrator)
     return model

--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -313,7 +313,7 @@ Returns true if the model has reached the configured `endtime`.
 function is_finished(model::Model)::Bool
     (; starttime, endtime) = model.config
     t = datetime_since(model.integrator.t, starttime)
-    return t >= endtime
+    return t == endtime
 end
 
 """
@@ -342,8 +342,8 @@ Solve a Model until the configured `endtime`.
 """
 function SciMLBase.solve!(model::Model)::Model
     (; config, integrator) = model
+    (; tspan) = integrator.sol.prob
     if config.allocation.use_allocation
-        (; tspan) = integrator.sol.prob
         (; timestep) = config.allocation
         allocation_times = 0:timestep:(tspan[end] - timestep)
         n_allocation_times = length(allocation_times)
@@ -351,9 +351,9 @@ function SciMLBase.solve!(model::Model)::Model
             update_allocation!(integrator)
             step!(integrator, timestep, true)
         end
-        check_error!(integrator)
     else
-        solve!(integrator)
+        step!(integrator, tspan[end], true)
     end
+    check_error!(integrator)
     return model
 end

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -6,6 +6,8 @@ Write all results to the Arrow files as specified in the model configuration.
 function write_results(model::Model)::Model
     (; config) = model
     (; results, experimental) = model.config
+    @debug "Writing results."
+
     compress = get_compressor(results)
     remove_empty_table = model.integrator.t != 0
 

--- a/core/test/allocation_test.jl
+++ b/core/test/allocation_test.jl
@@ -40,7 +40,6 @@ end
 
 @testitem "Allocation objective" begin
     using DataFrames: DataFrame
-    using SciMLBase: successful_retcode
     using Ribasim: NodeID
     import JuMP
 
@@ -49,7 +48,7 @@ end
     @test ispath(toml_path)
 
     model = Ribasim.run(toml_path)
-    @test successful_retcode(model)
+    @test success(model)
     (; p, t) = model.integrator
     (; p_non_diff) = p
     (; user_demand, allocation) = p_non_diff

--- a/core/test/bmi_test.jl
+++ b/core/test/bmi_test.jl
@@ -1,5 +1,6 @@
 @testitem "adaptive timestepping" begin
     import BasicModelInterface as BMI
+    using Ribasim: is_finished
 
     toml_path = normpath(@__DIR__, "../../generated_testmodels/basic/ribasim.toml")
     model = BMI.initialize(Ribasim.Model, toml_path)
@@ -8,15 +9,21 @@
     @test BMI.get_time_step(model) ≈ dt0 atol = 5e-3
     @test BMI.get_start_time(model) === 0.0
     @test BMI.get_current_time(model) === 0.0
-    @test BMI.get_end_time(model) ≈ 3.16224e7
+    endtime = BMI.get_end_time(model)
+    @test endtime ≈ 3.16224e7
     BMI.update(model)
-    @test BMI.get_current_time(model) ≈ dt0 atol = 5e-3
     @test BMI.get_current_time(model) ≈ dt0 atol = 5e-3
     BMI.update_until(model, 86400.0)
     @test BMI.get_current_time(model) == 86400.0
     # cannot go back in time
     @test_throws ErrorException BMI.update_until(model, 3600.0)
     @test BMI.get_current_time(model) == 86400.0
+    @test !is_finished(model)
+    @test !success(model)
+    BMI.update_until(model, endtime)
+    @test BMI.get_current_time(model) == endtime
+    @test is_finished(model)
+    @test success(model)
 end
 
 @testitem "fixed timestepping" begin

--- a/core/test/control_test.jl
+++ b/core/test/control_test.jl
@@ -246,7 +246,7 @@ end
         weight = 0.5,
         look_ahead = 0.0,
     )
-    @test record.time ≈ [0.0, model.integrator.sol.t[end] / 2] rtol = 1e-2
+    @test record.time ≈ [0.0, model.integrator.t / 2] rtol = 1e-2
     @test record.truth_state == ["F", "T"]
     @test record.control_state == ["Off", "On"]
 end

--- a/core/test/equations_test.jl
+++ b/core/test/equations_test.jl
@@ -16,13 +16,11 @@
 # Solution: storage(t) = limit_storage + (storage0 - limit_storage)*exp(-t/(basin_area*resistance))
 # Here limit_storage is the storage at which the level of the basin is equal to the level of the level boundary
 @testitem "LinearResistance" begin
-    using SciMLBase: successful_retcode
-
     toml_path =
         normpath(@__DIR__, "../../generated_testmodels/linear_resistance/ribasim.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
-    @test successful_retcode(model)
+    @test success(model)
     (; level_boundary, basin, linear_resistance) = model.integrator.p.p_non_diff
 
     t = Ribasim.tsaves(model)
@@ -49,12 +47,10 @@ end
 # Solution: w = 1/(α(t-t0)/basin_area + 1/w(t0)),
 # storage = storage_min + 1/(α(t-t0)/basin_area^2 + 1/(storage(t0)-storage_min))
 @testitem "TabulatedRatingCurve" begin
-    using SciMLBase: successful_retcode
-
     toml_path = normpath(@__DIR__, "../../generated_testmodels/rating_curve/ribasim.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
-    @test successful_retcode(model)
+    @test success(model)
     (; basin) = model.integrator.p.p_non_diff
 
     t = Ribasim.tsaves(model)
@@ -83,13 +79,11 @@ end
 # Note: The Wolfram Alpha solution contains a factor of the hypergeometric function 2F1, but these values are
 # so close to 1 that they are omitted.
 @testitem "ManningResistance" begin
-    using SciMLBase: successful_retcode
-
     toml_path =
         normpath(@__DIR__, "../../generated_testmodels/manning_resistance/ribasim.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
-    @test successful_retcode(model)
+    @test success(model)
     (; manning_resistance, basin) = model.integrator.p.p_non_diff
 
     t = Ribasim.tsaves(model)
@@ -119,13 +113,11 @@ end
 # differentiating the equation for the storage of the controlled basin
 # once to time to get rid of the integral term.
 @testitem "PID control" begin
-    using SciMLBase: successful_retcode
-
     toml_path =
         normpath(@__DIR__, "../../generated_testmodels/pid_control_equation/ribasim.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
-    @test successful_retcode(model)
+    @test success(model)
     (; basin, pid_control) = model.integrator.p.p_non_diff
 
     storage = Ribasim.get_storages_and_levels(model).storage[:]
@@ -166,7 +158,6 @@ end
 # storage2 = storage2(t0) + (t-t0)*q_pump
 # Note: uses Euler algorithm
 @testitem "MiscellaneousNodes" begin
-    using SciMLBase: successful_retcode
     using Ribasim: tsaves, get_storages_and_levels
 
     toml_path = normpath(@__DIR__, "../../generated_testmodels/misc_nodes/ribasim.toml")
@@ -175,7 +166,7 @@ end
     model = Ribasim.Model(toml_path)
     @test config.solver.dt === model.integrator.dt
     Ribasim.solve!(model)
-    @test successful_retcode(model)
+    @test success(model)
     (; p_non_diff) = model.integrator.p
     (; flow_boundary, pump) = p_non_diff
 

--- a/core/test/io_test.jl
+++ b/core/test/io_test.jl
@@ -106,14 +106,13 @@ end
 end
 
 @testitem "results" begin
-    using SciMLBase: successful_retcode
     import Arrow
 
     toml_path = normpath(@__DIR__, "../../generated_testmodels/bucket/ribasim.toml")
     @test ispath(toml_path)
     config = Ribasim.Config(toml_path)
     model = Ribasim.run(config)
-    @test successful_retcode(model)
+    @test success(model)
 
     path = Ribasim.results_path(config, Ribasim.RESULTS_FILENAME.basin)
     bytes = read(path)

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -218,7 +218,7 @@ end
     @test alg.step_limiter! == Ribasim.limit_flow!
 
     @test success(model)
-    @test length(model.integrator.sol) == 1
+    @test length(model.integrator.sol) == 2 # start and end
     @test diff_cache.current_storage ≈ Float32[804.22156, 803.6474, 495.18243, 1318.3053] skip =
         Sys.isapple() atol = 1.5
 

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -1,5 +1,4 @@
 @testitem "trivial model" begin
-    using SciMLBase: successful_retcode
     using Tables: Tables
     using Tables.DataAPI: nrow
     using Dates: DateTime
@@ -19,7 +18,7 @@
     config = Ribasim.Config(toml_path)
     model = Ribasim.run(config)
     @test model isa Ribasim.Model
-    @test successful_retcode(model)
+    @test success(model)
     (; p_non_diff) = model.integrator.p
 
     @test p_non_diff.node_id == [0, 6, 6]
@@ -126,7 +125,6 @@
 end
 
 @testitem "bucket model" begin
-    using SciMLBase: successful_retcode
     using OrdinaryDiffEqCore: get_du
 
     toml_path = normpath(@__DIR__, "../../generated_testmodels/bucket/ribasim.toml")
@@ -143,11 +141,10 @@ end
     du_infiltration = view(du, state_ranges.infiltration)
     @test du_evaporation == [0.0]
     @test du_infiltration == [0.0]
-    @test successful_retcode(model)
+    @test success(model)
 end
 
 @testitem "leaky bucket model" begin
-    using SciMLBase: successful_retcode
     using OrdinaryDiffEqCore: get_du
     import BasicModelInterface as BMI
 
@@ -187,13 +184,12 @@ end
     @test drng == [0.001]
     @test infl == [0.002]
     stor ≈ Float32[init_stor + 86400 * (0.003 * 2.0 + 0.001 * 0.5 - 0.001 - 0.002 * 0.5)]
-    @test successful_retcode(Ribasim.solve!(model))
+    @test success(Ribasim.solve!(model))
 end
 
 @testitem "basic model" begin
     using Logging: Debug, with_logger
     using LoggingExtras
-    using SciMLBase: successful_retcode
     using OrdinaryDiffEqBDF: QNDF
     import Tables
     using Dates
@@ -221,7 +217,7 @@ end
     @test alg isa QNDF
     @test alg.step_limiter! == Ribasim.limit_flow!
 
-    @test successful_retcode(model)
+    @test success(model)
     @test length(model.integrator.sol) == 2 # start and end
     @test diff_cache.current_storage ≈ Float32[804.22156, 803.6474, 495.18243, 1318.3053] skip =
         Sys.isapple() atol = 1.5
@@ -242,17 +238,14 @@ end
 end
 
 @testitem "basic arrow model" begin
-    using SciMLBase: successful_retcode
-
     toml_path = normpath(@__DIR__, "../../generated_testmodels/basic_arrow/ribasim.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
     @test model isa Ribasim.Model
-    @test successful_retcode(model)
+    @test success(model)
 end
 
 @testitem "basic transient model" begin
-    using SciMLBase: successful_retcode
     using OrdinaryDiffEqCore: get_du
 
     toml_path =
@@ -260,7 +253,7 @@ end
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
     @test model isa Ribasim.Model
-    @test successful_retcode(model)
+    @test success(model)
     @test allunique(Ribasim.tsaves(model))
     (; p_non_diff, diff_cache) = model.integrator.p
     precipitation = p_non_diff.basin.vertical_flux.precipitation
@@ -270,19 +263,15 @@ end
 end
 
 @testitem "Allocation example model" begin
-    using SciMLBase: successful_retcode
-
     toml_path =
         normpath(@__DIR__, "../../generated_testmodels/allocation_example/ribasim.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
     @test model isa Ribasim.Model
-    @test successful_retcode(model)
+    @test success(model)
 end
 
 @testitem "sparse and AD/FDM jac solver options" begin
-    using SciMLBase: successful_retcode
-
     toml_path =
         normpath(@__DIR__, "../../generated_testmodels/basic_transient/ribasim.toml")
 
@@ -295,10 +284,10 @@ end
     config = Ribasim.Config(toml_path; solver_sparse = false, solver_autodiff = false)
     dense_fdm = Ribasim.run(config)
 
-    @test successful_retcode(sparse_ad)
-    @test successful_retcode(dense_ad)
-    @test successful_retcode(sparse_fdm)
-    @test successful_retcode(dense_fdm)
+    @test success(sparse_ad)
+    @test success(dense_ad)
+    @test success(sparse_fdm)
+    @test success(dense_fdm)
 
     @test dense_ad.integrator.u ≈ sparse_ad.integrator.u atol = 0.1
     @test sparse_fdm.integrator.u ≈ sparse_ad.integrator.u atol = 4
@@ -306,12 +295,11 @@ end
 
     config = Ribasim.Config(toml_path; solver_algorithm = "Rodas5P", solver_autodiff = true)
     time_ad = Ribasim.run(config)
-    @test successful_retcode(time_ad)
+    @test success(time_ad)
     @test time_ad.integrator.u ≈ sparse_ad.integrator.u atol = 10
 end
 
 @testitem "TabulatedRatingCurve model" begin
-    using SciMLBase: successful_retcode
     using DataInterpolations.ExtrapolationType: Constant, Periodic
 
     toml_path =
@@ -319,7 +307,7 @@ end
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
     @test model isa Ribasim.Model
-    @test successful_retcode(model)
+    @test success(model)
     (; p_non_diff, diff_cache) = model.integrator.p
     @test diff_cache.current_storage ≈ Float32[368.31558, 365.68442] skip = Sys.isapple()
     (; tabulated_rating_curve) = p_non_diff
@@ -341,13 +329,12 @@ end
 
 @testitem "Outlet constraints" begin
     using DataFrames: DataFrame
-    using SciMLBase: successful_retcode
 
     toml_path = normpath(@__DIR__, "../../generated_testmodels/outlet/ribasim.toml")
     @test ispath(toml_path)
 
     model = Ribasim.run(toml_path)
-    @test successful_retcode(model)
+    @test success(model)
     (; level_boundary, outlet) = model.integrator.p.p_non_diff
     (; level) = level_boundary
     level = level[1]
@@ -373,7 +360,6 @@ end
 end
 
 @testitem "UserDemand" begin
-    using SciMLBase: successful_retcode
     using Dates
     using DataFrames: DataFrame
     using Ribasim: formulate_storages!
@@ -416,7 +402,6 @@ end
 end
 
 @testitem "ManningResistance" begin
-    using SciMLBase: successful_retcode
     using OrdinaryDiffEqCore: get_du
     using Ribasim: NodeID
 
@@ -477,7 +462,7 @@ end
     toml_path = normpath(@__DIR__, "../../generated_testmodels/backwater/ribasim.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
-    @test successful_retcode(model)
+    @test success(model)
 
     du = get_du(model.integrator)
     (; p, t) = model.integrator
@@ -576,8 +561,9 @@ end
 end
 
 @testitem "stroboscopic_forcing" begin
-    import BasicModelInterface as BMI
     using SciMLBase: successful_retcode
+    using Ribasim: is_finished
+    import BasicModelInterface as BMI
 
     toml_path = normpath(@__DIR__, "../../generated_testmodels/bucket/ribasim.toml")
     model = BMI.initialize(Ribasim.Model, toml_path)
@@ -607,7 +593,8 @@ end
         drn_out[day + 1] = only(drn_sum)
     end
 
-    @test successful_retcode(model)
+    @test successful_retcode(model.integrator.sol)
+    @test !is_finished(model)
 
     Δdrn = diff(drn_out)
     Δinf = diff(inf_out)

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -218,7 +218,7 @@ end
     @test alg.step_limiter! == Ribasim.limit_flow!
 
     @test success(model)
-    @test length(model.integrator.sol) == 2 # start and end
+    @test length(model.integrator.sol) == 1
     @test diff_cache.current_storage ≈ Float32[804.22156, 803.6474, 495.18243, 1318.3053] skip =
         Sys.isapple() atol = 1.5
 

--- a/core/test/time_test.jl
+++ b/core/test/time_test.jl
@@ -1,13 +1,12 @@
 @testitem "Time dependent flow boundary" begin
     using Dates
     using DataFrames: DataFrame
-    using SciMLBase: successful_retcode
 
     toml_path =
         normpath(@__DIR__, "../../generated_testmodels/flow_boundary_time/ribasim.toml")
     @test ispath(toml_path)
     model = Ribasim.run(toml_path)
-    @test successful_retcode(model)
+    @test success(model)
 
     flow = DataFrame(Ribasim.flow_table(model))
     # only from March to September the FlowBoundary varies


### PR DESCRIPTION
This is a follow-up of #2191. An issue with that is that it logged a warning about crashing simulations also when it succeeded. Also it didn't log the bottlenecks when you interrupt a (hanging) simulation.

Now it does both, this is what is shown when interrupting a simulation, stacktrace is clipped off:

```
┌ Info: Starting a Ribasim simulation.
│   toml_path = c:\Users\visser_mn\Downloads\lhm-sel\lhm-sel.toml
│   cli.ribasim_version = 2025.2.0
│   starttime = 2020-01-01T00:00:00
│   endtime = 2021-01-01T00:00:00
└ @ Ribasim C:\ProgramData\DevDrives\repo\ribasim\Ribasim\core\src\main.jl:40
┌ Warning: Simulation crashed or interrupted.
└ @ Ribasim C:\ProgramData\DevDrives\repo\ribasim\Ribasim\core\src\main.jl:51
┌ Warning: Convergence bottlenecks in descending order of severity:
│   Outlet #591225 = 48782.889544290454
│   Outlet #591226 = 48782.889544290454
│   ManningResistance #340784 = 0.04819449424793999
│   Pump #340303 = 0.045638255628477994
│   Pump #340194 = 0.04563825461806383
└ @ Ribasim C:\ProgramData\DevDrives\repo\ribasim\Ribasim\core\src\logging.jl:55
ERROR: InterruptException:
Stacktrace:
  [1] bracketstrictlymontonic(v::Vector{Float64}, x::Float64, guess::Int64, o::Base.Order.ForwardOrdering)
```

This implements `Base.success(::Model)::Bool`. Before we checked the SciML retcode. I noticed that the retcode of an ongoing simulation that gets interrupted is also successfull. So now we check both the retcode and if it `is_finished`.