### PR TITLE
Add migrate-model task

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -178,6 +178,10 @@ ribasim-core-testmodels = { cmd = "julia --project --check-bounds=yes --threads=
     "generate-testmodels",
     "initialize-julia",
 ] }
+migrate-model = { cmd = "python utils/migrate_model.py {{ input_toml }} {{ output_toml }}", args = [
+    "input_toml",
+    "output_toml",
+] }
 # Release
 github-release = "python utils/github-release.py"
 

--- a/utils/migrate_model.py
+++ b/utils/migrate_model.py
@@ -1,0 +1,11 @@
+import argparse
+
+from ribasim import Model
+
+parser = argparse.ArgumentParser(description="Migrate Ribasim model.")
+parser.add_argument("input_toml", help="Path to input TOML file")
+parser.add_argument("output_toml", help="Path to output TOML file")
+args = parser.parse_args()
+
+model = Model.read(args.input_toml)
+model.write(args.output_toml)


### PR DESCRIPTION
Fix #2350

```
❯ pixi run migrate-model models\hws\hws.toml models\hws-storage\hws.toml
✨ Pixi task (migrate-model in default): python utils/migrate_model.py models\hws\hws.toml models\hws-storage\hws.toml
C:\ProgramData\DevDrives\repo\ribasim\Ribasim\python\ribasim\ribasim\migrations.py:148: UserWarning: Migrating outdated Basin / profile table.
  warnings.warn("Migrating outdated Basin / profile table.", UserWarning)
```