### PR TITLE
Update Delwaq artifact rule

### DIFF
--- a/.teamcity/Ribasim_Windows/RibasimWindowsProject.kt
+++ b/.teamcity/Ribasim_Windows/RibasimWindowsProject.kt
@@ -128,7 +128,7 @@ object Windows_TestDelwaqCoupling : BuildType({
             id = "ARTIFACT_DEPENDENCY_4206"
             buildRule = lastSuccessful()
             artifactRules = """
-                DWAQ_win64_Release_Visual Studio 16 2019_ifx_*.zip!** => dimr
+                DWAQ_win64_Release_Visual Studio *.zip!** => dimr
             """.trimIndent()
         }
     }


### PR DESCRIPTION
In #2256 I noticed Delwaq CI now fails.

```
[12:51:12]: Dependency resolving started...
[12:51:12]: Downloading artifacts from: https://dpcbuild.deltares.nl/
[12:51:12]: Failed to download artifact dependency <D-Waq/D-Part / Windows / Build, build #5025dc116bd934487371ff7258baefed5ed21521 [id 5707232]>: No files matched for patterns "DWAQ_win64_Release_Visual Studio 16 2019_ifx_*.zip" from <D-Waq/D-Part / Windows / Build, build #5025dc116bd934487371ff7258baefed5ed21521 [id 5707232]> (jetbrains.buildServer.artifacts.impl.SourcePathAwareResolvingFailedException)
[12:51:12]: Failed to resolve 1 dependencies
[12:51:12]: Dependency resolving finished with errors
```

Looking at the latest successful build it seems they updated the Visual Studio version. To make it more robust to this I removed this version from the rule, as they don't have multiple anyway.