### PR TITLE
Add julia task that can generate the SBOM for Ribasim.jl

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.5"
 manifest_format = "2.0"
-project_hash = "08df9cf37f934d9c54c355f731e7bb06c158c106"
+project_hash = "4d0893bccb4d42d99b346d744c070e35cc420ff7"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "e2478490447631aedba0823d4d7a80b2cc8cdb32"
@@ -1253,6 +1253,11 @@ git-tree-sha1 = "a9eaadb366f5493a5654e843864c13d8b107548c"
 uuid = "10f19ff3-798f-405d-979b-55457f8fc047"
 version = "0.1.17"
 
+[[deps.LazilyInitializedFields]]
+git-tree-sha1 = "0f2da712350b020bc3957f269c9caad516383ee0"
+uuid = "0e77f7df-68c5-4e49-93ce-4cd80f5598bf"
+version = "1.3.0"
+
 [[deps.LazyArrays]]
 deps = ["ArrayLayouts", "FillArrays", "LinearAlgebra", "MacroTools", "SparseArrays"]
 git-tree-sha1 = "866ce84b15e54d758c11946aacd4e5df0e60b7a3"
@@ -1361,6 +1366,12 @@ deps = ["Artifacts", "JLLWrappers", "Libdl"]
 git-tree-sha1 = "321ccef73a96ba828cd51f2ab5b9f917fa73945a"
 uuid = "38a345b3-de98-5d2b-a5d3-14cd9215e700"
 version = "2.41.0+0"
+
+[[deps.LicenseCheck]]
+deps = ["licensecheck_jll"]
+git-tree-sha1 = "e98bc9e1f773123cfdb1fa3d7a4c898e1f030341"
+uuid = "726dbf0d-6eb6-41af-b36c-cd770e0f00cc"
+version = "0.2.2"
 
 [[deps.LineSearch]]
 deps = ["ADTypes", "CommonSolve", "ConcreteStructs", "FastClosures", "LinearAlgebra", "MaybeInplace", "SciMLBase", "SciMLJacobianOperators", "StaticArraysCore"]
@@ -1890,6 +1901,12 @@ weakdeps = ["REPL"]
     [deps.Pkg.extensions]
     REPLExt = "REPL"
 
+[[deps.PkgToSoftwareBOM]]
+deps = ["Artifacts", "Downloads", "LicenseCheck", "Logging", "Pkg", "Reexport", "RegistryInstances", "SPDX", "UUIDs"]
+git-tree-sha1 = "e1d6a871220e356ca43a242cf0088c604f043893"
+uuid = "6254a0f9-6143-4104-aa2e-fd339a2830a6"
+version = "0.1.13"
+
 [[deps.PkgVersion]]
 deps = ["Pkg"]
 git-tree-sha1 = "f9501cc0430a26bc3d156ae1b5b0c1b47af4d6da"
@@ -2065,6 +2082,12 @@ git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 version = "1.2.2"
 
+[[deps.RegistryInstances]]
+deps = ["LazilyInitializedFields", "Pkg", "TOML", "Tar"]
+git-tree-sha1 = "ffd19052caf598b8653b99404058fce14828be51"
+uuid = "2792f1a3-b283-48e8-9a74-f99dce5104f3"
+version = "0.1.0"
+
 [[deps.RelocatableFolders]]
 deps = ["SHA", "Scratch"]
 git-tree-sha1 = "ffdaf70d81cf6ff22c2b6e733c900c3321cab864"
@@ -2130,6 +2153,12 @@ version = "3.7.1"
 git-tree-sha1 = "330289636fb8107c5f32088d2741e9fd7a061a5c"
 uuid = "94e857df-77ce-4151-89e5-788b33177be4"
 version = "0.1.0"
+
+[[deps.SPDX]]
+deps = ["DataStructures", "Dates", "JSON", "Logging", "SHA", "TimeZones", "UUIDs"]
+git-tree-sha1 = "de73a6f48b8efa0eeb7e0c526c6b0e38e62b981a"
+uuid = "47358f48-d834-4249-91f5-f6185eb3d540"
+version = "0.4.1"
 
 [[deps.SQLite]]
 deps = ["DBInterface", "Random", "SQLite_jll", "Serialization", "Tables", "WeakRefStrings"]
