### PR TITLE
POC

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.5"
 manifest_format = "2.0"
-project_hash = "08df9cf37f934d9c54c355f731e7bb06c158c106"
+project_hash = "894c8ea720d33034c3bd8832c6eefadddb850a81"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "e2478490447631aedba0823d4d7a80b2cc8cdb32"
@@ -448,11 +448,11 @@ version = "1.7.0"
 
 [[deps.DataInterpolations]]
 deps = ["EnumX", "FindFirstFunctions", "ForwardDiff", "LinearAlgebra", "PrettyTables", "RecipesBase", "Reexport"]
-git-tree-sha1 = "42d49c3860a1ed45a67c2984565796f2f67d19d7"
+git-tree-sha1 = "ee37a31646bd0f644ce03711f96ee02ab28c8b38"
 repo-rev = "master"
-repo-url = "https://github.com/SciML/DataInterpolations.jl.git"
+repo-url = "https://github.com/SciML/DataInterpolations.jl"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "8.0.0"
+version = "8.0.1"
 
     [deps.DataInterpolations.extensions]
     DataInterpolationsChainRulesCoreExt = "ChainRulesCore"

--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -60,6 +60,7 @@ using LinearAlgebra: mul!
 using DataInterpolations:
     ConstantInterpolation,
     LinearInterpolation,
+    SmoothedConstantInterpolation,
     LinearInterpolationIntInv,
     invert_integral,
     derivative,

--- a/core/src/config.jl
+++ b/core/src/config.jl
@@ -120,6 +120,11 @@ const nodetypes = collect(keys(nodekinds))
     evaporate_mass::Bool = true
 end
 
+@option struct Interpolation <: TableOption
+    flow_boundary::String = "linear"
+    stepwise_smoothing::Float64 = 60.0
+end
+
 # Separate struct, as basin clashes with nodetype
 @option struct Results <: TableOption
     compression::Bool = true
@@ -165,6 +170,7 @@ end
     ribasim_version::String
     input_dir::String
     results_dir::String
+    interpolation::Interpolation = Interpolation()
     allocation::Allocation = Allocation()
     solver::Solver = Solver()
     logging::Logging = Logging()

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -155,11 +155,22 @@ const ScalarConstantInterpolation =
     ConstantInterpolation{Vector{Float64}, Vector{Float64}, Vector{Float64}, Float64}
 
 "LinearInterpolation from a Float64 to a Float64"
