### PR TITLE
Add computation time

### DIFF
--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -94,7 +94,7 @@ using TerminalLoggers: TerminalLogger
 
 # Date and time handling; externally we use the proleptic Gregorian calendar,
 # internally we use a Float64; seconds since the start of the simulation.
-using Dates: Dates, DateTime, Millisecond, @dateformat_str
+using Dates: Dates, DateTime, Millisecond, @dateformat_str, canonicalize
 
 # Callbacks are used to trigger function calls at specific points in the similation.
 # E.g. after each timestep for discrete control,

--- a/core/src/callback.jl
+++ b/core/src/callback.jl
@@ -449,6 +449,7 @@ function save_solver_stats(u, t, integrator)
     (; stats) = integrator.sol
     (;
         time = t,
+        time_ns = time_ns(),
         rhs_calls = stats.nf,
         linear_solves = stats.nsolve,
         accepted_timesteps = stats.naccept,

--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -343,7 +343,8 @@ Solve a Model until the configured `endtime`.
 function solve!(model::Model)::Model
     (; config, integrator) = model
     (; tspan) = integrator.sol.prob
-    if config.allocation.use_allocation
+
+    comptime_s = @elapsed if config.allocation.use_allocation
         (; timestep) = config.allocation
         n_allocation_times = floor(Int, tspan[end] / timestep)
         for _ in 1:n_allocation_times
@@ -360,5 +361,7 @@ function solve!(model::Model)::Model
         SciMLBase.solve!(integrator)
     end
     check_error!(integrator)
+    comptime = canonicalize(Millisecond(round(Int, comptime_s * 1000)))
+    @info "Computation time: $comptime"
     return model
 end

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -6,6 +6,7 @@ const USER_DEMAND_MIN_LEVEL_THRESHOLD = 0.1
 
 const SolverStats = @NamedTuple{
     time::Float64,
+    time_ns::UInt64,
     rhs_calls::Int,
     linear_solves::Int,
     accepted_timesteps::Int,

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -187,6 +187,7 @@ function solver_stats_table(
     model::Model,
 )::@NamedTuple{
     time::Vector{DateTime},
+    computation_time::Vector{Float64},
     rhs_calls::Vector{Int},
     linear_solves::Vector{Int},
     accepted_timesteps::Vector{Int},
@@ -198,6 +199,8 @@ function solver_stats_table(
             solver_stats.time[1:(end - 1)],
             model.integrator.p.p_non_diff.starttime,
         ),
+        # convert nanosecond to millisecond
+        computation_time = diff(solver_stats.time_ns) .* 1e-6,
         rhs_calls = diff(solver_stats.rhs_calls),
         linear_solves = diff(solver_stats.linear_solves),
         accepted_timesteps = diff(solver_stats.accepted_timesteps),

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -81,8 +81,15 @@
             (DateTime, Int32, Float64),
         )
         @test Tables.schema(solver_stats) == Tables.Schema(
-            (:time, :rhs_calls, :linear_solves, :accepted_timesteps, :rejected_timesteps),
-            (DateTime, Int, Int, Int, Int),
+            (
+                :time,
+                :computation_time,
+                :rhs_calls,
+                :linear_solves,
+                :accepted_timesteps,
+                :rejected_timesteps,
+            ),
+            (DateTime, Float64, Int, Int, Int, Int),
         )
     end
 

--- a/docs/reference/usage.qmd
+++ b/docs/reference/usage.qmd
@@ -371,10 +371,14 @@ subgrid_level  | Float64
 
 This result file contains statistics about the solver, which can give an insight into how well the solver is performing over time. The data is solved by `saveat` (see [configuration file](#configuration-file)). `water_balance` refers to the right-hand-side function of the system of differential equations solved by the Ribasim core.
 
-column              | type
---------------------| -----
-time                | DateTime
-water_balance_calls | Int
-linear_solves       | Int
-accepted_timesteps  | Int
-rejected_timesteps  | Int
+The `computation_time` is the wall time in milliseconds spent on the given period.
+The first row tends to include compilation time as well.
+
+column              | type     | unit
+--------------------| -------- | ----
+time                | DateTime | -
+computation_time    | Float64  | $\text{ms}$
+water_balance_calls | Int      | -
+linear_solves       | Int      | -
+accepted_timesteps  | Int      | -
+rejected_timesteps  | Int      | -


### PR DESCRIPTION
Fixes #2207. This logs the computation time:

```
┌ Info: Starting a Ribasim simulation.
│   toml_path = "models\\hws\\hws_2025_3_0\\hws.toml"
│   cli.ribasim_version = "2025.2.0"
│   starttime = 2023-01-20T00:00:00
└   endtime = 2024-04-27T00:00:00
Simulating 100%|███████████████████████████████████████████████████████████████████████████████| Time: 0:00:50
[ Info: Computation time: 49 seconds, 955 milliseconds
```

The time is also at the end of the progress bar, but this bar is not logged to `ribasim.log` so there was no record of it there.

There is also a new column `computation_time` in `solver_stats.arrow`, with the time in milliseconds for that period. I went for millisecond since the order of seconds per day is only really applicable for very large models.

```python
In [1]: import pandas as pd

In [2]: df = pd.read_feather("solver_stats.arrow")

In [3]: df
Out[3]:
          time  computation_time  rhs_calls  linear_solves  accepted_timesteps  rejected_timesteps
0   2023-01-20         2244.7489       7712           7709                2850                 458
1   2023-01-21          632.4497       2513           2513                 737                 128
2   2023-01-22          164.0670        662            662                 195                  36
3   2023-01-23          387.5130       1428           1428                 402                  80
4   2023-01-24          190.5293        751            751                 214                  37
..         ...               ...        ...            ...                 ...                 ...
458 2024-04-22          132.2348        542            542                  67                   6
459 2024-04-23          181.5635        703            703                  64                  10
460 2024-04-24           67.9207        292            292                  32                   2
461 2024-04-25          117.8029        451            451                  30                   8
462 2024-04-26            5.1752         16             16                   7                   0

[463 rows x 6 columns]

In [4]: df["computation_time"].sum() / 1000
Out[4]: np.float64(50.0540202)
```
