### PR TITLE
Reduce allocations in residual function

### DIFF
--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -780,18 +780,13 @@ end
 Compute the residual of the non-linear solver, i.e. a measure of the
 error in the solution to the implicit equation defined by the solver algorithm
 """
-function residual(z, integrator, nlsolver, f)
+function residual(z, integrator, nlsolver, f::TF) where {TF}
     (; uprev, t, p, dt, opts, isdae) = integrator
     (; tmp, ztmp, γ, α, cache, method) = nlsolver
     (; ustep, atmp, tstep, k, invγdt, tstep, k, invγdt) = cache
-    if isdae
-        _uprev = get_dae_uprev(integrator, uprev)
-        b, ustep2 =
-            _compute_rhs!(tmp, ztmp, ustep, α, tstep, k, invγdt, p, _uprev, f::TF, z)
-    else
-        b, ustep2 =
-            _compute_rhs!(tmp, ztmp, ustep, γ, α, tstep, k, invγdt, method, p, dt, f, z)
-    end
+    @assert !isdae
+    b, ustep2 =
+        _compute_rhs!(tmp, ztmp, ustep, γ, α, tstep, k, invγdt, method, p, dt, f::TF, z)
     calculate_residuals!(
         atmp,
         b,


### PR DESCRIPTION
Continuing from #2224:

```
18.086399 seconds (4.01 M allocations: 3.255 GiB, 2.81% gc time)
17.879659 seconds (2.95 M allocations: 2.949 GiB, 1.69% gc time)
```

Adding the type assert on the function does the trick. I also go rid of the `isdae` check because it shouldn't be needed, and I noticed `get_dae_uprev` leads to runtime dispatch since it is using `isdefined(integrator, ...)`

There are still more optimizations to be made to backtracking, but good to bag this one already.
I also noticed many extra allocations if `concentration = true`, we should also look at that.