### PR TITLE
Use `check-bounds=yes` when starting Julia

### DIFF
--- a/.github/workflows/core_testmodels.yml
+++ b/.github/workflows/core_testmodels.yml
@@ -19,6 +19,7 @@ jobs:
   test:
     name: Julia ${{ matrix.os }} - ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,7 @@ jobs:
   publish:
     name: Docs Julia
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: write
     steps:

--- a/.teamcity/Ribasim/Project.kt
+++ b/.teamcity/Ribasim/Project.kt
@@ -4,6 +4,8 @@ import Ribasim.buildTypes.GenerateTestmodels
 import Ribasim.buildTypes.Ribasim_MakeGitHubRelease
 import Ribasim.buildTypes.Ribasim_UploadToMinio
 import Ribasim.buildTypes.Ribasim_MakeQgisPlugin
+import Ribasim.buildTypes.Windows_GenerateCache
+import Ribasim.buildTypes.Linux_GenerateCache
 import Ribasim.vcsRoots.Ribasim
 import Ribasim_Linux.RibasimLinuxProject
 import Ribasim_Windows.RibasimWindowsProject
@@ -20,6 +22,8 @@ object Project : Project({
     buildType(Ribasim_MakeQgisPlugin)
     buildType(Ribasim_MakeGitHubRelease)
     buildType(Ribasim_UploadToMinio)
+    buildType(Windows_GenerateCache)
+    buildType(Linux_GenerateCache)
 
     template(GithubCommitStatusIntegration)
     template(GithubPullRequestsIntegration)

--- a/.teamcity/Ribasim_Linux/RibasimLinuxProject.kt
+++ b/.teamcity/Ribasim_Linux/RibasimLinuxProject.kt
@@ -14,7 +14,6 @@ object RibasimLinuxProject : Project({
     buildType(Linux_Main)
     buildType(Linux_BuildRibasim)
     buildType(Linux_TestRibasimBinaries)
-    buildType(Linux_GenerateCache)
 
     template(TestBinariesLinux)
     template(GenerateCacheLinux)
@@ -80,24 +79,6 @@ object Linux_TestRibasimBinaries : BuildType({
                     ribasim_linux.zip!/ribasim/** => ribasim/build/ribasim
                 """.trimIndent()
             }
-        }
-    }
-})
-
-object Linux_GenerateCache : BuildType({
-    templates(LinuxAgent, GithubCommitStatusIntegration, GenerateCacheLinux)
-    name = "Generate TC cache"
-
-    triggers {
-        vcs {
-            id = "TRIGGER_RIBA_L1"
-            triggerRules = """
-                +:root=Ribasim_Ribasim:/Manifest.toml
-                +:root=Ribasim_Ribasim:/Project.toml
-                +:root=Ribasim_Ribasim:/pixi.lock
-                +:root=Ribasim_Ribasim:/pixi.toml
-            """.trimIndent()
-            branchFilter = "+:<default>"
         }
     }
 })

--- a/.teamcity/Ribasim_Windows/RibasimWindowsProject.kt
+++ b/.teamcity/Ribasim_Windows/RibasimWindowsProject.kt
@@ -17,7 +17,6 @@ object RibasimWindowsProject : Project({
     buildType(Windows_BuildRibasim)
     buildType(Windows_TestDelwaqCoupling)
     buildType(Windows_TestRibasimBinaries)
-    buildType(Windows_GenerateCache)
 
     template(TestBinariesWindows)
     template(TestDelwaqCouplingWindows)
@@ -130,24 +129,6 @@ object Windows_TestDelwaqCoupling : BuildType({
             artifactRules = """
                 DWAQ_win64_Release_Visual Studio *.zip!** => dimr
             """.trimIndent()
-        }
-    }
-})
-
-object Windows_GenerateCache : BuildType({
-    templates(WindowsAgent, GithubCommitStatusIntegration, GenerateCacheWindows)
-    name = "Generate TC cache"
-
-    triggers {
-        vcs {
-            id = "TRIGGER_RIBA_W1"
-            triggerRules = """
-                +:root=Ribasim_Ribasim:/Manifest.toml
-                +:root=Ribasim_Ribasim:/Project.toml
-                +:root=Ribasim_Ribasim:/pixi.lock
-                +:root=Ribasim_Ribasim:/pixi.toml
-            """.trimIndent()
-            branchFilter = "+:<default>"
         }
     }
 })

--- a/pixi.toml
+++ b/pixi.toml
@@ -80,25 +80,33 @@ build = { "cmd" = "julia --project build.jl", cwd = "build", depends-on = [
 ] }
 # Tests
 s3-download = { cmd = "python utils/s3_download.py {{ remote }} {{ local }}", args = [
-    "remote", "local"
+    "remote",
+    "local",
 ] }
 s3-upload = { cmd = "python utils/s3_upload.py {{ source }} {{ destination }}", args = [
-    "source", "destination"
+    "source",
+    "destination",
 ] }
 test-ribasim-cli = "pytest --numprocesses=4 --basetemp=build/tests/temp --junitxml=report.xml build/tests"
-test-ribasim-core = { cmd = "julia --project=core --eval 'using Pkg; Pkg.test(allow_reresolve=false)'", depends-on = [
+test-ribasim-core = { cmd = "julia --project=core --check-bounds=yes --eval 'using Pkg; Pkg.test(allow_reresolve=false)'", depends-on = [
     "generate-testmodels",
 ] }
 test-ribasim-migration = { cmd = "pytest --numprocesses=4 -m regression python/ribasim/tests", depends-on = [
-    { task = "s3-download", args = ["hws_migration_test/", "hws_migration_test/"] },
+    { task = "s3-download", args = [
+        "hws_migration_test/",
+        "hws_migration_test/",
+    ] },
 ] }
-test-ribasim-core-cov = { cmd = "julia --project=core --eval 'using Pkg; Pkg.test(allow_reresolve=false, coverage=true, julia_args=[\"--check-bounds=yes\"])'", depends-on = [
+test-ribasim-core-cov = { cmd = "julia --project=core --check-bounds=yes --eval 'using Pkg; Pkg.test(allow_reresolve=false, coverage=true, julia_args=[\"--check-bounds=yes\"])'", depends-on = [
     "generate-testmodels",
 ] }
-test-ribasim-regression = { cmd = "julia --project=core --eval 'using Pkg; Pkg.test(allow_reresolve=false, julia_args=[\"--check-bounds=yes\"], test_args=[\"regression\"])'", depends-on = [
+test-ribasim-regression = { cmd = "julia --project=core --check-bounds=yes --eval 'using Pkg; Pkg.test(allow_reresolve=false, julia_args=[\"--check-bounds=yes\"], test_args=[\"regression\"])'", depends-on = [
     "generate-testmodels",
     "test-ribasim-migration",
-    { task = "s3-download", args = ["benchmark/", "benchmark/"] },
+    { task = "s3-download", args = [
+        "benchmark/",
+        "benchmark/",
+    ] },
 ] }
 generate-testmodels = { cmd = "python utils/generate-testmodels.py", inputs = [
     "python/ribasim",
@@ -110,8 +118,11 @@ generate-testmodels = { cmd = "python utils/generate-testmodels.py", inputs = [
 tests = { depends-on = ["lint", "test-ribasim-python", "test-ribasim-core"] }
 delwaq = { cmd = "pytest python/ribasim/tests/test_delwaq.py" }
 gen-delwaq = { cmd = "python python/ribasim/ribasim/delwaq/generate.py" }
-model-integration-test = { cmd = "julia --project=core --eval 'using Pkg; Pkg.test(allow_reresolve=false, test_args=[\"integration\"])'", depends-on = [
-    { task = "s3-download", args = ["hws_2025_4_0/", "hws/"] },
+model-integration-test = { cmd = "julia --project=core --check-bounds=yes --eval 'using Pkg; Pkg.test(allow_reresolve=false, test_args=[\"integration\"])'", depends-on = [
+    { task = "s3-download", args = [
+        "hws_2025_4_0/",
+        "hws/",
+    ] },
 ] }
 # Codegen
 codegen = { cmd = "julia --project utils/gen_python.jl && ruff format python/ribasim/ribasim/schemas.py python/ribasim/ribasim/validation.py", depends-on = [
@@ -160,10 +171,10 @@ test-ribasim-qgis-cov = { cmd = "pytest --numprocesses=auto --cov=ribasim_qgis -
 ] }
 mypy-ribasim-qgis = "mypy ribasim_qgis"
 # Run
-ribasim-core = { cmd = "julia --project=core -e 'using Ribasim; Ribasim.main(ARGS)'", depends-on = [
+ribasim-core = { cmd = "julia --project=core --check-bounds=yes -e 'using Ribasim; Ribasim.main(ARGS)'", depends-on = [
     "initialize-julia",
 ] }
-ribasim-core-testmodels = { cmd = "julia --project --threads=4 utils/testmodelrun.jl", depends-on = [
+ribasim-core-testmodels = { cmd = "julia --project --check-bounds=yes --threads=4 utils/testmodelrun.jl", depends-on = [
     "generate-testmodels",
     "initialize-julia",
 ] }


### PR DESCRIPTION
Per suggestions in #2336. We choose to run check-bounds=yes everywhere. For longer runner models this decreases performance (I see a 20% drop), but we should precompile less overall, skipping the several minute hit on CI.

Other CI fixes:
- Timeout to 60 minutes (as we have 6 hours per #2338).
- Move the TC cache generation to the upper project, as regression/integration couldn't make find it now.