### PR TITLE
Low storage threshold based on 10 cm depth

### DIFF
--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -1,5 +1,5 @@
-# Universal reduction factor threshold for the low storage factor
-const LOW_STORAGE_THRESHOLD = 10.0
+# Universal depth at which the low storage factor kicks in
+const LOW_STORAGE_DEPTH = 0.01
 
 # Universal reduction factor threshold for the minimum upstream level of UserDemand nodes
 const USER_DEMAND_MIN_LEVEL_THRESHOLD = 0.1
@@ -475,6 +475,8 @@ of vectors or Arrow Tables, and is added to avoid type instabilities.
     node_id::Vector{NodeID}
     inflow_ids::Vector{Vector{NodeID}} = fill(NodeID[], length(node_id))
     outflow_ids::Vector{Vector{NodeID}} = fill(NodeID[], length(node_id))
+    # Storage below which outflows are reduced
+    low_storage_threshold::Vector{Float64} = zeros(length(node_id))
     # Vertical fluxes
     vertical_flux::VerticalFlux = VerticalFlux(length(node_id))
     # Initial_storage

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -1,5 +1,5 @@
 # Universal depth at which the low storage factor kicks in
-const LOW_STORAGE_DEPTH = 0.01
+const LOW_STORAGE_DEPTH = 0.1
 
 # Universal reduction factor threshold for the minimum upstream level of UserDemand nodes
 const USER_DEMAND_MIN_LEVEL_THRESHOLD = 0.1

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -867,6 +867,14 @@ function Basin(db::DB, config::Config, graph::MetaGraph)::Basin
     basin.storage_prev .= storage0
     basin.concentration_data.mass .*= storage0  # was initialized by concentration_state, resulting in mass
 
+    # Compute the low storage threshold as the disk of water between the bottom
+    # and 10 cm above the bottom
+    for id in node_id
+        bottom = basin_bottom(basin, id)[2]
+        basin.low_storage_threshold[id.idx] =
+            get_storage_from_level(basin, id.idx, bottom + LOW_STORAGE_DEPTH)
+    end
+
     basin
 end
 

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -996,14 +996,20 @@ end
 """
 Estimate the minimum reduction factor achieved over the last time step by
 estimating the lowest storage achieved over the last time step. To make sure
-it is an underestimate of the minimum, 2LOW_STORAGE_THRESHOLD is subtracted from this lowest storage.
+it is an underestimate of the minimum, 2low_storage_threshold is subtracted from this lowest storage.
 This is done to not be too strict in clamping the flow in the limiter
 """
-function min_low_storage_factor(storage_now::AbstractVector{T}, storage_prev, id) where {T}
+function min_low_storage_factor(
+    storage_now::AbstractVector{T},
+    storage_prev,
+    basin,
+    id,
+) where {T}
     if id.type == NodeType.Basin
+        low_storage_threshold = basin.low_storage_threshold[id.idx]
         reduction_factor(
-            min(storage_now[id.idx], storage_prev[id.idx]) - 2LOW_STORAGE_THRESHOLD,
-            LOW_STORAGE_THRESHOLD,
+            min(storage_now[id.idx], storage_prev[id.idx]) - 2low_storage_threshold,
+            low_storage_threshold,
         )
     else
         one(T)

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -227,7 +227,7 @@ end
 
     @test success(model)
     @test length(model.integrator.sol) == 2 # start and end
-    @test diff_cache.current_storage ≈ Float32[797.561, 797.112, 510.737, 1130.005] skip =
+    @test diff_cache.current_storage ≈ Float32[797.559, 797.110, 506.494, 1130.005] skip =
         Sys.isapple() atol = 1.5
 
     @test length(logger.logs) > 10

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -227,7 +227,7 @@ end
 
     @test success(model)
     @test length(model.integrator.sol) == 2 # start and end
-    @test diff_cache.current_storage ≈ Float32[797.559, 797.110, 506.494, 1130.005] skip =
+    @test diff_cache.current_storage ≈ Float32[797.56195, 797.11017, 508.48175, 1130.005] skip =
         Sys.isapple() atol = 1.5
 
     @test length(logger.logs) > 10

--- a/docs/reference/node/linear-resistance.qmd
+++ b/docs/reference/node/linear-resistance.qmd
@@ -28,4 +28,4 @@ $$
 Here $h_a$ is the water level in the incoming Basin and $h_b$ is the water level in the outgoing Basin.
 $R$ is the resistance of the link, and $Q_{\max}$ is the maximum flow rate.
 Water flows from high to low; either direction is possible.
