### PR TITLE
Formulate basin properties in flow limiter based on `u` instead of `du`

### DIFF
--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -673,8 +673,7 @@ function limit_flow!(
     # The current storage and level based on the proposed u are used to estimate the lowest
     # storage and level attained in the last time step to estimate whether there was an effect
     # of reduction factors
-    du = get_du(integrator)
-    set_current_basin_properties!(du, p, t)
+    set_current_basin_properties!(u, p, t)
 
     # TabulatedRatingCurve flow is in [0, ∞) and can be inactive
     for (id, active) in zip(tabulated_rating_curve.node_id, tabulated_rating_curve.active)


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/2315, fixes https://github.com/Deltares/Ribasim/issues/2314

There was a silly bug in de flow limiter (the part of the code where we nudge the solver step in the 'right' direction based on knowledge of the problem) where the basin properties where formulated based on du instead of u, giving completely wrong values for e.g. the low storage factors.

This bug was introduced in https://github.com/Deltares/Ribasim/pull/2137