@@ -2782,6 +2811,12 @@ deps = ["Artifacts", "Giflib_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Lib
 git-tree-sha1 = "d2408cac540942921e7bd77272c32e58c33d8a77"
 uuid = "c5f90fcd-3b7e-5836-afba-fc50a0988cb2"
 version = "1.5.0+0"
+
+[[deps.licensecheck_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "b790ad21ac235c39c0eb34214ccf3d5f5ea60efa"
+uuid = "4ecb348a-8b88-51ea-b912-4c460483ee91"
+version = "0.3.101+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/Project.toml
+++ b/Project.toml
@@ -51,6 +51,7 @@ OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 OteraEngine = "b2d7f28f-acd6-4007-8b26-bc27716e5513"
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
+PkgToSoftwareBOM = "6254a0f9-6143-4104-aa2e-fd339a2830a6"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Ribasim = "aac5e3d9-0b8f-4d4f-8241-b1a7a9632635"
 SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
@@ -67,4 +68,4 @@ TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [sources]
-Ribasim = {path = "core"}
+Ribasim = { path = "core" }

--- a/Ribasim.spdx.json
+++ b/Ribasim.spdx.json
@@ -1,0 +1,7222 @@
+{
+    "spdxVersion": "SPDX-2.3",
+    "dataLicense": "CC0-1.0",
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "name": "Ribasim.jl",
+    "documentNamespace": "https://github.com/Deltares/Ribasim/Ribasim.spdx.json-ecd05c3c-8714-4b9b-a502-adff613bc470",
+    "creationInfo": {
+        "creators": [
+            "Organization:  Deltares  (software@deltares.nl)"
+        ],
+        "created": "2025-05-28T13:35:05Z",
+        "comment": "Target Platform: Platform(\"x86_64\", \"windows\"; libgfortran_version = \"5.0.0\", julia_version = \"1.11.5\", cxxstring_abi = \"cxx11\")"
+    },
+    "comment": "Registries used for populating Package data:\nGeneral registry: https://github.com/JuliaRegistries/General.git\nOfficial general Julia package registry where people can\nregister any package they want without too much debate about\nnaming and without enforced standards on documentation or\ntesting. We nevertheless encourage documentation, testing and\nsome amount of consideration when choosing package names.\n",
+    "packages": [
+        {
+            "name": "ConstructionBase",
+            "SPDXID": "SPDXRef-ConstructionBase-187b0558-2788-49d3-abe0-74a17ed4e7c9",
+            "versionInfo": "1.5.8",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaObjects/ConstructionBase.jl.git@76219f1ed5771adbb096743bff43fb5fdd4c1157",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "4f8cb825d9f4c3ba701a4b00fc24ffe007082657"
+            },
+            "homepage": "https://github.com/JuliaObjects/ConstructionBase.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "CompositionsBase",
+            "SPDXID": "SPDXRef-CompositionsBase-a33af91c-f02d-484b-be07-31d278c5ca2b",
+            "versionInfo": "0.1.2",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaFunctional/CompositionsBase.jl.git@802bb88cd69dfd1509f6670416bd4434015693ad",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "e4eb24060849d5c1b36c5c80c8cc5f17223f2cc6"
+            },
+            "homepage": "https://github.com/JuliaFunctional/CompositionsBase.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "InverseFunctions",
+            "SPDXID": "SPDXRef-InverseFunctions-3587e190-3f89-42d0-90ee-14403ec27112",
+            "versionInfo": "0.1.17",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaMath/InverseFunctions.jl.git@a779299d77cd080bf77b97535acecd73e1c5e5cb",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "b551a46b93f802b142439546c82e8e99540ed6aa"
+            },
+            "homepage": "https://github.com/JuliaMath/InverseFunctions.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "MacroTools",
+            "SPDXID": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
+            "versionInfo": "0.5.16",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/FluxML/MacroTools.jl.git@1e0228a030642014fe5cfe68c2c0a818f9e3f522",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "60a805e46073bc69096355e98a798602bca4c675"
+            },
+            "homepage": "https://github.com/FluxML/MacroTools.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Accessors",
+            "SPDXID": "SPDXRef-Accessors-7d9f7c33-5ae7-4f3b-8dc6-eff91059b697",
+            "versionInfo": "0.1.42",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaObjects/Accessors.jl.git@3b86719127f50670efe356bc11073d84b4ed7a5d",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "65e6b67b66ed7ae9e2495b8cec128d83b95943c1"
+            },
+            "homepage": "https://github.com/JuliaObjects/Accessors.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Preferences",
+            "SPDXID": "SPDXRef-Preferences-21216c6a-2e73-6563-6e65-726566657250",
+            "versionInfo": "1.4.3",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/Preferences.jl.git@9306f6085165d270f7e3db02af26a400d580f5c6",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "ae41d492334f497fd074d1a966eb1662759ed5c5"
+            },
+            "homepage": "https://github.com/JuliaPackaging/Preferences.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "JLLWrappers",
+            "SPDXID": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "versionInfo": "1.7.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/JLLWrappers.jl.git@a007feb38b422fbdab534406aeca1b86823cb4d6",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "725e0c312ccefee7b8a62d30591d8a91690dd6df"
+            },
+            "homepage": "https://github.com/JuliaPackaging/JLLWrappers.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "HiGHS_source",
+            "SPDXID": "SPDXRef-db01335a6b9c8c7f797115be3e9d7e50e979acb4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/Yggdrasil.git@db01335a6b9c8c7f797115be3e9d7e50e979acb4#/H/HiGHS/HiGHS/",
+            "filesAnalyzed": false,
+            "sourceInfo": "The location of this repository was extracted from the README.md file of SPDXRef-8f98efd8e73db8cafc6637dc0b18b1f87a4201b8",
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "The binary artifact SPDXRef-8f98efd8e73db8cafc6637dc0b18b1f87a4201b8 is built using the scripts and source files in this package.\nThe build system is called Yggdrasil, the Julia community build tree.",
+            "comment": "The SPDX ID field is derived from the Git hash in the DownloadLocation"
+        },
+        {
+            "name": "HiGHS",
+            "SPDXID": "SPDXRef-8f98efd8e73db8cafc6637dc0b18b1f87a4201b8",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/HiGHS_jll.jl/releases/download/HiGHS-v1.10.0+0/HiGHS.v1.10.0.x86_64-w64-mingw32-cxx11.tar.gz",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "2ac19a3ba79d9db09687ef292371c79097536519"
+            },
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "ee44b15352420d2ecd5086affd60b39950f0f91c1ba7e3779f0b15695b632712"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: x86_64\ncxxstring_abi: cxx11\nos: windows",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "Zlib",
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "HiGHS_jll",
+            "SPDXID": "SPDXRef-HiGHS_jll-8fd58aa0-07eb-5a78-9b36-339c94fd15ea",
+            "versionInfo": "1.10.0+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/HiGHS_jll.jl.git@72bceb63d4ae3683f091f812b6958a199c494a1b",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "30a5f4af0253ff856a5f79ed7be2cf960b124558"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/HiGHS_jll.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "PrecompileTools",
+            "SPDXID": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "versionInfo": "1.2.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaLang/PrecompileTools.jl.git@5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "c53702e9539ec14e6b3627ed7390e7e4bae7fae2"
+            },
+            "homepage": "https://github.com/JuliaLang/PrecompileTools.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "StaticArraysCore",
+            "SPDXID": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
+            "versionInfo": "1.4.3",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaArrays/StaticArraysCore.jl.git@192954ef1208c7019899fbf8049e717f92959682",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "30f96471fa9dcc1425267634210c2251d28b176c"
+            },
+            "homepage": "https://github.com/JuliaArrays/StaticArraysCore.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "DiffResults",
+            "SPDXID": "SPDXRef-DiffResults-163ba53b-c6d8-5494-b064-1a9d43ac40c5",
+            "versionInfo": "1.1.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaDiff/DiffResults.jl.git@782dd5f4561f5d267313f23853baaaa4c52ea621",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "515ccd03f1d7739488013c1e756a3422a2795894"
+            },
+            "homepage": "https://github.com/JuliaDiff/DiffResults.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "IrrationalConstants",
+            "SPDXID": "SPDXRef-IrrationalConstants-92d709cd-6900-40b7-9082-c6be49f344b6",
+            "versionInfo": "0.2.4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaMath/IrrationalConstants.jl.git@e2222959fbc6c19554dc15174c81bf7bf3aa691c",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "6c7e9e2947a13b98028ada82b57054f94637a0ff"
+            },
+            "homepage": "https://github.com/JuliaMath/IrrationalConstants.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "DocStringExtensions",
+            "SPDXID": "SPDXRef-DocStringExtensions-ffbed154-4ef7-542d-bbb7-c09d3a79fcae",
+            "versionInfo": "0.9.4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaDocs/DocStringExtensions.jl.git@e7b7e6f178525d17c720ab9c081e4ef04429f860",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "f00a540de8f5abcbfd6fd04b5a4fa0390394078c"
+            },
+            "homepage": "https://github.com/JuliaDocs/DocStringExtensions.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "LogExpFunctions",
+            "SPDXID": "SPDXRef-LogExpFunctions-2ab3a3ac-af41-5b50-aa03-7779005ae688",
+            "versionInfo": "0.3.29",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaStats/LogExpFunctions.jl.git@13ca9e2586b89836fd20cccf56e57e2b9ae7f38f",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "0dcbeb37acf19b33b4afb73ac1f4a956f1bce3be"
+            },
+            "homepage": "https://github.com/JuliaStats/LogExpFunctions.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "OpenSpecFun_source",
+            "SPDXID": "SPDXRef-a09b23447486767cbc7f74078c5b2ecdbdbbdeaa",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/Yggdrasil.git@a09b23447486767cbc7f74078c5b2ecdbdbbdeaa#/O/OpenSpecFun/",
+            "filesAnalyzed": false,
+            "sourceInfo": "The location of this repository was extracted from the README.md file of SPDXRef-c1bc0753f7d08c4dcb1f132c45ca0cc509294c81",
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "The binary artifact SPDXRef-c1bc0753f7d08c4dcb1f132c45ca0cc509294c81 is built using the scripts and source files in this package.\nThe build system is called Yggdrasil, the Julia community build tree.",
+            "comment": "The SPDX ID field is derived from the Git hash in the DownloadLocation"
+        },
+        {
+            "name": "OpenSpecFun",
+            "SPDXID": "SPDXRef-c1bc0753f7d08c4dcb1f132c45ca0cc509294c81",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/OpenSpecFun_jll.jl/releases/download/OpenSpecFun-v0.5.6+0/OpenSpecFun.v0.5.6.x86_64-w64-mingw32-libgfortran5.tar.gz",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "e546d1f8d260d1b3bfd51e167aa5195cf0acfd0b"
+            },
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "b1d57a279d8b6c9202c31a2efbfa38a10c540075affa1fd9984623e24686cb47"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\nlibgfortran_version: 5.0.0\narch: x86_64\nos: windows",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "OpenSpecFun_jll",
+            "SPDXID": "SPDXRef-OpenSpecFun_jll-efe28fd5-8261-553b-a9e1-b2916fc3738e",
+            "versionInfo": "0.5.6+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/OpenSpecFun_jll.jl.git@1346c9208249809840c91b26703912dff463d335",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "5a51cf2367a25683d562dd6e62f29d73469adcbe"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/OpenSpecFun_jll.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "SpecialFunctions",
+            "SPDXID": "SPDXRef-SpecialFunctions-276daf66-3868-5448-9aa4-cd146d93841b",
+            "versionInfo": "2.5.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaMath/SpecialFunctions.jl.git@41852b8679f78c8d8961eeadc8f62cef861a52e3",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "70ccfdd8b619adf235ac4df0e296e9a074f96940"
+            },
+            "homepage": "https://github.com/JuliaMath/SpecialFunctions.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "NaNMath",
+            "SPDXID": "SPDXRef-NaNMath-77ba4419-2d1f-58cd-9bb1-8ffee604a2e3",
+            "versionInfo": "1.1.3",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaMath/NaNMath.jl.git@9b8215b1ee9e78a293f99797cd31375471b2bcae",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "51298892656657e14ebc4aaa844a9518e3abded6"
+            },
+            "homepage": "https://github.com/JuliaMath/NaNMath.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "DiffRules",
+            "SPDXID": "SPDXRef-DiffRules-b552c78f-8df3-52c6-915a-8e097449b14b",
+            "versionInfo": "1.15.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaDiff/DiffRules.jl.git@23163d55f885173722d1e4cf0f6110cdbaf7e272",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "1413458a74a1ce11322a3fa9b44104f69bb3a214"
+            },
+            "homepage": "https://github.com/JuliaDiff/DiffRules.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "CommonSubexpressions",
+            "SPDXID": "SPDXRef-CommonSubexpressions-bbf7d656-a473-5ed7-a52c-81e309532950",
+            "versionInfo": "0.3.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/rdeits/CommonSubexpressions.jl.git@cda2cfaebb4be89c9084adaca7dd7333369715c5",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "c3a42a4f67574a1939c9ebc207c17b048e4f67d3"
+            },
+            "homepage": "https://github.com/rdeits/CommonSubexpressions.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "ForwardDiff",
+            "SPDXID": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210",
+            "versionInfo": "0.10.38",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaDiff/ForwardDiff.jl.git@a2df1b776752e3f344e5116c06d75a10436ab853",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "d26085f343d33f10979f4154ddcbf285bfa1e189"
+            },
+            "homepage": "https://github.com/JuliaDiff/ForwardDiff.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Parsers",
+            "SPDXID": "SPDXRef-Parsers-69de0a69-1ddd-5017-9359-2bf0b02dc9f0",
+            "versionInfo": "2.8.3",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaData/Parsers.jl.git@7d2f8f21da5db6a806faf7b9b292296da42b2810",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "cc9e97ad3b67747372a8cdcc4981a3816f95f22d"
+            },
+            "homepage": "https://github.com/JuliaData/Parsers.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "StructTypes",
+            "SPDXID": "SPDXRef-StructTypes-856f2bd8-1eba-4b0a-8007-ebc267875bd4",
+            "versionInfo": "1.11.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaData/StructTypes.jl.git@159331b30e94d7b11379037feeb9b690950cace8",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "ac2a6f54440605fd89e531b4eb76ce6f354ab2fb"
+            },
+            "homepage": "https://github.com/JuliaData/StructTypes.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "JSON3",
+            "SPDXID": "SPDXRef-JSON3-0f8b85d8-7281-11e9-16c2-39a750bddbf1",
+            "versionInfo": "1.14.3",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/quinnj/JSON3.jl.git@411eccfe8aba0814ffa0fdf4860913ed09c34975",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "beb8803b988ab2ffe0fd1660007631d996ab4dea"
+            },
+            "homepage": "https://github.com/quinnj/JSON3.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "JSON",
+            "SPDXID": "SPDXRef-JSON-682c06a0-de6a-54ab-a142-c8b1cf79cde6",
+            "versionInfo": "0.21.4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaIO/JSON.jl.git@31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "c522102198b25a282dd50a4648f3424bb0ea60e6"
+            },
+            "homepage": "https://github.com/JuliaIO/JSON.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Statistics",
+            "SPDXID": "SPDXRef-Statistics-10745b16-79ce-11e8-11f9-7d13ad32a3b2",
+            "versionInfo": "1.11.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaStats/Statistics.jl.git@ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "0d59a4f81366f9b4dd7c3f42d50ffabdbfa874b9"
+            },
+            "homepage": "https://github.com/JuliaStats/Statistics.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Compat",
+            "SPDXID": "SPDXRef-Compat-34da2185-b29b-5c13-b0c7-acf172513d20",
+            "versionInfo": "4.16.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaLang/Compat.jl.git@8ae8d32e09f0dcf42a36b90d4e17f5dd2e4c4215",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "ce595242ac64e357314d81f6c2167557826dd651"
+            },
+            "homepage": "https://github.com/JuliaLang/Compat.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "BenchmarkTools",
+            "SPDXID": "SPDXRef-BenchmarkTools-6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf",
+            "versionInfo": "1.6.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaCI/BenchmarkTools.jl.git@e38fbc49a620f5d0b660d7f543db1009fe0f8336",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "56ce86b654b17d59a2281b490ea841a2f959bc2d"
+            },
+            "homepage": "https://github.com/JuliaCI/BenchmarkTools.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "OrderedCollections",
+            "SPDXID": "SPDXRef-OrderedCollections-bac558e1-5e72-5ebc-8fee-abe8a469f55d",
+            "versionInfo": "1.8.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaCollections/OrderedCollections.jl.git@05868e21324cede2207c6f0f466b4bfef6d5e7ee",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "44de9ddb8dcadaa3ecfc1931229397cdd313524a"
+            },
+            "homepage": "https://github.com/JuliaCollections/OrderedCollections.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "TranscodingStreams",
+            "SPDXID": "SPDXRef-TranscodingStreams-3bb67fe8-82b1-5028-8e26-92a6c54297fa",
+            "versionInfo": "0.11.3",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaIO/TranscodingStreams.jl.git@0c45878dcfdcfa8480052b6ab162cdd138781742",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "c630abb6954069742be2f29e5f18134a4aa7ae90"
+            },
+            "homepage": "https://github.com/JuliaIO/TranscodingStreams.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "CodecZlib",
+            "SPDXID": "SPDXRef-CodecZlib-944b1d66-785c-5afd-91f1-9de20f533193",
+            "versionInfo": "0.7.8",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaIO/CodecZlib.jl.git@962834c22b66e32aa10f7611c08c8ca4e20749a9",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "d78961e67980f48080340a68fe0108eb4884403e"
+            },
+            "homepage": "https://github.com/JuliaIO/CodecZlib.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "DataStructures",
+            "SPDXID": "SPDXRef-DataStructures-864edb3b-99cc-5e75-8d2d-829cb0a9cfe8",
+            "versionInfo": "0.18.22",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaCollections/DataStructures.jl.git@4e1fe97fdaed23e9dc21d4d664bea76b65fc50a0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "1d85a8e41c624e614d6924a4c5e4bcdd14957cfb"
+            },
+            "homepage": "https://github.com/JuliaCollections/DataStructures.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Bzip2_source",
+            "SPDXID": "SPDXRef-4f5224a8ba03ee7be81c164c6f85745f9a1e8cc5",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/Yggdrasil.git@4f5224a8ba03ee7be81c164c6f85745f9a1e8cc5#/B/Bzip2/",
+            "filesAnalyzed": false,
+            "sourceInfo": "The location of this repository was extracted from the README.md file of SPDXRef-3af036b12a076c2d4c042dde6d956ef4eac2c2ce",
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "The binary artifact SPDXRef-3af036b12a076c2d4c042dde6d956ef4eac2c2ce is built using the scripts and source files in this package.\nThe build system is called Yggdrasil, the Julia community build tree.",
+            "comment": "The SPDX ID field is derived from the Git hash in the DownloadLocation"
+        },
+        {
+            "name": "Bzip2",
+            "SPDXID": "SPDXRef-3af036b12a076c2d4c042dde6d956ef4eac2c2ce",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Bzip2_jll.jl/releases/download/Bzip2-v1.0.9+0/Bzip2.v1.0.9.x86_64-w64-mingw32.tar.gz",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "8c514f6e956419e1df1d72e8683bbf1a23f2ef2f"
+            },
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "4672bad158716479b25b3d26a123519bb42843451ea0adf3622ec253d742c81d"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: x86_64\nos: windows",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "bzip2-1.0.6"
+            ],
+            "licenseDeclared": "bzip2-1.0.6",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "Bzip2_jll",
+            "SPDXID": "SPDXRef-Bzip2_jll-6e34b625-4abd-537c-b88f-471c36dfa7a0",
+            "versionInfo": "1.0.9+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Bzip2_jll.jl.git@1b96ea4a01afe0ea4090c5c8039690672dd13f2e",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "5a081186140ca883aca458755202a0c8715e9c7b"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Bzip2_jll.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "CodecBzip2",
+            "SPDXID": "SPDXRef-CodecBzip2-523fee87-0ab8-5b00-afb7-3ecf72e48cfd",
+            "versionInfo": "0.8.5",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaIO/CodecBzip2.jl.git@84990fa864b7f2b4901901ca12736e45ee79068c",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "96d7b85a4a34fd40e0a5ef3a7108096c9258d1cf"
+            },
+            "homepage": "https://github.com/JuliaIO/CodecBzip2.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "MutableArithmetics",
+            "SPDXID": "SPDXRef-MutableArithmetics-d8a4904e-b15c-11e9-3269-09a3773c0cb0",
+            "versionInfo": "1.6.4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/jump-dev/MutableArithmetics.jl.git@491bdcdc943fcbc4c005900d7463c9f216aabf4c",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "c70ec86942f3b284b43e792d65b1d8cfc1fca205"
+            },
+            "homepage": "https://github.com/jump-dev/MutableArithmetics.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MPL-2.0"
+            ],
+            "licenseDeclared": "MPL-2.0",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "MathOptInterface",
+            "SPDXID": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee",
+            "versionInfo": "1.40.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/jump-dev/MathOptInterface.jl.git@d4eb6037ce33f974a58a2ea9ccba28beab2a93c1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "2237fd6a9b7b311aa076354790dd55f9f506225b"
+            },
+            "homepage": "https://github.com/jump-dev/MathOptInterface.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "HiGHS",
+            "SPDXID": "SPDXRef-HiGHS-87dc4568-4c63-4d18-b0c0-bb2238e4078b",
+            "versionInfo": "1.17.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/jump-dev/HiGHS.jl.git@ffc9974c62b3bb8a7965a122901361a011bfd766",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "66f8881bfe751adb61e0f4064a3c0dbd2b3c831a"
+            },
+            "homepage": "https://github.com/jump-dev/HiGHS.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "ManualMemory",
+            "SPDXID": "SPDXRef-ManualMemory-d125e4d3-2237-4719-b19c-fa641b8a4667",
+            "versionInfo": "0.1.8",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaSIMD/ManualMemory.jl.git@bcaef4fc7a0cfe2cba636d84cda54b5e4e4ca3cd",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "58d4b3431ae1623c957a6f4b71e8fcef7a1a7ce2"
+            },
+            "homepage": "https://github.com/JuliaSIMD/ManualMemory.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "ThreadingUtilities",
+            "SPDXID": "SPDXRef-ThreadingUtilities-8290d209-cae3-49c0-8002-c8c24d57dab5",
+            "versionInfo": "0.5.4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaSIMD/ThreadingUtilities.jl.git@2d529b6b22791f3e22e7ec5c60b9016e78f5f6bf",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "7883933767ed36aca183220df795a472265da07d"
+            },
+            "homepage": "https://github.com/JuliaSIMD/ThreadingUtilities.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "IfElse",
+            "SPDXID": "SPDXRef-IfElse-615f187c-cbe4-4ef1-ba3b-2fcf58d6d173",
+            "versionInfo": "0.1.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/IfElse.jl.git@debdd00ffef04665ccbb3e150747a77560e8fad1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "f22cb16b1d746e2399882e4d8cd54519b4ae5ac0"
+            },
+            "homepage": "https://github.com/SciML/IfElse.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "CommonWorldInvalidations",
+            "SPDXID": "SPDXRef-CommonWorldInvalidations-f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8",
+            "versionInfo": "1.0.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/CommonWorldInvalidations.jl.git@ae52d1c52048455e85a387fbee9be553ec2b68d0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "8c596a6ddb48006cc5ec13b3a5fe7d96146d0df0"
+            },
+            "homepage": "https://github.com/SciML/CommonWorldInvalidations.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Static",
+            "SPDXID": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3",
+            "versionInfo": "1.2.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/Static.jl.git@f737d444cb0ad07e61b3c1bef8eb91203c321eff",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "e03e7ea4cac7cd4bf4ed1f40911d06dac5580bb2"
+            },
+            "homepage": "https://github.com/SciML/Static.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "BitTwiddlingConvenienceFunctions",
+            "SPDXID": "SPDXRef-BitTwiddlingConvenienceFunctions-62783981-4cbd-42fc-bca8-16325de8dc4b",
+            "versionInfo": "0.1.6",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaSIMD/BitTwiddlingConvenienceFunctions.jl.git@f21cfd4950cb9f0587d5067e69405ad2acd27b87",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "13aeb7fd6ba1b13c74ee159488ab339b9768efc7"
+            },
+            "homepage": "https://github.com/JuliaSIMD/BitTwiddlingConvenienceFunctions.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "CpuId",
+            "SPDXID": "SPDXRef-CpuId-adafc99b-e345-5852-983c-f28acb93d879",
+            "versionInfo": "0.3.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/m-j-w/CpuId.jl.git@fcbb72b032692610bfbdb15018ac16a36cf2e406",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "a9e60ed8edd81ce4e4f1b32b2794eb0dff51d312"
+            },
+            "homepage": "https://github.com/m-j-w/CpuId.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "CPUSummary",
+            "SPDXID": "SPDXRef-CPUSummary-2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9",
+            "versionInfo": "0.2.6",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaSIMD/CPUSummary.jl.git@5a97e67919535d6841172016c9530fd69494e5ec",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "9d501a14a5a8d1f4cc1f06b71d48fa427e05b8f1"
+            },
+            "homepage": "https://github.com/JuliaSIMD/CPUSummary.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "PolyesterWeave",
+            "SPDXID": "SPDXRef-PolyesterWeave-1d0040c9-8b98-4ee7-8388-3f51789ca0ad",
+            "versionInfo": "0.2.2",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaSIMD/PolyesterWeave.jl.git@645bed98cd47f72f67316fd42fc47dee771aefcd",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "2353307bbe2fcced98a16ba09bd6682575d33da4"
+            },
+            "homepage": "https://github.com/JuliaSIMD/PolyesterWeave.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Requires",
+            "SPDXID": "SPDXRef-Requires-ae029012-a4dd-5104-9daa-d747884805df",
+            "versionInfo": "1.3.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/Requires.jl.git@62389eeff14780bfe55195b7204c0d8738436d64",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "0789c1a699ee68273416455e5906d305fdf7383a"
+            },
+            "homepage": "https://github.com/JuliaPackaging/Requires.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Adapt",
+            "SPDXID": "SPDXRef-Adapt-79e6a3ab-5dfb-504d-930d-738a2a938a0e",
+            "versionInfo": "4.3.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaGPU/Adapt.jl.git@f7817e2e585aa6d924fd714df1e2a84be7896c60",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "feb2efc5fca2736a55890380026753f821ba4874"
+            },
+            "homepage": "https://github.com/JuliaGPU/Adapt.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "ArrayInterface",
+            "SPDXID": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "versionInfo": "7.19.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaArrays/ArrayInterface.jl.git@9606d7832795cbef89e06a550475be300364a8aa",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "feba135962583d9d008bb566af19646192790e7b"
+            },
+            "homepage": "https://github.com/JuliaArrays/ArrayInterface.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "StaticArrayInterface",
+            "SPDXID": "SPDXRef-StaticArrayInterface-0d7ed370-da01-4f52-bd93-41d350b8b718",
+            "versionInfo": "1.8.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaArrays/StaticArrayInterface.jl.git@96381d50f1ce85f2663584c8e886a6ca97e60554",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "600e52a2f0d9b0af66c81a905aa09dcadc4fd765"
+            },
+            "homepage": "https://github.com/JuliaArrays/StaticArrayInterface.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "SIMDTypes",
+            "SPDXID": "SPDXRef-SIMDTypes-94e857df-77ce-4151-89e5-788b33177be4",
+            "versionInfo": "0.1.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaSIMD/SIMDTypes.jl.git@330289636fb8107c5f32088d2741e9fd7a061a5c",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "13f4ce91a0003a31d1635209c4a9dc5dce3f53ee"
+            },
+            "homepage": "https://github.com/JuliaSIMD/SIMDTypes.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "LayoutPointers",
+            "SPDXID": "SPDXRef-LayoutPointers-10f19ff3-798f-405d-979b-55457f8fc047",
+            "versionInfo": "0.1.17",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaSIMD/LayoutPointers.jl.git@a9eaadb366f5493a5654e843864c13d8b107548c",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "6dab017b7618f81c2dbbe06ef526d964778b8289"
+            },
+            "homepage": "https://github.com/JuliaSIMD/LayoutPointers.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "CloseOpenIntervals",
+            "SPDXID": "SPDXRef-CloseOpenIntervals-fb6a15b2-703c-40df-9091-08a04967cfa9",
+            "versionInfo": "0.1.13",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaSIMD/CloseOpenIntervals.jl.git@05ba0d07cd4fd8b7a39541e31a7b0254704ea581",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "aee8a8d90663194c8ebdd32bbb7dd95841b63431"
+            },
+            "homepage": "https://github.com/JuliaSIMD/CloseOpenIntervals.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "StrideArraysCore",
+            "SPDXID": "SPDXRef-StrideArraysCore-7792a7ef-975c-4747-a70f-980b88e8d1da",
+            "versionInfo": "0.5.7",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaSIMD/StrideArraysCore.jl.git@f35f6ab602df8413a50c4a25ca14de821e8605fb",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "2c236f5649fb166006bb3134df2e0a1655c797db"
+            },
+            "homepage": "https://github.com/JuliaSIMD/StrideArraysCore.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Polyester",
+            "SPDXID": "SPDXRef-Polyester-f517fe37-dbe3-4b94-8317-1923a5111588",
+            "versionInfo": "0.7.17",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaSIMD/Polyester.jl.git@2082cc4be5e765bd982ed04ea06c068f4f702410",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "359bf5f55376710893b2a8df709cdc1baa374a92"
+            },
+            "homepage": "https://github.com/JuliaSIMD/Polyester.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "FastBroadcast",
+            "SPDXID": "SPDXRef-FastBroadcast-7034ab61-46d4-4ed7-9d0f-46aef9175898",
+            "versionInfo": "0.3.5",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/YingboMa/FastBroadcast.jl.git@ab1b34570bcdf272899062e1a56285a53ecaae08",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "560731b2a1cf5137e20e240ce9249a0a16545199"
+            },
+            "homepage": "https://github.com/YingboMa/FastBroadcast.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "MuladdMacro",
+            "SPDXID": "SPDXRef-MuladdMacro-46d2c3a1-f734-5fdb-9937-b9b9aeba4221",
+            "versionInfo": "0.2.4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/MuladdMacro.jl.git@cac9cc5499c25554cba55cd3c30543cff5ca4fab",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "b644a4a72d97ffc2fe770fdb9d41eec16501a869",
+                "packageVerificationCodeExcludedFiles": [
+                    "docs\\src\\index.md"
+                ]
+            },
+            "homepage": "https://github.com/SciML/MuladdMacro.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "TruncatedStacktraces",
+            "SPDXID": "SPDXRef-TruncatedStacktraces-781d530d-4396-4725-bb49-402e4bee1e77",
+            "versionInfo": "1.4.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/TruncatedStacktraces.jl.git@ea3e54c2bdde39062abf5a9758a23735558705e1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "74054bfbcb43c552a22c3eeeab3e9c66bccb3e7f"
+            },
+            "homepage": "https://github.com/SciML/TruncatedStacktraces.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "SciMLOperators",
+            "SPDXID": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961",
+            "versionInfo": "0.4.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/SciMLOperators.jl.git@d82853c515a8d9d42c1ab493a2687a37f1e26c91",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "6133c6358ed5e727c2a2d66be70fa4dec9c76012"
+            },
+            "homepage": "https://github.com/SciML/SciMLOperators.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "SciMLStructures",
+            "SPDXID": "SPDXRef-SciMLStructures-53ae85a6-f571-4167-b2af-e1d143709226",
+            "versionInfo": "1.7.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/SciMLStructures.jl.git@566c4ed301ccb2a44cbd5a27da5f885e0ed1d5df",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "d7535be02321ac2975fc3f80ccabc5ca74217b15"
+            },
+            "homepage": "https://github.com/SciML/SciMLStructures.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "FunctionWrappers",
+            "SPDXID": "SPDXRef-FunctionWrappers-069b7b12-0de2-55c6-9aab-29f3d0a68a2e",
+            "versionInfo": "1.1.3",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaLang/FunctionWrappers.jl.git@d62485945ce5ae9c0c48f124a84998d755bae00e",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "34062b6a87a110e8bfe2fdf89fb2ef4fabaa1b39"
+            },
+            "homepage": "https://github.com/JuliaLang/FunctionWrappers.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "FunctionWrappersWrappers",
+            "SPDXID": "SPDXRef-FunctionWrappersWrappers-77dc65aa-8811-40c2-897b-53d922fa7daf",
+            "versionInfo": "0.1.3",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/chriselrod/FunctionWrappersWrappers.jl.git@b104d487b34566608f8b4e1c39fb0b10aa279ff8",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "e4ece447567f87331cae951aea38cdaf2724c171"
+            },
+            "homepage": "https://github.com/chriselrod/FunctionWrappersWrappers.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "EnumX",
+            "SPDXID": "SPDXRef-EnumX-4e289a0a-7415-4d19-859d-a7e5c4648b56",
+            "versionInfo": "1.0.5",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/fredrikekre/EnumX.jl.git@bddad79635af6aec424f53ed8aad5d7555dc6f00",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "aa9d11d2b21363866cd00cb87f0cfb4ee24f51a3"
+            },
+            "homepage": "https://github.com/fredrikekre/EnumX.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "SimpleUnPack",
+            "SPDXID": "SPDXRef-SimpleUnPack-ce78b400-467f-4804-87d8-8f486da07d0a",
+            "versionInfo": "1.1.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/devmotion/SimpleUnPack.jl.git@58e6353e72cde29b90a69527e56df1b5c3d8c437",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "73532bef6950b474ed64f7637940cabbbb1a8a22"
+            },
+            "homepage": "https://github.com/devmotion/SimpleUnPack.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "ExprTools",
+            "SPDXID": "SPDXRef-ExprTools-e2ba6199-217a-4e67-a87a-7c52f15ade04",
+            "versionInfo": "0.1.10",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/invenia/ExprTools.jl.git@27415f162e6028e81c72b82ef756bf321213b6ec",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "5bb45aaebe5918e568d0feac99fd4d6b507d3451"
+            },
+            "homepage": "https://github.com/invenia/ExprTools.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "RuntimeGeneratedFunctions",
+            "SPDXID": "SPDXRef-RuntimeGeneratedFunctions-7e49a35a-f44a-4d26-94aa-eba1b4ca6b47",
+            "versionInfo": "0.5.14",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/RuntimeGeneratedFunctions.jl.git@7cb9d10026d630ce2dd2a1fc6006a3d5041b34c0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "ed2c5bd4ef9093e99f7c474f6ac4c41180ddac90"
+            },
+            "homepage": "https://github.com/SciML/RuntimeGeneratedFunctions.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "IteratorInterfaceExtensions",
+            "SPDXID": "SPDXRef-IteratorInterfaceExtensions-82899510-4779-5014-852e-03e436cf321d",
+            "versionInfo": "1.0.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/queryverse/IteratorInterfaceExtensions.jl.git@a3f24677c21f5bbe9d2a714f95dcd58337fb2856",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "aa032610e4e7052ddb688cd8cb7e0ad0f87be3bd"
+            },
+            "homepage": "https://github.com/queryverse/IteratorInterfaceExtensions.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "ExproniconLite",
+            "SPDXID": "SPDXRef-ExproniconLite-55351af7-c7e9-48d6-89ff-24e801d99491",
+            "versionInfo": "0.10.14",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/Roger-luo/ExproniconLite.jl.git@c13f0b150373771b0fdc1713c97860f8df12e6c2",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "e5ac68add5b6b2793a5c8e0a294c8e86157ea32f"
+            },
+            "homepage": "https://github.com/Roger-luo/ExproniconLite.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Jieko",
+            "SPDXID": "SPDXRef-Jieko-ae98c720-c025-4a4a-838c-29b094483192",
+            "versionInfo": "0.2.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/Roger-luo/Jieko.jl.git@2f05ed29618da60c06a87e9c033982d4f71d0b6c",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "13c9ac36824a013d60f569e4ccaad790e0c28509"
+            },
+            "homepage": "https://github.com/Roger-luo/Jieko.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Moshi",
+            "SPDXID": "SPDXRef-Moshi-2e0e35c7-a2e4-4343-998d-7ef72827ed2d",
+            "versionInfo": "0.3.5",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/Roger-luo/Moshi.jl.git@453de0fc2be3d11b9b93ca4d0fddd91196dcf1ed",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "341556d9b0cc2d841cb17c03446bcb8aa07b0630"
+            },
+            "homepage": "https://github.com/Roger-luo/Moshi.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "StringManipulation",
+            "SPDXID": "SPDXRef-StringManipulation-892a3eda-7b42-436c-8928-eab12a02cf0e",
+            "versionInfo": "0.4.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/ronisbr/StringManipulation.jl.git@725421ae8e530ec29bcbdddbe91ff8053421d023",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "cb2c2939b689357334cea3a5be45fdf1cfc5818e"
+            },
+            "homepage": "https://github.com/ronisbr/StringManipulation.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "DataAPI",
+            "SPDXID": "SPDXRef-DataAPI-9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a",
+            "versionInfo": "1.16.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaData/DataAPI.jl.git@abe83f3a2f1b857aac70ef8b269080af17764bbe",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "c805e6bc1fadf7e296e04c3fcea2d3c54667f4a9"
+            },
+            "homepage": "https://github.com/JuliaData/DataAPI.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "DataValueInterfaces",
+            "SPDXID": "SPDXRef-DataValueInterfaces-e2d170a0-9d28-54be-80f0-106bbe20a464",
+            "versionInfo": "1.0.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/queryverse/DataValueInterfaces.jl.git@bfc1187b79289637fa0ef6d4436ebdfe6905cbd6",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "0bdd53669ceed059c3bd1670fee3613edfa48e70"
+            },
+            "homepage": "https://github.com/queryverse/DataValueInterfaces.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "TableTraits",
+            "SPDXID": "SPDXRef-TableTraits-3783bdb8-4a98-5b6b-af9a-565f29a5fe9c",
+            "versionInfo": "1.0.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/queryverse/TableTraits.jl.git@c06b2f539df1c6efa794486abfb6ed2022561a39",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "7573f9aea80f5279e3897a4d58ba785e596e1fae"
+            },
+            "homepage": "https://github.com/queryverse/TableTraits.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Tables",
+            "SPDXID": "SPDXRef-Tables-bd369af6-aec1-5ad0-b16a-f7cc5008161c",
+            "versionInfo": "1.12.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaData/Tables.jl.git@598cd7c1f68d1e205689b1c2fe65a9f85846f297",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "aeea5accc6c7774de1b202615c99838fccf537a0"
+            },
+            "homepage": "https://github.com/JuliaData/Tables.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Crayons",
+            "SPDXID": "SPDXRef-Crayons-a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f",
+            "versionInfo": "4.1.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/KristofferC/Crayons.jl.git@249fe38abf76d48563e2f4556bebd215aa317e15",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "8043da605b335ed644781cdf653c76a075d06664"
+            },
+            "homepage": "https://github.com/KristofferC/Crayons.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "LaTeXStrings",
+            "SPDXID": "SPDXRef-LaTeXStrings-b964fa9f-0449-5b57-a5c2-d3ea65f4040f",
+            "versionInfo": "1.4.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaStrings/LaTeXStrings.jl.git@dda21b8cbd6a6c40d9d02a73230f9d70fed6918c",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "af1bd49f1e85747c98f9681e54b0cc1a078abace"
+            },
+            "homepage": "https://github.com/JuliaStrings/LaTeXStrings.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Reexport",
+            "SPDXID": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
+            "versionInfo": "1.2.2",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/simonster/Reexport.jl.git@45e428421666073eab6f2da5c9d310d99bb12f9b",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "bc482721504c6a77b7c436c7343cf5ac19ccc9b3"
+            },
+            "homepage": "https://github.com/simonster/Reexport.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "PrettyTables",
+            "SPDXID": "SPDXRef-PrettyTables-08abe8d2-0d0c-5749-adfa-8a2ac140af0d",
+            "versionInfo": "2.4.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/ronisbr/PrettyTables.jl.git@1101cd475833706e4d0e7b122218257178f48f34",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "df34e78bc274f050ddb3006e03577248922af06f"
+            },
+            "homepage": "https://github.com/ronisbr/PrettyTables.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "SymbolicIndexingInterface",
+            "SPDXID": "SPDXRef-SymbolicIndexingInterface-2efcf032-c050-4f8e-a9bb-153293bab1f5",
+            "versionInfo": "0.3.40",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/SymbolicIndexingInterface.jl.git@b6a641e38efa01355aa721246dd246e10c7dcd4d",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "84ffd758caf2f5e671090be808b80ff774a13253"
+            },
+            "homepage": "https://github.com/SciML/SymbolicIndexingInterface.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "RecipesBase",
+            "SPDXID": "SPDXRef-RecipesBase-3cdcf5f2-1ef4-517c-9805-6587b60abb01",
+            "versionInfo": "1.3.4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPlots/Plots.jl.git@5c3d09cc4f31f5fc6af001c250bf1278733100ff#RecipesBase",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "d5c0defd3e1cac88a2875e2913563c8ba671d3fc"
+            },
+            "homepage": "https://github.com/JuliaPlots/Plots.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "ADTypes",
+            "SPDXID": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+            "versionInfo": "1.14.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/ADTypes.jl.git@e2478490447631aedba0823d4d7a80b2cc8cdb32",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "f9a741e2983dfc76e2695e0e87c546110f73df00"
+            },
+            "homepage": "https://github.com/SciML/ADTypes.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "GPUArraysCore",
+            "SPDXID": "SPDXRef-GPUArraysCore-46192b85-c4d5-4398-a991-12ede77f4527",
+            "versionInfo": "0.2.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaGPU/GPUArrays.jl.git@83cf05ab16a73219e5f6bd1bdfa9848fa24ac627#lib/GPUArraysCore",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "ad0e8ef8a6f3ab9e20408cb55f62283409419ad1"
+            },
+            "homepage": "https://github.com/JuliaGPU/GPUArrays.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "RecursiveArrayTools",
+            "SPDXID": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd",
+            "versionInfo": "3.33.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/RecursiveArrayTools.jl.git@2e154f7d7e38db1af0a14ec751aba33360c3bef9",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "a729c0fdc737260fcf1f5134788351f931c9e7c7"
+            },
+            "homepage": "https://github.com/SciML/RecursiveArrayTools.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "CommonSolve",
+            "SPDXID": "SPDXRef-CommonSolve-38540f10-b2f7-11e9-35d8-d573e4eb0ff2",
+            "versionInfo": "0.2.4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/CommonSolve.jl.git@0eee5eb66b1cf62cd6ad1b460238e60e4b09400c",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "179cf3d54d47bcc7b063962fe37cacd9bee41ece"
+            },
+            "homepage": "https://github.com/SciML/CommonSolve.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "SciMLBase",
+            "SPDXID": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+            "versionInfo": "2.95.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/SciMLBase.jl.git@aaf71a2dcc93838a73cad354bbefa494cea2e4e6",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "bce823276b58b9a58d2ba701ff072c9a385c0b64"
+            },
+            "homepage": "https://github.com/SciML/SciMLBase.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "FastClosures",
+            "SPDXID": "SPDXRef-FastClosures-9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a",
+            "versionInfo": "0.3.2",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/c42f/FastClosures.jl.git@acebe244d53ee1b461970f8910c235b259e772ef",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "b5c8fa3650f0e0e78bc07dcaa04daf43f01f049b"
+            },
+            "homepage": "https://github.com/c42f/FastClosures.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "FastPower",
+            "SPDXID": "SPDXRef-FastPower-a4df4552-cc26-4903-aec0-212e50a0e84b",
+            "versionInfo": "1.1.2",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/FastPower.jl.git@df32f07f373f06260cd6af5371385b5ef85dd762",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "043db087de084bcb22e9c5c479e288413f6ab499"
+            },
+            "homepage": "https://github.com/SciML/FastPower.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Setfield",
+            "SPDXID": "SPDXRef-Setfield-efcf1570-3423-57d1-acb7-fd33fddbac46",
+            "versionInfo": "1.1.2",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/jw3126/Setfield.jl.git@c5391c6ace3bc430ca630251d02ea9687169ca68",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "c34db932cc527b201a1c99296ae7fe48f4dfc6be"
+            },
+            "homepage": "https://github.com/jw3126/Setfield.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "EnzymeCore",
+            "SPDXID": "SPDXRef-EnzymeCore-f151be2c-9106-41f4-ab19-57ee4f262869",
+            "versionInfo": "0.8.9",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/EnzymeAD/Enzyme.jl.git@1eb59f40a772d0fbd4cb75e00b3fa7f5f79c975a#lib/EnzymeCore",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "5da4563d782ed442f54df5b053b290f84e3b1108"
+            },
+            "homepage": "https://github.com/EnzymeAD/Enzyme.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "ConcreteStructs",
+            "SPDXID": "SPDXRef-ConcreteStructs-2569d6c7-a4a2-43d3-a901-331e8e4be471",
+            "versionInfo": "0.2.3",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/jonniedie/ConcreteStructs.jl.git@f749037478283d372048690eb3b5f92a79432b34",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "ad5d29e37f39373a026e261ea21beb7d2b0d4885"
+            },
+            "homepage": "https://github.com/jonniedie/ConcreteStructs.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "UnPack",
+            "SPDXID": "SPDXRef-UnPack-3a884ed6-31ef-47d7-9d2a-63182c4928ed",
+            "versionInfo": "1.0.2",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/mauro3/UnPack.jl.git@387c1f73762231e86e0c9c5443ce3b4a0a9a0c2b",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "c49b9ceab5b1e380e0284343698d40d0f5b40600"
+            },
+            "homepage": "https://github.com/mauro3/UnPack.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Parameters",
+            "SPDXID": "SPDXRef-Parameters-d96e819e-fc66-5662-9728-84c9c7592b0a",
+            "versionInfo": "0.12.3",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/mauro3/Parameters.jl.git@34c0e9ad262e5f7fc75b10a9952ca7692cfc5fbe",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "1e99aa438cb98039329cdbbef4c963dd69b5911f"
+            },
+            "homepage": "https://github.com/mauro3/Parameters.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "DiffEqBase",
+            "SPDXID": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
+            "versionInfo": "6.175.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/DiffEqBase.jl.git@a0e5b5669df9465bc3dd32ea4a8ddeefbc0f7b5c",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "b8a1ace546f94c9880e837f4aa9ae0c2b8a91af5"
+            },
+            "homepage": "https://github.com/SciML/DiffEqBase.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "FillArrays",
+            "SPDXID": "SPDXRef-FillArrays-1a297f60-69ca-5386-bcde-b61e274b549b",
+            "versionInfo": "1.13.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaArrays/FillArrays.jl.git@6a70198746448456524cb442b8af316927ff3e1a",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "ccc3face6f25846016b5a99bec699e0fd095909e"
+            },
+            "homepage": "https://github.com/JuliaArrays/FillArrays.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "OrdinaryDiffEqCore",
+            "SPDXID": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8",
+            "versionInfo": "1.26.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@d29adfeb720dd7c251b216d91c4bd4fe67c087df#lib/OrdinaryDiffEqCore",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "940352cc9f167805f8d45db2c86659a83c8417da"
+            },
+            "homepage": "https://github.com/SciML/OrdinaryDiffEq.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "OrdinaryDiffEqTsit5",
+            "SPDXID": "SPDXRef-OrdinaryDiffEqTsit5-b1df2697-797e-41e3-8120-5422d3b24e4a",
+            "versionInfo": "1.1.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@96552f7d4619fabab4038a29ed37dd55e9eb513a#lib/OrdinaryDiffEqTsit5",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "99d7b6507e1025be45d3adc5eed176e52068727b"
+            },
+            "homepage": "https://github.com/SciML/OrdinaryDiffEq.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "InlineStrings",
+            "SPDXID": "SPDXRef-InlineStrings-842dd82b-1e85-43dc-bf29-5d0ee9dffc48",
+            "versionInfo": "1.4.3",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaStrings/InlineStrings.jl.git@6a9fde685a7ac1eb3495f8e812c5a7c3711c2d5e",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "dc5fc31ff09bb85c1b25b0fe0789b79077fbaffa"
+            },
+            "homepage": "https://github.com/JuliaStrings/InlineStrings.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "WeakRefStrings",
+            "SPDXID": "SPDXRef-WeakRefStrings-ea10d353-3f73-51f8-a26c-33c1cb351aa5",
+            "versionInfo": "1.4.2",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaData/WeakRefStrings.jl.git@b1be2855ed9ed8eac54e5caff2afcdb442d52c23",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "013819220cdf0c58272905d1ec5372c9005ad35c"
+            },
+            "homepage": "https://github.com/JuliaData/WeakRefStrings.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "DBInterface",
+            "SPDXID": "SPDXRef-DBInterface-a10d1c49-ce27-4219-8d33-6db1a4562965",
+            "versionInfo": "2.6.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaDatabases/DBInterface.jl.git@a444404b3f94deaa43ca2a58e18153a82695282b",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "103a2d624d4388110b5b7173c8e5019b70f4b0b5"
+            },
+            "homepage": "https://github.com/JuliaDatabases/DBInterface.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "SQLite_source",
+            "SPDXID": "SPDXRef-b0220b79727dcc10748a80b9b16463d628e0ce83",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/Yggdrasil.git@b0220b79727dcc10748a80b9b16463d628e0ce83#/S/SQLite/",
+            "filesAnalyzed": false,
+            "sourceInfo": "The location of this repository was extracted from the README.md file of SPDXRef-2779bb3ec0b70d8b6e0311bd8e662ebd81d9dcc4",
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "The binary artifact SPDXRef-2779bb3ec0b70d8b6e0311bd8e662ebd81d9dcc4 is built using the scripts and source files in this package.\nThe build system is called Yggdrasil, the Julia community build tree.",
+            "comment": "The SPDX ID field is derived from the Git hash in the DownloadLocation"
+        },
+        {
+            "name": "SQLite",
+            "SPDXID": "SPDXRef-2779bb3ec0b70d8b6e0311bd8e662ebd81d9dcc4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/SQLite_jll.jl/releases/download/SQLite-v3.48.0+0/SQLite.v3.48.0.x86_64-w64-mingw32.tar.gz",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "301e3428de20a128cc5ad64c7214f957f051adaa"
+            },
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "2d3deae7b0f95b9c6f9f1e3b3feaf8aa5bf5a7205e1e3981e333aca77ed22e4b"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: x86_64\nos: windows",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "blessing"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "SQLite_jll",
+            "SPDXID": "SPDXRef-SQLite_jll-76ed43ae-9a5d-5a62-8c75-30186b810ce8",
+            "versionInfo": "3.48.0+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/SQLite_jll.jl.git@9a325057cdb9b066f1f96dc77218df60fe3007cb",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "1631ab04cdf53a9f7b0470e8ccc80af6dd3949c3"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/SQLite_jll.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "SQLite",
+            "SPDXID": "SPDXRef-SQLite-0aa819cd-b072-5ff4-a722-6bc24af294d9",
+            "versionInfo": "1.6.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaDatabases/SQLite.jl.git@38b82dbc52b7db40bea182688c7a1103d06948a4",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "2098d71ba8121ee9d17f66ce978b0d07b506abca"
+            },
+            "homepage": "https://github.com/JuliaDatabases/SQLite.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "StructArrays",
+            "SPDXID": "SPDXRef-StructArrays-09ab397b-f2b6-538f-b94a-2f83cf4a842a",
+            "versionInfo": "0.7.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaArrays/StructArrays.jl.git@8ad2e38cbb812e29348719cc63580ec1dfeb9de4",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "28fe15244d6a264091345c9a7bb789319c9b72e2"
+            },
+            "homepage": "https://github.com/JuliaArrays/StructArrays.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "SparseConnectivityTracer",
+            "SPDXID": "SPDXRef-SparseConnectivityTracer-9f842d2f-2579-4b1d-911e-f412cf18a3f5",
+            "versionInfo": "0.6.15",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/visr/SparseConnectivityTracer.jl@datainterpolations-8.0.0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "94a38fb61842b2c34633ca679f8096423d705abd"
+            },
+            "homepage": "https://github.com/visr/SparseConnectivityTracer.jl",
+            "sourceInfo": "SparseConnectivityTracer is directly tracking a git repository.",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "BasicModelInterface",
+            "SPDXID": "SPDXRef-BasicModelInterface-59605e27-edc0-445a-b93d-c09a3a50b330",
+            "versionInfo": "0.1.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/Deltares/BasicModelInterface.jl.git@ca36dc6dc9bbeea3dbbe3901837496ece85276e5",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "8f2eb9c19ce3599db2258b1f803bfcb05b00b402"
+            },
+            "homepage": "https://github.com/Deltares/BasicModelInterface.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "FiniteDiff",
+            "SPDXID": "SPDXRef-FiniteDiff-6a86dc24-6348-571c-b903-95158fe2bd41",
+            "versionInfo": "2.27.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaDiff/FiniteDiff.jl.git@f089ab1f834470c525562030c8cfde4025d5e915",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "2f45caf72644d306de6dd4adef2f6a69c0130128"
+            },
+            "homepage": "https://github.com/JuliaDiff/FiniteDiff.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "DifferentiationInterface",
+            "SPDXID": "SPDXRef-DifferentiationInterface-a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63",
+            "versionInfo": "0.6.54",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaDiff/DifferentiationInterface.jl.git@c8d85ecfcbaef899308706bebdd8b00107f3fb43#DifferentiationInterface",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "f54811b15e50e1c2c67319eb44a68fec73c46bd9"
+            },
+            "homepage": "https://github.com/JuliaDiff/DifferentiationInterface.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Krylov",
+            "SPDXID": "SPDXRef-Krylov-ba0b0d4f-ebba-5204-a429-3ac8c609bfb7",
+            "versionInfo": "0.10.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaSmoothOptimizers/Krylov.jl.git@b94257a1a8737099ca40bc7271a8b374033473ed",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "d6334675947d30ad076afea8b05612b5cd7da714"
+            },
+            "homepage": "https://github.com/JuliaSmoothOptimizers/Krylov.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MPL-2.0"
+            ],
+            "licenseDeclared": "MPL-2.0",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "ArrayLayouts",
+            "SPDXID": "SPDXRef-ArrayLayouts-4c555306-a7a7-4459-81d9-ec55ddd5c99a",
+            "versionInfo": "1.11.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaLinearAlgebra/ArrayLayouts.jl.git@4e25216b8fea1908a0ce0f5d87368587899f75be",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "c1334694d6372a69f5b7ea28b9c7200930fcf121"
+            },
+            "homepage": "https://github.com/JuliaLinearAlgebra/ArrayLayouts.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "LazyArrays",
+            "SPDXID": "SPDXRef-LazyArrays-5078a376-72f3-5289-bfd5-ec5146d43c02",
+            "versionInfo": "2.6.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaArrays/LazyArrays.jl.git@866ce84b15e54d758c11946aacd4e5df0e60b7a3",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "e1c9b150275ff29fd93377b77b1132a2534034bc"
+            },
+            "homepage": "https://github.com/JuliaArrays/LazyArrays.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "ChainRulesCore",
+            "SPDXID": "SPDXRef-ChainRulesCore-d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4",
+            "versionInfo": "1.25.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaDiff/ChainRulesCore.jl.git@1713c74e00545bfe14605d2a2be1712de8fbcb58",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "962d002da88d5b1458fcbb3a9e2300b7ed2a2613"
+            },
+            "homepage": "https://github.com/JuliaDiff/ChainRulesCore.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "IntelOpenMP_source",
+            "SPDXID": "SPDXRef-f068f7f0488327514de4f7feb9fbdbf935d51754",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/Yggdrasil.git@f068f7f0488327514de4f7feb9fbdbf935d51754#/I/IntelOpenMP/",
+            "filesAnalyzed": false,
+            "sourceInfo": "The location of this repository was extracted from the README.md file of SPDXRef-87c04cd6024ac13d04b9f0e9695b9dbc54a38511",
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "The binary artifact SPDXRef-87c04cd6024ac13d04b9f0e9695b9dbc54a38511 is built using the scripts and source files in this package.\nThe build system is called Yggdrasil, the Julia community build tree.",
+            "comment": "The SPDX ID field is derived from the Git hash in the DownloadLocation"
+        },
+        {
+            "name": "IntelOpenMP",
+            "SPDXID": "SPDXRef-87c04cd6024ac13d04b9f0e9695b9dbc54a38511",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/IntelOpenMP_jll.jl/releases/download/IntelOpenMP-v2025.0.4+0/IntelOpenMP.v2025.0.4.x86_64-w64-mingw32.tar.gz",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "405bd6d55651f7d0ee6d1bc52b66449bf5720822"
+            },
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "886a72bd6f0cdcdab0b95c9a96bcde25bfe53d24518033d4f21b6fbfb820e0e3"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: x86_64\nos: windows",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "BSD-3-Clause",
+                "MIT",
+                "Apache-2.0",
+                "NCSA"
+            ],
+            "licenseDeclared": "BSD-3-Clause",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "IntelOpenMP_jll",
+            "SPDXID": "SPDXRef-IntelOpenMP_jll-1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0",
+            "versionInfo": "2025.0.4+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/IntelOpenMP_jll.jl.git@0f14a5456bdc6b9731a5682f439a672750a09e48",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "91e9cc8b24695df6645754237006e7b37029f1a8"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/IntelOpenMP_jll.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "oneTBB_source",
+            "SPDXID": "SPDXRef-6482ac5f223a8e1799775539a9bb353a4ba882c6",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/Yggdrasil.git@6482ac5f223a8e1799775539a9bb353a4ba882c6#/O/oneTBB/",
+            "filesAnalyzed": false,
+            "sourceInfo": "The location of this repository was extracted from the README.md file of SPDXRef-41ef323658240d98dd24a78f07fe284c212fd3fb",
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "The binary artifact SPDXRef-41ef323658240d98dd24a78f07fe284c212fd3fb is built using the scripts and source files in this package.\nThe build system is called Yggdrasil, the Julia community build tree.",
+            "comment": "The SPDX ID field is derived from the Git hash in the DownloadLocation"
+        },
+        {
+            "name": "oneTBB",
+            "SPDXID": "SPDXRef-41ef323658240d98dd24a78f07fe284c212fd3fb",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/oneTBB_jll.jl/releases/download/oneTBB-v2022.0.0+0/oneTBB.v2022.0.0.x86_64-w64-mingw32-cxx11.tar.gz",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "86e845830744f2745b4130e023be8a1c3c47d1f5"
+            },
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "e73c4cb3e6d70ac5edf5fb9f66de1541ef79ad32663867bf58dee530ce7329d0"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: x86_64\ncxxstring_abi: cxx11\nos: windows",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "Apache-2.0"
+            ],
+            "licenseDeclared": "Apache-2.0",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "oneTBB_jll",
+            "SPDXID": "SPDXRef-oneTBB_jll-1317d2d5-d96f-522e-a858-c73665f53c3e",
+            "versionInfo": "2022.0.0+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/oneTBB_jll.jl.git@d5a767a3bb77135a99e433afe0eb14cd7f6914c3",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "b8270a19c7661c227bae1b6f3d748c7b903ed6cb"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/oneTBB_jll.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "MKL_source",
+            "SPDXID": "SPDXRef-5120cfdb56bd540d6b656a4139c2f6b8b8168e7b",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/Yggdrasil.git@5120cfdb56bd540d6b656a4139c2f6b8b8168e7b#/M/MKL/",
+            "filesAnalyzed": false,
+            "sourceInfo": "The location of this repository was extracted from the README.md file of SPDXRef-b4be4a930ca1e5fa6ec9e96c45b7420bf1a0b40c",
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "The binary artifact SPDXRef-b4be4a930ca1e5fa6ec9e96c45b7420bf1a0b40c is built using the scripts and source files in this package.\nThe build system is called Yggdrasil, the Julia community build tree.",
+            "comment": "The SPDX ID field is derived from the Git hash in the DownloadLocation"
+        },
+        {
+            "name": "MKL",
+            "SPDXID": "SPDXRef-b4be4a930ca1e5fa6ec9e96c45b7420bf1a0b40c",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/MKL_jll.jl/releases/download/MKL-v2025.0.1+1/MKL.v2025.0.1.x86_64-w64-mingw32.tar.gz",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "d8470e6bf0ca5e90154974b5f16cb3eaa1d4543d"
+            },
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "ca3d055c1eb4842586fd20447da95242d4de7b2f709d37a398d6a5ae42ae014e"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: x86_64\nos: windows",
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "MKL_jll",
+            "SPDXID": "SPDXRef-MKL_jll-856f044c-d86e-5d09-b602-aeab76dc8ba7",
+            "versionInfo": "2025.0.1+1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/MKL_jll.jl.git@5de60bc6cb3899cd318d80d627560fae2e2d99ae",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "377d54e40c039a0edb098747a86849b0c03d74c5"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/MKL_jll.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "LinearSolve",
+            "SPDXID": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae",
+            "versionInfo": "3.14.2",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/LinearSolve.jl.git@04fd9d7265b5794363fa24c2e8ae0fd21ec796db",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "c5ecd689f7dc27cf75113d16b8e30bbb503157ed"
+            },
+            "homepage": "https://github.com/SciML/LinearSolve.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "StaticArrays",
+            "SPDXID": "SPDXRef-StaticArrays-90137ffa-7385-5640-81b9-e52037218182",
+            "versionInfo": "1.9.13",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaArrays/StaticArrays.jl.git@0feb6b9031bd5c51f9072393eb5ab3efd31bf9e4",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "862a8f77b9c6e7c369029e4c30b23bd4dc678d1e"
+            },
+            "homepage": "https://github.com/JuliaArrays/StaticArrays.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT",
+                "BSL-1.0"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "SparseMatrixColorings",
+            "SPDXID": "SPDXRef-SparseMatrixColorings-0a514795-09f3-496d-8182-132a7b665d35",
+            "versionInfo": "0.4.19",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/gdalle/SparseMatrixColorings.jl.git@76e9564f0de0d1d7a46095e758ae13ceba680cfb",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "afa4d83397eced6747b9aff88cc5cdb1fa61ada4"
+            },
+            "homepage": "https://github.com/gdalle/SparseMatrixColorings.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "OrdinaryDiffEqDifferentiation",
+            "SPDXID": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b",
+            "versionInfo": "1.9.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@315d25dd06614e199973cc13d22e533073bd7458#lib/OrdinaryDiffEqDifferentiation",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "bb48da60aa3289df72475a1c13e1227440475186"
+            },
+            "homepage": "https://github.com/SciML/OrdinaryDiffEq.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "TimerOutputs",
+            "SPDXID": "SPDXRef-TimerOutputs-a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f",
+            "versionInfo": "0.5.29",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/KristofferC/TimerOutputs.jl.git@3748bd928e68c7c346b52125cf41fff0de6937d0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "7762137f62f8a848c56abdbf088b26a528e21a38"
+            },
+            "homepage": "https://github.com/KristofferC/TimerOutputs.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "SciMLJacobianOperators",
+            "SPDXID": "SPDXRef-SciMLJacobianOperators-19f34311-ddf3-4b8b-af20-060888a46c0e",
+            "versionInfo": "0.1.5",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@d563758f3ce5153810adebc534d88e24d34eeb95#lib/SciMLJacobianOperators",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "76416166be7fbb5781eab72d90e9cb322c351ba8"
+            },
+            "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "MaybeInplace",
+            "SPDXID": "SPDXRef-MaybeInplace-bb5d69b7-63fc-4a16-80bd-7e42200c7bdb",
+            "versionInfo": "0.1.4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/MaybeInplace.jl.git@54e2fdc38130c05b42be423e90da3bade29b74bd",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "f113d740af1e2c943a91e7df9e6bd5c4a5f8b8a7"
+            },
+            "homepage": "https://github.com/SciML/MaybeInplace.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "NonlinearSolveBase",
+            "SPDXID": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0",
+            "versionInfo": "1.10.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@b6a5501988532484a62ef1e2060d57824093ce2c#lib/NonlinearSolveBase",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "24b9eaf7ba221b729677468d0fbd02da7c9b4c6b"
+            },
+            "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "NonlinearSolveQuasiNewton",
+            "SPDXID": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114",
+            "versionInfo": "1.5.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@b69a68ef3a7bba7ab1d5ef6321ed6d9a613142b0#lib/NonlinearSolveQuasiNewton",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "90a9cfce3fe9a29ec1385ba6ad392c01f407fc16"
+            },
+            "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "BracketingNonlinearSolve",
+            "SPDXID": "SPDXRef-BracketingNonlinearSolve-70df07ce-3d50-431d-a3e7-ca6ddb60ac1e",
+            "versionInfo": "1.2.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@637ebe439ba587828fd997b7810d8171eed2ea1b#lib/BracketingNonlinearSolve",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "0fd105ad153e9b884a1a42ec88b310fbdc1abc51"
+            },
+            "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "LineSearch",
+            "SPDXID": "SPDXRef-LineSearch-87fe0de2-c867-4266-b59a-2f0a94fc965b",
+            "versionInfo": "0.1.4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/LineSearch.jl.git@97d502765cc5cf3a722120f50da03c2474efce04",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "3fb235129491d986f82cc96f4c52c1b192a8582e"
+            },
+            "homepage": "https://github.com/SciML/LineSearch.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "SimpleNonlinearSolve",
+            "SPDXID": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7",
+            "versionInfo": "2.5.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@7aaa5fe4617271b64fce0466d187f2a72edbd81a#lib/SimpleNonlinearSolve",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "84db66cba480356f142528bb9402b33921cc1072"
+            },
+            "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "NonlinearSolveSpectralMethods",
+            "SPDXID": "SPDXRef-NonlinearSolveSpectralMethods-26075421-4e9a-44e1-8bd1-420ed7ad02b2",
+            "versionInfo": "1.2.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@3398222199e4b9ca0b5840907fb509f28f1a2fdc#lib/NonlinearSolveSpectralMethods",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "c2ea71478e961e42c63adcd8e7ebd8f5956fee66"
+            },
+            "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "NonlinearSolveFirstOrder",
+            "SPDXID": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d",
+            "versionInfo": "1.5.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@9c8cd0a986518ba317af263549b48e34ac8f776d#lib/NonlinearSolveFirstOrder",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "554f945bcfe2340289826133f34982b909174861"
+            },
+            "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "NonlinearSolve",
+            "SPDXID": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec",
+            "versionInfo": "4.9.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@aeb6fb02e63b4d4f90337ed90ce54ceb4c0efe77",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "6d56337b47dea1b870e7782ccc4ef75a48a445de"
+            },
+            "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "PreallocationTools",
+            "SPDXID": "SPDXRef-PreallocationTools-d236fae5-4411-538c-8e31-a6e3d9e00b46",
+            "versionInfo": "0.4.27",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/PreallocationTools.jl.git@6d98eace73d82e47f5b16c393de198836d9f790a",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "bd722896e93f8cde59bd2fa14a6f05a735067cf4"
+            },
+            "homepage": "https://github.com/SciML/PreallocationTools.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "OrdinaryDiffEqNonlinearSolve",
+            "SPDXID": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8",
+            "versionInfo": "1.9.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@2f956f14c97ff507e855703ac760d513f7c3e372#lib/OrdinaryDiffEqNonlinearSolve",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "751b185aae256f7548a82229c4fe18b3a254f20e"
+            },
+            "homepage": "https://github.com/SciML/OrdinaryDiffEq.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "OrdinaryDiffEqSDIRK",
+            "SPDXID": "SPDXRef-OrdinaryDiffEqSDIRK-2d112036-d095-4a1e-ab9a-08536f3ecdbf",
+            "versionInfo": "1.3.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@b3a7e3a2f355d837c823b435630f035aef446b45#lib/OrdinaryDiffEqSDIRK",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "7ef36152be073e2925269744c02ddb816c1a0838"
+            },
+            "homepage": "https://github.com/SciML/OrdinaryDiffEq.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "OrdinaryDiffEqBDF",
+            "SPDXID": "SPDXRef-OrdinaryDiffEqBDF-6ad6398a-0878-4a85-9266-38940aa047c8",
+            "versionInfo": "1.5.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@a72bf554d5fd1f33a8d2aead3562eddd28ba4c76#lib/OrdinaryDiffEqBDF",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "ddff5337cd8e8e5ea363e2e4b66a20c27e49bdab"
+            },
+            "homepage": "https://github.com/SciML/OrdinaryDiffEq.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "JuMP",
+            "SPDXID": "SPDXRef-JuMP-4076af6c-e467-56ae-b986-b466b2749572",
+            "versionInfo": "1.26.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/jump-dev/JuMP.jl.git@90002c976264d2f571c98cd1d12851f4cba403df",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "65558ad57eebd5fced57a7cd5e7c39753dc92fd2"
+            },
+            "homepage": "https://github.com/jump-dev/JuMP.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MPL-2.0",
+                "MIT"
+            ],
+            "licenseDeclared": "MPL-2.0",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Mocking",
+            "SPDXID": "SPDXRef-Mocking-78c3b35d-d492-501b-9361-3d52fe80e533",
+            "versionInfo": "0.8.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaTesting/Mocking.jl.git@2c140d60d7cb82badf06d8783800d0bcd1a7daa2",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "882eeb8e144f8253b3799296cddeb3934d9beadd"
+            },
+            "homepage": "https://github.com/JuliaTesting/Mocking.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "tzjdata",
+            "SPDXID": "SPDXRef-a2939c302ec6f8c6eeb94e4734c96b162e1ff7b5",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaTime/TZJData.jl/releases/download/v1.5.0+2025b/tzjfile-v1-tzdata2025b.tar.gz",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "ab98ecfa339cb2ee03783886b43674f0534fce20"
+            },
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "75d5f6bf78963b5362e46263a9493dc0d460a720eb5f468fdeb50a61dd63649d"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "TZJData",
+            "SPDXID": "SPDXRef-TZJData-dc5dba14-91b3-4cab-a142-028a31da12f7",
+            "versionInfo": "1.5.0+2025b",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaTime/TZJData.jl.git@72df96b3a595b7aab1e101eb07d2a435963a97e2",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "eca95a7b6ec9a18642dfc8b39e15cdfe0006ce6e"
+            },
+            "homepage": "https://github.com/JuliaTime/TZJData.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Scratch",
+            "SPDXID": "SPDXRef-Scratch-6c6a2e73-6563-6170-7368-637461726353",
+            "versionInfo": "1.2.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/Scratch.jl.git@3bac05bc7e74a75fd9cba4295cde4045d9fe2386",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "0f03ad467b403e04922df52dcf10d76e76b0b16e"
+            },
+            "homepage": "https://github.com/JuliaPackaging/Scratch.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "TimeZones",
+            "SPDXID": "SPDXRef-TimeZones-f269a46b-ccf7-5d73-abea-4c690281aa53",
+            "versionInfo": "1.21.3",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaTime/TimeZones.jl.git@2c705e96825b66c4a3f25031a683c06518256dd3",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "942bf3a7e709844aa2a25afa585a18c113f59312"
+            },
+            "homepage": "https://github.com/JuliaTime/TimeZones.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "BitIntegers",
+            "SPDXID": "SPDXRef-BitIntegers-c3b6d118-76ef-56ca-8cc7-ebb389d030a1",
+            "versionInfo": "0.3.5",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/rfourquet/BitIntegers.jl.git@f98cfeaba814d9746617822032d50a31c9926604",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "b22865467a7917d154e1d7b6bab41f3723b60dab"
+            },
+            "homepage": "https://github.com/rfourquet/BitIntegers.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "PooledArrays",
+            "SPDXID": "SPDXRef-PooledArrays-2dfb63ee-cc39-5dd5-95bd-886bf059d720",
+            "versionInfo": "1.4.3",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaData/PooledArrays.jl.git@36d8b4b899628fb92c2749eb488d884a926614d3",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "29e2b441bf270233f774d3d31a0f4922d80a577d"
+            },
+            "homepage": "https://github.com/JuliaData/PooledArrays.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "ArrowTypes",
+            "SPDXID": "SPDXRef-ArrowTypes-31f734f8-188a-4ce0-8406-c8a06bd891cd",
+            "versionInfo": "2.3.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/apache/arrow-julia.git@404265cd8128a2515a81d5eae16de90fdef05101#src/ArrowTypes",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "e8f07f91c83e410c57486720ca3595245ac75191"
+            },
+            "homepage": "https://github.com/apache/arrow-julia.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "Apache-2.0"
+            ],
+            "licenseDeclared": "Apache-2.0",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Zstd_source",
+            "SPDXID": "SPDXRef-dbd764b283c2da22563bb2d2a1fe82107a7808c2",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/Yggdrasil.git@dbd764b283c2da22563bb2d2a1fe82107a7808c2#/Z/Zstd/",
+            "filesAnalyzed": false,
+            "sourceInfo": "The location of this repository was extracted from the README.md file of SPDXRef-8e19ee77a5aed0ac3f6828efb9671b8c619cd27b",
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "The binary artifact SPDXRef-8e19ee77a5aed0ac3f6828efb9671b8c619cd27b is built using the scripts and source files in this package.\nThe build system is called Yggdrasil, the Julia community build tree.",
+            "comment": "The SPDX ID field is derived from the Git hash in the DownloadLocation"
+        },
+        {
+            "name": "Zstd",
+            "SPDXID": "SPDXRef-8e19ee77a5aed0ac3f6828efb9671b8c619cd27b",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Zstd_jll.jl/releases/download/Zstd-v1.5.7+1/Zstd.v1.5.7.x86_64-w64-mingw32.tar.gz",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "f59092ab23580c0dba94651b9a600f3453f45322"
+            },
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "193b3d0e349a54c4fe30566bd2d225a20d11ffc2411180d1cd3ba81e803708d0"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: x86_64\nos: windows",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "BSD-2-Clause",
+                "GPL-2.0",
+                "BSD-3-Clause"
+            ],
+            "licenseDeclared": "GPL-2.0",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "Zstd_jll",
+            "SPDXID": "SPDXRef-Zstd_jll-3161d3a3-bdf6-5164-811a-617609db77b4",
+            "versionInfo": "1.5.7+1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Zstd_jll.jl.git@446b23e73536f84e8037f5dce465e92275f6a308",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "7e238f6810a10484646587404435a940af6e29b9"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Zstd_jll.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "CodecZstd",
+            "SPDXID": "SPDXRef-CodecZstd-6b39b394-51ab-5f42-8807-6242bab2b4c2",
+            "versionInfo": "0.8.6",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaIO/CodecZstd.jl.git@d0073f473757f0d39ac9707f1eb03b431573cbd8",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "20ee06128ca79a3be07a27fd3bf7a94d4484a8d9"
+            },
+            "homepage": "https://github.com/JuliaIO/CodecZstd.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "ConcurrentUtilities",
+            "SPDXID": "SPDXRef-ConcurrentUtilities-f0e56b4a-5159-44fe-b623-3e5288b988bb",
+            "versionInfo": "2.5.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaServices/ConcurrentUtilities.jl.git@d9d26935a0bcffc87d2613ce14c527c99fc543fd",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "694f5c099fe57650119a1d188727fd23a03918b0"
+            },
+            "homepage": "https://github.com/JuliaServices/ConcurrentUtilities.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "StringViews",
+            "SPDXID": "SPDXRef-StringViews-354b36f9-a18e-4713-926e-db85100087ba",
+            "versionInfo": "1.3.4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaStrings/StringViews.jl.git@ec4bf39f7d25db401bcab2f11d2929798c0578e5",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "118089a4a506d392514fcb37b0f25a23db3d2f44"
+            },
+            "homepage": "https://github.com/JuliaStrings/StringViews.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Lz4_source",
+            "SPDXID": "SPDXRef-97c36a2efda61823ec3546cadf43c9298c8dd403",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/Yggdrasil.git@97c36a2efda61823ec3546cadf43c9298c8dd403#/L/Lz4/",
+            "filesAnalyzed": false,
+            "sourceInfo": "The location of this repository was extracted from the README.md file of SPDXRef-fb31c14fc601537fb564f393a63b7e3707c1173e",
+            "licenseConcluded": "NOASSERTION",
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "The binary artifact SPDXRef-fb31c14fc601537fb564f393a63b7e3707c1173e is built using the scripts and source files in this package.\nThe build system is called Yggdrasil, the Julia community build tree.",
+            "comment": "The SPDX ID field is derived from the Git hash in the DownloadLocation"
+        },
+        {
+            "name": "Lz4",
+            "SPDXID": "SPDXRef-fb31c14fc601537fb564f393a63b7e3707c1173e",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/Lz4_jll.jl/releases/download/Lz4-v1.10.1+0/Lz4.v1.10.1.x86_64-w64-mingw32.tar.gz",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "56aa82958b9ce9af8144d76d68d4693db29d6d23"
+            },
+            "checksums": [
+                {
+                    "algorithm": "SHA256",
+                    "checksumValue": "e8ca1c683c736d72d26b48b2818beb661fcefb143e11e390046b407fe8c2e5ba"
+                }
+            ],
+            "homepage": "NOASSERTION",
+            "sourceInfo": "The artifact download URL was determined using the following platform specific parameters:\narch: x86_64\nos: windows",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "BSD-2-Clause"
+            ],
+            "licenseDeclared": "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia artifact. \nAn artifact is a binary runtime or other data store not written in the Julia language that is used by a Julia package.",
+            "comment": "The SPDX ID field is derived from the Git tree hash of the artifact files which is used to uniquely identify it."
+        },
+        {
+            "name": "Lz4_jll",
+            "SPDXID": "SPDXRef-Lz4_jll-5ced341a-0733-55b8-9ab6-a4889d929147",
+            "versionInfo": "1.10.1+0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/Lz4_jll.jl.git@191686b1ac1ea9c89fc52e996ad15d1d241d1e33",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "0459b1539d01148532bae3554d1cf2ddc7a5a10f"
+            },
+            "homepage": "https://github.com/JuliaBinaryWrappers/Lz4_jll.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "CodecLz4",
+            "SPDXID": "SPDXRef-CodecLz4-5ba52731-8f18-5e0d-9241-30f10d1ec561",
+            "versionInfo": "0.4.6",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaIO/CodecLz4.jl.git@d58afcd2833601636b48ee8cbeb2edcb086522c2",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "e53716631fb0e9802dc0d877e7c69c5636adf4ba"
+            },
+            "homepage": "https://github.com/JuliaIO/CodecLz4.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "SentinelArrays",
+            "SPDXID": "SPDXRef-SentinelArrays-91c51154-3ec4-41a3-a24f-3f23e20d615c",
+            "versionInfo": "1.4.8",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaData/SentinelArrays.jl.git@712fb0231ee6f9120e005ccd56297abbc053e7e0",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "4f28951db269be996da903b3a4b1e423edc8e132"
+            },
+            "homepage": "https://github.com/JuliaData/SentinelArrays.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Arrow",
+            "SPDXID": "SPDXRef-Arrow-69666777-d1a9-59fb-9406-91d4454c9d45",
+            "versionInfo": "2.8.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/apache/arrow-julia.git@00f0b3f05bc33cc5b68db6cc22e4a7b16b65e505",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "587513ceac2d3655b344f4753ab9e5e9815d2110"
+            },
+            "homepage": "https://github.com/apache/arrow-julia.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "Apache-2.0"
+            ],
+            "licenseDeclared": "Apache-2.0",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Inflate",
+            "SPDXID": "SPDXRef-Inflate-d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9",
+            "versionInfo": "0.1.5",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/GunnarFarneback/Inflate.jl.git@d1b1b796e47d94588b3757fe84fbf65a5ec4a80d",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "718515bc376ee990ab971b62714ecf50d65598c1"
+            },
+            "homepage": "https://github.com/GunnarFarneback/Inflate.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "SimpleTraits",
+            "SPDXID": "SPDXRef-SimpleTraits-699a6c99-e7fa-54fc-8d76-47d257e15c1d",
+            "versionInfo": "0.9.4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/mauro3/SimpleTraits.jl.git@5d7e3f4e11935503d3ecaf7186eac40602e7d231",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "f5654f32fce8a4ae3eda5b7ce055eda96aa9e0af"
+            },
+            "homepage": "https://github.com/mauro3/SimpleTraits.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "ArnoldiMethod",
+            "SPDXID": "SPDXRef-ArnoldiMethod-ec485272-7323-5ecc-a04f-4719b315124d",
+            "versionInfo": "0.4.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaLinearAlgebra/ArnoldiMethod.jl.git@d57bd3762d308bded22c3b82d033bff85f6195c6",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "bfe37b9e45e4677b9f06188ce6bdfa3e64cd7aaa"
+            },
+            "homepage": "https://github.com/JuliaLinearAlgebra/ArnoldiMethod.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Graphs",
+            "SPDXID": "SPDXRef-Graphs-86223c79-3864-5bf0-83f7-82e725a168b6",
+            "versionInfo": "1.12.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaGraphs/Graphs.jl.git@3169fd3440a02f35e549728b0890904cfd4ae58a",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "e9a7f8352d97e65f711f0b7afcf021fb5329e75d"
+            },
+            "homepage": "https://github.com/JuliaGraphs/Graphs.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "BSD-2-Clause",
+                "MIT"
+            ],
+            "licenseDeclared": "BSD-2-Clause",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "IterTools",
+            "SPDXID": "SPDXRef-IterTools-c8e1da08-722c-5040-9ed9-7db0dc04731e",
+            "versionInfo": "1.10.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaCollections/IterTools.jl.git@42d5f897009e7ff2cf88db414a389e5ed1bdd023",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "2fa98c3a3d337a028e8743ad8d8353fa62bcb83c"
+            },
+            "homepage": "https://github.com/JuliaCollections/IterTools.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "NLSolversBase",
+            "SPDXID": "SPDXRef-NLSolversBase-d41bc354-129a-5804-8e4c-c37616107c6c",
+            "versionInfo": "7.9.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaNLSolvers/NLSolversBase.jl.git@b14c7be6046e7d48e9063a0053f95ee0fc954176",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "54b827a4d79af9c63e239b63a63ced5485624b7b"
+            },
+            "homepage": "https://github.com/JuliaNLSolvers/NLSolversBase.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "LineSearches",
+            "SPDXID": "SPDXRef-LineSearches-d3d80556-e9d4-5f37-9878-2ab0fcc64255",
+            "versionInfo": "7.3.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaNLSolvers/LineSearches.jl.git@e4c3be53733db1051cc15ecf573b1042b3a712a1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "62afea12e363409e03da30a57b65da12434ffb7d"
+            },
+            "homepage": "https://github.com/JuliaNLSolvers/LineSearches.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Configurations",
+            "SPDXID": "SPDXRef-Configurations-5218b696-f38b-4ac9-8b61-a12ec717816d",
+            "versionInfo": "0.17.6",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/Roger-luo/Configurations.jl.git@4358750bb58a3caefd5f37a4a0c5bfdbbf075252",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "d2eb3a1a91f60e240f4acd440b2f80df6bf54e56"
+            },
+            "homepage": "https://github.com/Roger-luo/Configurations.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "LoggingExtras",
+            "SPDXID": "SPDXRef-LoggingExtras-e6f89c97-d47a-5376-807f-9c37f3926c36",
+            "versionInfo": "1.1.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaLogging/LoggingExtras.jl.git@f02b56007b064fbfddb4c9cd60161b6dd0f40df3",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "4675fd2b0a58050eeaf58331e5303bacd51e3d83"
+            },
+            "homepage": "https://github.com/JuliaLogging/LoggingExtras.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "FileIO",
+            "SPDXID": "SPDXRef-FileIO-5789e2e9-d7fb-5bc7-8068-2c6fae9b9549",
+            "versionInfo": "1.17.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaIO/FileIO.jl.git@b66970a70db13f45b7e57fbda1736e1cf72174ea",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "4980aa00d003aa32ea9f07323740f7c1fd38c00a"
+            },
+            "homepage": "https://github.com/JuliaIO/FileIO.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "JLD2",
+            "SPDXID": "SPDXRef-JLD2-033835bb-8acc-5ee8-8aae-3f567f8a3819",
+            "versionInfo": "0.5.13",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaIO/JLD2.jl.git@8e071648610caa2d3a5351aba03a936a0c37ec61",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "4c0d4985e68392e368ab12750f2ded7e3a85385d"
+            },
+            "homepage": "https://github.com/JuliaIO/JLD2.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "MetaGraphsNext",
+            "SPDXID": "SPDXRef-MetaGraphsNext-fa8bd995-216d-47f1-8a91-f3b68fbeb377",
+            "versionInfo": "0.7.3",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaGraphs/MetaGraphsNext.jl.git@1e3b196ecbbf221d4d3696ea9de4288bea4c39f9",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "b65f318b50cb977080b2ea92be4d6a3f55079599"
+            },
+            "homepage": "https://github.com/JuliaGraphs/MetaGraphsNext.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "OrdinaryDiffEqLowOrderRK",
+            "SPDXID": "SPDXRef-OrdinaryDiffEqLowOrderRK-1344f307-1e59-4825-a18e-ace9aa3fa4c6",
+            "versionInfo": "1.2.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@d4bb32e09d6b68ce2eb45fb81001eab46f60717a#lib/OrdinaryDiffEqLowOrderRK",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "83383372031ac9588b813ddf520dd10b183d359b"
+            },
+            "homepage": "https://github.com/SciML/OrdinaryDiffEq.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "ProgressLogging",
+            "SPDXID": "SPDXRef-ProgressLogging-33c8b6b6-d38a-422a-b730-caa89a2f386c",
+            "versionInfo": "0.1.4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaLogging/ProgressLogging.jl.git@80d919dee55b9c50e8d9e2da5eeafff3fe58b539",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "3cab127758300cef495122f5cc94f119e0afbf2d"
+            },
+            "homepage": "https://github.com/JuliaLogging/ProgressLogging.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "AbstractTrees",
+            "SPDXID": "SPDXRef-AbstractTrees-1520ce14-60c1-5f80-bbc7-55ef81b5835c",
+            "versionInfo": "0.4.5",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaCollections/AbstractTrees.jl.git@2d9c9a55f9c93e8887ad391fbae72f8ef55e1177",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "2e01583dc74ef5d6c19fde5ea01430a2104e1359"
+            },
+            "homepage": "https://github.com/JuliaCollections/AbstractTrees.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "LeftChildRightSiblingTrees",
+            "SPDXID": "SPDXRef-LeftChildRightSiblingTrees-1d6d02ad-be62-4b6b-8a6d-2f90e265016e",
+            "versionInfo": "0.2.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaCollections/LeftChildRightSiblingTrees.jl.git@fb6803dafae4a5d62ea5cab204b1e657d9737e7f",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "3175a7494c568445018c7b5601a45ea67680173a"
+            },
+            "homepage": "https://github.com/JuliaCollections/LeftChildRightSiblingTrees.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "TerminalLoggers",
+            "SPDXID": "SPDXRef-TerminalLoggers-5d786b92-1e48-4d6f-9151-6b4477ca9bed",
+            "versionInfo": "0.1.7",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaLogging/TerminalLoggers.jl.git@f133fab380933d042f6796eda4e130272ba520ca",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "bb05ec07eeb5cab560956757b792bfbf9678bab6"
+            },
+            "homepage": "https://github.com/JuliaLogging/TerminalLoggers.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "FindFirstFunctions",
+            "SPDXID": "SPDXRef-FindFirstFunctions-64ca27bc-2ba2-4a57-88aa-44e436879224",
+            "versionInfo": "1.4.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/FindFirstFunctions.jl.git@670e1d9ceaa4a3161d32fe2d2fb2177f8d78b330",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "d77e35630ffd0c875daf71f2f22a5173fe0e4cea"
+            },
+            "homepage": "https://github.com/SciML/FindFirstFunctions.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "DataInterpolations",
+            "SPDXID": "SPDXRef-DataInterpolations-82cc6244-b520-54b8-b5a6-8a565e85f1d0",
+            "versionInfo": "8.0.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/DataInterpolations.jl.git@master",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "a2ef506a2498fbf3785338ae0168609bc166c295"
+            },
+            "homepage": "https://github.com/SciML/DataInterpolations.jl.git",
+            "sourceInfo": "DataInterpolations is directly tracking a git repository.",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Legolas",
+            "SPDXID": "SPDXRef-Legolas-741b9549-f6ed-4911-9fbf-4a1c0c97f0cd",
+            "versionInfo": "0.5.23",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/beacon-biosignals/Legolas.jl.git@f47437d6a4ca074d2dec739cfd831bb9de09ad61",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "1b8fd93c1a1adb3b85647f127ae3bb4c53d64430"
+            },
+            "homepage": "https://github.com/beacon-biosignals/Legolas.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "Functors",
+            "SPDXID": "SPDXRef-Functors-d9f16b24-f501-4c13-a1f2-28368ffc5196",
+            "versionInfo": "0.5.2",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/FluxML/Functors.jl.git@60a0339f28a233601cb74468032b5c302d5067de",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "1356fbe86b744f44d001a4636ffe718ff17a09ba"
+            },
+            "homepage": "https://github.com/FluxML/Functors.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "DiffEqCallbacks",
+            "SPDXID": "SPDXRef-DiffEqCallbacks-459566f4-90b8-5000-8ac3-15dfb0a30def",
+            "versionInfo": "4.6.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/DiffEqCallbacks.jl.git@76292e889472e810d40a844b714743c0ffb1c53b",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "61c3ca4539b7ad6b905043331dbdb313d39bee30"
+            },
+            "homepage": "https://github.com/SciML/DiffEqCallbacks.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "OrdinaryDiffEqRosenbrock",
+            "SPDXID": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce",
+            "versionInfo": "1.10.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@a9b9aff8e740bfc09a2ea669f7fc02e867f95ab7#lib/OrdinaryDiffEqRosenbrock",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "af440a393aca142cf0352d2cb6c309ff412086e5"
+            },
+            "homepage": "https://github.com/SciML/OrdinaryDiffEq.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        }
+    ],
+    "relationships": [
+        {
+            "spdxElementId": "SPDXRef-ConstructionBase-187b0558-2788-49d3-abe0-74a17ed4e7c9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Accessors-7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+        },
+        {
+            "spdxElementId": "SPDXRef-CompositionsBase-a33af91c-f02d-484b-be07-31d278c5ca2b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Accessors-7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+        },
+        {
+            "spdxElementId": "SPDXRef-InverseFunctions-3587e190-3f89-42d0-90ee-14403ec27112",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Accessors-7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+        },
+        {
+            "spdxElementId": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Accessors-7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+        },
+        {
+            "spdxElementId": "SPDXRef-Preferences-21216c6a-2e73-6563-6e65-726566657250",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-HiGHS_jll-8fd58aa0-07eb-5a78-9b36-339c94fd15ea"
+        },
+        {
+            "spdxElementId": "SPDXRef-8f98efd8e73db8cafc6637dc0b18b1f87a4201b8",
+            "relationshipType": "GENERATED_FROM",
+            "relatedSpdxElement": "SPDXRef-db01335a6b9c8c7f797115be3e9d7e50e979acb4"
+        },
+        {
+            "spdxElementId": "SPDXRef-8f98efd8e73db8cafc6637dc0b18b1f87a4201b8",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-HiGHS_jll-8fd58aa0-07eb-5a78-9b36-339c94fd15ea"
+        },
+        {
+            "spdxElementId": "SPDXRef-HiGHS_jll-8fd58aa0-07eb-5a78-9b36-339c94fd15ea",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-HiGHS-87dc4568-4c63-4d18-b0c0-bb2238e4078b"
+        },
+        {
+            "spdxElementId": "SPDXRef-Preferences-21216c6a-2e73-6563-6e65-726566657250",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-HiGHS-87dc4568-4c63-4d18-b0c0-bb2238e4078b"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffResults-163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+        },
+        {
+            "spdxElementId": "SPDXRef-DiffResults-163ba53b-c6d8-5494-b064-1a9d43ac40c5",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210"
+        },
+        {
+            "spdxElementId": "SPDXRef-IrrationalConstants-92d709cd-6900-40b7-9082-c6be49f344b6",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LogExpFunctions-2ab3a3ac-af41-5b50-aa03-7779005ae688"
+        },
+        {
+            "spdxElementId": "SPDXRef-DocStringExtensions-ffbed154-4ef7-542d-bbb7-c09d3a79fcae",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LogExpFunctions-2ab3a3ac-af41-5b50-aa03-7779005ae688"
+        },
+        {
+            "spdxElementId": "SPDXRef-LogExpFunctions-2ab3a3ac-af41-5b50-aa03-7779005ae688",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210"
+        },
+        {
+            "spdxElementId": "SPDXRef-IrrationalConstants-92d709cd-6900-40b7-9082-c6be49f344b6",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffRules-b552c78f-8df3-52c6-915a-8e097449b14b"
+        },
+        {
+            "spdxElementId": "SPDXRef-LogExpFunctions-2ab3a3ac-af41-5b50-aa03-7779005ae688",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffRules-b552c78f-8df3-52c6-915a-8e097449b14b"
+        },
+        {
+            "spdxElementId": "SPDXRef-IrrationalConstants-92d709cd-6900-40b7-9082-c6be49f344b6",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SpecialFunctions-276daf66-3868-5448-9aa4-cd146d93841b"
+        },
+        {
+            "spdxElementId": "SPDXRef-LogExpFunctions-2ab3a3ac-af41-5b50-aa03-7779005ae688",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SpecialFunctions-276daf66-3868-5448-9aa4-cd146d93841b"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OpenSpecFun_jll-efe28fd5-8261-553b-a9e1-b2916fc3738e"
+        },
+        {
+            "spdxElementId": "SPDXRef-c1bc0753f7d08c4dcb1f132c45ca0cc509294c81",
+            "relationshipType": "GENERATED_FROM",
+            "relatedSpdxElement": "SPDXRef-a09b23447486767cbc7f74078c5b2ecdbdbbdeaa"
+        },
+        {
+            "spdxElementId": "SPDXRef-c1bc0753f7d08c4dcb1f132c45ca0cc509294c81",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OpenSpecFun_jll-efe28fd5-8261-553b-a9e1-b2916fc3738e"
+        },
+        {
+            "spdxElementId": "SPDXRef-OpenSpecFun_jll-efe28fd5-8261-553b-a9e1-b2916fc3738e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SpecialFunctions-276daf66-3868-5448-9aa4-cd146d93841b"
+        },
+        {
+            "spdxElementId": "SPDXRef-SpecialFunctions-276daf66-3868-5448-9aa4-cd146d93841b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffRules-b552c78f-8df3-52c6-915a-8e097449b14b"
+        },
+        {
+            "spdxElementId": "SPDXRef-NaNMath-77ba4419-2d1f-58cd-9bb1-8ffee604a2e3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffRules-b552c78f-8df3-52c6-915a-8e097449b14b"
+        },
+        {
+            "spdxElementId": "SPDXRef-DiffRules-b552c78f-8df3-52c6-915a-8e097449b14b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210"
+        },
+        {
+            "spdxElementId": "SPDXRef-SpecialFunctions-276daf66-3868-5448-9aa4-cd146d93841b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210"
+        },
+        {
+            "spdxElementId": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-CommonSubexpressions-bbf7d656-a473-5ed7-a52c-81e309532950"
+        },
+        {
+            "spdxElementId": "SPDXRef-CommonSubexpressions-bbf7d656-a473-5ed7-a52c-81e309532950",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210"
+        },
+        {
+            "spdxElementId": "SPDXRef-Preferences-21216c6a-2e73-6563-6e65-726566657250",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210"
+        },
+        {
+            "spdxElementId": "SPDXRef-NaNMath-77ba4419-2d1f-58cd-9bb1-8ffee604a2e3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210"
+        },
+        {
+            "spdxElementId": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-JSON3-0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Parsers-69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+        },
+        {
+            "spdxElementId": "SPDXRef-Parsers-69de0a69-1ddd-5017-9359-2bf0b02dc9f0",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-JSON3-0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+        },
+        {
+            "spdxElementId": "SPDXRef-StructTypes-856f2bd8-1eba-4b0a-8007-ebc267875bd4",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-JSON3-0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+        },
+        {
+            "spdxElementId": "SPDXRef-JSON3-0f8b85d8-7281-11e9-16c2-39a750bddbf1",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+        },
+        {
+            "spdxElementId": "SPDXRef-Parsers-69de0a69-1ddd-5017-9359-2bf0b02dc9f0",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-JSON-682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+        },
+        {
+            "spdxElementId": "SPDXRef-JSON-682c06a0-de6a-54ab-a142-c8b1cf79cde6",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-BenchmarkTools-6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+        },
+        {
+            "spdxElementId": "SPDXRef-Statistics-10745b16-79ce-11e8-11f9-7d13ad32a3b2",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-BenchmarkTools-6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+        },
+        {
+            "spdxElementId": "SPDXRef-Compat-34da2185-b29b-5c13-b0c7-acf172513d20",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-BenchmarkTools-6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+        },
+        {
+            "spdxElementId": "SPDXRef-BenchmarkTools-6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrderedCollections-bac558e1-5e72-5ebc-8fee-abe8a469f55d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+        },
+        {
+            "spdxElementId": "SPDXRef-TranscodingStreams-3bb67fe8-82b1-5028-8e26-92a6c54297fa",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-CodecZlib-944b1d66-785c-5afd-91f1-9de20f533193"
+        },
+        {
+            "spdxElementId": "SPDXRef-CodecZlib-944b1d66-785c-5afd-91f1-9de20f533193",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+        },
+        {
+            "spdxElementId": "SPDXRef-Compat-34da2185-b29b-5c13-b0c7-acf172513d20",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DataStructures-864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrderedCollections-bac558e1-5e72-5ebc-8fee-abe8a469f55d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DataStructures-864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+        },
+        {
+            "spdxElementId": "SPDXRef-DataStructures-864edb3b-99cc-5e75-8d2d-829cb0a9cfe8",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Bzip2_jll-6e34b625-4abd-537c-b88f-471c36dfa7a0"
+        },
+        {
+            "spdxElementId": "SPDXRef-3af036b12a076c2d4c042dde6d956ef4eac2c2ce",
+            "relationshipType": "GENERATED_FROM",
+            "relatedSpdxElement": "SPDXRef-4f5224a8ba03ee7be81c164c6f85745f9a1e8cc5"
+        },
+        {
+            "spdxElementId": "SPDXRef-3af036b12a076c2d4c042dde6d956ef4eac2c2ce",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Bzip2_jll-6e34b625-4abd-537c-b88f-471c36dfa7a0"
+        },
+        {
+            "spdxElementId": "SPDXRef-Bzip2_jll-6e34b625-4abd-537c-b88f-471c36dfa7a0",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-CodecBzip2-523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
+        },
+        {
+            "spdxElementId": "SPDXRef-TranscodingStreams-3bb67fe8-82b1-5028-8e26-92a6c54297fa",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-CodecBzip2-523fee87-0ab8-5b00-afb7-3ecf72e48cfd"
+        },
+        {
+            "spdxElementId": "SPDXRef-CodecBzip2-523fee87-0ab8-5b00-afb7-3ecf72e48cfd",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+        },
+        {
+            "spdxElementId": "SPDXRef-SpecialFunctions-276daf66-3868-5448-9aa4-cd146d93841b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+        },
+        {
+            "spdxElementId": "SPDXRef-MutableArithmetics-d8a4904e-b15c-11e9-3269-09a3773c0cb0",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+        },
+        {
+            "spdxElementId": "SPDXRef-NaNMath-77ba4419-2d1f-58cd-9bb1-8ffee604a2e3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+        },
+        {
+            "spdxElementId": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-HiGHS-87dc4568-4c63-4d18-b0c0-bb2238e4078b"
+        },
+        {
+            "spdxElementId": "SPDXRef-ManualMemory-d125e4d3-2237-4719-b19c-fa641b8a4667",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-ThreadingUtilities-8290d209-cae3-49c0-8002-c8c24d57dab5"
+        },
+        {
+            "spdxElementId": "SPDXRef-ThreadingUtilities-8290d209-cae3-49c0-8002-c8c24d57dab5",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Polyester-f517fe37-dbe3-4b94-8317-1923a5111588"
+        },
+        {
+            "spdxElementId": "SPDXRef-ThreadingUtilities-8290d209-cae3-49c0-8002-c8c24d57dab5",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-PolyesterWeave-1d0040c9-8b98-4ee7-8388-3f51789ca0ad"
+        },
+        {
+            "spdxElementId": "SPDXRef-IfElse-615f187c-cbe4-4ef1-ba3b-2fcf58d6d173",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-PolyesterWeave-1d0040c9-8b98-4ee7-8388-3f51789ca0ad"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3"
+        },
+        {
+            "spdxElementId": "SPDXRef-IfElse-615f187c-cbe4-4ef1-ba3b-2fcf58d6d173",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3"
+        },
+        {
+            "spdxElementId": "SPDXRef-CommonWorldInvalidations-f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3"
+        },
+        {
+            "spdxElementId": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-PolyesterWeave-1d0040c9-8b98-4ee7-8388-3f51789ca0ad"
+        },
+        {
+            "spdxElementId": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-BitTwiddlingConvenienceFunctions-62783981-4cbd-42fc-bca8-16325de8dc4b"
+        },
+        {
+            "spdxElementId": "SPDXRef-BitTwiddlingConvenienceFunctions-62783981-4cbd-42fc-bca8-16325de8dc4b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-PolyesterWeave-1d0040c9-8b98-4ee7-8388-3f51789ca0ad"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-CPUSummary-2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
+        },
+        {
+            "spdxElementId": "SPDXRef-IfElse-615f187c-cbe4-4ef1-ba3b-2fcf58d6d173",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-CPUSummary-2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
+        },
+        {
+            "spdxElementId": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-CPUSummary-2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
+        },
+        {
+            "spdxElementId": "SPDXRef-CpuId-adafc99b-e345-5852-983c-f28acb93d879",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-CPUSummary-2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9"
+        },
+        {
+            "spdxElementId": "SPDXRef-CPUSummary-2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-PolyesterWeave-1d0040c9-8b98-4ee7-8388-3f51789ca0ad"
+        },
+        {
+            "spdxElementId": "SPDXRef-PolyesterWeave-1d0040c9-8b98-4ee7-8388-3f51789ca0ad",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Polyester-f517fe37-dbe3-4b94-8317-1923a5111588"
+        },
+        {
+            "spdxElementId": "SPDXRef-IfElse-615f187c-cbe4-4ef1-ba3b-2fcf58d6d173",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Polyester-f517fe37-dbe3-4b94-8317-1923a5111588"
+        },
+        {
+            "spdxElementId": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Polyester-f517fe37-dbe3-4b94-8317-1923a5111588"
+        },
+        {
+            "spdxElementId": "SPDXRef-BitTwiddlingConvenienceFunctions-62783981-4cbd-42fc-bca8-16325de8dc4b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Polyester-f517fe37-dbe3-4b94-8317-1923a5111588"
+        },
+        {
+            "spdxElementId": "SPDXRef-CPUSummary-2a0fbf3d-bb9c-48f3-b0a9-814d99fd7ab9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Polyester-f517fe37-dbe3-4b94-8317-1923a5111588"
+        },
+        {
+            "spdxElementId": "SPDXRef-Requires-ae029012-a4dd-5104-9daa-d747884805df",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Adapt-79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+        },
+        {
+            "spdxElementId": "SPDXRef-Adapt-79e6a3ab-5dfb-504d-930d-738a2a938a0e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Polyester-f517fe37-dbe3-4b94-8317-1923a5111588"
+        },
+        {
+            "spdxElementId": "SPDXRef-ManualMemory-d125e4d3-2237-4719-b19c-fa641b8a4667",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Polyester-f517fe37-dbe3-4b94-8317-1923a5111588"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StaticArrayInterface-0d7ed370-da01-4f52-bd93-41d350b8b718"
+        },
+        {
+            "spdxElementId": "SPDXRef-IfElse-615f187c-cbe4-4ef1-ba3b-2fcf58d6d173",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StaticArrayInterface-0d7ed370-da01-4f52-bd93-41d350b8b718"
+        },
+        {
+            "spdxElementId": "SPDXRef-Compat-34da2185-b29b-5c13-b0c7-acf172513d20",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StaticArrayInterface-0d7ed370-da01-4f52-bd93-41d350b8b718"
+        },
+        {
+            "spdxElementId": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StaticArrayInterface-0d7ed370-da01-4f52-bd93-41d350b8b718"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StaticArrayInterface-0d7ed370-da01-4f52-bd93-41d350b8b718"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArrayInterface-0d7ed370-da01-4f52-bd93-41d350b8b718",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Polyester-f517fe37-dbe3-4b94-8317-1923a5111588"
+        },
+        {
+            "spdxElementId": "SPDXRef-SIMDTypes-94e857df-77ce-4151-89e5-788b33177be4",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StrideArraysCore-7792a7ef-975c-4747-a70f-980b88e8d1da"
+        },
+        {
+            "spdxElementId": "SPDXRef-ThreadingUtilities-8290d209-cae3-49c0-8002-c8c24d57dab5",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StrideArraysCore-7792a7ef-975c-4747-a70f-980b88e8d1da"
+        },
+        {
+            "spdxElementId": "SPDXRef-IfElse-615f187c-cbe4-4ef1-ba3b-2fcf58d6d173",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StrideArraysCore-7792a7ef-975c-4747-a70f-980b88e8d1da"
+        },
+        {
+            "spdxElementId": "SPDXRef-SIMDTypes-94e857df-77ce-4151-89e5-788b33177be4",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LayoutPointers-10f19ff3-798f-405d-979b-55457f8fc047"
+        },
+        {
+            "spdxElementId": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LayoutPointers-10f19ff3-798f-405d-979b-55457f8fc047"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LayoutPointers-10f19ff3-798f-405d-979b-55457f8fc047"
+        },
+        {
+            "spdxElementId": "SPDXRef-ManualMemory-d125e4d3-2237-4719-b19c-fa641b8a4667",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LayoutPointers-10f19ff3-798f-405d-979b-55457f8fc047"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArrayInterface-0d7ed370-da01-4f52-bd93-41d350b8b718",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LayoutPointers-10f19ff3-798f-405d-979b-55457f8fc047"
+        },
+        {
+            "spdxElementId": "SPDXRef-LayoutPointers-10f19ff3-798f-405d-979b-55457f8fc047",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StrideArraysCore-7792a7ef-975c-4747-a70f-980b88e8d1da"
+        },
+        {
+            "spdxElementId": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StrideArraysCore-7792a7ef-975c-4747-a70f-980b88e8d1da"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StrideArraysCore-7792a7ef-975c-4747-a70f-980b88e8d1da"
+        },
+        {
+            "spdxElementId": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-CloseOpenIntervals-fb6a15b2-703c-40df-9091-08a04967cfa9"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArrayInterface-0d7ed370-da01-4f52-bd93-41d350b8b718",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-CloseOpenIntervals-fb6a15b2-703c-40df-9091-08a04967cfa9"
+        },
+        {
+            "spdxElementId": "SPDXRef-CloseOpenIntervals-fb6a15b2-703c-40df-9091-08a04967cfa9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StrideArraysCore-7792a7ef-975c-4747-a70f-980b88e8d1da"
+        },
+        {
+            "spdxElementId": "SPDXRef-ManualMemory-d125e4d3-2237-4719-b19c-fa641b8a4667",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StrideArraysCore-7792a7ef-975c-4747-a70f-980b88e8d1da"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArrayInterface-0d7ed370-da01-4f52-bd93-41d350b8b718",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StrideArraysCore-7792a7ef-975c-4747-a70f-980b88e8d1da"
+        },
+        {
+            "spdxElementId": "SPDXRef-StrideArraysCore-7792a7ef-975c-4747-a70f-980b88e8d1da",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Polyester-f517fe37-dbe3-4b94-8317-1923a5111588"
+        },
+        {
+            "spdxElementId": "SPDXRef-Polyester-f517fe37-dbe3-4b94-8317-1923a5111588",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-FastBroadcast-7034ab61-46d4-4ed7-9d0f-46aef9175898"
+        },
+        {
+            "spdxElementId": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-FastBroadcast-7034ab61-46d4-4ed7-9d0f-46aef9175898"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-FastBroadcast-7034ab61-46d4-4ed7-9d0f-46aef9175898"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArrayInterface-0d7ed370-da01-4f52-bd93-41d350b8b718",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-FastBroadcast-7034ab61-46d4-4ed7-9d0f-46aef9175898"
+        },
+        {
+            "spdxElementId": "SPDXRef-StrideArraysCore-7792a7ef-975c-4747-a70f-980b88e8d1da",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-FastBroadcast-7034ab61-46d4-4ed7-9d0f-46aef9175898"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastBroadcast-7034ab61-46d4-4ed7-9d0f-46aef9175898",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqTsit5-b1df2697-797e-41e3-8120-5422d3b24e4a"
+        },
+        {
+            "spdxElementId": "SPDXRef-MuladdMacro-46d2c3a1-f734-5fdb-9937-b9b9aeba4221",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqTsit5-b1df2697-797e-41e3-8120-5422d3b24e4a"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqTsit5-b1df2697-797e-41e3-8120-5422d3b24e4a"
+        },
+        {
+            "spdxElementId": "SPDXRef-Preferences-21216c6a-2e73-6563-6e65-726566657250",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-TruncatedStacktraces-781d530d-4396-4725-bb49-402e4bee1e77"
+        },
+        {
+            "spdxElementId": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-TruncatedStacktraces-781d530d-4396-4725-bb49-402e4bee1e77"
+        },
+        {
+            "spdxElementId": "SPDXRef-TruncatedStacktraces-781d530d-4396-4725-bb49-402e4bee1e77",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqTsit5-b1df2697-797e-41e3-8120-5422d3b24e4a"
+        },
+        {
+            "spdxElementId": "SPDXRef-Accessors-7d9f7c33-5ae7-4f3b-8dc6-eff91059b697",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961"
+        },
+        {
+            "spdxElementId": "SPDXRef-DocStringExtensions-ffbed154-4ef7-542d-bbb7-c09d3a79fcae",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961"
+        },
+        {
+            "spdxElementId": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLStructures-53ae85a6-f571-4167-b2af-e1d143709226"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLStructures-53ae85a6-f571-4167-b2af-e1d143709226",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-Accessors-7d9f7c33-5ae7-4f3b-8dc6-eff91059b697",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-FunctionWrappers-069b7b12-0de2-55c6-9aab-29f3d0a68a2e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-FunctionWrappersWrappers-77dc65aa-8811-40c2-897b-53d922fa7daf"
+        },
+        {
+            "spdxElementId": "SPDXRef-FunctionWrappersWrappers-77dc65aa-8811-40c2-897b-53d922fa7daf",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastBroadcast-7034ab61-46d4-4ed7-9d0f-46aef9175898",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArrayInterface-0d7ed370-da01-4f52-bd93-41d350b8b718",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-MuladdMacro-46d2c3a1-f734-5fdb-9937-b9b9aeba4221",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-EnumX-4e289a0a-7415-4d19-859d-a7e5c4648b56",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-Polyester-f517fe37-dbe3-4b94-8317-1923a5111588",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-TruncatedStacktraces-781d530d-4396-4725-bb49-402e4bee1e77",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-SimpleUnPack-ce78b400-467f-4804-87d8-8f486da07d0a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLStructures-53ae85a6-f571-4167-b2af-e1d143709226",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-Accessors-7d9f7c33-5ae7-4f3b-8dc6-eff91059b697",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-Statistics-10745b16-79ce-11e8-11f9-7d13ad32a3b2",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-FunctionWrappersWrappers-77dc65aa-8811-40c2-897b-53d922fa7daf",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-ExprTools-e2ba6199-217a-4e67-a87a-7c52f15ade04",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-RuntimeGeneratedFunctions-7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
+        },
+        {
+            "spdxElementId": "SPDXRef-RuntimeGeneratedFunctions-7e49a35a-f44a-4d26-94aa-eba1b4ca6b47",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConstructionBase-187b0558-2788-49d3-abe0-74a17ed4e7c9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-EnumX-4e289a0a-7415-4d19-859d-a7e5c4648b56",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-IteratorInterfaceExtensions-82899510-4779-5014-852e-03e436cf321d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-ExproniconLite-55351af7-c7e9-48d6-89ff-24e801d99491",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Moshi-2e0e35c7-a2e4-4343-998d-7ef72827ed2d"
+        },
+        {
+            "spdxElementId": "SPDXRef-ExproniconLite-55351af7-c7e9-48d6-89ff-24e801d99491",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Jieko-ae98c720-c025-4a4a-838c-29b094483192"
+        },
+        {
+            "spdxElementId": "SPDXRef-Jieko-ae98c720-c025-4a4a-838c-29b094483192",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Moshi-2e0e35c7-a2e4-4343-998d-7ef72827ed2d"
+        },
+        {
+            "spdxElementId": "SPDXRef-Moshi-2e0e35c7-a2e4-4343-998d-7ef72827ed2d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-DocStringExtensions-ffbed154-4ef7-542d-bbb7-c09d3a79fcae",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-Preferences-21216c6a-2e73-6563-6e65-726566657250",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-Accessors-7d9f7c33-5ae7-4f3b-8dc6-eff91059b697",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SymbolicIndexingInterface-2efcf032-c050-4f8e-a9bb-153293bab1f5"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SymbolicIndexingInterface-2efcf032-c050-4f8e-a9bb-153293bab1f5"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SymbolicIndexingInterface-2efcf032-c050-4f8e-a9bb-153293bab1f5"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StringManipulation-892a3eda-7b42-436c-8928-eab12a02cf0e"
+        },
+        {
+            "spdxElementId": "SPDXRef-StringManipulation-892a3eda-7b42-436c-8928-eab12a02cf0e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-PrettyTables-08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-PrettyTables-08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+        },
+        {
+            "spdxElementId": "SPDXRef-DataAPI-9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Tables-bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrderedCollections-bac558e1-5e72-5ebc-8fee-abe8a469f55d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Tables-bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+        },
+        {
+            "spdxElementId": "SPDXRef-IteratorInterfaceExtensions-82899510-4779-5014-852e-03e436cf321d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Tables-bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+        },
+        {
+            "spdxElementId": "SPDXRef-DataValueInterfaces-e2d170a0-9d28-54be-80f0-106bbe20a464",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Tables-bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+        },
+        {
+            "spdxElementId": "SPDXRef-IteratorInterfaceExtensions-82899510-4779-5014-852e-03e436cf321d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-TableTraits-3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+        },
+        {
+            "spdxElementId": "SPDXRef-TableTraits-3783bdb8-4a98-5b6b-af9a-565f29a5fe9c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Tables-bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+        },
+        {
+            "spdxElementId": "SPDXRef-Tables-bd369af6-aec1-5ad0-b16a-f7cc5008161c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-PrettyTables-08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+        },
+        {
+            "spdxElementId": "SPDXRef-Crayons-a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-PrettyTables-08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+        },
+        {
+            "spdxElementId": "SPDXRef-LaTeXStrings-b964fa9f-0449-5b57-a5c2-d3ea65f4040f",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-PrettyTables-08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+        },
+        {
+            "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-PrettyTables-08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrettyTables-08abe8d2-0d0c-5749-adfa-8a2ac140af0d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SymbolicIndexingInterface-2efcf032-c050-4f8e-a9bb-153293bab1f5"
+        },
+        {
+            "spdxElementId": "SPDXRef-RuntimeGeneratedFunctions-7e49a35a-f44a-4d26-94aa-eba1b4ca6b47",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SymbolicIndexingInterface-2efcf032-c050-4f8e-a9bb-153293bab1f5"
+        },
+        {
+            "spdxElementId": "SPDXRef-SymbolicIndexingInterface-2efcf032-c050-4f8e-a9bb-153293bab1f5",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-RecipesBase-3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+        },
+        {
+            "spdxElementId": "SPDXRef-RecipesBase-3cdcf5f2-1ef4-517c-9805-6587b60abb01",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-Statistics-10745b16-79ce-11e8-11f9-7d13ad32a3b2",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd"
+        },
+        {
+            "spdxElementId": "SPDXRef-Adapt-79e6a3ab-5dfb-504d-930d-738a2a938a0e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-GPUArraysCore-46192b85-c4d5-4398-a991-12ede77f4527"
+        },
+        {
+            "spdxElementId": "SPDXRef-GPUArraysCore-46192b85-c4d5-4398-a991-12ede77f4527",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd"
+        },
+        {
+            "spdxElementId": "SPDXRef-IteratorInterfaceExtensions-82899510-4779-5014-852e-03e436cf321d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd"
+        },
+        {
+            "spdxElementId": "SPDXRef-Tables-bd369af6-aec1-5ad0-b16a-f7cc5008161c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd"
+        },
+        {
+            "spdxElementId": "SPDXRef-DocStringExtensions-ffbed154-4ef7-542d-bbb7-c09d3a79fcae",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd"
+        },
+        {
+            "spdxElementId": "SPDXRef-SymbolicIndexingInterface-2efcf032-c050-4f8e-a9bb-153293bab1f5",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd"
+        },
+        {
+            "spdxElementId": "SPDXRef-RecipesBase-3cdcf5f2-1ef4-517c-9805-6587b60abb01",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd"
+        },
+        {
+            "spdxElementId": "SPDXRef-Adapt-79e6a3ab-5dfb-504d-930d-738a2a938a0e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd"
+        },
+        {
+            "spdxElementId": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-CommonSolve-38540f10-b2f7-11e9-35d8-d573e4eb0ff2",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-Adapt-79e6a3ab-5dfb-504d-930d-738a2a938a0e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastClosures-9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-DataStructures-864edb3b-99cc-5e75-8d2d-829cb0a9cfe8",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-DocStringExtensions-ffbed154-4ef7-542d-bbb7-c09d3a79fcae",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-Preferences-21216c6a-2e73-6563-6e65-726566657250",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-SymbolicIndexingInterface-2efcf032-c050-4f8e-a9bb-153293bab1f5",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastPower-a4df4552-cc26-4903-aec0-212e50a0e84b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConstructionBase-187b0558-2788-49d3-abe0-74a17ed4e7c9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Setfield-efcf1570-3423-57d1-acb7-fd33fddbac46"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Setfield-efcf1570-3423-57d1-acb7-fd33fddbac46"
+        },
+        {
+            "spdxElementId": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Setfield-efcf1570-3423-57d1-acb7-fd33fddbac46"
+        },
+        {
+            "spdxElementId": "SPDXRef-Setfield-efcf1570-3423-57d1-acb7-fd33fddbac46",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-Statistics-10745b16-79ce-11e8-11f9-7d13ad32a3b2",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-FunctionWrappersWrappers-77dc65aa-8811-40c2-897b-53d922fa7daf",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastBroadcast-7034ab61-46d4-4ed7-9d0f-46aef9175898",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-FunctionWrappers-069b7b12-0de2-55c6-9aab-29f3d0a68a2e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-EnzymeCore-f151be2c-9106-41f4-ab19-57ee4f262869",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-MuladdMacro-46d2c3a1-f734-5fdb-9937-b9b9aeba4221",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-EnumX-4e289a0a-7415-4d19-859d-a7e5c4648b56",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-TruncatedStacktraces-781d530d-4396-4725-bb49-402e4bee1e77",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastClosures-9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-DataStructures-864edb3b-99cc-5e75-8d2d-829cb0a9cfe8",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConcreteStructs-2569d6c7-a4a2-43d3-a901-331e8e4be471",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-DocStringExtensions-ffbed154-4ef7-542d-bbb7-c09d3a79fcae",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-SymbolicIndexingInterface-2efcf032-c050-4f8e-a9bb-153293bab1f5",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastPower-a4df4552-cc26-4903-aec0-212e50a0e84b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrderedCollections-bac558e1-5e72-5ebc-8fee-abe8a469f55d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Parameters-d96e819e-fc66-5662-9728-84c9c7592b0a"
+        },
+        {
+            "spdxElementId": "SPDXRef-UnPack-3a884ed6-31ef-47d7-9d2a-63182c4928ed",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Parameters-d96e819e-fc66-5662-9728-84c9c7592b0a"
+        },
+        {
+            "spdxElementId": "SPDXRef-Parameters-d96e819e-fc66-5662-9728-84c9c7592b0a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLStructures-53ae85a6-f571-4167-b2af-e1d143709226",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-FillArrays-1a297f60-69ca-5386-bcde-b61e274b549b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-Adapt-79e6a3ab-5dfb-504d-930d-738a2a938a0e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqTsit5-b1df2697-797e-41e3-8120-5422d3b24e4a"
+        },
+        {
+            "spdxElementId": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqTsit5-b1df2697-797e-41e3-8120-5422d3b24e4a"
+        },
+        {
+            "spdxElementId": "SPDXRef-Preferences-21216c6a-2e73-6563-6e65-726566657250",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqTsit5-b1df2697-797e-41e3-8120-5422d3b24e4a"
+        },
+        {
+            "spdxElementId": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqTsit5-b1df2697-797e-41e3-8120-5422d3b24e4a"
+        },
+        {
+            "spdxElementId": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqTsit5-b1df2697-797e-41e3-8120-5422d3b24e4a"
+        },
+        {
+            "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqTsit5-b1df2697-797e-41e3-8120-5422d3b24e4a"
+        },
+        {
+            "spdxElementId": "SPDXRef-Tables-bd369af6-aec1-5ad0-b16a-f7cc5008161c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SQLite-0aa819cd-b072-5ff4-a722-6bc24af294d9"
+        },
+        {
+            "spdxElementId": "SPDXRef-DataAPI-9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-WeakRefStrings-ea10d353-3f73-51f8-a26c-33c1cb351aa5"
+        },
+        {
+            "spdxElementId": "SPDXRef-InlineStrings-842dd82b-1e85-43dc-bf29-5d0ee9dffc48",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-WeakRefStrings-ea10d353-3f73-51f8-a26c-33c1cb351aa5"
+        },
+        {
+            "spdxElementId": "SPDXRef-Parsers-69de0a69-1ddd-5017-9359-2bf0b02dc9f0",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-WeakRefStrings-ea10d353-3f73-51f8-a26c-33c1cb351aa5"
+        },
+        {
+            "spdxElementId": "SPDXRef-WeakRefStrings-ea10d353-3f73-51f8-a26c-33c1cb351aa5",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SQLite-0aa819cd-b072-5ff4-a722-6bc24af294d9"
+        },
+        {
+            "spdxElementId": "SPDXRef-DBInterface-a10d1c49-ce27-4219-8d33-6db1a4562965",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SQLite-0aa819cd-b072-5ff4-a722-6bc24af294d9"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SQLite_jll-76ed43ae-9a5d-5a62-8c75-30186b810ce8"
+        },
+        {
+            "spdxElementId": "SPDXRef-2779bb3ec0b70d8b6e0311bd8e662ebd81d9dcc4",
+            "relationshipType": "GENERATED_FROM",
+            "relatedSpdxElement": "SPDXRef-b0220b79727dcc10748a80b9b16463d628e0ce83"
+        },
+        {
+            "spdxElementId": "SPDXRef-2779bb3ec0b70d8b6e0311bd8e662ebd81d9dcc4",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SQLite_jll-76ed43ae-9a5d-5a62-8c75-30186b810ce8"
+        },
+        {
+            "spdxElementId": "SPDXRef-SQLite_jll-76ed43ae-9a5d-5a62-8c75-30186b810ce8",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SQLite-0aa819cd-b072-5ff4-a722-6bc24af294d9"
+        },
+        {
+            "spdxElementId": "SPDXRef-DataAPI-9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StructArrays-09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConstructionBase-187b0558-2788-49d3-abe0-74a17ed4e7c9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StructArrays-09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+        },
+        {
+            "spdxElementId": "SPDXRef-Tables-bd369af6-aec1-5ad0-b16a-f7cc5008161c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StructArrays-09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+        },
+        {
+            "spdxElementId": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SparseConnectivityTracer-9f842d2f-2579-4b1d-911e-f412cf18a3f5"
+        },
+        {
+            "spdxElementId": "SPDXRef-DocStringExtensions-ffbed154-4ef7-542d-bbb7-c09d3a79fcae",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SparseConnectivityTracer-9f842d2f-2579-4b1d-911e-f412cf18a3f5"
+        },
+        {
+            "spdxElementId": "SPDXRef-FillArrays-1a297f60-69ca-5386-bcde-b61e274b549b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SparseConnectivityTracer-9f842d2f-2579-4b1d-911e-f412cf18a3f5"
+        },
+        {
+            "spdxElementId": "SPDXRef-Setfield-efcf1570-3423-57d1-acb7-fd33fddbac46",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-FiniteDiff-6a86dc24-6348-571c-b903-95158fe2bd41"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-FiniteDiff-6a86dc24-6348-571c-b903-95158fe2bd41"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastBroadcast-7034ab61-46d4-4ed7-9d0f-46aef9175898",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqBDF-6ad6398a-0878-4a85-9266-38940aa047c8"
+        },
+        {
+            "spdxElementId": "SPDXRef-MuladdMacro-46d2c3a1-f734-5fdb-9937-b9b9aeba4221",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqBDF-6ad6398a-0878-4a85-9266-38940aa047c8"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqBDF-6ad6398a-0878-4a85-9266-38940aa047c8"
+        },
+        {
+            "spdxElementId": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b"
+        },
+        {
+            "spdxElementId": "SPDXRef-FunctionWrappersWrappers-77dc65aa-8811-40c2-897b-53d922fa7daf",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastBroadcast-7034ab61-46d4-4ed7-9d0f-46aef9175898",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b"
+        },
+        {
+            "spdxElementId": "SPDXRef-FiniteDiff-6a86dc24-6348-571c-b903-95158fe2bd41",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArrayInterface-0d7ed370-da01-4f52-bd93-41d350b8b718",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b"
+        },
+        {
+            "spdxElementId": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DifferentiationInterface-a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
+        },
+        {
+            "spdxElementId": "SPDXRef-DifferentiationInterface-a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+        },
+        {
+            "spdxElementId": "SPDXRef-Krylov-ba0b0d4f-ebba-5204-a429-3ac8c609bfb7",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+        },
+        {
+            "spdxElementId": "SPDXRef-EnumX-4e289a0a-7415-4d19-859d-a7e5c4648b56",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+        },
+        {
+            "spdxElementId": "SPDXRef-GPUArraysCore-46192b85-c4d5-4398-a991-12ede77f4527",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+        },
+        {
+            "spdxElementId": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LazyArrays-5078a376-72f3-5289-bfd5-ec5146d43c02"
+        },
+        {
+            "spdxElementId": "SPDXRef-FillArrays-1a297f60-69ca-5386-bcde-b61e274b549b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LazyArrays-5078a376-72f3-5289-bfd5-ec5146d43c02"
+        },
+        {
+            "spdxElementId": "SPDXRef-FillArrays-1a297f60-69ca-5386-bcde-b61e274b549b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-ArrayLayouts-4c555306-a7a7-4459-81d9-ec55ddd5c99a"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayLayouts-4c555306-a7a7-4459-81d9-ec55ddd5c99a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LazyArrays-5078a376-72f3-5289-bfd5-ec5146d43c02"
+        },
+        {
+            "spdxElementId": "SPDXRef-LazyArrays-5078a376-72f3-5289-bfd5-ec5146d43c02",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConcreteStructs-2569d6c7-a4a2-43d3-a901-331e8e4be471",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+        },
+        {
+            "spdxElementId": "SPDXRef-DocStringExtensions-ffbed154-4ef7-542d-bbb7-c09d3a79fcae",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+        },
+        {
+            "spdxElementId": "SPDXRef-Preferences-21216c6a-2e73-6563-6e65-726566657250",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+        },
+        {
+            "spdxElementId": "SPDXRef-Compat-34da2185-b29b-5c13-b0c7-acf172513d20",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-ChainRulesCore-d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+        },
+        {
+            "spdxElementId": "SPDXRef-ChainRulesCore-d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-IntelOpenMP_jll-1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0"
+        },
+        {
+            "spdxElementId": "SPDXRef-87c04cd6024ac13d04b9f0e9695b9dbc54a38511",
+            "relationshipType": "GENERATED_FROM",
+            "relatedSpdxElement": "SPDXRef-f068f7f0488327514de4f7feb9fbdbf935d51754"
+        },
+        {
+            "spdxElementId": "SPDXRef-87c04cd6024ac13d04b9f0e9695b9dbc54a38511",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-IntelOpenMP_jll-1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0"
+        },
+        {
+            "spdxElementId": "SPDXRef-IntelOpenMP_jll-1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MKL_jll-856f044c-d86e-5d09-b602-aeab76dc8ba7"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MKL_jll-856f044c-d86e-5d09-b602-aeab76dc8ba7"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-oneTBB_jll-1317d2d5-d96f-522e-a858-c73665f53c3e"
+        },
+        {
+            "spdxElementId": "SPDXRef-41ef323658240d98dd24a78f07fe284c212fd3fb",
+            "relationshipType": "GENERATED_FROM",
+            "relatedSpdxElement": "SPDXRef-6482ac5f223a8e1799775539a9bb353a4ba882c6"
+        },
+        {
+            "spdxElementId": "SPDXRef-41ef323658240d98dd24a78f07fe284c212fd3fb",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-oneTBB_jll-1317d2d5-d96f-522e-a858-c73665f53c3e"
+        },
+        {
+            "spdxElementId": "SPDXRef-oneTBB_jll-1317d2d5-d96f-522e-a858-c73665f53c3e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MKL_jll-856f044c-d86e-5d09-b602-aeab76dc8ba7"
+        },
+        {
+            "spdxElementId": "SPDXRef-b4be4a930ca1e5fa6ec9e96c45b7420bf1a0b40c",
+            "relationshipType": "GENERATED_FROM",
+            "relatedSpdxElement": "SPDXRef-5120cfdb56bd540d6b656a4139c2f6b8b8168e7b"
+        },
+        {
+            "spdxElementId": "SPDXRef-b4be4a930ca1e5fa6ec9e96c45b7420bf1a0b40c",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MKL_jll-856f044c-d86e-5d09-b602-aeab76dc8ba7"
+        },
+        {
+            "spdxElementId": "SPDXRef-MKL_jll-856f044c-d86e-5d09-b602-aeab76dc8ba7",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+        },
+        {
+            "spdxElementId": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+        },
+        {
+            "spdxElementId": "SPDXRef-Setfield-efcf1570-3423-57d1-acb7-fd33fddbac46",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+        },
+        {
+            "spdxElementId": "SPDXRef-UnPack-3a884ed6-31ef-47d7-9d2a-63182c4928ed",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+        },
+        {
+            "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+        },
+        {
+            "spdxElementId": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConstructionBase-187b0558-2788-49d3-abe0-74a17ed4e7c9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConcreteStructs-2569d6c7-a4a2-43d3-a901-331e8e4be471",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StaticArrays-90137ffa-7385-5640-81b9-e52037218182"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-StaticArrays-90137ffa-7385-5640-81b9-e52037218182"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArrays-90137ffa-7385-5640-81b9-e52037218182",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b"
+        },
+        {
+            "spdxElementId": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SparseMatrixColorings-0a514795-09f3-496d-8182-132a7b665d35"
+        },
+        {
+            "spdxElementId": "SPDXRef-DocStringExtensions-ffbed154-4ef7-542d-bbb7-c09d3a79fcae",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SparseMatrixColorings-0a514795-09f3-496d-8182-132a7b665d35"
+        },
+        {
+            "spdxElementId": "SPDXRef-SparseMatrixColorings-0a514795-09f3-496d-8182-132a7b665d35",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b"
+        },
+        {
+            "spdxElementId": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b"
+        },
+        {
+            "spdxElementId": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqBDF-6ad6398a-0878-4a85-9266-38940aa047c8"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastBroadcast-7034ab61-46d4-4ed7-9d0f-46aef9175898",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqSDIRK-2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+        },
+        {
+            "spdxElementId": "SPDXRef-MuladdMacro-46d2c3a1-f734-5fdb-9937-b9b9aeba4221",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqSDIRK-2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqSDIRK-2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+        },
+        {
+            "spdxElementId": "SPDXRef-TruncatedStacktraces-781d530d-4396-4725-bb49-402e4bee1e77",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqSDIRK-2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqSDIRK-2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqSDIRK-2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+        },
+        {
+            "spdxElementId": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqSDIRK-2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+        },
+        {
+            "spdxElementId": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqSDIRK-2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+        },
+        {
+            "spdxElementId": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqSDIRK-2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
+            "spdxElementId": "SPDXRef-EnzymeCore-f151be2c-9106-41f4-ab19-57ee4f262869",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
+            "spdxElementId": "SPDXRef-ExprTools-e2ba6199-217a-4e67-a87a-7c52f15ade04",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-TimerOutputs-a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
+        },
+        {
+            "spdxElementId": "SPDXRef-TimerOutputs-a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
+            "spdxElementId": "SPDXRef-DifferentiationInterface-a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
+            "spdxElementId": "SPDXRef-DifferentiationInterface-a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLJacobianOperators-19f34311-ddf3-4b8b-af20-060888a46c0e"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastClosures-9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLJacobianOperators-19f34311-ddf3-4b8b-af20-060888a46c0e"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConstructionBase-187b0558-2788-49d3-abe0-74a17ed4e7c9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLJacobianOperators-19f34311-ddf3-4b8b-af20-060888a46c0e"
+        },
+        {
+            "spdxElementId": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLJacobianOperators-19f34311-ddf3-4b8b-af20-060888a46c0e"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConcreteStructs-2569d6c7-a4a2-43d3-a901-331e8e4be471",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLJacobianOperators-19f34311-ddf3-4b8b-af20-060888a46c0e"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLJacobianOperators-19f34311-ddf3-4b8b-af20-060888a46c0e"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLJacobianOperators-19f34311-ddf3-4b8b-af20-060888a46c0e"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLJacobianOperators-19f34311-ddf3-4b8b-af20-060888a46c0e"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLJacobianOperators-19f34311-ddf3-4b8b-af20-060888a46c0e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastClosures-9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
+            "spdxElementId": "SPDXRef-Compat-34da2185-b29b-5c13-b0c7-acf172513d20",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MaybeInplace-bb5d69b7-63fc-4a16-80bd-7e42200c7bdb"
+        },
+        {
+            "spdxElementId": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MaybeInplace-bb5d69b7-63fc-4a16-80bd-7e42200c7bdb"
+        },
+        {
+            "spdxElementId": "SPDXRef-MaybeInplace-bb5d69b7-63fc-4a16-80bd-7e42200c7bdb",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConcreteStructs-2569d6c7-a4a2-43d3-a901-331e8e4be471",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
+            "spdxElementId": "SPDXRef-Preferences-21216c6a-2e73-6563-6e65-726566657250",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
+            "spdxElementId": "SPDXRef-SymbolicIndexingInterface-2efcf032-c050-4f8e-a9bb-153293bab1f5",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
+            "spdxElementId": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
+            "spdxElementId": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
+            "spdxElementId": "SPDXRef-CommonSolve-38540f10-b2f7-11e9-35d8-d573e4eb0ff2",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
+            "spdxElementId": "SPDXRef-Adapt-79e6a3ab-5dfb-504d-930d-738a2a938a0e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
+            "spdxElementId": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114"
+        },
+        {
+            "spdxElementId": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114"
+        },
+        {
+            "spdxElementId": "SPDXRef-MaybeInplace-bb5d69b7-63fc-4a16-80bd-7e42200c7bdb",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConcreteStructs-2569d6c7-a4a2-43d3-a901-331e8e4be471",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114"
+        },
+        {
+            "spdxElementId": "SPDXRef-CommonSolve-38540f10-b2f7-11e9-35d8-d573e4eb0ff2",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114"
+        },
+        {
+            "spdxElementId": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114"
+        },
+        {
+            "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114"
+        },
+        {
+            "spdxElementId": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-FiniteDiff-6a86dc24-6348-571c-b903-95158fe2bd41",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-BracketingNonlinearSolve-70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConcreteStructs-2569d6c7-a4a2-43d3-a901-331e8e4be471",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-BracketingNonlinearSolve-70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
+        },
+        {
+            "spdxElementId": "SPDXRef-CommonSolve-38540f10-b2f7-11e9-35d8-d573e4eb0ff2",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-BracketingNonlinearSolve-70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-BracketingNonlinearSolve-70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
+        },
+        {
+            "spdxElementId": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-BracketingNonlinearSolve-70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
+        },
+        {
+            "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-BracketingNonlinearSolve-70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
+        },
+        {
+            "spdxElementId": "SPDXRef-BracketingNonlinearSolve-70df07ce-3d50-431d-a3e7-ca6ddb60ac1e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-DifferentiationInterface-a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-FiniteDiff-6a86dc24-6348-571c-b903-95158fe2bd41",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-BracketingNonlinearSolve-70df07ce-3d50-431d-a3e7-ca6ddb60ac1e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-DifferentiationInterface-a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastClosures-9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastClosures-9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LineSearch-87fe0de2-c867-4266-b59a-2f0a94fc965b"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LineSearch-87fe0de2-c867-4266-b59a-2f0a94fc965b"
+        },
+        {
+            "spdxElementId": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LineSearch-87fe0de2-c867-4266-b59a-2f0a94fc965b"
+        },
+        {
+            "spdxElementId": "SPDXRef-MaybeInplace-bb5d69b7-63fc-4a16-80bd-7e42200c7bdb",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LineSearch-87fe0de2-c867-4266-b59a-2f0a94fc965b"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConcreteStructs-2569d6c7-a4a2-43d3-a901-331e8e4be471",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LineSearch-87fe0de2-c867-4266-b59a-2f0a94fc965b"
+        },
+        {
+            "spdxElementId": "SPDXRef-CommonSolve-38540f10-b2f7-11e9-35d8-d573e4eb0ff2",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LineSearch-87fe0de2-c867-4266-b59a-2f0a94fc965b"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LineSearch-87fe0de2-c867-4266-b59a-2f0a94fc965b"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLJacobianOperators-19f34311-ddf3-4b8b-af20-060888a46c0e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LineSearch-87fe0de2-c867-4266-b59a-2f0a94fc965b"
+        },
+        {
+            "spdxElementId": "SPDXRef-LineSearch-87fe0de2-c867-4266-b59a-2f0a94fc965b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-MaybeInplace-bb5d69b7-63fc-4a16-80bd-7e42200c7bdb",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConcreteStructs-2569d6c7-a4a2-43d3-a901-331e8e4be471",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-Setfield-efcf1570-3423-57d1-acb7-fd33fddbac46",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-CommonSolve-38540f10-b2f7-11e9-35d8-d573e4eb0ff2",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7"
+        },
+        {
+            "spdxElementId": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastClosures-9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveSpectralMethods-26075421-4e9a-44e1-8bd1-420ed7ad02b2"
+        },
+        {
+            "spdxElementId": "SPDXRef-LineSearch-87fe0de2-c867-4266-b59a-2f0a94fc965b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveSpectralMethods-26075421-4e9a-44e1-8bd1-420ed7ad02b2"
+        },
+        {
+            "spdxElementId": "SPDXRef-MaybeInplace-bb5d69b7-63fc-4a16-80bd-7e42200c7bdb",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveSpectralMethods-26075421-4e9a-44e1-8bd1-420ed7ad02b2"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConcreteStructs-2569d6c7-a4a2-43d3-a901-331e8e4be471",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveSpectralMethods-26075421-4e9a-44e1-8bd1-420ed7ad02b2"
+        },
+        {
+            "spdxElementId": "SPDXRef-CommonSolve-38540f10-b2f7-11e9-35d8-d573e4eb0ff2",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveSpectralMethods-26075421-4e9a-44e1-8bd1-420ed7ad02b2"
+        },
+        {
+            "spdxElementId": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveSpectralMethods-26075421-4e9a-44e1-8bd1-420ed7ad02b2"
+        },
+        {
+            "spdxElementId": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveSpectralMethods-26075421-4e9a-44e1-8bd1-420ed7ad02b2"
+        },
+        {
+            "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveSpectralMethods-26075421-4e9a-44e1-8bd1-420ed7ad02b2"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveSpectralMethods-26075421-4e9a-44e1-8bd1-420ed7ad02b2"
+        },
+        {
+            "spdxElementId": "SPDXRef-NonlinearSolveSpectralMethods-26075421-4e9a-44e1-8bd1-420ed7ad02b2",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-LineSearch-87fe0de2-c867-4266-b59a-2f0a94fc965b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConcreteStructs-2569d6c7-a4a2-43d3-a901-331e8e4be471",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+        },
+        {
+            "spdxElementId": "SPDXRef-FiniteDiff-6a86dc24-6348-571c-b903-95158fe2bd41",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+        },
+        {
+            "spdxElementId": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+        },
+        {
+            "spdxElementId": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLJacobianOperators-19f34311-ddf3-4b8b-af20-060888a46c0e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+        },
+        {
+            "spdxElementId": "SPDXRef-LineSearch-87fe0de2-c867-4266-b59a-2f0a94fc965b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+        },
+        {
+            "spdxElementId": "SPDXRef-MaybeInplace-bb5d69b7-63fc-4a16-80bd-7e42200c7bdb",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConcreteStructs-2569d6c7-a4a2-43d3-a901-331e8e4be471",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+        },
+        {
+            "spdxElementId": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+        },
+        {
+            "spdxElementId": "SPDXRef-Setfield-efcf1570-3423-57d1-acb7-fd33fddbac46",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+        },
+        {
+            "spdxElementId": "SPDXRef-CommonSolve-38540f10-b2f7-11e9-35d8-d573e4eb0ff2",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+        },
+        {
+            "spdxElementId": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+        },
+        {
+            "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
+        },
+        {
+            "spdxElementId": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-Preferences-21216c6a-2e73-6563-6e65-726566657250",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-SymbolicIndexingInterface-2efcf032-c050-4f8e-a9bb-153293bab1f5",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-SparseMatrixColorings-0a514795-09f3-496d-8182-132a7b665d35",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-CommonSolve-38540f10-b2f7-11e9-35d8-d573e4eb0ff2",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
+        },
+        {
+            "spdxElementId": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+        },
+        {
+            "spdxElementId": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastBroadcast-7034ab61-46d4-4ed7-9d0f-46aef9175898",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+        },
+        {
+            "spdxElementId": "SPDXRef-MuladdMacro-46d2c3a1-f734-5fdb-9937-b9b9aeba4221",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+        },
+        {
+            "spdxElementId": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+        },
+        {
+            "spdxElementId": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastClosures-9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArrays-90137ffa-7385-5640-81b9-e52037218182",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+        },
+        {
+            "spdxElementId": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+        },
+        {
+            "spdxElementId": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+        },
+        {
+            "spdxElementId": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-PreallocationTools-d236fae5-4411-538c-8e31-a6e3d9e00b46"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-PreallocationTools-d236fae5-4411-538c-8e31-a6e3d9e00b46"
+        },
+        {
+            "spdxElementId": "SPDXRef-Adapt-79e6a3ab-5dfb-504d-930d-738a2a938a0e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-PreallocationTools-d236fae5-4411-538c-8e31-a6e3d9e00b46"
+        },
+        {
+            "spdxElementId": "SPDXRef-PreallocationTools-d236fae5-4411-538c-8e31-a6e3d9e00b46",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+        },
+        {
+            "spdxElementId": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLStructures-53ae85a6-f571-4167-b2af-e1d143709226",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqSDIRK-2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+        },
+        {
+            "spdxElementId": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqSDIRK-2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+        },
+        {
+            "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqSDIRK-2d112036-d095-4a1e-ab9a-08536f3ecdbf"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrdinaryDiffEqSDIRK-2d112036-d095-4a1e-ab9a-08536f3ecdbf",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqBDF-6ad6398a-0878-4a85-9266-38940aa047c8"
+        },
+        {
+            "spdxElementId": "SPDXRef-TruncatedStacktraces-781d530d-4396-4725-bb49-402e4bee1e77",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqBDF-6ad6398a-0878-4a85-9266-38940aa047c8"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqBDF-6ad6398a-0878-4a85-9266-38940aa047c8"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqBDF-6ad6398a-0878-4a85-9266-38940aa047c8"
+        },
+        {
+            "spdxElementId": "SPDXRef-Preferences-21216c6a-2e73-6563-6e65-726566657250",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqBDF-6ad6398a-0878-4a85-9266-38940aa047c8"
+        },
+        {
+            "spdxElementId": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqBDF-6ad6398a-0878-4a85-9266-38940aa047c8"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArrays-90137ffa-7385-5640-81b9-e52037218182",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqBDF-6ad6398a-0878-4a85-9266-38940aa047c8"
+        },
+        {
+            "spdxElementId": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqBDF-6ad6398a-0878-4a85-9266-38940aa047c8"
+        },
+        {
+            "spdxElementId": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqBDF-6ad6398a-0878-4a85-9266-38940aa047c8"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqBDF-6ad6398a-0878-4a85-9266-38940aa047c8"
+        },
+        {
+            "spdxElementId": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqBDF-6ad6398a-0878-4a85-9266-38940aa047c8"
+        },
+        {
+            "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqBDF-6ad6398a-0878-4a85-9266-38940aa047c8"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-JuMP-4076af6c-e467-56ae-b986-b466b2749572"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrderedCollections-bac558e1-5e72-5ebc-8fee-abe8a469f55d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-JuMP-4076af6c-e467-56ae-b986-b466b2749572"
+        },
+        {
+            "spdxElementId": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-JuMP-4076af6c-e467-56ae-b986-b466b2749572"
+        },
+        {
+            "spdxElementId": "SPDXRef-MutableArithmetics-d8a4904e-b15c-11e9-3269-09a3773c0cb0",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-JuMP-4076af6c-e467-56ae-b986-b466b2749572"
+        },
+        {
+            "spdxElementId": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-JuMP-4076af6c-e467-56ae-b986-b466b2749572"
+        },
+        {
+            "spdxElementId": "SPDXRef-Compat-34da2185-b29b-5c13-b0c7-acf172513d20",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Mocking-78c3b35d-d492-501b-9361-3d52fe80e533"
+        },
+        {
+            "spdxElementId": "SPDXRef-ExprTools-e2ba6199-217a-4e67-a87a-7c52f15ade04",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Mocking-78c3b35d-d492-501b-9361-3d52fe80e533"
+        },
+        {
+            "spdxElementId": "SPDXRef-Mocking-78c3b35d-d492-501b-9361-3d52fe80e533",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-TimeZones-f269a46b-ccf7-5d73-abea-4c690281aa53"
+        },
+        {
+            "spdxElementId": "SPDXRef-a2939c302ec6f8c6eeb94e4734c96b162e1ff7b5",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-TZJData-dc5dba14-91b3-4cab-a142-028a31da12f7"
+        },
+        {
+            "spdxElementId": "SPDXRef-TZJData-dc5dba14-91b3-4cab-a142-028a31da12f7",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-TimeZones-f269a46b-ccf7-5d73-abea-4c690281aa53"
+        },
+        {
+            "spdxElementId": "SPDXRef-Scratch-6c6a2e73-6563-6170-7368-637461726353",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-TimeZones-f269a46b-ccf7-5d73-abea-4c690281aa53"
+        },
+        {
+            "spdxElementId": "SPDXRef-InlineStrings-842dd82b-1e85-43dc-bf29-5d0ee9dffc48",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-TimeZones-f269a46b-ccf7-5d73-abea-4c690281aa53"
+        },
+        {
+            "spdxElementId": "SPDXRef-TimeZones-f269a46b-ccf7-5d73-abea-4c690281aa53",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Arrow-69666777-d1a9-59fb-9406-91d4454c9d45"
+        },
+        {
+            "spdxElementId": "SPDXRef-BitIntegers-c3b6d118-76ef-56ca-8cc7-ebb389d030a1",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Arrow-69666777-d1a9-59fb-9406-91d4454c9d45"
+        },
+        {
+            "spdxElementId": "SPDXRef-DataAPI-9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-PooledArrays-2dfb63ee-cc39-5dd5-95bd-886bf059d720"
+        },
+        {
+            "spdxElementId": "SPDXRef-PooledArrays-2dfb63ee-cc39-5dd5-95bd-886bf059d720",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Arrow-69666777-d1a9-59fb-9406-91d4454c9d45"
+        },
+        {
+            "spdxElementId": "SPDXRef-EnumX-4e289a0a-7415-4d19-859d-a7e5c4648b56",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Arrow-69666777-d1a9-59fb-9406-91d4454c9d45"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrowTypes-31f734f8-188a-4ce0-8406-c8a06bd891cd",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Arrow-69666777-d1a9-59fb-9406-91d4454c9d45"
+        },
+        {
+            "spdxElementId": "SPDXRef-TranscodingStreams-3bb67fe8-82b1-5028-8e26-92a6c54297fa",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-CodecZstd-6b39b394-51ab-5f42-8807-6242bab2b4c2"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Zstd_jll-3161d3a3-bdf6-5164-811a-617609db77b4"
+        },
+        {
+            "spdxElementId": "SPDXRef-8e19ee77a5aed0ac3f6828efb9671b8c619cd27b",
+            "relationshipType": "GENERATED_FROM",
+            "relatedSpdxElement": "SPDXRef-dbd764b283c2da22563bb2d2a1fe82107a7808c2"
+        },
+        {
+            "spdxElementId": "SPDXRef-8e19ee77a5aed0ac3f6828efb9671b8c619cd27b",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Zstd_jll-3161d3a3-bdf6-5164-811a-617609db77b4"
+        },
+        {
+            "spdxElementId": "SPDXRef-Zstd_jll-3161d3a3-bdf6-5164-811a-617609db77b4",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-CodecZstd-6b39b394-51ab-5f42-8807-6242bab2b4c2"
+        },
+        {
+            "spdxElementId": "SPDXRef-CodecZstd-6b39b394-51ab-5f42-8807-6242bab2b4c2",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Arrow-69666777-d1a9-59fb-9406-91d4454c9d45"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConcurrentUtilities-f0e56b4a-5159-44fe-b623-3e5288b988bb",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Arrow-69666777-d1a9-59fb-9406-91d4454c9d45"
+        },
+        {
+            "spdxElementId": "SPDXRef-Tables-bd369af6-aec1-5ad0-b16a-f7cc5008161c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Arrow-69666777-d1a9-59fb-9406-91d4454c9d45"
+        },
+        {
+            "spdxElementId": "SPDXRef-DataAPI-9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Arrow-69666777-d1a9-59fb-9406-91d4454c9d45"
+        },
+        {
+            "spdxElementId": "SPDXRef-StringViews-354b36f9-a18e-4713-926e-db85100087ba",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Arrow-69666777-d1a9-59fb-9406-91d4454c9d45"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLLWrappers-692b3bcd-3c85-4b1f-b108-f13ce0eb3210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Lz4_jll-5ced341a-0733-55b8-9ab6-a4889d929147"
+        },
+        {
+            "spdxElementId": "SPDXRef-fb31c14fc601537fb564f393a63b7e3707c1173e",
+            "relationshipType": "GENERATED_FROM",
+            "relatedSpdxElement": "SPDXRef-97c36a2efda61823ec3546cadf43c9298c8dd403"
+        },
+        {
+            "spdxElementId": "SPDXRef-fb31c14fc601537fb564f393a63b7e3707c1173e",
+            "relationshipType": "RUNTIME_DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Lz4_jll-5ced341a-0733-55b8-9ab6-a4889d929147"
+        },
+        {
+            "spdxElementId": "SPDXRef-Lz4_jll-5ced341a-0733-55b8-9ab6-a4889d929147",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-CodecLz4-5ba52731-8f18-5e0d-9241-30f10d1ec561"
+        },
+        {
+            "spdxElementId": "SPDXRef-TranscodingStreams-3bb67fe8-82b1-5028-8e26-92a6c54297fa",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-CodecLz4-5ba52731-8f18-5e0d-9241-30f10d1ec561"
+        },
+        {
+            "spdxElementId": "SPDXRef-CodecLz4-5ba52731-8f18-5e0d-9241-30f10d1ec561",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Arrow-69666777-d1a9-59fb-9406-91d4454c9d45"
+        },
+        {
+            "spdxElementId": "SPDXRef-TranscodingStreams-3bb67fe8-82b1-5028-8e26-92a6c54297fa",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Arrow-69666777-d1a9-59fb-9406-91d4454c9d45"
+        },
+        {
+            "spdxElementId": "SPDXRef-SentinelArrays-91c51154-3ec4-41a3-a24f-3f23e20d615c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Arrow-69666777-d1a9-59fb-9406-91d4454c9d45"
+        },
+        {
+            "spdxElementId": "SPDXRef-Statistics-10745b16-79ce-11e8-11f9-7d13ad32a3b2",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Graphs-86223c79-3864-5bf0-83f7-82e725a168b6"
+        },
+        {
+            "spdxElementId": "SPDXRef-Inflate-d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Graphs-86223c79-3864-5bf0-83f7-82e725a168b6"
+        },
+        {
+            "spdxElementId": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SimpleTraits-699a6c99-e7fa-54fc-8d76-47d257e15c1d"
+        },
+        {
+            "spdxElementId": "SPDXRef-SimpleTraits-699a6c99-e7fa-54fc-8d76-47d257e15c1d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Graphs-86223c79-3864-5bf0-83f7-82e725a168b6"
+        },
+        {
+            "spdxElementId": "SPDXRef-DataStructures-864edb3b-99cc-5e75-8d2d-829cb0a9cfe8",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Graphs-86223c79-3864-5bf0-83f7-82e725a168b6"
+        },
+        {
+            "spdxElementId": "SPDXRef-Compat-34da2185-b29b-5c13-b0c7-acf172513d20",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Graphs-86223c79-3864-5bf0-83f7-82e725a168b6"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArrays-90137ffa-7385-5640-81b9-e52037218182",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-ArnoldiMethod-ec485272-7323-5ecc-a04f-4719b315124d"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArnoldiMethod-ec485272-7323-5ecc-a04f-4719b315124d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Graphs-86223c79-3864-5bf0-83f7-82e725a168b6"
+        },
+        {
+            "spdxElementId": "SPDXRef-Parameters-d96e819e-fc66-5662-9728-84c9c7592b0a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LineSearches-d3d80556-e9d4-5f37-9878-2ab0fcc64255"
+        },
+        {
+            "spdxElementId": "SPDXRef-DifferentiationInterface-a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NLSolversBase-d41bc354-129a-5804-8e4c-c37616107c6c"
+        },
+        {
+            "spdxElementId": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NLSolversBase-d41bc354-129a-5804-8e4c-c37616107c6c"
+        },
+        {
+            "spdxElementId": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NLSolversBase-d41bc354-129a-5804-8e4c-c37616107c6c"
+        },
+        {
+            "spdxElementId": "SPDXRef-FiniteDiff-6a86dc24-6348-571c-b903-95158fe2bd41",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NLSolversBase-d41bc354-129a-5804-8e4c-c37616107c6c"
+        },
+        {
+            "spdxElementId": "SPDXRef-NLSolversBase-d41bc354-129a-5804-8e4c-c37616107c6c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LineSearches-d3d80556-e9d4-5f37-9878-2ab0fcc64255"
+        },
+        {
+            "spdxElementId": "SPDXRef-NaNMath-77ba4419-2d1f-58cd-9bb1-8ffee604a2e3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LineSearches-d3d80556-e9d4-5f37-9878-2ab0fcc64255"
+        },
+        {
+            "spdxElementId": "SPDXRef-ExproniconLite-55351af7-c7e9-48d6-89ff-24e801d99491",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Configurations-5218b696-f38b-4ac9-8b61-a12ec717816d"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrderedCollections-bac558e1-5e72-5ebc-8fee-abe8a469f55d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Configurations-5218b696-f38b-4ac9-8b61-a12ec717816d"
+        },
+        {
+            "spdxElementId": "SPDXRef-Graphs-86223c79-3864-5bf0-83f7-82e725a168b6",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MetaGraphsNext-fa8bd995-216d-47f1-8a91-f3b68fbeb377"
+        },
+        {
+            "spdxElementId": "SPDXRef-Requires-ae029012-a4dd-5104-9daa-d747884805df",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-FileIO-5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+        },
+        {
+            "spdxElementId": "SPDXRef-FileIO-5789e2e9-d7fb-5bc7-8068-2c6fae9b9549",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-JLD2-033835bb-8acc-5ee8-8aae-3f567f8a3819"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-JLD2-033835bb-8acc-5ee8-8aae-3f567f8a3819"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrderedCollections-bac558e1-5e72-5ebc-8fee-abe8a469f55d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-JLD2-033835bb-8acc-5ee8-8aae-3f567f8a3819"
+        },
+        {
+            "spdxElementId": "SPDXRef-TranscodingStreams-3bb67fe8-82b1-5028-8e26-92a6c54297fa",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-JLD2-033835bb-8acc-5ee8-8aae-3f567f8a3819"
+        },
+        {
+            "spdxElementId": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-JLD2-033835bb-8acc-5ee8-8aae-3f567f8a3819"
+        },
+        {
+            "spdxElementId": "SPDXRef-JLD2-033835bb-8acc-5ee8-8aae-3f567f8a3819",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MetaGraphsNext-fa8bd995-216d-47f1-8a91-f3b68fbeb377"
+        },
+        {
+            "spdxElementId": "SPDXRef-SimpleTraits-699a6c99-e7fa-54fc-8d76-47d257e15c1d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MetaGraphsNext-fa8bd995-216d-47f1-8a91-f3b68fbeb377"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqLowOrderRK-1344f307-1e59-4825-a18e-ace9aa3fa4c6"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastBroadcast-7034ab61-46d4-4ed7-9d0f-46aef9175898",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqLowOrderRK-1344f307-1e59-4825-a18e-ace9aa3fa4c6"
+        },
+        {
+            "spdxElementId": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqLowOrderRK-1344f307-1e59-4825-a18e-ace9aa3fa4c6"
+        },
+        {
+            "spdxElementId": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqLowOrderRK-1344f307-1e59-4825-a18e-ace9aa3fa4c6"
+        },
+        {
+            "spdxElementId": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqLowOrderRK-1344f307-1e59-4825-a18e-ace9aa3fa4c6"
+        },
+        {
+            "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqLowOrderRK-1344f307-1e59-4825-a18e-ace9aa3fa4c6"
+        },
+        {
+            "spdxElementId": "SPDXRef-MuladdMacro-46d2c3a1-f734-5fdb-9937-b9b9aeba4221",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqLowOrderRK-1344f307-1e59-4825-a18e-ace9aa3fa4c6"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqLowOrderRK-1344f307-1e59-4825-a18e-ace9aa3fa4c6"
+        },
+        {
+            "spdxElementId": "SPDXRef-ProgressLogging-33c8b6b6-d38a-422a-b730-caa89a2f386c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-TerminalLoggers-5d786b92-1e48-4d6f-9151-6b4477ca9bed"
+        },
+        {
+            "spdxElementId": "SPDXRef-AbstractTrees-1520ce14-60c1-5f80-bbc7-55ef81b5835c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-LeftChildRightSiblingTrees-1d6d02ad-be62-4b6b-8a6d-2f90e265016e"
+        },
+        {
+            "spdxElementId": "SPDXRef-LeftChildRightSiblingTrees-1d6d02ad-be62-4b6b-8a6d-2f90e265016e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-TerminalLoggers-5d786b92-1e48-4d6f-9151-6b4477ca9bed"
+        },
+        {
+            "spdxElementId": "SPDXRef-RecipesBase-3cdcf5f2-1ef4-517c-9805-6587b60abb01",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DataInterpolations-82cc6244-b520-54b8-b5a6-8a565e85f1d0"
+        },
+        {
+            "spdxElementId": "SPDXRef-EnumX-4e289a0a-7415-4d19-859d-a7e5c4648b56",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DataInterpolations-82cc6244-b520-54b8-b5a6-8a565e85f1d0"
+        },
+        {
+            "spdxElementId": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DataInterpolations-82cc6244-b520-54b8-b5a6-8a565e85f1d0"
+        },
+        {
+            "spdxElementId": "SPDXRef-FindFirstFunctions-64ca27bc-2ba2-4a57-88aa-44e436879224",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DataInterpolations-82cc6244-b520-54b8-b5a6-8a565e85f1d0"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrettyTables-08abe8d2-0d0c-5749-adfa-8a2ac140af0d",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DataInterpolations-82cc6244-b520-54b8-b5a6-8a565e85f1d0"
+        },
+        {
+            "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DataInterpolations-82cc6244-b520-54b8-b5a6-8a565e85f1d0"
+        },
+        {
+            "spdxElementId": "SPDXRef-Arrow-69666777-d1a9-59fb-9406-91d4454c9d45",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Legolas-741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
+        },
+        {
+            "spdxElementId": "SPDXRef-Tables-bd369af6-aec1-5ad0-b16a-f7cc5008161c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Legolas-741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
+        },
+        {
+            "spdxElementId": "SPDXRef-ArrowTypes-31f734f8-188a-4ce0-8406-c8a06bd891cd",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Legolas-741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqCallbacks-459566f4-90b8-5000-8ac3-15dfb0a30def"
+        },
+        {
+            "spdxElementId": "SPDXRef-DifferentiationInterface-a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqCallbacks-459566f4-90b8-5000-8ac3-15dfb0a30def"
+        },
+        {
+            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqCallbacks-459566f4-90b8-5000-8ac3-15dfb0a30def"
+        },
+        {
+            "spdxElementId": "SPDXRef-DataStructures-864edb3b-99cc-5e75-8d2d-829cb0a9cfe8",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqCallbacks-459566f4-90b8-5000-8ac3-15dfb0a30def"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConcreteStructs-2569d6c7-a4a2-43d3-a901-331e8e4be471",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqCallbacks-459566f4-90b8-5000-8ac3-15dfb0a30def"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConstructionBase-187b0558-2788-49d3-abe0-74a17ed4e7c9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Functors-d9f16b24-f501-4c13-a1f2-28368ffc5196"
+        },
+        {
+            "spdxElementId": "SPDXRef-Compat-34da2185-b29b-5c13-b0c7-acf172513d20",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Functors-d9f16b24-f501-4c13-a1f2-28368ffc5196"
+        },
+        {
+            "spdxElementId": "SPDXRef-Functors-d9f16b24-f501-4c13-a1f2-28368ffc5196",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqCallbacks-459566f4-90b8-5000-8ac3-15dfb0a30def"
+        },
+        {
+            "spdxElementId": "SPDXRef-RecipesBase-3cdcf5f2-1ef4-517c-9805-6587b60abb01",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqCallbacks-459566f4-90b8-5000-8ac3-15dfb0a30def"
+        },
+        {
+            "spdxElementId": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqCallbacks-459566f4-90b8-5000-8ac3-15dfb0a30def"
+        },
+        {
+            "spdxElementId": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiffEqCallbacks-459566f4-90b8-5000-8ac3-15dfb0a30def"
+        },
+        {
+            "spdxElementId": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce"
+        },
+        {
+            "spdxElementId": "SPDXRef-FastBroadcast-7034ab61-46d4-4ed7-9d0f-46aef9175898",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce"
+        },
+        {
+            "spdxElementId": "SPDXRef-FiniteDiff-6a86dc24-6348-571c-b903-95158fe2bd41",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce"
+        },
+        {
+            "spdxElementId": "SPDXRef-MuladdMacro-46d2c3a1-f734-5fdb-9937-b9b9aeba4221",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce"
+        },
+        {
+            "spdxElementId": "SPDXRef-DifferentiationInterface-a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce"
+        },
+        {
+            "spdxElementId": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce"
+        },
+        {
+            "spdxElementId": "SPDXRef-Polyester-f517fe37-dbe3-4b94-8317-1923a5111588",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce"
+        },
+        {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce"
+        },
+        {
+            "spdxElementId": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce"
+        },
+        {
+            "spdxElementId": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce"
+        },
+        {
+            "spdxElementId": "SPDXRef-Preferences-21216c6a-2e73-6563-6e65-726566657250",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce"
+        },
+        {
+            "spdxElementId": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce"
+        },
+        {
+            "spdxElementId": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce"
+        },
+        {
+            "spdxElementId": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce"
+        },
+        {
+            "spdxElementId": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce"
+        },
+        {
+            "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce"
+        }
+    ],
+    "documentDescribes": [
+        "SPDXRef-Accessors-7d9f7c33-5ae7-4f3b-8dc6-eff91059b697",
+        "SPDXRef-HiGHS-87dc4568-4c63-4d18-b0c0-bb2238e4078b",
+        "SPDXRef-OrdinaryDiffEqTsit5-b1df2697-797e-41e3-8120-5422d3b24e4a",
+        "SPDXRef-SQLite-0aa819cd-b072-5ff4-a722-6bc24af294d9",
+        "SPDXRef-StructArrays-09ab397b-f2b6-538f-b94a-2f83cf4a842a",
+        "SPDXRef-SparseConnectivityTracer-9f842d2f-2579-4b1d-911e-f412cf18a3f5",
+        "SPDXRef-BasicModelInterface-59605e27-edc0-445a-b93d-c09a3a50b330",
+        "SPDXRef-FiniteDiff-6a86dc24-6348-571c-b903-95158fe2bd41",
+        "SPDXRef-OrdinaryDiffEqBDF-6ad6398a-0878-4a85-9266-38940aa047c8",
+        "SPDXRef-JuMP-4076af6c-e467-56ae-b986-b466b2749572",
+        "SPDXRef-Arrow-69666777-d1a9-59fb-9406-91d4454c9d45",
+        "SPDXRef-DifferentiationInterface-a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63",
+        "SPDXRef-Graphs-86223c79-3864-5bf0-83f7-82e725a168b6",
+        "SPDXRef-EnumX-4e289a0a-7415-4d19-859d-a7e5c4648b56",
+        "SPDXRef-IterTools-c8e1da08-722c-5040-9ed9-7db0dc04731e",
+        "SPDXRef-LineSearches-d3d80556-e9d4-5f37-9878-2ab0fcc64255",
+        "SPDXRef-Configurations-5218b696-f38b-4ac9-8b61-a12ec717816d",
+        "SPDXRef-DBInterface-a10d1c49-ce27-4219-8d33-6db1a4562965",
+        "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae",
+        "SPDXRef-LoggingExtras-e6f89c97-d47a-5376-807f-9c37f3926c36",
+        "SPDXRef-OrdinaryDiffEqSDIRK-2d112036-d095-4a1e-ab9a-08536f3ecdbf",
+        "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
+        "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8",
+        "SPDXRef-MetaGraphsNext-fa8bd995-216d-47f1-8a91-f3b68fbeb377",
+        "SPDXRef-CodecZstd-6b39b394-51ab-5f42-8807-6242bab2b4c2",
+        "SPDXRef-DataStructures-864edb3b-99cc-5e75-8d2d-829cb0a9cfe8",
+        "SPDXRef-Tables-bd369af6-aec1-5ad0-b16a-f7cc5008161c",
+        "SPDXRef-OrdinaryDiffEqLowOrderRK-1344f307-1e59-4825-a18e-ace9aa3fa4c6",
+        "SPDXRef-TerminalLoggers-5d786b92-1e48-4d6f-9151-6b4477ca9bed",
+        "SPDXRef-DataInterpolations-82cc6244-b520-54b8-b5a6-8a565e85f1d0",
+        "SPDXRef-Legolas-741b9549-f6ed-4911-9fbf-4a1c0c97f0cd",
+        "SPDXRef-DiffEqCallbacks-459566f4-90b8-5000-8ac3-15dfb0a30def",
+        "SPDXRef-SparseMatrixColorings-0a514795-09f3-496d-8182-132a7b665d35",
+        "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
+        "SPDXRef-OrdinaryDiffEqNonlinearSolve-127b3ac7-2247-4354-8eb6-78cf4e7c58e8",
+        "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce",
+        "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
+        "SPDXRef-TranscodingStreams-3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+    ]
+}

--- a/pixi.toml
+++ b/pixi.toml
@@ -29,13 +29,14 @@ install = { depends-on = [
     "install-pre-commit",
 ] }
 # Julia
-update-registry-julia = { cmd = "julia --eval='using Pkg; Registry.update()'"}
-update-manifest-julia = { cmd = "julia --project utils/update-manifest.jl"}
-instantiate-julia = { cmd = "julia --project --eval='using Pkg; Pkg.instantiate()'"}
+update-registry-julia = { cmd = "julia --eval='using Pkg; Registry.update()'" }
+update-manifest-julia = { cmd = "julia --project utils/update-manifest.jl" }
+instantiate-julia = { cmd = "julia --project --eval='using Pkg; Pkg.instantiate()'" }
 initialize-julia = { depends-on = [
     "update-registry-julia",
     "instantiate-julia",
 ] }
+generate-sbom-ribasim-core = { cmd = "julia --project -- utils/generate-sbom.jl" }
 # Docs
 quartodoc-build = { cmd = "quartodoc build && rm objects.json", cwd = "docs", inputs = [
     "docs/_quarto.yml",

--- a/pixi.toml
+++ b/pixi.toml
@@ -36,7 +36,13 @@ initialize-julia = { depends-on = [
     "update-registry-julia",
     "instantiate-julia",
 ] }
-generate-sbom-ribasim-core = { cmd = "julia --project -- utils/generate-sbom.jl" }
+generate-sbom-ribasim-core = { cmd = "julia --project -- utils/generate-sbom.jl", depends-on = [
+    "instantiate-julia",
+], inputs = [
+    "core/Project.toml",
+], outputs = [
+    "Ribasim.spdx.json",
+] }
 # Docs
 quartodoc-build = { cmd = "quartodoc build && rm objects.json", cwd = "docs", inputs = [
     "docs/_quarto.yml",

--- a/utils/generate-sbom.jl
+++ b/utils/generate-sbom.jl
@@ -1,0 +1,30 @@
+using PkgToSoftwareBOM
+using UUIDs
+using Pkg
+
+Pkg.activate("core")
+
+myLicense = SpdxLicenseExpressionV2("MIT")
+myOrg = SpdxCreatorV2("Organization", "Deltares", "software@deltares.nl")
+myPackage_instr = spdxPackageInstructions(;
+    spdxfile_toexclude = ["Ribasim.spdx.json"],
+    originator = myOrg,  # Could be myOrg if appropriate
+    declaredLicense = myLicense,
+    copyright = "Copyright (c) 2025 Deltares <software@deltares.nl>",
+    name = "Ribasim",
+)
+
+active_pkgs = Pkg.project().dependencies;
+spdxData = spdxCreationData(;
+    Name = "Ribasim.jl",
+    Creators = [myOrg],
+    NamespaceURL = "https://github.com/Deltares/Ribasim/Ribasim.spdx.json",
+    rootpackages = active_pkgs,
+    find_artifactsource = true,
+    packageInstructions = Dict{UUID, spdxPackageInstructions}(
+        Pkg.project().uuid => myPackage_instr,
+    ),
+)
+
+sbom = generateSPDX(spdxData)
+writespdx(sbom, "Ribasim.spdx.json")

--- a/utils/generate-sbom.jl
+++ b/utils/generate-sbom.jl
@@ -4,25 +4,25 @@ using Pkg
 
 Pkg.activate("core")
 
-myLicense = SpdxLicenseExpressionV2("MIT")
-myOrg = SpdxCreatorV2("Organization", "Deltares", "software@deltares.nl")
-myPackage_instr = spdxPackageInstructions(;
+ribasimLicense = SpdxLicenseExpressionV2("MIT")
+organization = SpdxCreatorV2("Organization", "Deltares", "software@deltares.nl")
+packageInstructions = spdxPackageInstructions(;
     spdxfile_toexclude = ["Ribasim.spdx.json"],
-    originator = myOrg,  # Could be myOrg if appropriate
-    declaredLicense = myLicense,
+    originator = organization,
+    declaredLicense = ribasimLicense,
     copyright = "Copyright (c) 2025 Deltares <software@deltares.nl>",
     name = "Ribasim",
 )
 
-active_pkgs = Pkg.project().dependencies;
+dependencies = Pkg.project().dependencies;
 spdxData = spdxCreationData(;
     Name = "Ribasim.jl",
-    Creators = [myOrg],
+    Creators = [organization],
     NamespaceURL = "https://github.com/Deltares/Ribasim/Ribasim.spdx.json",
-    rootpackages = active_pkgs,
+    rootpackages = dependencies,
     find_artifactsource = true,
     packageInstructions = Dict{UUID, spdxPackageInstructions}(
-        Pkg.project().uuid => myPackage_instr,
+        Pkg.project().uuid => packageInstructions,
     ),
 )
 


### PR DESCRIPTION
Add task `generate-sbom-ribasim-core`
Add package `PkgToSoftwareBOM`
Add Ribasim.spdx.json, which is the output of the task.

We could connect this task to when the Julia packages get updated, so that the SBOM is always up-to-date with the manifest.toml