### PR TITLE
Test `LinearResistance` and `TabulatedRatingCurve` in allocation

### DIFF
--- a/core/src/allocation_init.jl
+++ b/core/src/allocation_init.jl
@@ -592,12 +592,13 @@ function add_linear_resistance!(
 
                 Δlevel_min = min_inflow_level - max_outflow_level
                 Δlevel_max = max_inflow_level - min_outflow_level
+                Δlevel_max_flow = resistance[node_id.idx] * max_flow
 
                 input = [-Δlevel_max_flow, Δlevel_max_flow]
                 output = [-max_flow, max_flow]
 
                 if Δlevel_min < -Δlevel_max_flow
-                    pushfirst!(input, Δllevel_min)
+                    pushfirst!(input, Δlevel_min)
                     pushfirst!(output, -max_flow)
                 end
 

--- a/core/src/allocation_init.jl
+++ b/core/src/allocation_init.jl
@@ -103,8 +103,9 @@ function add_basin!(
     values_storage = Dict{NodeID, Vector{Float64}}()
     values_level = Dict{NodeID, Vector{Float64}}()
 
-    # TODO: Not just split in segments given by input data, but look for changes in slope
+    # TODO: Use DouglasPeucker algorithm here and for TabulatedRatingCurve
 
+    # TODO: Find lowest level within subnetwork of basins and level boundaries
     lowest_level = minimum(itp -> itp.t[1], level_to_area)
 
     for node_id in basin_ids_subnetwork
@@ -607,7 +608,6 @@ function add_linear_resistance!(
                     push!(output, max_flow)
                 end
 
-                Δlevel_max_flow = resistance[node_id.idx] * max_flow
                 piecewiselinear(problem, Δlevel, input, output)
             end
         end,

--- a/core/src/allocation_optim.jl
+++ b/core/src/allocation_optim.jl
@@ -177,11 +177,6 @@ end
 function reset_goal_programming!(allocation_model::AllocationModel)::Nothing
     (; problem) = allocation_model
 
-    # From physics_forcing objective
-    for forcing_variable in problem[:basin_forcing]
-        JuMP.is_fixed(forcing_variable) && JuMP.unfix(forcing_variable)
-    end
-
     # From demand objectives
     JuMP.fix.(problem[:user_demand_allocated], 0.0; force = true)
     JuMP.fix.(problem[:flow_demand_allocated], -MAX_ABS_FLOW; force = true)
@@ -355,11 +350,10 @@ end
 
 function assign_allocations!(
     p_independent::ParametersIndependent,
-    allocation_model::AllocationModel,
+    problem::JuMP.Model,
     objective::AllocationObjective,
 )::Nothing
     (; allocated, inflow_link) = p_independent.user_demand
-    (; problem) = allocation_model
     (; demand_priority_idx) = objective
     user_demand_allocated = problem[:user_demand_allocated]
     flow = problem[:flow]
@@ -476,13 +470,11 @@ function save_allocation_flows!(
     p_independent::ParametersIndependent,
     t::Float64,
     allocation_model::AllocationModel,
-    objective::AllocationObjective,
     optimization_type::AllocationOptimizationType.T,
 )::Nothing
     (; problem, subnetwork_id) = allocation_model
     (; graph, allocation) = p_independent
     (; record_flow) = allocation
-    (; demand_priority) = objective
     flow = problem[:flow]
     basin_forcing = problem[:basin_forcing]
 
@@ -498,7 +490,6 @@ function save_allocation_flows!(
         push!(record_flow.to_node_type, string(id_to.type))
         push!(record_flow.to_node_id, Int32(id_to))
         push!(record_flow.subnetwork_id, subnetwork_id)
-        push!(record_flow.demand_priority, demand_priority)
         push!(record_flow.flow_rate, JuMP.value(flow[link]))
         push!(record_flow.optimization_type, string(optimization_type))
     end
@@ -512,7 +503,6 @@ function save_allocation_flows!(
         push!(record_flow.to_node_type, string(NodeType.Basin))
         push!(record_flow.to_node_id, node_id)
         push!(record_flow.subnetwork_id, subnetwork_id)
-        push!(record_flow.demand_priority, demand_priority)
         push!(record_flow.flow_rate, JuMP.value(basin_forcing[node_id]))
         push!(record_flow.optimization_type, string(optimization_type))
     end
@@ -520,47 +510,66 @@ function save_allocation_flows!(
     return nothing
 end
 
-function optimize_for_objective!(
-    allocation_model::AllocationModel,
-    integrator::DEIntegrator,
+"""
+Preprocess for the specific objective type
+"""
+function preprocess_objective!(
+    problem::JuMP.Model,
+    p_independent::ParametersIndependent,
     objective::AllocationObjective,
-    optimization_type::AllocationOptimizationType.T,
 )::Nothing
-    args = (allocation_model, integrator, objective, optimization_type)
     if objective.type == AllocationObjectiveType.demand
-        optimize_for_demand!(args...)
+        set_demands!(problem, p_independent, objective)
     elseif objective.type == AllocationObjectiveType.source_priorities
-        optimize_for_sources!(args...)
+        nothing
     else
         error("Unsupported objective type $(objective.type).")
     end
     return nothing
 end
 
-function optimize_for_sources!(
-    allocation_model::AllocationModel,
-    integrator::DEIntegrator,
+"""
+Postprocess for the specific objective type
+"""
+function postprocess_objective!(
+    problem::JuMP.Model,
+    p_independent::ParametersIndependent,
     objective::AllocationObjective,
-    optimization_type::AllocationOptimizationType.T,
 )::Nothing
-    # TODO
+    if objective.type == AllocationObjectiveType.demand
+        # Update allocation constraints so that the results of the optimization for this demand priority are retained
+        # in subsequent optimizations
+        update_allocated_values!(problem, p_independent, objective)
+
+        assign_allocations!(p_independent, problem, objective)
+
+        # Save the demands and allocated values for all demand nodes that have a demand of the current priority
+        save_demands_and_allocations!(
+            p_independent,
+            t,
+            allocation_model,
+            subnetwork_id,
+            objective,
+        )
+    elseif objective.type == AllocationObjectiveType.source_priorities
+        nothing
+    end
     return nothing
 end
 
-function optimize_for_demand!(
+function optimize_for_objective!(
     allocation_model::AllocationModel,
     integrator::DEIntegrator,
     objective::AllocationObjective,
-    optimization_type::AllocationOptimizationType.T,
 )::Nothing
     (; p, t) = integrator
     (; p_independent) = p
     (; problem, subnetwork_id) = allocation_model
 
-    # Set objective corresponding to the demand_priority
-    JuMP.@objective(problem, Min, objective.expression)
+    preprocess_objective!(problem, p_independent, objective)
 
-    set_demands!(problem, p_independent, objective)
+    # Set the objective
+    JuMP.@objective(problem, Min, objective.expression)
 
     # Solve problem
     JuMP.optimize!(problem)
@@ -572,23 +581,7 @@ function optimize_for_demand!(
         )
     end
 
-    # Update allocation constraints so that the results of the optimization for this demand priority are retained
-    # in subsequent optimizations
-    update_allocated_values!(problem, p_independent, objective)
-
-    assign_allocations!(p_independent, allocation_model, objective)
-
-    # Save the demands and allocated values for all demand nodes that have a demand of the current priority
-    save_demands_and_allocations!(
-        p_independent,
-        t,
-        allocation_model,
-        subnetwork_id,
-        objective,
-    )
-
-    # Save the flows over all links in the subnetwork in this stage of the goal programming
-    save_allocation_flows!(p_independent, t, allocation_model, objective, optimization_type)
+    postprocess_objective!(problem, p_independent, objective)
     return nothing
 end
 
@@ -712,13 +705,14 @@ function update_allocation!(integrator)::Nothing
             reset_goal_programming!(allocation_model)
             prepare_demand_collection!(allocation_model, p_independent)
             for objective in allocation_model.objectives
-                optimize_for_objective!(
-                    allocation_model,
-                    integrator,
-                    objective,
-                    AllocationOptimizationType.collect_demands,
-                )
+                optimize_for_objective!(allocation_model, integrator, objective)
             end
+            save_allocation_flows!(
+                p_independent,
+                t,
+                allocation_model,
+                AllocationOptimizationType.collect_demands,
+            )
             get_subnetwork_demand!(allocation_model)
         end
     end
@@ -727,12 +721,7 @@ function update_allocation!(integrator)::Nothing
     for allocation_model in allocation_models
         reset_goal_programming!(allocation_model)
         for objective in allocation_model.objectives
-            optimize_for_objective!(
-                allocation_model,
-                integrator,
-                objective,
-                AllocationOptimizationType.allocate,
-            )
+            optimize_for_objective!(allocation_model, integrator, objective)
         end
 
         if is_primary_network(allocation_model.subnetwork_id)
@@ -751,6 +740,13 @@ function update_allocation!(integrator)::Nothing
             allocation_model,
             graph,
             state_time_dependent_cache.current_flow_rate_outlet,
+        )
+
+        save_allocation_flows!(
+            p_independent,
+            t,
+            allocation_model,
+            AllocationOptimizationType.collect_demands,
         )
 
         # Reset cumulative data

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -252,7 +252,6 @@ end
     to_node_type::Vector{String} = []
     to_node_id::Vector{Int32} = []
     subnetwork_id::Vector{Int32} = []
-    demand_priority::Vector{Int32} = []
     flow_rate::Vector{Float64} = []
     optimization_type::Vector{String} = []
 end
@@ -454,6 +453,8 @@ of vectors or Arrow Tables, and is added to avoid type instabilities.
     vertical_flux::VerticalFlux = VerticalFlux(length(node_id))
     # Initial_storage
     storage0::Vector{Float64} = zeros(length(node_id))
+    # The storage rate for computing the minimum basin emptying_time
+    dstorage::Vector{Float64} = zeros(length(node_id))
     # Storage at previous saveat without storage0
     Δstorage_prev_saveat::Vector{Float64} = zeros(length(node_id))
     # Analytically integrated forcings

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -127,11 +127,11 @@ function set_current_basin_properties!(u::CVector, p::Parameters, t::Number)::No
     # The exact cumulative precipitation and drainage up to the t of this water_balance call
     if p_mutable.new_t
         dt = t - p_mutable.tprev
-        for node_id in node_id
-            fixed_area = basin_areas(basin, node_id.idx)[end]
-            time_dependent_cache.basin.current_cumulative_precipitation[node_id.idx] =
-                cumulative_precipitation[node_id.idx] +
-                fixed_area * vertical_flux.precipitation[node_id.idx] * dt
+        for id in node_id
+            fixed_area = basin_areas(basin, id.idx)[end]
+            time_dependent_cache.basin.current_cumulative_precipitation[id.idx] =
+                cumulative_precipitation[id.idx] +
+                fixed_area * vertical_flux.precipitation[id.idx] * dt
         end
         @. time_dependent_cache.basin.current_cumulative_drainage =
             cumulative_drainage + dt * vertical_flux.drainage

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -354,7 +354,6 @@ function allocation_flow_table(
     to_node_type::Vector{String},
     to_node_id::Vector{Int32},
     subnetwork_id::Vector{Int32},
-    demand_priority::Vector{Int32},
     flow_rate::Vector{Float64},
     optimization_type::Vector{String},
 }
@@ -371,7 +370,6 @@ function allocation_flow_table(
         record_flow.to_node_type,
         record_flow.to_node_id,
         record_flow.subnetwork_id,
-        record_flow.demand_priority,
         record_flow.flow_rate,
         record_flow.optimization_type,
     )

--- a/core/test/allocation_physics_test.jl
+++ b/core/test/allocation_physics_test.jl
@@ -16,3 +16,21 @@
 
     @test allocation_flow_table.flow_rate ≈ flow_table.flow_rate rtol = 1e-2
 end
+
+@testitem "Tabulated Rating Curve" begin
+    using DataFrames: DataFrame
+
+    toml_path = normpath(@__DIR__, "../../generated_testmodels/rating_curve/ribasim.toml")
+    @test ispath(toml_path)
+
+    config = Ribasim.Config(toml_path; experimental_allocation = true)
+    model = Ribasim.Model(config)
+    @profview Ribasim.solve!(model)
+    allocation_flow_table = DataFrame(Ribasim.allocation_flow_table(model))
+    flow_table = DataFrame(Ribasim.flow_table(model))
+
+    filter!(:link_id => ==(1), allocation_flow_table)
+    filter!(:link_id => ==(1), flow_table)
+
+    @test allocation_flow_table.flow_rate ≈ flow_table.flow_rate rtol = 1e-1
+end

--- a/core/test/allocation_physics_test.jl
+++ b/core/test/allocation_physics_test.jl
@@ -1,0 +1,18 @@
+@testitem "Linear Resistance" begin
+    using DataFrames: DataFrame
+
+    toml_path =
+        normpath(@__DIR__, "../../generated_testmodels/linear_resistance/ribasim.toml")
+    @test ispath(toml_path)
+
+    config = Ribasim.Config(toml_path; experimental_allocation = true)
+    model = Ribasim.Model(config)
+    Ribasim.solve!(model)
+    allocation_flow_table = DataFrame(Ribasim.allocation_flow_table(model))
+    flow_table = DataFrame(Ribasim.flow_table(model))
+
+    filter!(:link_id => ==(1), allocation_flow_table)
+    filter!(:link_id => ==(1), flow_table)
+
+    @test allocation_flow_table.flow_rate ≈ flow_table.flow_rate rtol = 1e-2
+end

--- a/core/test/allocation_physics_test.jl
+++ b/core/test/allocation_physics_test.jl
@@ -25,7 +25,7 @@ end
 
     config = Ribasim.Config(toml_path; experimental_allocation = true)
     model = Ribasim.Model(config)
-    @profview Ribasim.solve!(model)
+    Ribasim.solve!(model)
     allocation_flow_table = DataFrame(Ribasim.allocation_flow_table(model))
     flow_table = DataFrame(Ribasim.flow_table(model))
 

--- a/python/ribasim_testmodels/ribasim_testmodels/equations.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/equations.py
@@ -27,14 +27,16 @@ def linear_resistance_model() -> Model:
     )
 
     model.basin.add(
-        Node(1, Point(0, 0)),
+        Node(1, Point(0, 0), subnetwork_id=1),
         [basin.Profile(area=100.0, level=[0.0, 10.0]), basin.State(level=[10.0])],
     )
     model.linear_resistance.add(
-        Node(2, Point(1, 0)),
+        Node(2, Point(1, 0), subnetwork_id=1),
         [linear_resistance.Static(resistance=[5e4], max_flow_rate=[6e-5])],
     )
-    model.level_boundary.add(Node(3, Point(2, 0)), [level_boundary.Static(level=[5.0])])
+    model.level_boundary.add(
+        Node(3, Point(2, 0), subnetwork_id=1), [level_boundary.Static(level=[5.0])]
+    )
 
     model.link.add(
         model.basin[1],

--- a/python/ribasim_testmodels/ribasim_testmodels/equations.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/equations.py
@@ -60,9 +60,9 @@ def rating_curve_model() -> Model:
     )
 
     model.basin.add(
-        Node(1, Point(0, 0)),
+        Node(1, Point(0, 0), subnetwork_id=1),
         [
-            basin.Profile(area=[0.01, 100.0, 100.0], level=[0.0, 1.0, 2.0]),
+            basin.Profile(area=[0.01, 100.0, 100.0], level=[0.0, 1.0, 12.0]),
             basin.State(level=[10.5]),
         ],
     )
@@ -71,11 +71,11 @@ def rating_curve_model() -> Model:
     level = np.linspace(1, 12, 100)
     flow_rate = np.square(level - level_min) / (60 * 60 * 24)
     model.tabulated_rating_curve.add(
-        Node(2, Point(1, 0)),
+        Node(2, Point(1, 0), subnetwork_id=1),
         [tabulated_rating_curve.Static(level=level, flow_rate=flow_rate)],
     )
 
-    model.terminal.add(Node(3, Point(2, 0)))
+    model.terminal.add(Node(3, Point(2, 0), subnetwork_id=1))
 
     model.link.add(
         model.basin[1],


### PR DESCRIPTION
Fixes the `LinearResistance` part of #2149, fixes #2148.

Here's a comparison of `LinearResistance` flow in a simple model between the physical layer and allocation:

![image](https://github.com/user-attachments/assets/db08f394-eca9-41b1-8a80-fead90f647b1)

It even takes `max_flow_rate` into account properly!

Here's a similar comparison of `TabulatedRatingCurve` flow:

![image](https://github.com/user-attachments/assets/3816ee7b-8085-49c4-ad80-358957be3d0d)


  