### PR TITLE
Fix writing result on water_balance_error callback error.

### DIFF
--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -92,6 +92,7 @@ function get_storages_and_levels(
     storage = zeros(length(node_id), length(tsteps))
     level = zero(storage)
     for (i, cvec) in enumerate(saved.basin_state.saveval)
+        i > length(tsteps) && continue
         storage[:, i] .= cvec.storage
         level[:, i] .= cvec.level
     end

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -92,7 +92,7 @@ function get_storages_and_levels(
     storage = zeros(length(node_id), length(tsteps))
     level = zero(storage)
     for (i, cvec) in enumerate(saved.basin_state.saveval)
-        i > length(tsteps) && continue
+        i > length(tsteps) && break
         storage[:, i] .= cvec.storage
         level[:, i] .= cvec.level
     end


### PR DESCRIPTION
When failing on a water balance error, the saved values are in an inconsistent state (the flows seems to have more timesteps than the basin) crashing our write method.

```
┌ Error: Too large water balance error
│   id = Basin #40
│   balance_error = -0.001659908081632593
│   relative_error = -0.19294117647058828
└ @ Ribasim /Users/evetion/code/Ribasim/core/src/callback.jl:456
┌ Error: Too large water balance error
│   id = Basin #57
│   balance_error = -0.0018341382494009707
│   relative_error = -2.0
└ @ Ribasim /Users/evetion/code/Ribasim/core/src/callback.jl:456
┌ Warning: Simulation crashed or interrupted.
└ @ Ribasim /Users/evetion/code/Ribasim/core/src/main.jl:51
ERROR: BoundsError: attempt to access 145×886 Matrix{Float64} at index [1:145, 887]
Stacktrace:
  [1] throw_boundserror(A::Matrix{Float64}, I::Tuple{Base.Slice{Base.OneTo{Int64}}, Int64})
    @ Base ./essentials.jl:14
  [2] checkbounds
    @ ./abstractarray.jl:699 [inlined]
  [3] view
    @ ./subarray.jl:214 [inlined]
  [4] maybeview
    @ ./views.jl:149 [inlined]
  [5] dotview
    @ ./broadcast.jl:1228 [inlined]
  [6] get_storages_and_levels(model::Ribasim.Model{OrdinaryDiffEqCore.ODEIntegrator{OrdinaryDiffEqBDF.QNDF{5, 0, ADTypes.AutoSparse{ADTypes.AutoForwardDiff{nothing, ForwardDiff.Tag{DiffEqBase.OrdinaryDiffEqTag, Float64}}, ADTypes.KnownJacobianSparsityDetector{SparseArrays.SparseMatrixCSC{Bool, Int64}},
```