### PR TITLE
Fix allocation from control cache

### DIFF
--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -590,7 +590,7 @@ function formulate_flow!(
             continue
         end
 
-        if control_type == ControlType.None
+        if control_type ∈ (ControlType.None, ControlType.Allocation)
             eval_time_interp(flow_rate_itp, current_flow_rate_pump, id.idx, p, t)
         end
 
@@ -658,8 +658,7 @@ function formulate_flow!(
         if !(active || all_nodes_active) || (control_type != control_type_)
             continue
         end
-
-        if control_type == ControlType.None
+        if control_type ∈ (ControlType.None, ControlType.Allocation)
             eval_time_interp(flow_rate_itp, current_flow_rate_outlet, id.idx, p, t)
         end
 


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/2420.

I did something different from what I proposed in the issue. I found out that `DiscreteControl` updates the `*.flow_rate` vector of interpolations for Pump and Outlet (and then it's read from there in `solve.jl`), so I decided that allocation should do the same.