-const ScalarInterpolation = LinearInterpolation{
+const ScalarLinearInterpolation = LinearInterpolation{
     Vector{Float64},
     Vector{Float64},
     Vector{Float64},
     Vector{Float64},
+    Float64,
+}
+
+"SmoothedConstantInterpolation from a Float64 to a Float64"
+const ScalarStepwiseInterpolation = SmoothedConstantInterpolation{
+    Vector{Float64},
+    Vector{Float64},
+    Vector{Float64},
+    Vector{Float64},
+    Vector{Float64},
+    Float64,
     Float64,
 }
 
@@ -342,8 +353,8 @@ The parameter update associated with a certain control state for discrete contro
 @kwdef struct ControlStateUpdate
     active::ParameterUpdate{Bool}
     scalar_update::Vector{ParameterUpdate{Float64}} = ParameterUpdate{Float64}[]
-    itp_update_linear::Vector{ParameterUpdate{ScalarInterpolation}} =
-        ParameterUpdate{ScalarInterpolation}[]
+    itp_update_linear::Vector{ParameterUpdate{ScalarLinearInterpolation}} =
+        ParameterUpdate{ScalarLinearInterpolation}[]
     itp_update_lookup::Vector{ParameterUpdate{IndexLookup}} = ParameterUpdate{IndexLookup}[]
 end
 
@@ -402,8 +413,8 @@ abstract type AbstractDemandNode <: AbstractParameterNode end
     # substances in use by the model (ordered like their axis in the concentration matrices)
     substances::OrderedSet{Symbol}
     # Data source for external concentrations (used in control)
-    concentration_external::Vector{Dict{String, ScalarInterpolation}} =
-        Dict{String, ScalarInterpolation}[]
+    concentration_external::Vector{Dict{String, ScalarLinearInterpolation}} =
+        Dict{String, ScalarLinearInterpolation}[]
 end
 
 """
@@ -446,7 +457,7 @@ VerticalFlux(n::Int) = VerticalFlux(zeros(n), zeros(n), zeros(n), zeros(n))
 const StorageToLevelType = LinearInterpolationIntInv{
     Vector{Float64},
     Vector{Float64},
-    ScalarInterpolation,
+    ScalarLinearInterpolation,
     Float64,
 }
 
@@ -478,8 +489,8 @@ of vectors or Arrow Tables, and is added to avoid type instabilities.
     # Discrete values for interpolation
     storage_to_level::Vector{StorageToLevelType} =
         Vector{StorageToLevelType}(undef, length(node_id))
-    level_to_area::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
+    level_to_area::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
     # Values for allocation if applicable
     demand::Vector{Float64} = zeros(length(node_id))
     allocated::Vector{Float64} = zeros(length(node_id))
@@ -517,7 +528,7 @@ control_mapping: dictionary from (node_id, control_state) to Q(h) and/or active 
     outflow_link::Vector{LinkMetadata} = Vector{LinkMetadata}(undef, length(node_id))
     active::Vector{Bool} = ones(Bool, length(node_id))
     max_downstream_level::Vector{Float64} = fill(Inf, length(node_id))
-    interpolations::Vector{ScalarInterpolation} = ScalarInterpolation[]
+    interpolations::Vector{ScalarLinearInterpolation} = ScalarLinearInterpolation[]
     current_interpolation_index::Vector{IndexLookup} = IndexLookup[]
     control_mapping::Dict{Tuple{NodeID, String}, ControlStateUpdate} =
         Dict{Tuple{NodeID, String}, ControlStateUpdate}()
@@ -608,7 +619,8 @@ concentration_time: Data source for concentration updates
 @kwdef struct LevelBoundary{C} <: AbstractParameterNode
     node_id::Vector{NodeID}
     active::Vector{Bool} = ones(Bool, length(node_id))
-    level::Vector{ScalarInterpolation} = Vector{ScalarInterpolation}(undef, length(node_id))
+    level::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
     concentration::Matrix{Float64}
     concentration_time::StructVector{LevelBoundaryConcentrationV1, C, Int}
 end
@@ -623,14 +635,13 @@ flow_rate: flow rate (exact)
 concentration: matrix with boundary concentrations for each Basin and substance
 concentration_time: Data source for concentration updates
 """
-@kwdef struct FlowBoundary{C} <: AbstractParameterNode
+@kwdef struct FlowBoundary{C, I} <: AbstractParameterNode
     node_id::Vector{NodeID}
     outflow_link::Vector{LinkMetadata} = Vector{LinkMetadata}(undef, length(node_id))
     active::Vector{Bool} = ones(Bool, length(node_id))
     cumulative_flow::Vector{Float64} = zeros(length(node_id))
     cumulative_flow_saveat::Vector{Float64} = zeros(length(node_id))
-    flow_rate::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
+    flow_rate::Vector{I}
     concentration::Matrix{Float64}
     concentration_time::StructVector{FlowBoundaryConcentrationV1, C, Int}
 end
@@ -655,16 +666,16 @@ continuous_control_type: one of None, ContinuousControl, PidControl
     inflow_link::Vector{LinkMetadata} = Vector{LinkMetadata}(undef, length(node_id))
     outflow_link::Vector{LinkMetadata} = Vector{LinkMetadata}(undef, length(node_id))
     active::Vector{Bool} = fill(true, length(node_id))
-    flow_rate::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
-    min_flow_rate::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
-    max_flow_rate::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
-    min_upstream_level::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
-    max_downstream_level::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
+    flow_rate::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
+    min_flow_rate::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
+    max_flow_rate::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
+    min_upstream_level::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
+    max_downstream_level::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
     control_mapping::Dict{Tuple{NodeID, String}, ControlStateUpdate} =
         Dict{Tuple{NodeID, String}, ControlStateUpdate}()
     continuous_control_type::Vector{ContinuousControlType.T} =
@@ -691,16 +702,16 @@ continuous_control_type: one of None, ContinuousControl, PidControl
     inflow_link::Vector{LinkMetadata} = Vector{LinkMetadata}(undef, length(node_id))
     outflow_link::Vector{LinkMetadata} = Vector{LinkMetadata}(undef, length(node_id))
     active::Vector{Bool} = ones(Bool, length(node_id))
-    flow_rate::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
-    min_flow_rate::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
-    max_flow_rate::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
-    min_upstream_level::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
-    max_downstream_level::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
+    flow_rate::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
+    min_flow_rate::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
+    max_flow_rate::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
+    min_upstream_level::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
+    max_downstream_level::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
     control_mapping::Dict{Tuple{NodeID, String}, ControlStateUpdate} = Dict()
     continuous_control_type::Vector{ContinuousControlType.T} =
         fill(ContinuousControlType.None, length(node_id))
@@ -825,7 +836,7 @@ end
     compound_variable::Vector{CompoundVariable}
     controlled_variable::Vector{String}
     target_ref::Vector{DiffCacheRef} = Vector{DiffCacheRef}(undef, length(node_id))
-    func::Vector{ScalarInterpolation}
+    func::Vector{ScalarLinearInterpolation}
 end
 
 """
@@ -846,15 +857,15 @@ control_mapping: dictionary from (node_id, control_state) to target flow rate
     node_id::Vector{NodeID}
     active::Vector{Bool} = ones(Bool, length(node_id))
     listen_node_id::Vector{NodeID} = Vector{NodeID}(undef, length(node_id))
-    target::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
+    target::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
     target_ref::Vector{DiffCacheRef} = Vector{DiffCacheRef}(undef, length(node_id))
-    proportional::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
-    integral::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
-    derivative::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
+    proportional::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
+    integral::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
+    derivative::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
     control_mapping::Dict{Tuple{NodeID, String}, ControlStateUpdate} =
         Dict{Tuple{NodeID, String}, ControlStateUpdate}()
 end
@@ -892,7 +903,7 @@ concentration_time: Data source for concentration updates
         zeros(Bool, length(node_id), length(demand_priorities))
     demand::Matrix{Float64} = zeros(length(node_id), length(demand_priorities))
     demand_reduced::Matrix{Float64} = zeros(length(node_id), length(demand_priorities))
-    demand_itp::Vector{Vector{ScalarInterpolation}} = [
+    demand_itp::Vector{Vector{ScalarLinearInterpolation}} = [
         fill(
             LinearInterpolation(
                 [0.0, 0.0],
@@ -904,8 +915,8 @@ concentration_time: Data source for concentration updates
     ]
     demand_from_timeseries::Vector{Bool} = Vector{Bool}(undef, length(node_id))
     allocated::Matrix{Float64} = fill(Inf, length(node_id), length(demand_priorities))
-    return_factor::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
+    return_factor::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
     min_level::Vector{Float64} = zeros(length(node_id))
     concentration::Matrix{Float64}
     concentration_time::StructVector{UserDemandConcentrationV1, C, Int}
@@ -919,10 +930,10 @@ demand_priority: If in a shortage state, the priority of the demand of the conne
 """
 @kwdef struct LevelDemand <: AbstractDemandNode
     node_id::Vector{NodeID}
-    min_level::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
-    max_level::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
+    min_level::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
+    max_level::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
     demand_priority::Vector{Int32} = Vector{Int32}(undef, length(node_id))
 end
 
@@ -934,8 +945,8 @@ demand_priority: The priority of the demand of the node
 """
 @kwdef struct FlowDemand <: AbstractDemandNode
     node_id::Vector{NodeID}
-    demand_itp::Vector{ScalarInterpolation} =
-        Vector{ScalarInterpolation}(undef, length(node_id))
+    demand_itp::Vector{ScalarLinearInterpolation} =
+        Vector{ScalarLinearInterpolation}(undef, length(node_id))
     demand::Vector{Float64} = zeros(length(node_id))
     demand_priority::Vector{Int32} = zeros(length(node_id))
 end
@@ -953,7 +964,7 @@ end
     # index into the subgrid.level vector for each static subgrid_id
     level_index_static::Vector{Int} = []
     # per subgrid one relation
-    interpolations_static::Vector{ScalarInterpolation} = []
+    interpolations_static::Vector{ScalarLinearInterpolation} = []
 
     # Dynamic part
     # Dynamic subgrid ids
@@ -963,7 +974,7 @@ end
     # index into the subgrid.level vector for each dynamic subgrid_id
     level_index_time::Vector{Int} = []
     # per subgrid n relations, n being the number of timesteps for that subgrid
-    interpolations_time::Vector{ScalarInterpolation} = []
+    interpolations_time::Vector{ScalarLinearInterpolation} = []
     # per subgrid 1 lookup from t to an index in interpolations_time
     current_interpolation_index::Vector{IndexLookup} = []
 end
@@ -1008,7 +1019,7 @@ and not derived from the state vector `u` (or the time `t`). In this context e.g
 of floats (not dependent on `u`) is not considered mutable, because even though it's elements are mutable,
 the object itself is not.
 """
-@kwdef struct ParametersNonDiff{C1, C2, C3, C4, C5}
+@kwdef struct ParametersNonDiff{C1, C2, C3, C4, C5, C6}
     starttime::DateTime
     graph::ModelGraph
     allocation::Allocation
@@ -1017,7 +1028,7 @@ the object itself is not.
     manning_resistance::ManningResistance
     tabulated_rating_curve::TabulatedRatingCurve
     level_boundary::LevelBoundary{C3}
-    flow_boundary::FlowBoundary{C4}
+    flow_boundary::FlowBoundary{C4, C5}
     pump::Pump
     outlet::Outlet
     terminal::Terminal
@@ -1025,7 +1036,7 @@ the object itself is not.
     discrete_control::DiscreteControl
     continuous_control::ContinuousControl
     pid_control::PidControl
-    user_demand::UserDemand{C5}
+    user_demand::UserDemand{C6}
     level_demand::LevelDemand
     flow_demand::FlowDemand
     subgrid::Subgrid
@@ -1065,8 +1076,8 @@ end
 """
 The collection of all parameters that are passed to the rhs (`water_balance!`) and callbacks.
 """
-@kwdef struct Parameters{C1, C2, C3, C4, C5, T}
-    p_non_diff::ParametersNonDiff{C1, C2, C3, C4, C5}
+@kwdef struct Parameters{C1, C2, C3, C4, C5, C6, T}
+    p_non_diff::ParametersNonDiff{C1, C2, C3, C4, C5, C6}
     diff_cache::DiffCache{T} = DiffCache(p_non_diff)
     p_mutable::ParametersMutable = ParametersMutable()
 end

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -201,10 +201,18 @@ function get_parameter_value(
 end
 
 # Map interpolation type -> constructor
-make_itp(::Type{<:LinearInterpolation}, args...; kwargs...) =
-    LinearInterpolation(args...; kwargs...)
-make_itp(::Type{<:ConstantInterpolation}, args...; kwargs...) =
-    ConstantInterpolation(args...; kwargs...)
+make_itp(::Type{<:LinearInterpolation}, u, t; extrapolation, kwargs...) =
+    LinearInterpolation(u, t; cache_parameters = true, extrapolation)
+make_itp(::Type{<:ConstantInterpolation}, u, t; extrapolation, kwargs...) =
+    ConstantInterpolation(u, t; extrapolation, kwargs...)
+make_itp(
+    ::Type{<:SmoothedConstantInterpolation},
+    u,
+    t;
+    extrapolation,
+    stepwise_smoothing,
+    kwargs...,
+) = SmoothedConstantInterpolation(u, t; extrapolation, d_max = stepwise_smoothing)
 
 # Get interpolation parameter value
 function get_parameter_value(
@@ -240,7 +248,7 @@ function get_parameter_value(
         u,
         t;
         extrapolation = cyclic_time ? Periodic : ConstantExtrapolation,
-        cache_parameters = true,
+        config.interpolation.stepwise_smoothing,
     )
     return itp, valid
 end
@@ -283,7 +291,12 @@ function parse_parameter!(
 
     if has_default
         if is_itp
-            itp_default = make_itp(T, [default, default], [0.0, prevfloat(Inf)])
+            itp_default = make_itp(
+                T,
+                [default, default],
+                [0.0, prevfloat(Inf)];
+                extrapolation = ConstantExtrapolation,
+            )
         else
             @assert default isa T
         end
@@ -634,8 +647,9 @@ function FlowBoundary(db::DB, config::Config, graph::MetaGraph)
     concentration[:, Substance.Continuity] .= 1.0
     concentration[:, Substance.FlowBoundary] .= 1.0
     set_concentrations!(concentration, concentration_time, substances, node_id)
+    flow_rate = get_interpolation_vec(config.interpolation.flow_boundary, node_id)
 
-    flow_boundary = FlowBoundary(; node_id, concentration, concentration_time)
+    flow_boundary = FlowBoundary(; node_id, concentration, concentration_time, flow_rate)
 
     set_inoutflow_links!(flow_boundary, graph; inflow = false)
     errors = parse_parameter!(flow_boundary, config, :flow_rate; static, time, cyclic_times)
@@ -759,9 +773,9 @@ function ConcentrationData(
 
     concentration_external_data =
         load_structvector(db, config, BasinConcentrationExternalV1)
-    concentration_external = Dict{String, ScalarInterpolation}[]
+    concentration_external = Dict{String, ScalarLinearInterpolation}[]
     for (id, cyclic_time) in zip(node_id, cyclic_times)
-        concentration_external_id = Dict{String, ScalarInterpolation}()
+        concentration_external_id = Dict{String, ScalarLinearInterpolation}()
         data_id = filter(row -> row.node_id == id.value, concentration_external_data)
         for group in IterTools.groupby(row -> row.substance, data_id)
             first_row = first(group)
@@ -1052,7 +1066,7 @@ function continuous_control_functions(db, config, ids)
     errors = false
     # Parse the function table
     # Create linear interpolation objects out of the provided functions
-    functions = ScalarInterpolation[]
+    functions = ScalarLinearInterpolation[]
     controlled_variables = String[]
 
     # Loop over the IDs of the ContinuousControl nodes

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -90,14 +90,14 @@ function get_scalar_interpolation(
 end
 
 """
-Create a valid Qh ScalarInterpolation.
+Create a valid Qh ScalarLinearInterpolation.
 Takes a node_id for validation logging, and a vector of level (h) and flow_rate (Q).
 """
 function qh_interpolation(
     node_id::NodeID,
     level::Vector{Float64},
     flow_rate::Vector{Float64},
-)::ScalarInterpolation
+)::ScalarLinearInterpolation
     errors = false
     n = length(level)
     if n < 2
@@ -1095,4 +1095,15 @@ function ranges(lengths::Vector{<:Integer})
     # standardize empty ranges to 1:0 for easier testing
     replace!(x -> isempty(x) ? (1:0) : x, ranges)
     return ranges
+end
+
+function get_interpolation_vec(interpolation_type::String, node_id::Vector{NodeID})::Vector
+    type = if interpolation_type == "linear"
+        ScalarLinearInterpolation
+    elseif interpolation_type == "stepwise"
+        ScalarStepwiseInterpolation
+    else
+        error("Invalid interpolation type specified: $interpolation_type.")
+    end
+    return Vector{type}(undef, length(node_id))
 end

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -282,7 +282,7 @@ Test whether static or discrete controlled flow rates are indeed non-negative.
 """
 function valid_flow_rates(
     node_id::Vector{NodeID},
-    flow_rate::Vector{ScalarInterpolation},
+    flow_rate::Vector{ScalarLinearInterpolation},
     control_mapping::Dict{Tuple{NodeID, String}, <:ControlStateUpdate},
 )::Bool
     errors = false
@@ -383,7 +383,7 @@ end
 
 function valid_demand(
     node_id::Vector{NodeID},
-    demand_itp::Vector{Vector{ScalarInterpolation}},
+    demand_itp::Vector{Vector{ScalarLinearInterpolation}},
     demand_priorities::Vector{Int32},
 )::Bool
     errors = false

--- a/core/test/docs.toml
+++ b/core/test/docs.toml
@@ -20,6 +20,10 @@ ribasim_version = "2025.3.0" # required
 [basin]
 time = "basin/time.arrow"
 
+[interpolation]
+flow_boundary = "linear"   # optional, default "linear", can otherwise be "stepwise"
+stepwise_smoothing = 60.0  # optional, default 60.0
+
 [allocation]
 timestep = 86400                                 # optional (required if use_allocation = true), default 86400
 use_allocation = false                           # optional, default false

--- a/core/test/validation_test.jl
+++ b/core/test/validation_test.jl
@@ -26,7 +26,7 @@ end
 @testitem "Q(h) validation" begin
     import SQLite
     using Logging
-    using Ribasim: NodeID, qh_interpolation, ScalarInterpolation
+    using Ribasim: NodeID, qh_interpolation, ScalarLinearInterpolation
 
     node_id = NodeID(:TabulatedRatingCurve, 1, 1)
     level = [1.0, 2.0]
@@ -38,7 +38,7 @@ end
     @test itp(1.5) ≈ 0.05
     @test itp(2.0) ≈ 0.1
     @test itp(3.0) ≈ 0.2
-    @test itp isa ScalarInterpolation
+    @test itp isa ScalarLinearInterpolation
 
     toml_path = normpath(@__DIR__, "../../generated_testmodels/invalid_qh/ribasim.toml")
     @test ispath(toml_path)

--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -71,6 +71,25 @@ class SourcePriority(ChildModel):
     subnetwork_inlet: int = 5000
 
 
+class Interpolation(ChildModel):
+    """
+    Defines interpolation types used for various node types.
+
+    Supported interpolation types are: linear, stepwise
+
+    Attributes
+    ----------
+    flow_boundary : string
+        The interpolation type used for the flow rate timeseries (optional, defaults to 'linear')
+    stepwise_smoothing : float
+        If stepwise interpolation is used, this is the maximum time span on either side of the data points over which
+        the transition between data points is smoothed.
+    """
+
+    flow_boundary: str = "linear"
+    stepwise_smoothing: float = 60.0
+
+
 class Allocation(ChildModel):
     """
     Defines the allocation optimization algorithm options.

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -31,6 +31,7 @@ from ribasim.config import (
     Experimental,
     FlowBoundary,
     FlowDemand,
+    Interpolation,
     Junction,
     LevelBoundary,
     LevelDemand,
@@ -89,6 +90,7 @@ class Model(FileModel):
     results: Results = Field(default_factory=Results)
 
     allocation: Allocation = Field(default_factory=Allocation)
+    interpolation: Interpolation = Field(default_factory=Interpolation)
 
     experimental: Experimental = Field(default_factory=Experimental)
 

--- a/python/ribasim_testmodels/ribasim_testmodels/__init__.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/__init__.py
@@ -23,6 +23,7 @@ from ribasim_testmodels.allocation import (
 )
 from ribasim_testmodels.backwater import backwater_model
 from ribasim_testmodels.basic import (
+    Wilson_model,
     basic_arrow_model,
     basic_model,
     basic_transient_model,
@@ -128,6 +129,7 @@ __all__ = [
     "trivial_model",
     "two_basin_model",
     "user_demand_model",
+    "Wilson_model",
 ]
 
 # provide a mapping from model name to its constructor, so we can iterate over all models

--- a/python/ribasim_testmodels/ribasim_testmodels/basic.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/basic.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import ribasim
 from ribasim import Model
-from ribasim.config import Experimental, Node
+from ribasim.config import Experimental, Interpolation, Node
 from ribasim.input_base import TableModel
 from ribasim.nodes import (
     basin,
@@ -456,5 +456,45 @@ def cyclic_time_model() -> Model:
     model.edge.add(bsn, lr)
     model.edge.add(lr, lb)
     model.edge.add(fb, bsn)
+
+    return model
+
+
+def Wilson_model() -> Model:
+    model = Model(
+        starttime="2020-01-01",
+        endtime="2020-01-09",
+        crs="EPSG:28992",
+        interpolation=Interpolation(flow_boundary="stepwise", stepwise_smoothing=7200),
+    )
+
+    fb = model.flow_boundary.add(
+        Node(1, Point(0, 0), cyclic_time=True),
+        [
+            flow_boundary.Time(
+                time=["2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04"],
+                flow_rate=[1e-3, 2.5e-3, 0.0, 1e-3],
+            )
+        ],
+    )
+
+    bsn = model.basin.add(
+        Node(2, Point(4, 0)),
+        [
+            basin.State(level=[1.0]),
+            basin.Profile(level=[0.0, 3.0], area=[1000.0, 1000.0]),
+        ],
+    )
+
+    trc = model.tabulated_rating_curve.add(
+        Node(3, Point(5, 0)),
+        [tabulated_rating_curve.Static(level=[0.0, 2.0], flow_rate=[0.0, 1e-3])],
+    )
+
+    tml = model.terminal.add(Node(4, Point(0, 12)))
+
+    model.link.add(fb, bsn)
+    model.link.add(bsn, trc)
+    model.link.add(trc, tml)
 
     return model


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/2281.

Results with schematizations that look like this:

```python
model = Model(
    starttime="2020-01-01",
    endtime="2020-01-09",
    crs="EPSG:28992",
    interpolation=Interpolation(flow_boundary="stepwise", stepwise_smoothing=7200),
)

fb = model.flow_boundary.add(
    Node(1, Point(0, 0), cyclic_time=True),
    [
        flow_boundary.Time(
            time=["2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04"],
            flow_rate=[1e-3, 2.5e-3, 0.0, 1e-3],
        )
    ],
)

...
```

Old behavior:

![image](https://github.com/user-attachments/assets/eb2376a5-a112-40e7-b486-d1f45a545660)

New behavior with a smoothing period of 2 ours on either side of each data point:

![image](https://github.com/user-attachments/assets/64a3b6f6-a690-4c13-9c53-ca98c33dce84)

New behavior without smoothing:

![image](https://github.com/user-attachments/assets/07877839-ca00-4458-a71e-80db45f16a06)

