### PR TITLE
Transient basin forcing

### DIFF
--- a/core/src/callback.jl
+++ b/core/src/callback.jl
@@ -35,12 +35,10 @@ function create_callbacks(
 
     # Update Basin forcings
     # All variables are given at the same time, so just precipitation works
-    times = [itp.t for itp in basin.forcing.precipitation]
-    tstops = Float64[]
-    for t in times
-        append!(tstops, t)
-    end
-    unique!(sort!(tstops))
+    tstops = Vector{Float64}[]
+    t_end = seconds_since(config.endtime, config.starttime)
+    get_timeseries_tstops!(tstops, t_end, basin.forcing.precipitation)
+    tstops = sort(unique(vcat(tstops...)))
     basin_cb = PresetTimeCallback(tstops, update_basin!; save_positions = (false, false))
     push!(callbacks, basin_cb)
 

--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -144,20 +144,7 @@ function Model(config::Config)::Model
             error("Invalid discrete control state definition(s).")
         end
 
-        (;
-            basin,
-            discrete_control,
-            flow_boundary,
-            flow_demand,
-            graph,
-            level_boundary,
-            level_demand,
-            outlet,
-            pid_control,
-            pump,
-            tabulated_rating_curve,
-            user_demand,
-        ) = p_non_diff
+        (; basin, graph, outlet, pid_control, pump, tabulated_rating_curve) = p_non_diff
         if !valid_pid_connectivity(pid_control.node_id, pid_control.listen_node_id, graph)
             error("Invalid PidControl connectivity.")
         end
@@ -176,37 +163,7 @@ function Model(config::Config)::Model
 
         # Tell the solver to stop at all data points from timeseries,
         # extrapolating periodically if applicable.
-        tstops = Vector{Float64}[]
-        for interpolations in [
-            basin.forcing.drainage,
-            basin.forcing.infiltration,
-            basin.forcing.potential_evaporation,
-            basin.forcing.precipitation,
-            flow_boundary.flow_rate,
-            flow_demand.demand_itp,
-            level_boundary.level,
-            level_demand.max_level,
-            level_demand.min_level,
-            pid_control.derivative,
-            pid_control.integral,
-            pid_control.proportional,
-            pid_control.target,
-            tabulated_rating_curve.current_interpolation_index,
-            user_demand.demand_itp...,
-            user_demand.return_factor,
-            reduce(
-                vcat,
-                [
-                    [cv.greater_than for cv in cvs] for
-                    cvs in discrete_control.compound_variables
-                ];
-                init = ScalarConstantInterpolation[],
-            )...,
-        ]
-            for itp in interpolations
-                push!(tstops, get_timeseries_tstops(itp, t_end))
-            end
-        end
+        tstops = get_timeseries_tstops(p_non_diff, t_end)
 
     finally
         # always close the database, also in case of an error

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -1043,6 +1043,9 @@ the object itself is not.
     u_prev_saveat::Vector{Float64} = Float64[]
     # Node ID associated with each state
     node_id::Vector{NodeID} = NodeID[]
+    # Callback configurations
+    do_concentration::Bool
+    do_subgrid::Bool
 end
 
 """

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -1608,6 +1608,8 @@ function Parameters(db::DB, config::Config)::Parameters
         config.solver.water_balance_reltol,
         u_prev_saveat = zeros(n_states),
         node_id,
+        do_concentration = config.experimental.concentration,
+        do_subgrid = config.results.subgrid,
     )
 
     collect_control_mappings!(p_non_diff)

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -1067,9 +1067,61 @@ function find_index(x::Symbol, s::OrderedSet{Symbol})
 end
 
 function get_timeseries_tstops(
-    itp::AbstractInterpolation,
-    endtime::Float64,
-)::Vector{Float64}
+    p_non_diff::ParametersNonDiff,
+    t_end::Float64,
+)::Vector{Vector{Float64}}
+    (;
+        basin,
+        flow_boundary,
+        flow_demand,
+        level_boundary,
+        level_demand,
+        pid_control,
+        tabulated_rating_curve,
+        user_demand,
+        discrete_control,
+    ) = p_non_diff
+    tstops = Vector{Float64}[]
+
+    # For nodes that have multiple timeseries associated with them defined in the same table
+    # (e.g. multiple Basin forcings and multiple PID terms)
+    # only one timeseries is used as all timeseries use the same timesteps
+    get_timeseries_tstops!(tstops, t_end, basin.forcing.precipitation)
+    get_timeseries_tstops!(tstops, t_end, flow_boundary.flow_rate)
+    get_timeseries_tstops!(tstops, t_end, flow_demand.demand_itp)
+    get_timeseries_tstops!(tstops, t_end, level_boundary.level)
+    get_timeseries_tstops!(tstops, t_end, level_demand.min_level)
+    get_timeseries_tstops!(tstops, t_end, pid_control.target)
+    get_timeseries_tstops!(
+        tstops,
+        t_end,
+        tabulated_rating_curve.current_interpolation_index,
+    )
+    get_timeseries_tstops!(tstops, t_end, user_demand.return_factor)
+    for row in user_demand.demand_itp
+        get_timeseries_tstops!(tstops, t_end, row)
+    end
+    for compound_variables in discrete_control.compound_variables
+        for compound_variable in compound_variables
+            get_timeseries_tstops!(tstops, t_end, compound_variable.greater_than)
+        end
+    end
+
+    return tstops
+end
+
+function get_timeseries_tstops!(
+    tstops::Vector{Vector{Float64}},
+    t_end::Float64,
+    interpolations::AbstractArray{<:AbstractInterpolation},
+)::Nothing
+    for itp in interpolations
+        push!(tstops, get_timeseries_tstops(itp, t_end))
+    end
+    return nothing
+end
+
+function get_timeseries_tstops(itp::AbstractInterpolation, t_end::Float64)::Vector{Float64}
     # The length of the period
     T = last(itp.t) - first(itp.t)
 
@@ -1078,7 +1130,7 @@ function get_timeseries_tstops(
 
     # How many periods forward from first(itp.t) are needed
     nT_forward =
-        itp.extrapolation_right == Periodic ? Int(ceil((endtime - first(itp.t)) / T)) : 0
+        itp.extrapolation_right == Periodic ? Int(ceil((t_end - first(itp.t)) / T)) : 0
 
     tstops = Float64[]
 
@@ -1086,12 +1138,12 @@ function get_timeseries_tstops(
         # Append the timepoints of the interpolation shifted by an integer amount of
         # periods to the tstops, filtering out values outside the simulation period
         if i == nT_forward
-            append!(tstops, filter(t -> 0 ≤ t ≤ endtime, itp.t .+ i * T))
+            append!(tstops, filter(t -> 0 ≤ t ≤ t_end, itp.t .+ i * T))
         else
             # Because of floating point errors last(itp.t) = first(itp.t) + T
             # does not always hold exactly, so to prevent that these become separate
             # very close tstops we only use the last time point of the period in the last period
-            append!(tstops, filter(t -> 0 ≤ t ≤ endtime, itp.t[1:(end - 1)] .+ i * T))
+            append!(tstops, filter(t -> 0 ≤ t ≤ t_end, itp.t[1:(end - 1)] .+ i * T))
         end
     end
 
@@ -1099,10 +1151,10 @@ function get_timeseries_tstops(
 end
 
 """Get the exponential time stops for decreasing the tolerance."""
-function get_log_tstops(starttime, endtime)::Vector{Float64}
+function get_log_tstops(starttime, t_end)::Vector{Float64}
     log_tstops = Float64[]
     t = 60 * 60
-    while Second(t) <= round(endtime - starttime, Second)
+    while Second(t) <= round(t_end - starttime, Second)
         push!(log_tstops, t)
         t *= 2.0
     end

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -297,7 +297,7 @@ end
     @test success(sparse_fdm)
     @test success(dense_fdm)
 
-    @test dense_ad.integrator.u ≈ sparse_ad.integrator.u atol = 0.3
+    @test dense_ad.integrator.u ≈ sparse_ad.integrator.u atol = 0.4
     @test sparse_fdm.integrator.u ≈ sparse_ad.integrator.u atol = 4
     @test dense_fdm.integrator.u ≈ sparse_ad.integrator.u atol = 4
 

--- a/core/test/time_test.jl
+++ b/core/test/time_test.jl
@@ -103,6 +103,11 @@ end
     test_extrapolation(basin.forcing.precipitation[1])
     test_extrapolation(level_boundary.level[1])
     test_extrapolation(flow_boundary.flow_rate[1])
+
+    t_end = Ribasim.seconds_since(model.config.endtime, model.config.starttime)
+    tstops = Vector{Float64}[]
+    Ribasim.get_timeseries_tstops!(tstops, t_end, basin.forcing.precipitation)
+    @test length(only(tstops)) == 3996
 end
 
 @testitem "decrease tolerance" begin

--- a/docs/dev/bmi.qmd
+++ b/docs/dev/bmi.qmd
@@ -27,15 +27,15 @@ The following pointers to memory containing Ribasim internal arrays are given vi
 
 string                          | meaning                                | type    | unit         | temporal type         | writable  | sorted by
 ------------------------------- | -------------------------------------- | ------- | ------------ | --------------------- | --------  |----------
-`basin.storage`                 | storage per basin                      | Float64 | $m^3$        | instantaneous         | no        | basin node ID
-`basin.level`                   | level per basin                        | Float64 | $m$          | instantaneous         | no        |  basin node ID
-`basin.infiltration`            | infiltration flux per basin            | Float64 | $m^3 s^{-1}$ | forward fill          | yes       |  basin node ID
-`basin.drainage`                | drainage flux per basin                | Float64 | $m^3 s^{-1}$ | forward fill          | yes       |  basin node ID
-`basin.infiltration_integrated` | cumulative infiltration per basin      | Float64 | $m^3$        | integrated from start | yes       |  basin node ID
-`basin.drainage_integrated`     | cumulative drainage per basin          | Float64 | $m^3$        | integrated from start | yes       |  basin node ID
-`basin.subgrid_level`           | subgrid level                          | Float64 | $m$          | instantaneous         | no        |  subgrid ID
-`user_demand.demand`            | demand per node ID per priority        | Float64 | $m^3 s^{-1}$ | forward fill          | yes       |  user_demand node ID, priority index
-`user_demand.realized`          | cumulative intake flow per user        | Float64 | $m^3$        | integrated from start | yes       |  user_demand node ID
+`basin.storage`                 | storage per basin                      | Float64 | $\text{m}^3$        | instantaneous         | no        | basin node ID
+`basin.level`                   | level per basin                        | Float64 | $\text{m}$          | instantaneous         | no        |  basin node ID
+`basin.infiltration`            | infiltration flux per basin            | Float64 | $\text{m}^3 \text{s}^{-1}$ | forward fill          | yes       |  basin node ID
+`basin.drainage`                | drainage flux per basin                | Float64 | $\text{m}^3 \text{s}^{-1}$ | forward fill          | yes       |  basin node ID
+`basin.infiltration_integrated` | cumulative infiltration per basin      | Float64 | $\text{m}^3$        | integrated from start | yes       |  basin node ID
+`basin.drainage_integrated`     | cumulative drainage per basin          | Float64 | $\text{m}^3$        | integrated from start | yes       |  basin node ID
+`basin.subgrid_level`           | subgrid level                          | Float64 | $\text{m}$          | instantaneous         | no        |  subgrid ID
+`user_demand.demand`            | demand per node ID per priority        | Float64 | $\text{m}^3 \text{s}^{-1}$ | forward fill          | yes       |  user_demand node ID, priority index
+`user_demand.realized`          | cumulative intake flow per user        | Float64 | $\text{m}^3$        | integrated from start | yes       |  user_demand node ID
 
 Additional notes:
 

--- a/docs/reference/node/linear-resistance.qmd
+++ b/docs/reference/node/linear-resistance.qmd
@@ -22,9 +22,10 @@ A LinearResistance connects two Basins together.
 The flow between the two Basins is determined by a linear relationship, up to an optional maximum flow rate:
 
 $$
-Q_\text{linear\_resistance} = \mathrm{clamp}\left(\frac{h_a - h_b}{R}, -Q_{\max}, Q_{\max}\right)
+Q_\text{linear\_resistance} = \phi\mathrm{clamp}\left(\frac{h_a - h_b}{R}, -Q_{\max}, Q_{\max}\right)
 $$
 
 Here $h_a$ is the water level in the incoming Basin and $h_b$ is the water level in the outgoing Basin.
 $R$ is the resistance of the link, and $Q_{\max}$ is the maximum flow rate.
 Water flows from high to low; either direction is possible.
+$\phi$ is the reduction factor which makes the flow go smoothly to $0$ as the upstream storage (as determined by the flow direction) becomes smaller than $10 \;\text{m}^3$.

--- a/docs/reference/node/manning-resistance.qmd
+++ b/docs/reference/node/manning-resistance.qmd
@@ -129,7 +129,7 @@ if the head in basin $b$ is larger than in basin $a$.
 This expression however has a derivative which tends to $\infty$ as $\Delta h$ tends to $0$, which can lead to instabilities in simulation. Therefore we use the modified expression
 
 $$
-Q = \frac{A}{n} R_h^{2/3}s\left(\frac{\Delta h}{L}; 10^{-5}\right),
+Q = \phi\frac{A}{n} R_h^{2/3}s\left(\frac{\Delta h}{L}; 10^{-5}\right),
 $$
 
 where $s$ is a relaxed square root function:
@@ -169,6 +169,8 @@ ax.plot(x, y_o, ls = ":", label = r"sign$(x)\sqrt{|x|}$")
 ax.plot(x, y_s, color = "C0", label = r"$s\left(x; 10^{-3}\right)$")
 ax.legend();
 ```
+
+and $\phi$ is the reduction factor which makes the flow go smoothly to $0$ as the upstream storage (as determined by the flow direction) becomes smaller than $10 \;\text{m}^3$.
 
 :::{.callout-note}
 The computation of $S_f$ is not exact: we base it on a representative area and hydraulic radius, rather than integrating $S_f$ along the length of a reach.

--- a/docs/reference/node/outlet.qmd
+++ b/docs/reference/node/outlet.qmd
@@ -52,7 +52,7 @@ $$
 - $Q_\text{set}$ is the Outlet's target `flow_rate`.
 - $Q_{\min}$ and $Q_{\max}$ are the Outlet `min_flow_rate` and `max_flow_rate`.
 - $\phi$ is the reduction factor, which smoothly reduces flow based on all of these criteria:
-  - The upstream volume is below $10 m^3$.
-  - The upstream level is less than $0.02 m$ above the downstream level.
-  - The upstream level is below `min_upstream_level` + $0.02 m$
-  - The downstream level is above `max_downstream_level` - $0.02 m$
+  - The upstream volume is below $10 \;\text{m}^3$.
+  - The upstream level is less than $0.02 \;\text{m}$ above the downstream level.
+  - The upstream level is below `min_upstream_level` + $0.02 \;\text{m}$
+  - The downstream level is above `max_downstream_level` - $0.02 \;\text{m}$

--- a/docs/reference/node/pump.qmd
+++ b/docs/reference/node/pump.qmd
@@ -54,6 +54,6 @@ $$
 - $Q_\text{set}$ is the Pump's target `flow_rate`.
 - $Q_{\min}$ and $Q_{\max}$ are the Pump `min_flow_rate` and `max_flow_rate`.
 - $\phi$ is the reduction factor, which smoothly reduces flow based on all of these criteria:
-  - The upstream volume is below $10 m^3$.
-  - The upstream level is below `min_upstream_level` + $0.02 m$
-  - The downstream level is above `max_downstream_level` - $0.02 m$
+  - The upstream volume is below $10 \;\text{m}^3$.
+  - The upstream level is below `min_upstream_level` + $0.02 \;\text{m}$
+  - The downstream level is above `max_downstream_level` - $0.02 \;\text{m}$

--- a/docs/reference/node/tabulated-rating-curve.qmd
+++ b/docs/reference/node/tabulated-rating-curve.qmd
@@ -109,6 +109,6 @@ Where:
 - $h$ is the upstream water level
 - $f$ is a piecewise linear function describing the given rating curve $Q(h)$
 - $\phi$ is the reduction factor, which smoothly reduces flow based on all of these criteria:
-  - The upstream volume is below $10 m^3$.
-  - The upstream level is less than $0.02 m$ above the downstream level.
-  - The downstream level is above `max_downstream_level` - $0.02 m$
+  - The upstream volume is below $10 \;\text{m}^3$.
+  - The upstream level is less than $0.02 \;\text{m}$ above the downstream level.
+  - The downstream level is above `max_downstream_level` - $0.02 \;\text{m}$

--- a/docs/reference/usage.qmd
+++ b/docs/reference/usage.qmd
@@ -129,10 +129,10 @@ The Ribasim version that was used to create the results is written to each file 
 Below we give details per file, in which we describe the schema of the table using a syntax
 like this:
 
-column    | type    | unit         | restriction
---------- | ------- | ------------ | -----------
-node_id   | Int32   | -            | sorted
-storage   | Float64 | $m^3$        | non-negative
+column    | type    | unit                | restriction
+--------- | ------- | ------------------- | -----------
+node_id   | Int32   | -                   | sorted
+storage   | Float64 | $\text{m}^3$        | non-negative
 
 This means that two columns are required, one named `node_id`, that contained elements of
 type `Int32`, and a column named `storage` that contains elements of type `Float64`. The order


### PR DESCRIPTION
Fixes #2298, fixes #2291

Notes:
- Refactored getting `tstops` from timeseries interpolations in type stable manner
- Refactored callbacks so that now always all of them are created
- Running 1000 year `cyclic_time` model now takes 15 seconds
- Concentrations cannot yet be periodic (silent problem)
- Fixed some unit formatting and added reduction factor for resistance nodes in docs