### PR TITLE
[skip ci] Docs: Fix unit notation for Outlet.

### DIFF
--- a/docs/reference/node/outlet.qmd
+++ b/docs/reference/node/outlet.qmd
@@ -11,16 +11,16 @@ When PID controlled, the Outlet must point towards the controlled Basin in terms
 
 ## Static
 
-column                | type    | unit                   | restriction
----------             | ------- | ---------------------- | -----------
-node_id               | Int32   | -                      |
-control_state         | String  | -                      | (optional)
-active                | Bool    | -                      | (optional, default true)
-flow_rate             | Float64 | $\text{m}^3/\text{s}\$ | non-negative
-min_flow_rate         | Float64 | $\text{m}^3/\text{s}\$ | (optional, default 0.0)
-max_flow_rate         | Float64 | $\text{m}^3/\text{s}\$ | (optional)
-min_upstream_level    | Float64 | $\text{m}$             | (optional)
-max_downstream_level  | Float64 | $\text{m}$             | (optional)
+column                | type    | unit                  | restriction
+---------             | ------- | --------------------- | -----------
+node_id               | Int32   | -                     |
+control_state         | String  | -                     | (optional)
+active                | Bool    | -                     | (optional, default true)
+flow_rate             | Float64 | $\text{m}^3/\text{s}$ | non-negative
+min_flow_rate         | Float64 | $\text{m}^3/\text{s}$ | (optional, default 0.0)
+max_flow_rate         | Float64 | $\text{m}^3/\text{s}$ | (optional)
+min_upstream_level    | Float64 | $\text{m}$            | (optional)
+max_downstream_level  | Float64 | $\text{m}$            | (optional)
 
 ## Time
 
@@ -30,15 +30,15 @@ flow_rate is interpolated linearly, and outside the flow rate is constant given 
 nearest time value.
 Note that a `node_id` can be either in this table or in the static one, but not both.
 
-column                | type    | unit                   | restriction
----------             | ------- | ---------------------- | -----------
-node_id               | Int32   | -                      |
-time                  | DateTime| -                      |
-flow_rate             | Float64 | $\text{m}^3/\text{s}\$ | non-negative
-min_flow_rate         | Float64 | $\text{m}^3/\text{s}\$ | (optional, default 0.0)
-max_flow_rate         | Float64 | $\text{m}^3/\text{s}\$ | (optional)
-min_upstream_level    | Float64 | $\text{m}$             | (optional)
-max_downstream_level  | Float64 | $\text{m}$             | (optional)
+column                | type    | unit                  | restriction
+---------             | ------- | --------------------- | -----------
+node_id               | Int32   | -                     |
+time                  | DateTime| -                     |
+flow_rate             | Float64 | $\text{m}^3/\text{s}$ | non-negative
+min_flow_rate         | Float64 | $\text{m}^3/\text{s}$ | (optional, default 0.0)
+max_flow_rate         | Float64 | $\text{m}^3/\text{s}$ | (optional)
+min_upstream_level    | Float64 | $\text{m}$            | (optional)
+max_downstream_level  | Float64 | $\text{m}$            | (optional)
 
 # Equations
 


### PR DESCRIPTION
As it's currently [broken](https://ribasim.org/reference/node/outlet.html) showing `$^3/$ `