### PR TITLE
Allow Junction to Terminal links

### DIFF
--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -23,6 +23,7 @@ neighbortypes(::Val{:junction}) = Set((
     :pump,
     :outlet,
     :user_demand,
+    :terminal,
 ))
 neighbortypes(::Val{:flow_boundary}) = Set((:basin, :terminal, :level_boundary, :junction))
 neighbortypes(::Val{:level_boundary}) =

--- a/python/ribasim/ribasim/validation.py
+++ b/python/ribasim/ribasim/validation.py
@@ -6,6 +6,7 @@ node_type_connectivity: dict[str, list[str]] = {
     "Junction": [
         "LinearResistance",
         "UserDemand",
+        "Terminal",
         "Junction",
         "Outlet",
         "Basin",


### PR DESCRIPTION
E.g. if the rightmost Basin in the examples would be a Terminal, it would also be valid.
https://ribasim.org/reference/node/junction.html#examples
