### PR TITLE
QGIS reload Ribasim model

### DIFF
--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -296,8 +296,10 @@ class DatasetWidget(QWidget):
         self.dataset_tree.clear()
         geo_path = get_database_path_from_model_file(self.path)
         nodes = load_nodes_from_geopackage(geo_path)
-
-        self.ribasim_widget.create_groups(self.path.with_suffix("").as_posix())
+        
+        name = self.path.stem
+        parent = self.path.parent.stem
+        self.ribasim_widget.create_groups(f"{parent}/{name}")
 
         # Make sure "Node", "Link", "Basin / area" are the top three layers
         node = nodes.pop("Node")

--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -296,7 +296,7 @@ class DatasetWidget(QWidget):
         self.dataset_tree.clear()
         geo_path = get_database_path_from_model_file(self.path)
         nodes = load_nodes_from_geopackage(geo_path)
-        
+
         name = self.path.stem
         parent = self.path.parent.stem
         self.ribasim_widget.create_groups(f"{parent}/{name}")

--- a/ribasim_qgis/widgets/nodes_widget.py
+++ b/ribasim_qgis/widgets/nodes_widget.py
@@ -66,7 +66,7 @@ class NodesWidget(QWidget):
         # Write to geopackage
         node.write()
         # Add to QGIS
-        self.ribasim_widget.add_layer(node.layer, "Ribasim Input", labels=node.labels)
+        self.ribasim_widget.add_layer(node.layer, "Input", labels=node.labels)
         # Setup relationship
         self.ribasim_widget.add_relationship(node.layer, node_type)
         # Add to dataset tree

--- a/ribasim_qgis/widgets/ribasim_widget.py
+++ b/ribasim_qgis/widgets/ribasim_widget.py
@@ -25,7 +25,7 @@ from qgis.core import (
 from qgis.gui import QgisInterface
 
 from ribasim_qgis.core.nodes import Input
-from ribasim_qgis.widgets.dataset_widget import DatasetWidget
+from ribasim_qgis.widgets.dataset_widget import DatasetWidget, group_position_var
 from ribasim_qgis.widgets.nodes_widget import NodesWidget
 
 PYQT_DELETED_ERROR = "wrapped C/C++ object of type QgsLayerTreeGroup has been deleted"
@@ -104,13 +104,13 @@ class RibasimWidget(QWidget):
 
     # QGIS layers
     # -----------
-    def create_subgroup(self, name: str, part: str, visible=True) -> None:
+    def create_subgroup(self, name: str, subgroup: str, visible=True) -> None:
         try:
             assert self.group is not None
-            value = self.group.addGroup(f"{name}-{part}")
+            value = self.group.addGroup(subgroup)
             assert value is not None
             value.setItemVisibilityChecked(visible)
-            self.groups[part] = value
+            self.groups[subgroup] = value
         except RuntimeError as e:
             if e.args[0] == PYQT_DELETED_ERROR:
                 # This means the main group has been deleted: recreate
@@ -123,9 +123,11 @@ class RibasimWidget(QWidget):
         assert project is not None
         root = project.layerTreeRoot()
         assert root is not None
-        self.group = root.insertGroup(0, name)  # insert at the top
-        self.create_subgroup(name, "Ribasim Input")
-        self.create_subgroup(name, "Ribasim Results", visible=False)
+        self.group = root.insertGroup(
+            group_position_var.get(), name
+        )  # insert at the top
+        self.create_subgroup(name, "Input")
+        self.create_subgroup(name, "Results", visible=False)
         assert self.group is not None
         self.group.setIsMutuallyExclusive(True)
 


### PR DESCRIPTION
This PR adds a Reload Ribasim model as right-click option in the layers menu.

The QGIS plugin (and the dataset widget specifically) currently only tracks the last opened model, which makes it hard to have a reload button
work for other models. I often work with multiple models at the same time, and I want to be able to reload any of them quickly.

This adds the full path as a custom property to all Ribasim made layers, which is how we can detect a Ribasim group.
When clicked, we save the group position in the layer list, remove the group, and then open the model again in the same position.
Any changes made to the group will thus be lost.

I've also added the full path as the group name, so that it is easier to find the model in the list of layers.

<img width="578" alt="Screenshot 2025-05-29 at 09 05 10" src="https://github.com/user-attachments/assets/5ea29d81-b7ba-49b1-8ed1-b51e096d3ed1" />

