### PR TITLE
Switch to latest `SparseConnectivityTracer` release

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2337,11 +2337,9 @@ version = "1.11.0"
 
 [[deps.SparseConnectivityTracer]]
 deps = ["ADTypes", "DocStringExtensions", "FillArrays", "LinearAlgebra", "Random", "SparseArrays"]
-git-tree-sha1 = "45135436bd57b5c6e9352690aab54d25262253d8"
-repo-rev = "datainterpolations-8.0.0"
-repo-url = "https://github.com/visr/SparseConnectivityTracer.jl"
+git-tree-sha1 = "2c3cbb3703f77045d4eb891b2831ca132ef4183c"
 uuid = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
-version = "0.6.15"
+version = "0.6.19"
 
     [deps.SparseConnectivityTracer.extensions]
     SparseConnectivityTracerDataInterpolationsExt = "DataInterpolations"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2337,9 +2337,9 @@ version = "1.11.0"
 
 [[deps.SparseConnectivityTracer]]
 deps = ["ADTypes", "DocStringExtensions", "FillArrays", "LinearAlgebra", "Random", "SparseArrays"]
-git-tree-sha1 = "2c3cbb3703f77045d4eb891b2831ca132ef4183c"
+git-tree-sha1 = "affde0bfd920cfcaa0944d3c0eb3a573fa9c4d1e"
 uuid = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
-version = "0.6.19"
+version = "0.6.20"
 
     [deps.SparseConnectivityTracer.extensions]
     SparseConnectivityTracerDataInterpolationsExt = "DataInterpolations"

--- a/core/src/carrays.jl
+++ b/core/src/carrays.jl
@@ -75,7 +75,6 @@ function Base.similar(x::CArray, ::Type{T}) where {T}
 end
 
 Base.iterate(x::CArray, state...) = iterate(getdata(x), state...)
-Base.map!(f, y::AbstractArray, x::CArray) = CArray(map!(f, y, getdata(x)), getaxes(x))
 Base.map(f, x::CArray) = CArray(map(f, getdata(x)), getaxes(x))
 
 # Implement broadcasting such that `u - uprev` returns a CArray.

--- a/core/src/carrays.jl
+++ b/core/src/carrays.jl
@@ -66,7 +66,8 @@ Base.copy(x::CArray) = CArray(copy(getdata(x)), getaxes(x))
 Base.zero(x::CArray) = CArray(zero(getdata(x)), getaxes(x))
 Base.similar(x::CArray) = CArray(similar(getdata(x)), getaxes(x))
 Base.similar(x::CArray, dims::Vararg{Int}) = similar(getdata(x), dims...)
-Base.similar(x::CArray, ::Type{T}, dims::Vararg{Int}) where {T} = similar(getdata(x), T, dims...)
+Base.similar(x::CArray, ::Type{T}, dims::Vararg{Int}) where {T} =
+    similar(getdata(x), T, dims...)
 
 function Base.similar(x::CArray, ::Type{T}) where {T}
     data = similar(getdata(x), T)
@@ -74,6 +75,7 @@ function Base.similar(x::CArray, ::Type{T}) where {T}
 end
 
 Base.iterate(x::CArray, state...) = iterate(getdata(x), state...)
+Base.map(f, x::CArray) = CArray(map(f, getdata(x)), getaxes(x))
 
 # Implement broadcasting such that `u - uprev` returns a CArray.
 # Based on https://docs.julialang.org/en/v1/manual/interfaces/#Selecting-an-appropriate-output-array

--- a/core/src/carrays.jl
+++ b/core/src/carrays.jl
@@ -75,6 +75,7 @@ function Base.similar(x::CArray, ::Type{T}) where {T}
 end
 
 Base.iterate(x::CArray, state...) = iterate(getdata(x), state...)
+Base.map!(f, y::AbstractArray, x::CArray) = CArray(map!(f, y, getdata(x)), getaxes(x))
 Base.map(f, x::CArray) = CArray(map(f, getdata(x)), getaxes(x))
 
 # Implement broadcasting such that `u - uprev` returns a CArray.

--- a/core/test/carrays_test.jl
+++ b/core/test/carrays_test.jl
@@ -22,6 +22,10 @@
     @test similar(x, 2, 3) isa Matrix{Float64}
     @test similar(x, Int, 2, 3) isa Matrix{Int}
     @test iterate(x) === (1.0, 2)
+
+    @test map(identity, x) isa CVector{Float64}
+    @test map!(identity, similar(data), x) isa Vector{Float64}
+    @test map!(identity, similar(x), x) isa CVector{Float64}
 end
 
 @testitem "Int" begin


### PR DESCRIPTION
It took some digging, but it turns out we needed a `Base.map` overload for `CArrays` to make it work.