### PR TITLE
Add convergence and dt to output.

### DIFF
--- a/core/src/callback.jl
+++ b/core/src/callback.jl
@@ -327,8 +327,8 @@ function save_flow(u, t, integrator)
     n_basin = length(basin.node_id)
     inflow_mean = zeros(n_basin)
     outflow_mean = zeros(n_basin)
-    flow_convergence = fill(NaN, length(u))
-    basin_convergence = fill(NaN, n_basin)
+    flow_convergence = fill(missing, length(u)) |> Vector{Union{Missing, Float64}}
+    basin_convergence = fill(missing, n_basin) |> Vector{Union{Missing, Float64}}
 
     # Flow contributions from horizontal flow states
     for (flow, inflow_link, outflow_link) in
@@ -371,6 +371,7 @@ function save_flow(u, t, integrator)
 
     if hasproperty(cache, :nlsolver)
         @. flow_convergence = abs(cache.nlsolver.cache.atmp / u)
+        flow_convergence = CVector(flow_convergence, getaxes(u))
         for (i, (evap, infil)) in
             enumerate(zip(flow_convergence.evaporation, flow_convergence.infiltration))
             if isnan(evap)

--- a/core/src/graph.jl
+++ b/core/src/graph.jl
@@ -353,6 +353,24 @@ function get_flow(
     end
 end
 
+"""
+Like `get_flow` and `get_state_index`, but for convergence, so without the boundary flow.
+"""
+function get_convergence(
+    convergence::CVector,
+    link::Tuple{NodeID, NodeID},
+)::Union{Missing, Float64}
+    a = get_state_index(getaxes(convergence), link[1]; inflow = false)
+    b = get_state_index(getaxes(convergence), link[2])
+    if isnothing(a) && isnothing(b)
+        missing
+    elseif isnothing(a)
+        convergence[b]
+    elseif isnothing(b)
+        convergence[a]
+    end
+end
+
 function get_influx(du::CVector, id::NodeID, p::Parameters)
     @assert id.type == NodeType.Basin
     (; basin) = p.p_independent

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -356,8 +356,8 @@ In-memory storage of saved mean flows for writing to results.
     storage_rate::Vector{Float64} = zero(precipitation)
     balance_error::Vector{Float64} = zero(precipitation)
     relative_error::Vector{Float64} = zero(precipitation)
-    basin_convergence::Vector{Float64}
-    flow_convergence::Vector{Float64}
+    basin_convergence::Vector{Union{Missing, Float64}}
+    flow_convergence::Vector{Union{Missing, Float64}}
     t::Float64
 end
 

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -11,6 +11,7 @@ const SolverStats = @NamedTuple{
     linear_solves::Int,
     accepted_timesteps::Int,
     rejected_timesteps::Int,
+    dt::Float64,
 }
 
 const state_components = (
@@ -355,6 +356,8 @@ In-memory storage of saved mean flows for writing to results.
     storage_rate::Vector{Float64} = zero(precipitation)
     balance_error::Vector{Float64} = zero(precipitation)
     relative_error::Vector{Float64} = zero(precipitation)
+    basin_convergence::Vector{Float64}
+    flow_convergence::Vector{Float64}
     t::Float64
 end
 

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -133,9 +133,7 @@ function basin_table(
     convergence::Vector{Float64},
 }
     (; saved) = model
-    (; u, p) = model.integrator
-    (; basin,) = p.p_independent
-
+    (; u) = model.integrator
     state_ranges = getaxes(u)
 
     # The last timestep is not included; there is no period over which to compute flows.

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -130,9 +130,12 @@ function basin_table(
     infiltration::Vector{Float64},
     balance_error::Vector{Float64},
     relative_error::Vector{Float64},
+    convergence::Vector{Float64},
 }
     (; saved) = model
-    (; u) = model.integrator
+    (; u, p) = model.integrator
+    (; basin,) = p.p_independent
+
     state_ranges = getaxes(u)
 
     # The last timestep is not included; there is no period over which to compute flows.
@@ -153,6 +156,7 @@ function basin_table(
     storage_rate = FlatVector(saved.flow.saveval, :storage_rate)
     balance_error = FlatVector(saved.flow.saveval, :balance_error)
     relative_error = FlatVector(saved.flow.saveval, :relative_error)
+    convergence = FlatVector(saved.flow.saveval, :basin_convergence)
 
     idx_row = 0
     for saved_flow in saved.flow.saveval
@@ -182,6 +186,7 @@ function basin_table(
         infiltration,
         balance_error,
         relative_error,
+        convergence,
     )
 end
 
@@ -194,6 +199,7 @@ function solver_stats_table(
     linear_solves::Vector{Int},
     accepted_timesteps::Vector{Int},
     rejected_timesteps::Vector{Int},
+    dt::Vector{Float64},
 }
     solver_stats = StructVector(model.saved.solver_stats.saveval)
     (;
@@ -207,6 +213,7 @@ function solver_stats_table(
         linear_solves = diff(solver_stats.linear_solves),
         accepted_timesteps = diff(solver_stats.accepted_timesteps),
         rejected_timesteps = diff(solver_stats.rejected_timesteps),
+        dt = solver_stats.dt[2:end],
     )
 end
 
@@ -219,6 +226,7 @@ function flow_table(
     from_node_id::Vector{Int32},
     to_node_id::Vector{Int32},
     flow_rate::Vector{Float64},
+    convergence::Vector{Float64},
 }
     (; config, saved, integrator) = model
     (; t, saveval) = saved.flow
@@ -240,19 +248,38 @@ function flow_table(
     nflow = length(unique_link_ids_flow)
     ntsteps = length(t)
     flow_rate = zeros(nflow * ntsteps)
+    flow_rate_conv = zeros(nflow * ntsteps)
     internal_flow_rate = zeros(length(internal_flow_links))
+    internal_flow_rate_conv = zeros(length(internal_flow_links))
 
     for (ti, cvec) in enumerate(saveval)
-        (; flow, flow_boundary) = cvec
+        (; flow, flow_boundary, flow_convergence) = cvec
         flow = CVector(flow, getaxes(u))
+        convergence = CVector(flow_convergence, getaxes(u))
         for (fi, link) in enumerate(internal_flow_links)
             internal_flow_rate[fi] =
                 get_flow(flow, p_independent, 0.0, link.link; boundary_flow = flow_boundary)
+
+            a = get_state_index(getaxes(convergence), link.link[2])
+            b = get_state_index(getaxes(convergence), link.link[1]; inflow = false)
+            conv = if isnothing(a) && isnothing(b)
+                NaN
+            elseif isnothing(a)
+                convergence[b]
+            elseif isnothing(b)
+                convergence[a]
+            end
+            internal_flow_rate_conv[fi] = conv
         end
         mul!(
             view(flow_rate, (1 + (ti - 1) * nflow):(ti * nflow)),
             flow_link_map,
             internal_flow_rate,
+        )
+        mul!(
+            view(flow_rate_conv, (1 + (ti - 1) * nflow):(ti * nflow)),
+            flow_link_map,
+            internal_flow_rate_conv,
         )
     end
 
@@ -266,7 +293,14 @@ function flow_table(
     from_node_id = repeat(from_node_id; outer = ntsteps)
     to_node_id = repeat(to_node_id; outer = ntsteps)
 
-    return (; time, link_id, from_node_id, to_node_id, flow_rate)
+    return (;
+        time,
+        link_id,
+        from_node_id,
+        to_node_id,
+        flow_rate,
+        convergence = flow_rate_conv,
+    )
 end
 
 "Create a concentration result table from the saved data"

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -44,8 +44,8 @@
 
     @testset Teamcity.TeamcityTestSet "Schema" begin
         @test Tables.schema(flow) == Tables.Schema(
-            (:time, :link_id, :from_node_id, :to_node_id, :flow_rate),
-            (DateTime, Union{Int32, Missing}, Int32, Int32, Float64),
+            (:time, :link_id, :from_node_id, :to_node_id, :flow_rate, :convergence),
+            (DateTime, Union{Int32, Missing}, Int32, Int32, Float64, Float64),
         )
         @test Tables.schema(basin) == Tables.Schema(
             (

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -62,10 +62,12 @@
                 :infiltration,
                 :balance_error,
                 :relative_error,
+                :convergence,
             ),
             (
                 DateTime,
                 Int32,
+                Float64,
                 Float64,
                 Float64,
                 Float64,
@@ -91,8 +93,9 @@
                 :linear_solves,
                 :accepted_timesteps,
                 :rejected_timesteps,
+                :dt,
             ),
-            (DateTime, Float64, Int, Int, Int, Int),
+            (DateTime, Float64, Int, Int, Int, Int, Float64),
         )
     end
 

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -45,7 +45,14 @@
     @testset Teamcity.TeamcityTestSet "Schema" begin
         @test Tables.schema(flow) == Tables.Schema(
             (:time, :link_id, :from_node_id, :to_node_id, :flow_rate, :convergence),
-            (DateTime, Union{Int32, Missing}, Int32, Int32, Float64, Float64),
+            (
+                DateTime,
+                Union{Int32, Missing},
+                Int32,
+                Int32,
+                Float64,
+                Union{Missing, Float64},
+            ),
         )
         @test Tables.schema(basin) == Tables.Schema(
             (
@@ -78,7 +85,7 @@
                 Float64,
                 Float64,
                 Float64,
-                Float64,
+                Union{Missing, Float64},
             ),
         )
         @test Tables.schema(subgrid) == Tables.Schema(

--- a/docs/guide/debug.qmd
+++ b/docs/guide/debug.qmd
@@ -2,6 +2,25 @@
 title: "Debugging models"
 ---
 
+## Slow models
+
+When your model is slow, it's often only a handful of nodes that are hard to solve. If the model finishes or is interrupted, convergence bottlenecks are shown like so:
+
+```julia
+┌ Info: Convergence bottlenecks in descending order of severity:
+│   ManningResistance #251242 = 0.09023997405863035
+│   ManningResistance #70523 = 0.006218636603583534
+│   ManningResistance #251181 = 0.004716432403226626
+│   ManningResistance #251182 = 0.0035319514660666165
+└   ManningResistance #591558 = 0.003284110004804508
+```
+
+It's best to inspect these nodes, and try to adjust the parametrization, or merge smaller nodes. You can find the convergence measure per node over time in the `flow.arrow` and `basin.arrow` [output files](reference/usage.qmd#sec-results).
+
+To gain further insight into model performance, one can inspect the `solver_stats.arrow` output file, which gives the number of computations, number of rejected and accepted solutions, and the size of each calculation timestep.
+
+## Unstable models
+
 When your model exits with a message like so:
 ```julia
 ┌ Error: The model exited at model time 2024-01-27T14:46:17.791 with return code Unstable. See https://docs.sciml.ai/DiffEqDocs/stable/basics/solution/#retcodes

--- a/docs/reference/usage.qmd
+++ b/docs/reference/usage.qmd
@@ -236,7 +236,7 @@ name          | String                        | (optional, does not have to be u
 Similarly to the node table, you can use a geometry to visualize the connections between the
 nodes in QGIS. For instance, you can draw a line connecting the two node coordinates.
 
-# Results
+# Results {#sec-results}
 
 ## Basin - `basin.arrow`
 
@@ -255,24 +255,26 @@ The Basin table contains:
 - The `balance_error` is the difference between the `storage_rate` on one side and the `inflow_rate` and `outflow_rate` on the other side: `storage_rate` - (`inflow_rate` - `outflow_rate`).
   It can be used to check if the numerical error when solving the water balance is sufficiently small.
 - The `relative_error` is the fraction of the `balance_error` over the mean of the `total_inflow` and `total_outflow`.
+- The `convergence` is the scaled residual of the solver, giving an indication of which nodes converge the worst (are hardest to solve).
 
 For a more in-depth explanation of the water balance error see [here](/concept/equations.qmd#the-water-balance-error).
 
-column         | type     | unit
--------------- | ---------| ----
-time           | DateTime | -
-node_id        | Int32    | -
-level          | Float64  | $\text{m}$
-storage        | Float64  | $\text{m}^3$
-inflow_rate    | Float64  | $\text{m}^3/\text{s}$
-outflow_rate   | Float64  | $\text{m}^3/\text{s}$
-storage_rate   | Float64  | $\text{m}^3/\text{s}$
-precipitation  | Float64  | $\text{m}^3/\text{s}$
-evaporation    | Float64  | $\text{m}^3/\text{s}$
-drainage       | Float64  | $\text{m}^3/\text{s}$
-infiltration   | Float64  | $\text{m}^3/\text{s}$
-balance_error  | Float64  | $\text{m}^3/\text{s}$
-relative_error | Float64  | -
+column         | type            | unit
+-------------- | --------------- | ----
+time           | DateTime        | -
+node_id        | Int32           | -
+level          | Float64         | $\text{m}$
+storage        | Float64         | $\text{m}^3$
+inflow_rate    | Float64         | $\text{m}^3/\text{s}$
+outflow_rate   | Float64         | $\text{m}^3/\text{s}$
+storage_rate   | Float64         | $\text{m}^3/\text{s}$
+precipitation  | Float64         | $\text{m}^3/\text{s}$
+evaporation    | Float64         | $\text{m}^3/\text{s}$
+drainage       | Float64         | $\text{m}^3/\text{s}$
+infiltration   | Float64         | $\text{m}^3/\text{s}$
+balance_error  | Float64         | $\text{m}^3/\text{s}$
+relative_error | Float64         | -
+convergence    | Float64/Missing | -
 
 The table is sorted by time, and per time it is sorted by `node_id`.
 
@@ -290,10 +292,12 @@ from_node_id   | Int32                 | -
 to_node_type   | String                | -
 to_node_id     | Int32                 | -
 flow_rate      | Float64               | $\text{m}^3/\text{s}$
+convergence    | Float64/Missing       | -
 
 The table is sorted by time, and per time the same `link_id` order is used, though not sorted.
 The `link_id` value is the same as the `fid` written to the Link table, and can be used to directly look up the Link geometry.
 Flows from the "from" to the "to" node have a positive sign, and if the flow is reversed it will be negative.
+- The `convergence` is the scaled residual of the solver, giving an indication of which nodes converge the worst (are hardest to solve).
 
 ## State - `basin_state.arrow` {#sec-state}
 
@@ -398,6 +402,7 @@ This result file contains statistics about the solver, which can give an insight
 
 The `computation_time` is the wall time in milliseconds spent on the given period.
 The first row tends to include compilation time as well.
+The `dt` is the size (in seconds) of the last calculation timestep (at the `saveat` timestep).
 
 column              | type     | unit
 --------------------| -------- | ----
@@ -407,3 +412,4 @@ water_balance_calls | Int      | -
 linear_solves       | Int      | -
 accepted_timesteps  | Int      | -
 rejected_timesteps  | Int      | -
+dt                  | Float64  | s


### PR DESCRIPTION
This should help with debugging, as we now only get the convergence (`flow_error`) values on a crash/interrupt/end. Now we can see it over time. This includes the `dt` in the solver stats. All values are instantaneous for the saveat timestep.

It already gives interesting patterns for the `basic` model, such as a peak later in time. There are similar peaks for the ManningResistance after a month without a clear explanation.

<img width="833" alt="Screenshot 2025-06-26 at 09 09 36" src="https://github.com/user-attachments/assets/ddb03cb7-8c84-4b65-b0e4-041da329812c" />
