### PR TITLE
Pixi: initialize julia before SBOM and Quarto render

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -48,7 +48,7 @@ quarto-preview = { cmd = "quarto preview docs", depends-on = [
     "generate-testmodels",
 ] }
 quarto-check = { cmd = "quarto check all", depends-on = ["quartodoc-build"] }
-quarto-render = { cmd = "julia --project --check-bounds=yes --eval 'using Pkg; Pkg.build(\"IJulia\")' && quarto render docs --to html --execute", depends-on = [
+quarto-render = { cmd = "julia --project --check-bounds=yes --eval 'using Pkg; Pkg.build(\"IJulia\")' && quarto render docs --to html", depends-on = [
     "quartodoc-build",
     "generate-testmodels",
     "initialize-julia",


### PR DESCRIPTION
These are some fixes out of #2381

(cherry picked from commit 7b9c262854843faa710bd5ee37056e55d7bb4126)