-$\phi$ is the reduction factor which makes the flow go smoothly to $0$ as the upstream storage (as determined by the flow direction) becomes smaller than $10 \;\text{m}^3$.
+$\phi$ is the reduction factor which makes the flow go smoothly to $0$ as the upstream storage (as determined by the flow direction) becomes smaller than the equivalent of a water depth of $10 \;\text{cm}$.

--- a/docs/reference/node/manning-resistance.qmd
+++ b/docs/reference/node/manning-resistance.qmd
@@ -170,7 +170,7 @@ ax.plot(x, y_s, color = "C0", label = r"$s\left(x; 10^{-3}\right)$")
 ax.legend();
 ```
 
-and $\phi$ is the reduction factor which makes the flow go smoothly to $0$ as the upstream storage (as determined by the flow direction) becomes smaller than $10 \;\text{m}^3$.
+and $\phi$ is the reduction factor which makes the flow go smoothly to $0$ as the upstream storage (as determined by the flow direction) becomes smaller than the equivalent of a water depth of $10 \;\text{cm}$.
 
 :::{.callout-note}
 The computation of $S_f$ is not exact: we base it on a representative area and hydraulic radius, rather than integrating $S_f$ along the length of a reach.

--- a/docs/reference/node/outlet.qmd
+++ b/docs/reference/node/outlet.qmd
@@ -52,7 +52,7 @@ $$
 - $Q_\text{set}$ is the Outlet's target `flow_rate`.
 - $Q_{\min}$ and $Q_{\max}$ are the Outlet `min_flow_rate` and `max_flow_rate`.
 - $\phi$ is the reduction factor, which smoothly reduces flow based on all of these criteria:
-  - The upstream volume is below $10 \;\text{m}^3$.
+  - The upstream volume is below the equivalent of a water depth of $10 \;\text{cm}$.
   - The upstream level is less than $0.02 \;\text{m}$ above the downstream level.
   - The upstream level is below `min_upstream_level` + $0.02 \;\text{m}$
   - The downstream level is above `max_downstream_level` - $0.02 \;\text{m}$

--- a/docs/reference/node/pump.qmd
+++ b/docs/reference/node/pump.qmd
@@ -54,6 +54,6 @@ $$
 - $Q_\text{set}$ is the Pump's target `flow_rate`.
 - $Q_{\min}$ and $Q_{\max}$ are the Pump `min_flow_rate` and `max_flow_rate`.
 - $\phi$ is the reduction factor, which smoothly reduces flow based on all of these criteria:
-  - The upstream volume is below $10 \;\text{m}^3$.
+  - The upstream volume is below the equivalent of a water depth of $10 \;\text{cm}$.
   - The upstream level is below `min_upstream_level` + $0.02 \;\text{m}$
   - The downstream level is above `max_downstream_level` - $0.02 \;\text{m}$

--- a/docs/reference/node/tabulated-rating-curve.qmd
+++ b/docs/reference/node/tabulated-rating-curve.qmd
@@ -109,6 +109,6 @@ Where:
 - $h$ is the upstream water level
 - $f$ is a piecewise linear function describing the given rating curve $Q(h)$
 - $\phi$ is the reduction factor, which smoothly reduces flow based on all of these criteria:
-  - The upstream volume is below $10 \;\text{m}^3$.
+  - The upstream volume is below the equivalent of a water depth of $10 \;\text{cm}$.
   - The upstream level is less than $0.02 \;\text{m}$ above the downstream level.
   - The downstream level is above `max_downstream_level` - $0.02 \;\text{m}$

--- a/docs/reference/node/user-demand.qmd
+++ b/docs/reference/node/user-demand.qmd
@@ -74,7 +74,7 @@ $$
 
 From left to right:
 
-- The first reduction factor lets the UserDemand abstraction go smoothly to $0$ as the source Basin dries out;
+- The first reduction factor lets the UserDemand abstraction go smoothly to $0$ as the source Basin dries out below a storage which is the equivalent of a water depth of $10 \;\text{cm}$;
 - The second reduction factor lets the UserDemand abstraction go smoothly to $0$ as the source Basin level approaches the minimum source Basin level (from above);
 - The last term is the sum of the allocations over the priorities.
   If the current demand happens to be lower than the allocation at some demand priority, the demand is taken instead.


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/2354.

Note that this implementation, other than what the issue title implies, still uses the storage as the argument for the reduction factor, only the threshold storage is based on a depth of 10 cm.