### PR TITLE
Add `label_flow_rate` function to QGIS

### DIFF
--- a/python/ribasim_testmodels/ribasim_testmodels/allocation.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/allocation.py
@@ -1179,6 +1179,7 @@ def bommelerwaard_model():
         endtime="2016-03-31",
         crs="EPSG:28992",
         allocation=Allocation(use_allocation=True),
+        experimental=Experimental(concentration=True),
     )
 
     # Node coordinates

--- a/ribasim_qgis/core/model.py
+++ b/ribasim_qgis/core/model.py
@@ -43,7 +43,7 @@ def get_database_path_from_model_file(model_path: Path) -> Path:
     )
 
 
-@qgsfunction(args="auto", group="Custom", referenced_columns=[])
+@qgsfunction(args="auto", group="Custom", referenced_columns=[])  # type: ignore
 def label_flow_rate(value: float) -> str:
     """
     Format the label for `flow_rate`.

--- a/ribasim_qgis/core/model.py
+++ b/ribasim_qgis/core/model.py
@@ -50,7 +50,7 @@ def label_flow_rate(value: float) -> str:
 
     Above 1, show 2 decimals.
     Show 0 as 0.
-    Below 1, show 3 significant digits and scientific notation.
+    Between 0 and 1, and below 1, show 3 significant digits and scientific notation.
     Example outputs: 0, 1.23e-06, 12345.68
     """
     if abs(value) >= 1:

--- a/ribasim_qgis/core/model.py
+++ b/ribasim_qgis/core/model.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import Any
 
+from qgis.core import qgsfunction
+
 import ribasim_qgis.tomllib as tomllib
 
 
@@ -39,3 +41,21 @@ def get_database_path_from_model_file(model_path: Path) -> Path:
         get_directory_path_from_model_file(model_path, property="input_dir")
         / "database.gpkg"
     )
+
+
+@qgsfunction(args="auto", group="Custom", referenced_columns=[])
+def label_flow_rate(value: float) -> str:
+    """
+    Format the label for `flow_rate`.
+
+    Above 1, show 2 decimals.
+    Show 0 as 0.
+    Below 1, show 3 significant digits and scientific notation.
+    Example outputs: 0, 1.23e-06, 12345.68
+    """
+    if abs(value) >= 1:
+        return f"{value:.2f}"
+    if abs(value) == 0.0:
+        return "0"
+    else:
+        return f"{value:.2e}"


### PR DESCRIPTION
Will be hooked up after #2215.
Also adds concentration to Bommelerwaard, we run it in all other test models, this is good to test the combined output.