### PR TITLE
Update Julia manifest

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1503,9 +1503,9 @@ version = "1.1.0"
 
 [[deps.MathOptInterface]]
 deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "DataStructures", "ForwardDiff", "JSON3", "LinearAlgebra", "MutableArithmetics", "NaNMath", "OrderedCollections", "PrecompileTools", "Printf", "SparseArrays", "SpecialFunctions", "Test"]
-git-tree-sha1 = "6723502b2135aa492a65be9633e694482a340ee7"
+git-tree-sha1 = "2e20edca2492d30aeabdb099f3a80eb95d1d03d1"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.38.0"
+version = "1.38.1"
 
 [[deps.MathTeXEngine]]
 deps = ["AbstractTrees", "Automa", "DataStructures", "FreeTypeAbstraction", "GeometryBasics", "LaTeXStrings", "REPL", "RelocatableFolders", "UnicodeFun"]
@@ -1766,9 +1766,9 @@ version = "1.4.0"
 
 [[deps.OrdinaryDiffEqCore]]
 deps = ["ADTypes", "Accessors", "Adapt", "ArrayInterface", "DataStructures", "DiffEqBase", "DocStringExtensions", "EnumX", "FastBroadcast", "FastClosures", "FastPower", "FillArrays", "FunctionWrappersWrappers", "InteractiveUtils", "LinearAlgebra", "Logging", "MacroTools", "MuladdMacro", "Polyester", "PrecompileTools", "Preferences", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLOperators", "SciMLStructures", "SimpleUnPack", "Static", "StaticArrayInterface", "StaticArraysCore", "SymbolicIndexingInterface", "TruncatedStacktraces"]
-git-tree-sha1 = "86a991ae5454a6a412561d7e2de9e9049db58eb8"
+git-tree-sha1 = "ba84fa52a477a537213b7d0a6a83ba9b2f3aaa00"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
-version = "1.21.0"
+version = "1.22.0"
 weakdeps = ["EnzymeCore"]
 
     [deps.OrdinaryDiffEqCore.extensions]
@@ -2431,9 +2431,9 @@ version = "1.3.4"
 
 [[deps.StructArrays]]
 deps = ["ConstructionBase", "DataAPI", "Tables"]
-git-tree-sha1 = "5a3a31c41e15a1e042d60f2f4942adccba05d3c9"
+git-tree-sha1 = "8ad2e38cbb812e29348719cc63580ec1dfeb9de4"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.7.0"
+version = "0.7.1"
 
     [deps.StructArrays.extensions]
     StructArraysAdaptExt = "Adapt"


### PR DESCRIPTION
Update the Julia Manifest.toml to get the latest dependencies.

__Changed packages__
```
  Installing known registries into `~/.julia`
       Added `General` registry to ~/.julia/registries
    Updating registry at `~/.julia/registries/General.toml`
     Cloning git-repo `https://github.com/visr/SparseConnectivityTracer.jl`
    Updating git-repo `https://github.com/visr/SparseConnectivityTracer.jl`
    Updating `~/work/Ribasim/Ribasim/Project.toml`
  [bbf590c4] ↑ OrdinaryDiffEqCore v1.21.0 ⇒ v1.22.0
  [09ab397b] ↑ StructArrays v0.7.0 ⇒ v0.7.1
    Updating `~/work/Ribasim/Ribasim/Manifest.toml`
  [b8f27783] ↑ MathOptInterface v1.38.0 ⇒ v1.38.1
  [bbf590c4] ↑ OrdinaryDiffEqCore v1.21.0 ⇒ v1.22.0
  [09ab397b] ↑ StructArrays v0.7.0 ⇒ v0.7.1
    Building Conda ─→ `~/.julia/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/b19db3927f0db4151cb86d073689f2428e524576/build.log`
    Building IJulia → `~/.julia/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/be30be76e25b0aff2c9a85930ed3ac34c5f10c83/build.log`
        Info We haven't cleaned this depot up for a bit, running Pkg.gc()...
      Active manifest files: 1 found
      Active artifact files: 70 found
      Active scratchspaces: 2 found
     Deleted no artifacts, repos, packages or scratchspaces
```

__Packages still outdated after update__
```
Status `~/work/Ribasim/Ribasim/Project.toml`
```
<details>
<summary>
All package versions
</summary>

```

ADTypes ────────────────────────── v1.14.0
AbstractFFTs ───────────────────── v1.5.0
AbstractTrees ──────────────────── v0.4.5
Accessors ──────────────────────── v0.1.42
Adapt ──────────────────────────── v4.3.0
AdaptivePredicates ─────────────── v1.2.0
AliasTables ────────────────────── v1.1.3
Animations ─────────────────────── v0.4.2
ArgCheck ───────────────────────── v2.5.0
ArnoldiMethod ──────────────────── v0.4.0
ArrayInterface ─────────────────── v7.18.0
ArrayLayouts ───────────────────── v1.11.1
Arrow ──────────────────────────── v2.8.0
ArrowTypes ─────────────────────── v2.3.0
Automa ─────────────────────────── v1.1.0
AxisAlgorithms ─────────────────── v1.1.0
AxisArrays ─────────────────────── v0.4.7
BasicModelInterface ────────────── v0.1.1
BenchmarkTools ─────────────────── v1.6.0
BitIntegers ────────────────────── v0.3.5
BitTwiddlingConvenienceFunctions ─ v0.1.6
BracketingNonlinearSolve ───────── v1.1.2
Bzip2_jll ──────────────────────── v1.0.9+0
CEnum ──────────────────────────── v0.5.0
CPUSummary ─────────────────────── v0.2.6
CRlibm_jll ─────────────────────── v1.0.1+0
Cairo ──────────────────────────── v1.1.1
CairoMakie ─────────────────────── v0.13.2
Cairo_jll ──────────────────────── v1.18.4+0
ChainRulesCore ─────────────────── v1.25.1
CloseOpenIntervals ─────────────── v0.1.13
CodeTracking ───────────────────── v1.3.9
CodecBzip2 ─────────────────────── v0.8.5
CodecLz4 ───────────────────────── v0.4.6
CodecZlib ──────────────────────── v0.7.8
CodecZstd ──────────────────────── v0.8.6
ColorBrewer ────────────────────── v0.4.1
ColorSchemes ───────────────────── v3.29.0
ColorTypes ─────────────────────── v0.12.1
ColorVectorSpace ───────────────── v0.11.0
Colors ─────────────────────────── v0.13.0
CommonSolve ────────────────────── v0.2.4
CommonSubexpressions ───────────── v0.3.1
CommonWorldInvalidations ───────── v1.0.0
Compat ─────────────────────────── v4.16.0
CompositionsBase ───────────────── v0.1.2
ConcreteStructs ────────────────── v0.2.3
ConcurrentUtilities ────────────── v2.5.0
Conda ──────────────────────────── v1.10.2
Configurations ─────────────────── v0.17.6
ConstructionBase ───────────────── v1.5.8
Contour ────────────────────────── v0.6.3
CpuId ──────────────────────────── v0.3.1
Crayons ────────────────────────── v4.1.1
DBInterface ────────────────────── v2.6.1
DataAPI ────────────────────────── v1.16.0
DataFrames ─────────────────────── v1.7.0
DataInterpolations ─────────────── v8.0.0
DataStructures ─────────────────── v0.18.22
DataValueInterfaces ────────────── v1.0.0
DelaunayTriangulation ──────────── v1.6.4
DiffEqBase ─────────────────────── v6.167.2
DiffEqCallbacks ────────────────── v4.3.0
DiffResults ────────────────────── v1.1.0
DiffRules ──────────────────────── v1.15.1
DifferentiationInterface ───────── v0.6.50
DisplayAs ──────────────────────── v0.1.6
Distributions ──────────────────── v0.25.118
DocStringExtensions ────────────── v0.9.4
EarCut_jll ─────────────────────── v2.2.4+0
EnumX ──────────────────────────── v1.0.5
EnzymeCore ─────────────────────── v0.8.8
ExactPredicates ────────────────── v2.2.8
Expat_jll ──────────────────────── v2.6.5+0
ExprTools ──────────────────────── v0.1.10
ExproniconLite ─────────────────── v0.10.14
Extents ────────────────────────── v0.1.5
FFMPEG_jll ─────────────────────── v6.1.2+0
FFTW ───────────────────────────── v1.8.1
FFTW_jll ───────────────────────── v3.3.11+0
FastBroadcast ──────────────────── v0.3.5
FastClosures ───────────────────── v0.3.2
FastPower ──────────────────────── v1.1.2
FileIO ─────────────────────────── v1.17.0
FilePaths ──────────────────────── v0.8.3
FilePathsBase ──────────────────── v0.9.24
FillArrays ─────────────────────── v1.13.0
FindFirstFunctions ─────────────── v1.4.1
FiniteDiff ─────────────────────── v2.27.0
FixedPointNumbers ──────────────── v0.8.5
Fontconfig_jll ─────────────────── v2.16.0+0
Format ─────────────────────────── v1.3.7
ForwardDiff ────────────────────── v0.10.38
FreeType ───────────────────────── v4.1.1
FreeType2_jll ──────────────────── v2.13.4+0
FreeTypeAbstraction ────────────── v0.10.6
FriBidi_jll ────────────────────── v1.0.17+0
FunctionWrappers ───────────────── v1.1.3
FunctionWrappersWrappers ───────── v0.1.3
Functors ───────────────────────── v0.5.2
GPUArraysCore ──────────────────── v0.2.0
GeoFormatTypes ─────────────────── v0.4.4
GeoInterface ───────────────────── v1.4.1
GeometryBasics ─────────────────── v0.5.7
Gettext_jll ────────────────────── v0.21.0+0
Giflib_jll ─────────────────────── v5.2.3+0
Glib_jll ───────────────────────── v2.82.4+0
Glob ───────────────────────────── v1.3.1
Graphics ───────────────────────── v1.1.3
Graphite2_jll ──────────────────── v1.3.15+0
Graphs ─────────────────────────── v1.12.1
GridLayoutBase ─────────────────── v0.11.1
Grisu ──────────────────────────── v1.0.2
HarfBuzz_jll ───────────────────── v8.5.0+0
HiGHS ──────────────────────────── v1.15.0
HiGHS_jll ──────────────────────── v1.10.0+0
HypergeometricFunctions ────────── v0.3.28
IJulia ─────────────────────────── v1.27.0
IOCapture ──────────────────────── v0.2.5
IfElse ─────────────────────────── v0.1.1
ImageAxes ──────────────────────── v0.6.12
ImageBase ──────────────────────── v0.1.7
ImageCore ──────────────────────── v0.10.5
ImageIO ────────────────────────── v0.6.9
ImageMetadata ──────────────────── v0.9.10
Imath_jll ──────────────────────── v3.1.11+0
IndirectArrays ─────────────────── v1.0.0
Infiltrator ────────────────────── v1.8.7
Inflate ────────────────────────── v0.1.5
InlineStrings ──────────────────── v1.4.3
IntelOpenMP_jll ────────────────── v2025.0.4+0
Interpolations ─────────────────── v0.15.1
IntervalArithmetic ─────────────── v0.22.28
IntervalSets ───────────────────── v0.7.10
InverseFunctions ───────────────── v0.1.17
InvertedIndices ────────────────── v1.3.1
IrrationalConstants ────────────── v0.2.4
Isoband ────────────────────────── v0.1.1
IterTools ──────────────────────── v1.10.0
IteratorInterfaceExtensions ────── v1.0.0
JLD2 ───────────────────────────── v0.5.12
JLLWrappers ────────────────────── v1.7.0
JSON ───────────────────────────── v0.21.4
JSON3 ──────────────────────────── v1.14.2
Jieko ──────────────────────────── v0.2.1
JpegTurbo ──────────────────────── v0.1.6
JpegTurbo_jll ──────────────────── v3.1.1+0
JuMP ───────────────────────────── v1.25.0
JuliaInterpreter ───────────────── v0.9.42
KernelDensity ──────────────────── v0.6.9
Krylov ─────────────────────────── v0.9.10
LAME_jll ───────────────────────── v3.100.2+0
LERC_jll ───────────────────────── v4.0.1+0
LLVMOpenMP_jll ─────────────────── v18.1.7+0
LZO_jll ────────────────────────── v2.10.3+0
LaTeXStrings ───────────────────── v1.4.0
LayoutPointers ─────────────────── v0.1.17
LazyArrays ─────────────────────── v2.6.1
LazyModules ────────────────────── v0.3.1
LeftChildRightSiblingTrees ─────── v0.2.0
Legolas ────────────────────────── v0.5.23
Libffi_jll ─────────────────────── v3.2.2+2
Libgcrypt_jll ──────────────────── v1.11.1+0
Libglvnd_jll ───────────────────── v1.7.0+0
Libgpg_error_jll ───────────────── v1.51.1+0
Libiconv_jll ───────────────────── v1.18.0+0
Libmount_jll ───────────────────── v2.41.0+0
Libtiff_jll ────────────────────── v4.7.1+0
Libuuid_jll ────────────────────── v2.41.0+0
LineSearch ─────────────────────── v0.1.4
LineSearches ───────────────────── v7.3.0
LinearSolve ────────────────────── v3.7.2
LogExpFunctions ────────────────── v0.3.29
LoggingExtras ──────────────────── v1.1.0
LoweredCodeUtils ───────────────── v3.1.0
Lz4_jll ────────────────────────── v1.10.1+0
MKL_jll ────────────────────────── v2025.0.1+1
MacroTools ─────────────────────── v0.5.15
Makie ──────────────────────────── v0.22.2
MakieCore ──────────────────────── v0.9.1
ManualMemory ───────────────────── v0.1.8
MappedArrays ───────────────────── v0.4.2
MarkdownTables ─────────────────── v1.1.0
MathOptInterface ───────────────── v1.38.1
MathTeXEngine ──────────────────── v0.6.2
MaybeInplace ───────────────────── v0.1.4
MbedTLS ────────────────────────── v1.1.9
MetaGraphsNext ─────────────────── v0.7.3
Missings ───────────────────────── v1.2.0
Mocking ────────────────────────── v0.8.1
MosaicViews ────────────────────── v0.3.4
Moshi ──────────────────────────── v0.3.5
MuladdMacro ────────────────────── v0.2.4
MutableArithmetics ─────────────── v1.6.4
NLSolversBase ──────────────────── v7.9.1
NaNMath ────────────────────────── v1.1.3
Netpbm ─────────────────────────── v1.1.1
NonlinearSolve ─────────────────── v4.5.0
NonlinearSolveBase ─────────────── v1.5.1
NonlinearSolveFirstOrder ───────── v1.3.0
NonlinearSolveQuasiNewton ──────── v1.2.0
NonlinearSolveSpectralMethods ──── v1.1.0
Observables ────────────────────── v0.5.5
OffsetArrays ───────────────────── v1.16.0
Ogg_jll ────────────────────────── v1.3.5+1
OpenBLASConsistentFPCSR_jll ────── v0.3.29+0
OpenEXR ────────────────────────── v0.3.3
OpenEXR_jll ────────────────────── v3.2.4+0
OpenSSL_jll ────────────────────── v3.0.16+0
OpenSpecFun_jll ────────────────── v0.5.6+0
Opus_jll ───────────────────────── v1.3.3+0
OrderedCollections ─────────────── v1.8.0
OrdinaryDiffEqBDF ──────────────── v1.4.0
OrdinaryDiffEqCore ─────────────── v1.22.0
OrdinaryDiffEqDifferentiation ──── v1.6.0
OrdinaryDiffEqLowOrderRK ───────── v1.2.0
OrdinaryDiffEqNonlinearSolve ───── v1.6.0
OrdinaryDiffEqRosenbrock ───────── v1.9.0
OrdinaryDiffEqSDIRK ────────────── v1.3.0
OrdinaryDiffEqTsit5 ────────────── v1.1.0
OteraEngine ────────────────────── v1.1.1
PDMats ─────────────────────────── v0.11.33
PNGFiles ───────────────────────── v0.4.4
PackageCompiler ────────────────── v2.2.0
Packing ────────────────────────── v0.5.1
PaddedViews ────────────────────── v0.5.12
Pango_jll ──────────────────────── v1.56.1+0
Parameters ─────────────────────── v0.12.3
Parsers ────────────────────────── v2.8.1
Pixman_jll ─────────────────────── v0.44.2+0
PkgVersion ─────────────────────── v0.3.3
PlotUtils ──────────────────────── v1.4.3
Polyester ──────────────────────── v0.7.16
PolyesterWeave ─────────────────── v0.2.2
PolygonOps ─────────────────────── v0.1.2
PooledArrays ───────────────────── v1.4.3
PreallocationTools ─────────────── v0.4.26
PrecompileTools ────────────────── v1.2.1
Preferences ────────────────────── v1.4.3
PrettyTables ───────────────────── v2.4.0
ProgressLogging ────────────────── v0.1.4
ProgressMeter ──────────────────── v1.10.4
PtrArrays ──────────────────────── v1.3.0
QOI ────────────────────────────── v1.0.1
QuadGK ─────────────────────────── v2.11.2
RangeArrays ────────────────────── v0.3.2
Ratios ─────────────────────────── v0.4.5
RecipesBase ────────────────────── v1.3.4
RecursiveArrayTools ────────────── v3.31.2
Reexport ───────────────────────── v1.2.2
RelocatableFolders ─────────────── v1.0.1
Requires ───────────────────────── v1.3.1
Revise ─────────────────────────── v3.7.3
Rmath ──────────────────────────── v0.8.0
Rmath_jll ──────────────────────── v0.5.1+0
RoundingEmulator ───────────────── v0.2.1
RuntimeGeneratedFunctions ──────── v0.5.13
SIMD ───────────────────────────── v3.7.1
SIMDTypes ──────────────────────── v0.1.0
SQLite ─────────────────────────── v1.6.1
SQLite_jll ─────────────────────── v3.48.0+0
SciMLBase ──────────────────────── v2.82.0
SciMLJacobianOperators ─────────── v0.1.1
SciMLOperators ─────────────────── v0.3.13
SciMLStructures ────────────────── v1.7.0
Scratch ────────────────────────── v1.2.1
SentinelArrays ─────────────────── v1.4.8
Setfield ───────────────────────── v1.1.2
ShaderAbstractions ─────────────── v0.5.0
Showoff ────────────────────────── v1.0.3
SignedDistanceFields ───────────── v0.4.0
SimpleNonlinearSolve ───────────── v2.2.0
SimpleTraits ───────────────────── v0.9.4
SimpleUnPack ───────────────────── v1.1.0
Sixel ──────────────────────────── v0.1.3
SoftGlobalScope ────────────────── v1.1.0
SortingAlgorithms ──────────────── v1.2.1
SparseMatrixColorings ──────────── v0.4.16
SpecialFunctions ───────────────── v2.5.0
StableRNGs ─────────────────────── v1.0.2
StackViews ─────────────────────── v0.1.1
Static ─────────────────────────── v1.2.0
StaticArrayInterface ───────────── v1.8.0
StaticArrays ───────────────────── v1.9.13
StaticArraysCore ───────────────── v1.4.3
Statistics ─────────────────────── v1.11.1
StatsAPI ───────────────────────── v1.7.0
StatsBase ──────────────────────── v0.34.4
StatsFuns ──────────────────────── v1.4.0
StrideArraysCore ───────────────── v0.5.7
StringManipulation ─────────────── v0.4.1
StringViews ────────────────────── v1.3.4
StructArrays ───────────────────── v0.7.1
StructTypes ────────────────────── v1.11.0
SymbolicIndexingInterface ──────── v0.3.38
TZJData ────────────────────────── v1.5.0+2025b
TableTraits ────────────────────── v1.0.1
Tables ─────────────────────────── v1.12.0
TensorCore ─────────────────────── v0.1.1
TerminalLoggers ────────────────── v0.1.7
TestEnv ────────────────────────── v1.102.0
TestItemRunner ─────────────────── v1.1.0
TestItems ──────────────────────── v1.0.0
ThreadingUtilities ─────────────── v0.5.2
TiffImages ─────────────────────── v0.11.3
TimeZones ──────────────────────── v1.21.3
TimerOutputs ───────────────────── v0.5.28
TranscodingStreams ─────────────── v0.11.3
TriplotBase ────────────────────── v0.1.0
TruncatedStacktraces ───────────── v1.4.0
UnPack ─────────────────────────── v1.0.2
UnicodeFun ─────────────────────── v0.4.1
Unitful ────────────────────────── v1.22.0
VersionParsing ─────────────────── v1.3.0
WeakRefStrings ─────────────────── v1.4.2
WebP ───────────────────────────── v0.1.3
WoodburyMatrices ───────────────── v1.0.0
XML2_jll ───────────────────────── v2.13.6+1
XSLT_jll ───────────────────────── v1.1.43+0
XZ_jll ─────────────────────────── v5.8.1+0
Xorg_libX11_jll ────────────────── v1.8.6+3
Xorg_libXau_jll ────────────────── v1.0.12+0
Xorg_libXdmcp_jll ──────────────── v1.1.5+0
Xorg_libXext_jll ───────────────── v1.3.6+3
Xorg_libXrender_jll ────────────── v0.9.11+1
Xorg_libpthread_stubs_jll ──────── v0.1.2+0
Xorg_libxcb_jll ────────────────── v1.17.0+3
Xorg_xtrans_jll ────────────────── v1.6.0+0
ZMQ ────────────────────────────── v1.4.0
ZeroMQ_jll ─────────────────────── v4.3.6+0
Zstd_jll ───────────────────────── v1.5.7+1
isoband_jll ────────────────────── v0.2.3+0
libaom_jll ─────────────────────── v3.11.0+0
libass_jll ─────────────────────── v0.15.2+0
libfdk_aac_jll ─────────────────── v2.0.3+0
libpng_jll ─────────────────────── v1.6.47+0
libsixel_jll ───────────────────── v1.10.5+0
libsodium_jll ──────────────────── v1.0.21+0
libvorbis_jll ──────────────────── v1.3.7+2
libwebp_jll ────────────────────── v1.5.0+0
oneTBB_jll ─────────────────────── v2022.0.0+0
x264_jll ───────────────────────── v10164.0.1+0
x265_jll ───────────────────────── v3.6.0+0
