### PR TITLE
Add cumulative flow resetting

### DIFF
--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -435,7 +435,7 @@ of vectors or Arrow Tables, and is added to avoid type instabilities.
     outflow_ids::Vector{Vector{NodeID}} = [NodeID[]]
     # Vertical fluxes
     vertical_flux::VerticalFlux = VerticalFlux(length(node_id))
-    # Initial_storage
+    # Initial (or reset) storage
     storage0::Vector{Float64} = zeros(length(node_id))
     # Storage at previous saveat without storage0
     Δstorage_prev_saveat::Vector{Float64} = zeros(length(node_id))


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/1897.

This resets the cumulative flows when the water balance error gets above 1% of the tolerated value.

This works, but I still think that resetting the state like this can mess with the solver. Maybe it affects the adaptive time stepping, maybe it causes a very wrong initial guess in the Newton solve of the next timestep.