### PR TITLE
Fix s3-download for new folders.

### DIFF
--- a/utils/s3_download.py
+++ b/utils/s3_download.py
@@ -1,4 +1,5 @@
 import argparse
+from os import makedirs
 
 from minio import Minio
 from minio.error import S3Error
@@ -31,10 +32,16 @@ objects = client.list_objects(bucketName, prefix=args.remote, recursive=True)
 
 for obj in objects:
     try:
-        client.fget_object(
-            bucketName,
-            obj.object_name,
-            f"models/{args.local}" + obj.object_name.removeprefix(args.remote),
-        )
+        if obj.is_dir:
+            local_dir = f"models/{args.local}" + obj.object_name.removeprefix(
+                args.remote
+            )
+            makedirs(local_dir, exist_ok=True)
+        else:
+            client.fget_object(
+                bucketName,
+                obj.object_name,
+                f"models/{args.local}" + obj.object_name.removeprefix(args.remote),
+            )
     except S3Error as e:
         print(f"Error occurred: {e}")


### PR DESCRIPTION
I got folder errors when running `pixi run s3-download repro-models/lhm-vecht lhm-vecht`. If you do too, this PR might help.