### PR TITLE
Migrate surface_runoff in Ribasim Python.

### DIFF
--- a/python/ribasim/ribasim/__init__.py
+++ b/python/ribasim/ribasim/__init__.py
@@ -1,6 +1,6 @@
 __version__ = "2025.4.0"
 # Keep synced write_schema_version in ribasim_qgis/core/geopackage.py
-__schema_version__ = 6
+__schema_version__ = 7
 
 import logging
 

--- a/python/ribasim/ribasim/migrations.py
+++ b/python/ribasim/ribasim/migrations.py
@@ -59,7 +59,9 @@ def basinstaticschema_migration(df: DataFrame, schema_version: int) -> DataFrame
     if schema_version == 0:
         warnings.warn("Migrating outdated Basin / static table.", UserWarning)
         df.drop(columns="urban_runoff", inplace=True, errors="ignore")
-
+    if schema_version < 7 and "surface_runoff" not in df.columns:
+        warnings.warn("Migrating outdated Basin / static table.", UserWarning)
+        df["surface_runoff"] = None
     return df
 
 
@@ -67,6 +69,9 @@ def basintimeschema_migration(df: DataFrame, schema_version: int) -> DataFrame:
     if schema_version == 0:
         warnings.warn("Migrating outdated Basin / time table.", UserWarning)
         df.drop(columns="urban_runoff", inplace=True, errors="ignore")
+    if schema_version < 7 and "surface_runoff" not in df.columns:
+        warnings.warn("Migrating outdated Basin / static table.", UserWarning)
+        df["surface_runoff"] = None
 
     return df
 

--- a/ribasim_qgis/core/geopackage.py
+++ b/ribasim_qgis/core/geopackage.py
@@ -52,7 +52,7 @@ def layers(path: Path) -> list[str]:
 
 
 # Keep version synced __schema_version__ in ribasim/__init__.py
-def write_schema_version(path: Path, version: int = 6) -> None:
+def write_schema_version(path: Path, version: int = 7) -> None:
     """Write the schema version to the geopackage."""
     with sqlite3_cursor(path) as cursor:
         cursor.execute(

--- a/ribasim_qgis/tests/ui/test_load_plugin.py
+++ b/ribasim_qgis/tests/ui/test_load_plugin.py
@@ -58,7 +58,7 @@ class TestPlugin(unittest.TestCase):
             cursor.execute(
                 "SELECT value FROM ribasim_metadata WHERE key='schema_version'"
             )
-            self.assertTrue(int(cursor.fetchone()[0]) == 6, "schema_version is wrong")
+            self.assertTrue(int(cursor.fetchone()[0]) == 7, "schema_version is wrong")
 
         # Open the model
         datawidget._open_model("test.toml")


### PR DESCRIPTION
After bashing @simulutions for not updating migrations after his `storage` addition, I make the same mistakes with `surface_runoff`. 😅 