### PR TITLE
Update to Julia 1.11.5

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -63,7 +63,7 @@
         "Ribasim"
     ],
     "files.insertFinalNewline": true,
-    "julia.executablePath": "julia +1.11.4",
+    "julia.executablePath": "julia +1.11.5",
     "julia.lint.disabledDirs": [
         ".pixi"
     ],

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.4"
+julia_version = "1.11.5"
 manifest_format = "2.0"
 project_hash = "08df9cf37f934d9c54c355f731e7bb06c158c106"
 
@@ -1735,7 +1735,7 @@ version = "3.2.4+0"
 [[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
-version = "0.8.1+4"
+version = "0.8.5+0"
 
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -19,7 +19,7 @@ test-ribasim-python-cov = "pytest --numprocesses=4 --cov=ribasim --cov-report=xm
 test-ribasim-api = "pytest --basetemp=python/ribasim_api/tests/temp --junitxml=report.xml python/ribasim_api/tests"
 # Installation
 # Keep Julia version synced with julia.executablePath in .vscode/settings.json
-install-julia = "juliaup add 1.11.4 && juliaup override set 1.11.4"
+install-julia = "juliaup add 1.11.5 && juliaup override set 1.11.5"
 install-pre-commit = "pre-commit install"
 # Note that this has a Windows specific override
 install-ci = { depends-on = ["install-julia", "update-registry-julia"] }
@@ -29,7 +29,6 @@ install = { depends-on = [
     "install-pre-commit",
 ] }
 # Julia
-# Clear SSL_CERT_DIR to avoid Julia warnings, see https://github.com/JuliaLang/Downloads.jl/issues/244
 update-registry-julia = { cmd = "julia --eval='using Pkg; Registry.update()'"}
 update-manifest-julia = { cmd = "julia --project utils/update-manifest.jl"}
 instantiate-julia = { cmd = "julia --project --eval='using Pkg; Pkg.instantiate()'"}


### PR DESCRIPTION
https://discourse.julialang.org/t/julia-v1-11-5-has-been-released/128076

This contains a backport of my fix that breaks Pkg operations in an activated conda / pixi environment that need git like `dev` or `add Wflow#master`. The `unset-ssl-cert.bat` workaround is still needed for the other half that isn't backported, that just logs otherwise harmless but scary looking warnings from curl_easy_setopt.