### PR TITLE
Replace docs code block with markdown

### DIFF
--- a/docs/reference/node/discrete-control.qmd
+++ b/docs/reference/node/discrete-control.qmd
@@ -5,37 +5,14 @@ title: "DiscreteControl"
 Set parameters of other nodes based on model state conditions (e.g. Basin level).
 The table below shows which parameters are controllable for a given node type.
 
-```{julia}
-# | code-fold: true
-using Ribasim
-using DataFrames: DataFrame
-using MarkdownTables
-
-node_names = Symbol[]
-controllable_parameters = String[]
-
-for node_type in fieldtypes(Ribasim.ParametersIndependent)
-    if node_type <: Ribasim.AbstractParameterNode
-        node_name = nameof(node_type)
-        controllable_fields = Ribasim.controllablefields(node_name)
-        controllable_fields = sort!(string.(controllable_fields))
-        if node_name == :TabulatedRatingCurve
-            controllable_fields = map(
-                s -> replace(s, "table" => "q(h) relationship (given by level, flow_rate)"),
-                controllable_fields,
-            )
-        end
-        if !isempty(controllable_fields)
-            push!(node_names, Ribasim.snake_case(node_name))
-            push!(controllable_parameters, join(controllable_fields, ", "))
-        end
-    end
-end
-
-df = DataFrame(:node => node_names, :controllable_parameters => controllable_parameters)
-
-markdown_table(df)
-```
+| node                     | controllable_parameters                               |
+|--------------------------|-------------------------------------------------------|
+|      `linear_resistance` |                                    active, resistance |
+|     `manning_resistance` |                                     active, manning_n |
+| `tabulated_rating_curve` | active, q(h) relationship (given by level, flow_rate) |
+|                   `pump` |                                     active, flow_rate |
+|                 `outlet` |                                     active, flow_rate |
+|            `pid_control` |    active, derivative, integral, proportional, target |
 
 # Tables
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -55,7 +55,7 @@ quarto-preview = { cmd = "quarto preview docs", depends-on = [
     "generate-testmodels",
 ] }
 quarto-check = { cmd = "quarto check all", depends-on = ["quartodoc-build"] }
-quarto-render = { cmd = "julia --project --check-bounds=yes --eval 'using Pkg; Pkg.build(\"IJulia\")' && quarto render docs --to html --execute", depends-on = [
+quarto-render = { cmd = "julia --project --check-bounds=yes --eval 'using Pkg; Pkg.build(\"IJulia\")' && quarto render docs --to html --execute --log-level debug", depends-on = [
     "quartodoc-build",
     "generate-testmodels",
 ] }


### PR DESCRIPTION
Seeing if this helps with https://github.com/Deltares/Ribasim/pull/2371#issuecomment-2969343086. I can run the snippet fine locally.

```
df |> markdown_table(String) |> clipboard
```

Also make quarto more verbose.