### PR TITLE
Reduce residual calls

### DIFF
--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -813,22 +813,40 @@ function OrdinaryDiffEqNonlinearSolve.relax!(
     linesearch::MonitoredBackTracking,
 )
     (; linesearch, dz_tmp, z_tmp) = linesearch
+    atmp::Vector{Float64} = nlsolver.cache.atmp
 
-    # Store step before relaxation
-    @. dz_tmp = dz
+    let dz = dz,
+        integrator = integrator,
+        nlsolver = nlsolver,
+        f = f,
+        linesearch = linesearch
 
-    # Apply relaxation and measure the residual change
-    @. z_tmp = nlsolver.z + dz
-    resid_before = residual(z_tmp, integrator, nlsolver, f)
-    relax!(dz, nlsolver, integrator, f, linesearch)
-    @. z_tmp = nlsolver.z + dz
-    resid_after = residual(z_tmp, integrator, nlsolver, f)
+        function ϕ(α)
+            @. atmp = nlsolver.z - dz * α
+            residual(atmp, integrator, nlsolver, f)
+        end
 
-    # If the residual increased due to the relaxation, reject it
-    if resid_after > resid_before
-        @. dz = dz_tmp
+        # Store step before relaxation
+        @. dz_tmp = dz
+
+        # Apply relaxation and measure the residual change
+        @. z_tmp = nlsolver.z + dz
+        resid_before = residual(z_tmp, integrator, nlsolver, f)
+        α0 = 1.0
+        ϕ0 = ϕ(0.0)
+        ϵ = sqrt(eps())
+        dϕ0 = (ϕ(ϵ) - ϕ0) / ϵ
+
+        # This linesearch method is specific to BackTracking
+        α, resid_after = linesearch(ϕ, α0, ϕ0, dϕ0)
+        @. z_tmp = nlsolver.z + α * dz
+
+        # If the residual increased due to the relaxation, reject it
+        if resid_after > resid_before
+            @. dz = dz_tmp
+        end
+        return dz
     end
-    return dz
 end
 
 "Create a NamedTuple of the node IDs per state component in the state order"


### PR DESCRIPTION
A follow-up to https://github.com/Deltares/Ribasim/pull/2224. I managed to reduce the number of residual calls in the 'managing' of the backtracking.

I cannot find any type instabilities in the relaxation code with Cthulhu anymore. The profile with `hws_2025_4_0` now looks like this:

![image](https://github.com/user-attachments/assets/22c89dbc-2315-4121-a0f1-39da2b2b9a94)

What I also find interesting, is that time in the backtracking algorithm is completely dominated by the first call to the residual, which I think tells us that most of the time the residual reduction criterion is immediately satisfied. Maybe we can come up with a cheap criterion in the monitoring to skip the backtracking all together.

ping @visr @Huite 