### PR TITLE
[TC] Try to use cache with --check-bounds=yes.

### DIFF
--- a/.teamcity/Templates/Build.kt
+++ b/.teamcity/Templates/Build.kt
@@ -37,7 +37,7 @@ open class Build(platformOs: String) : Template() {
         features {
             buildCache {
                 id = "Ribasim${platformOs}Cache"
-                name = "Ribasim ${platformOs} Cache"
+                name = "Ribasim${platformOs}Cache"
                 publish = false
             }
         }

--- a/.teamcity/Templates/GenerateCache.kt
+++ b/.teamcity/Templates/GenerateCache.kt
@@ -30,7 +30,7 @@ open class GenerateCache(platformOs: String) : Template() {
         features {
             buildCache {
                 id = "Ribasim${platformOs}Cache"
-                name = "Ribasim ${platformOs} Cache"
+                name = "Ribasim${platformOs}Cache"
                 use = false
                 rules = """
                     %teamcity.build.checkoutDir%/.julia

--- a/.teamcity/Templates/IntegrationTest.kt
+++ b/.teamcity/Templates/IntegrationTest.kt
@@ -48,7 +48,7 @@ open class IntegrationTest (platformOs: String) : Template() {
         features {
             buildCache {
                 id = "Ribasim${platformOs}Cache"
-                name = "Ribasim ${platformOs} Cache"
+                name = "Ribasim${platformOs}Cache"
                 publish = false
             }
         }

--- a/.teamcity/Templates/RegressionTest.kt
+++ b/.teamcity/Templates/RegressionTest.kt
@@ -48,7 +48,7 @@ open class RegressionTest (platformOs: String) : Template() {
         features {
             buildCache {
                 id = "Ribasim${platformOs}Cache"
-                name = "Ribasim ${platformOs} Cache"
+                name = "Ribasim${platformOs}Cache"
                 publish = false
             }
         }

--- a/.teamcity/Templates/TestBinaries.kt
+++ b/.teamcity/Templates/TestBinaries.kt
@@ -44,7 +44,7 @@ open class TestBinaries (platformOs: String) : Template() {
         features {
             buildCache {
                 id = "Ribasim${platformOs}Cache"
-                name = "Ribasim ${platformOs} Cache"
+                name = "Ribasim${platformOs}Cache"
                 publish = false
             }
         }

--- a/.teamcity/Templates/TestDelwaqCoupling.kt
+++ b/.teamcity/Templates/TestDelwaqCoupling.kt
@@ -24,7 +24,7 @@ open class TestDelwaqCoupling(platformOs: String) : Template() {
         features {
             buildCache {
                 id = "Ribasim${platformOs}Cache"
-                name = "Ribasim ${platformOs} Cache"
+                name = "Ribasim${platformOs}Cache"
                 publish = false
             }
         }

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,7 +31,7 @@ install = { depends-on = [
 # Julia
 update-registry-julia = { cmd = "julia --eval='using Pkg; Registry.update()'" }
 update-manifest-julia = { cmd = "julia --project utils/update-manifest.jl" }
-instantiate-julia = { cmd = "julia --project --eval='using Pkg; Pkg.instantiate()'" }
+instantiate-julia = { cmd = "julia --project --check-bounds=yes --eval='using Pkg; Pkg.instantiate()'" }
 initialize-julia = { depends-on = [
     "update-registry-julia",
     "instantiate-julia",


### PR DESCRIPTION
Only some builds use the cache on TC, so this removes spaces from the name (not allowed as indicated by trying to edit the cache feature in the GUI). It also seems to recompile a lot, let's add --check-bounds=yes to the instantiate (used in cache creation) to try to prevent it.