### PR TITLE
Use view to avoid allocations in flow limiter

### DIFF
--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -786,7 +786,7 @@ function limit_flow!(u::Vector, integrator::DEIntegrator, p::Parameters, t::Numb
                 id,
                 inflow_id,
             )
-            allocated_total =
+            @views allocated_total =
                 is_active(allocation) ? sum(user_demand.allocated[id.idx, :]) :
                 sum(user_demand.demand[id.idx, :])
             factor_basin_min * factor_level_min * allocated_total, allocated_total


### PR DESCRIPTION
Helps to reduce the allocations:
```
# 17.378027 seconds (5.23 M allocations: 3.301 GiB, 2.81% gc time)
# 16.907372 seconds (4.01 M allocations: 3.255 GiB, 2.47% gc time)
```

The remaining allocations are almost all in relaxation, for which #2190 or #1784 are good candidates to help.

```julia
using Ribasim
m = Ribasim.Model("hws_2025_4_0/hws.toml")
@profview_allocs Ribasim.solve!(m)
```

![image](https://github.com/user-attachments/assets/d79515a1-1c37-4a25-9f37-1cb8c9868dcf)
