### PR TITLE
Don't automatically save the layer style on changes.

### DIFF
--- a/ribasim_qgis/core/nodes.py
+++ b/ribasim_qgis/core/nodes.py
@@ -149,8 +149,7 @@ class Input(abc.ABC):
         if not success:
             self.load_default_style()
             self.save_style()
-        # Connect signal to save style to database when changed
-        self.layer.styleChanged.connect(self.save_style)
+
         return self.layer
 
     def from_geopackage(self) -> tuple[QgsVectorLayer, Any]:


### PR DESCRIPTION
Fixes #1877

This was not documented anyway, was quite buggy, and users can save their changes themselves when they want it.