### PR TITLE
Switch from UMFPACK to KLU sparse linear solver

### DIFF
--- a/core/src/config.jl
+++ b/core/src/config.jl
@@ -21,6 +21,7 @@ using OrdinaryDiffEqTsit5: Tsit5
 using OrdinaryDiffEqSDIRK: ImplicitEuler, KenCarp4, TRBDF2
 using OrdinaryDiffEqBDF: FBDF, QNDF
 using OrdinaryDiffEqRosenbrock: Rosenbrock23, Rodas4P, Rodas5P
+using LinearSolve: KLUFactorization
 
 export Config, Solver, Results, Logging, Toml
 export algorithm,
@@ -313,6 +314,9 @@ function algorithm(solver::Solver; u0 = [])::OrdinaryDiffEqAlgorithm
 
     if algotype <: OrdinaryDiffEqNewtonAdaptiveAlgorithm
         kwargs[:nlsolve] = NLNewton()
+        if solver.sparse
+            kwargs[:linsolve] = KLUFactorization()
+        end
     end
 
     if function_accepts_kwarg(algotype, :step_limiter!)

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -198,7 +198,6 @@ end
 @testitem "basic model" begin
     using Logging: Debug, with_logger
     using LoggingExtras
-    using OrdinaryDiffEqBDF: QNDF
     import Tables
     using Dates
 
@@ -214,16 +213,13 @@ end
     @test model isa Ribasim.Model
 
     (; integrator) = model
-    (; p, alg) = integrator
+    (; p) = integrator
     (; p_independent, state_time_dependent_cache) = p
 
     @test p isa Ribasim.Parameters
     @test isconcretetype(typeof(p_independent))
     @test all(isconcretetype, fieldtypes(typeof(p_independent)))
     @test p_independent.node_id == [4, 5, 8, 7, 10, 12, 2, 1, 3, 6, 9, 1, 3, 6, 9]
-
-    @test alg isa QNDF
-    @test alg.step_limiter! == Ribasim.limit_flow!
 
     @test success(model)
     @test length(model.integrator.sol) == 2 # start and end

--- a/core/test/utils_test.jl
+++ b/core/test/utils_test.jl
@@ -294,6 +294,21 @@ end
     @test jac_prototype == jac_prototype_expected
 end
 
+@testitem "Solver algorithm" begin
+    using LinearSolve: KLUFactorization
+    using OrdinaryDiffEqNonlinearSolve: NLNewton
+    using OrdinaryDiffEqBDF: QNDF
+
+    model =
+        Ribasim.Model(normpath(@__DIR__, "../../generated_testmodels/bucket/ribasim.toml"))
+    (; alg) = model.integrator
+
+    @test alg isa QNDF
+    @test alg.step_limiter! == Ribasim.limit_flow!
+    @test alg.nlsolve == NLNewton()
+    @test alg.linsolve == KLUFactorization()
+end
+
 @testitem "FlatVector" begin
     vv = [[2.2, 3.2], [4.3, 5.3], [6.4, 7.4]]
     fv = Ribasim.FlatVector(vv)


### PR DESCRIPTION
I was talking to @Huite about linear solvers, and the last time I compared some options was in https://github.com/Deltares/Ribasim/pull/2043#issuecomment-2642537825.

I did benchmarks using `AmstelGooienVecht_parameterized_2025_6_13` since it is quite large and uses daily varying meteo forcing.

```
UMFPACKFactorization()
18.932428 seconds (20.04 M allocations: 6.932 GiB, 2.68% gc time)
PardisoJL(; vendor = :MKL)
47.083817 seconds (19.95 M allocations: 3.339 GiB, 0.60% gc time)
MKLPardisoIterate()
43.992427 seconds (19.95 M allocations: 3.339 GiB, 0.70% gc time)
MKLPardisoFactorize()
48.077815 seconds (19.95 M allocations: 3.339 GiB, 0.67% gc time)
KLUFactorization()
10.374421 seconds (19.93 M allocations: 1.061 GiB, 1.13% gc time)
```

So Pardiso is 2x slower than UMFPACK, but KLU is 2x faster, with a lot less allocated memory as well. This is probably better than MKL since that doesn't really support Apple anymore. As mentioned in [the LinearSolve docs](https://docs.sciml.ai/LinearSolve/stable/tutorials/accelerating_choices/#Understanding-Performance-of-Sparse-Linear-Solves), the best choice is highly problem dependent.
