### PR TITLE
revert relaxed root

### DIFF
--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -711,8 +711,7 @@ but the derivative is bounded at x = 0.
 """
 function relaxed_root(x, threshold)
     if abs(x) < threshold
-        x_scaled = x / threshold
-        sqrt(threshold) * x_scaled^3 * (9 - 5x_scaled^2) / 4
+        1 / 4 * (x / sqrt(threshold)) * (5 - (x / threshold)^2)
     else
         sign(x) * sqrt(abs(x))
     end

--- a/core/test/utils_test.jl
+++ b/core/test/utils_test.jl
@@ -464,17 +464,6 @@ end
     @test relaxed_root(2.0, 1.0) ≈ sqrt(2.0)
     @test relaxed_root(-2.0, 1.0) ≈ -sqrt(2.0)
 
-    # Test for x < threshold (smooth region)
-    eps = 1.0
-    x = 0.5
-    y = relaxed_root(x, eps)
-    # Should be continuous and differentiable at x = eps
-    @test y ≈ 1 / 4 * (x / sqrt(eps)) * (5 - (x / eps)^2)
-
-    x = -0.5
-    y = relaxed_root(x, eps)
-    @test y ≈ 1 / 4 * (x / sqrt(eps)) * (5 - (x / eps)^2)
-
     # Test at threshold boundary
     x = eps
     y1 = relaxed_root(x, eps)

--- a/core/test/utils_test.jl
+++ b/core/test/utils_test.jl
@@ -469,18 +469,18 @@ end
     x = eps
     y1 = relaxed_root(x, eps)
     y2 = sqrt(x)
-    @test isapprox(y1, y2; atol = 1e-12)
+    @test y1 ≈ y2 atol = 1e-12
 
     x = -eps
     y1 = relaxed_root(x, eps)
     y2 = -sqrt(abs(x))
-    @test isapprox(y1, y2; atol = 1e-12)
+    @test y1 ≈ y2 atol = 1e-12
 
     # Test half way threshold, relative diff is not more than 20 %
     x = eps / 2
     y1 = relaxed_root(x, eps)
     y2 = sqrt(eps / 2)
-    @test isapprox(y1, y2; rtol = 0.2)
+    @test y1 ≈ y2 atol = 0.2
 
     # Test for very small epsilon
     @test relaxed_root(1e-8, 1e-8) ≈ sqrt(1e-8)

--- a/core/test/utils_test.jl
+++ b/core/test/utils_test.jl
@@ -465,6 +465,7 @@ end
     @test relaxed_root(-2.0, 1.0) ≈ -sqrt(2.0)
 
     # Test at threshold boundary
+    eps = 1e-3
     x = eps
     y1 = relaxed_root(x, eps)
     y2 = sqrt(x)

--- a/core/test/utils_test.jl
+++ b/core/test/utils_test.jl
@@ -453,3 +453,46 @@ end
     @test find_index(:c, s) === 3
     @test_throws "not found" find_index(:d, s)
 end
+
+@testitem "relaxed_root basic behavior" begin
+    using Ribasim: relaxed_root
+
+    # Test for x = 0
+    @test relaxed_root(0.0, 1e-3) == 0.0
+
+    # Test for x > threshold
+    @test relaxed_root(2.0, 1.0) ≈ sqrt(2.0)
+    @test relaxed_root(-2.0, 1.0) ≈ -sqrt(2.0)
+
+    # Test for x < threshold (smooth region)
+    eps = 1.0
+    x = 0.5
+    y = relaxed_root(x, eps)
+    # Should be continuous and differentiable at x = eps
+    @test y ≈ 1 / 4 * (x / sqrt(eps)) * (5 - (x / eps)^2)
+
+    x = -0.5
+    y = relaxed_root(x, eps)
+    @test y ≈ 1 / 4 * (x / sqrt(eps)) * (5 - (x / eps)^2)
+
+    # Test at threshold boundary
+    x = eps
+    y1 = relaxed_root(x, eps)
+    y2 = sqrt(x)
+    @test isapprox(y1, y2; atol = 1e-12)
+
+    x = -eps
+    y1 = relaxed_root(x, eps)
+    y2 = -sqrt(abs(x))
+    @test isapprox(y1, y2; atol = 1e-12)
+
+    # Test half way threshold, relative diff is not more than 20 %
+    x = eps / 2
+    y1 = relaxed_root(x, eps)
+    y2 = sqrt(eps / 2)
+    @test isapprox(y1, y2; rtol = 0.2)
+
+    # Test for very small epsilon
+    @test relaxed_root(1e-8, 1e-8) ≈ sqrt(1e-8)
+    @test relaxed_root(-1e-8, 1e-8) ≈ -sqrt(1e-8)
+end

--- a/docs/reference/node/manning-resistance.qmd
+++ b/docs/reference/node/manning-resistance.qmd
@@ -139,7 +139,7 @@ s(x; x_0)
 =
 \begin{align}
   \begin{cases}
-    \frac{\sqrt{x_0}}{4}\left(\frac{x}{p}\right)^3\left(9 - 5\left(\frac{x}{p}\right)^2\right) &\text{ if } |x| < x_0 \\
+    \frac{x}{4\sqrt{p}}\left(5 - (\frac{x}{p})^2\right) &\text{ if } |x| < x_0 \\
     \textrm{sign}(x)\sqrt{|x|} &\text{ if } |x| \ge x_0
   \end{cases}
 \end{align}
@@ -153,7 +153,7 @@ import matplotlib.pyplot as plt
 def s(x, threshold):
   if np.abs(x) < threshold:
     x_scaled = x / threshold
-    return np.sqrt(threshold) * x_scaled**3 * (9 - 5*x_scaled**2) / 4
+    return x / (4*np.sqrt(threshold)) * (5 - (x/threshold)**2)
   else:
     return np.sign(x)*np.sqrt(np.abs(x))
 


### PR DESCRIPTION
Fixes #2356 by reverting to a previous implementation first introduced at #1750

Achieved performance gain:

HollandseDelta_parameterized_2025_6_0
relaxed_root_old = Computation time: 1 minute, 17 seconds, 392 milliseconds
relaxed_root = Computation time: 3 minutes, 9 seconds, 247 milliseconds