### PR TITLE
fix: resolve pixi task parsing errors and Windows symlink issues

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -73,23 +73,14 @@ build = { "cmd" = "julia --project --check-bounds=yes build.jl", cwd = "build", 
     "initialize-julia",
 ] }
 # Tests
-s3-download = { cmd = "python utils/s3_download.py {{ remote }} {{ local }}", args = [
-    "remote",
-    "local",
-] }
-s3-upload = { cmd = "python utils/s3_upload.py {{ source }} {{ destination }}", args = [
-    "source",
-    "destination",
-] }
+s3-download = { cmd = "python utils/s3_download.py {{ remote }} {{ local }}" }
+s3-upload = { cmd = "python utils/s3_upload.py {{ source }} {{ destination }}" }
 test-ribasim-cli = "pytest --numprocesses=4 --basetemp=build/tests/temp --junitxml=report.xml build/tests"
 test-ribasim-core = { cmd = "julia --project=core --check-bounds=yes --eval 'using Pkg; Pkg.test(allow_reresolve=false)'", depends-on = [
     "generate-testmodels",
 ] }
 test-ribasim-migration = { cmd = "pytest --numprocesses=4 -m regression python/ribasim/tests", depends-on = [
-    { task = "s3-download", args = [
-        "hws_migration_test/",
-        "hws_migration_test/",
-    ] },
+    "s3-download",
 ] }
 test-ribasim-core-cov = { cmd = "julia --project=core --check-bounds=yes --eval 'using Pkg; Pkg.test(allow_reresolve=false, coverage=true)'", depends-on = [
     "generate-testmodels",
@@ -97,10 +88,7 @@ test-ribasim-core-cov = { cmd = "julia --project=core --check-bounds=yes --eval 
 test-ribasim-regression = { cmd = "julia --project=core --check-bounds=yes --eval 'using Pkg; Pkg.test(allow_reresolve=false, test_args=[\"regression\"])'", depends-on = [
     "generate-testmodels",
     "test-ribasim-migration",
-    { task = "s3-download", args = [
-        "benchmark/",
-        "benchmark/",
-    ] },
+    "s3-download",
 ] }
 generate-testmodels = { cmd = "python utils/generate-testmodels.py", inputs = [
     "python/ribasim",
@@ -113,10 +101,7 @@ tests = { depends-on = ["lint", "test-ribasim-python", "test-ribasim-core"] }
 delwaq = { cmd = "pytest python/ribasim/tests/test_delwaq.py" }
 gen-delwaq = { cmd = "python python/ribasim/ribasim/delwaq/generate.py" }
 model-integration-test = { cmd = "julia --project=core --check-bounds=yes --eval 'using Pkg; Pkg.test(allow_reresolve=false, test_args=[\"integration\"])'", depends-on = [
-    { task = "s3-download", args = [
-        "hws_2025_4_0/",
-        "hws/",
-    ] },
+    "s3-download",
 ] }
 # Codegen
 codegen = { cmd = "julia --project utils/gen_python.jl && ruff format python/ribasim/ribasim/schemas.py python/ribasim/ribasim/validation.py", depends-on = [
@@ -172,10 +157,7 @@ ribasim-core-testmodels = { cmd = "julia --project --check-bounds=yes --threads=
     "generate-testmodels",
     "initialize-julia",
 ] }
-migrate-model = { cmd = "python utils/migrate_model.py {{ input_toml }} {{ output_toml }}", args = [
-    "input_toml",
-    "output_toml",
-] }
+migrate-model = { cmd = "python utils/migrate_model.py {{ input_toml }} {{ output_toml }}" }
 # Release
 github-release = "python utils/github-release.py"
 
@@ -186,27 +168,22 @@ inputs = ["core/Project.toml"]
 outputs = ["Ribasim.spdx.json"]
 
 [tasks.generate-sbom-ribasim-python-noarch]
-args = [{ "arg" = "path_sep" }]
 cmd = "sbom4python -m ribasim --system --sbom spdx --format json --output Ribasim-python.spdx.json"
-env = { "PATH" = "$PATH$path_sep$CONDA_PREFIX/Lib/site-packages/magic/libmagic" }
 inputs = ["python/ribasim/pyproject.toml"]
 outputs = ["Ribasim-python.spdx.json"]
 
 [target.win.tasks]
 add-ribasim-icon = { cmd = "rcedit build/ribasim/ribasim.exe --set-icon docs/assets/ribasim.ico" }
 install-ci = { depends-on = ["install-julia", "update-registry-julia"] }
+generate-sbom-ribasim-python = { cmd = "sbom4python -m ribasim --system --sbom spdx --format json --output Ribasim-python.spdx.json", env = { "PATH" = "$PATH;$CONDA_PREFIX/Lib/site-packages/magic/libmagic" }, inputs = ["python/ribasim/pyproject.toml"], outputs = ["Ribasim-python.spdx.json"] }
 
-[[target.win.tasks.generate-sbom-ribasim-python.depends-on]]
-task = "generate-sbom-ribasim-python-noarch"
-args = [";"]
+[target.linux.tasks]
+generate-sbom-ribasim-python = { cmd = "sbom4python -m ribasim --system --sbom spdx --format json --output Ribasim-python.spdx.json", env = { "PATH" = "$PATH:$CONDA_PREFIX/Lib/site-packages/magic/libmagic" }, inputs = ["python/ribasim/pyproject.toml"], outputs = ["Ribasim-python.spdx.json"] }
 
-[[target.linux.tasks.generate-sbom-ribasim-python.depends-on]]
-task = "generate-sbom-ribasim-python-noarch"
-args = [":"]
+[target.osx.tasks]
+generate-sbom-ribasim-python = { cmd = "sbom4python -m ribasim --system --sbom spdx --format json --output Ribasim-python.spdx.json", env = { "PATH" = "$PATH:$CONDA_PREFIX/Lib/site-packages/magic/libmagic" }, inputs = ["python/ribasim/pyproject.toml"], outputs = ["Ribasim-python.spdx.json"] }
 
-[[target.osx.tasks.generate-sbom-ribasim-python.depends-on]]
-task = "generate-sbom-ribasim-python-noarch"
-args = [":"]
+
 
 [target.win.activation]
 # Workaround a conflict between conda openssl activation and julia < 1.12

--- a/ribasim_qgis/scripts/install_ribasim_qgis.py
+++ b/ribasim_qgis/scripts/install_ribasim_qgis.py
@@ -1,3 +1,5 @@
+import platform
+import shutil
 from pathlib import Path
 
 from enable_plugin import enable_plugin
@@ -9,13 +11,29 @@ source_path = plugins_path / "ribasim_qgis"
 styles_source_path = target_path / "core" / "styles"
 styles_target_path = Path("python/ribasim/ribasim/styles").absolute()
 
-# Symlink ribasim_qgis styles to ribasim styles
+# Handle styles directory
 styles_source_path.unlink(missing_ok=True)
-styles_source_path.symlink_to(styles_target_path, target_is_directory=True)
+if styles_source_path.exists():
+    shutil.rmtree(styles_source_path)
 
-# Symlink qgis_env to ribasim_qgis, and hence qgis_env styles to ribasim styles
+if platform.system() == "Windows":
+    # On Windows, copy instead of symlink to avoid privilege issues
+    shutil.copytree(styles_target_path, styles_source_path)
+else:
+    # On Unix-like systems, use symlink
+    styles_source_path.symlink_to(styles_target_path, target_is_directory=True)
+
+# Handle plugin directory
 plugins_path.mkdir(parents=True, exist_ok=True)
 source_path.unlink(missing_ok=True)
-source_path.symlink_to(target_path, target_is_directory=True)
+if source_path.exists():
+    shutil.rmtree(source_path)
+
+if platform.system() == "Windows":
+    # On Windows, copy instead of symlink to avoid privilege issues
+    shutil.copytree(target_path, source_path)
+else:
+    # On Unix-like systems, use symlink
+    source_path.symlink_to(target_path, target_is_directory=True)
 
 enable_plugin("ribasim_qgis")


### PR DESCRIPTION
I found a couple of issues when trying to run pixi locally. I'm not sure if this is relevant to other users.

Here are some fixes I implemented:

The 'args' field is not supported in pixi task configuration, causing parsing failures. What was done:
- Remove invalid 'args' field from pixi task definitions (s3-download, s3-upload, migrate-model)
- Remove 'args' field from task dependencies that caused "expected a string, found table" errors

On Windows, creating symlinks requires administrator privileges.
- Remove problematic target-specific task dependency sections with incorrect syntax
- Add platform-specific generate-sbom-ribasim-python tasks with proper PATH environment handling
- Fix Windows symlink privilege error in QGIS plugin installation by using file copying instead of symlinks on Windows. The install script now detects the platform and uses shutil.copytree() instead of symlink_to() to avoid permission errors while maintaining the same functionality.