### PR TITLE
Update pixi lockfile

### DIFF
--- a/Ribasim-python.spdx.json
+++ b/Ribasim-python.spdx.json
@@ -4,14 +4,14 @@
   "creationInfo": {
     "comment": "SBOM Type: Build - This document has been automatically generated.",
     "creators": [
-      "Tool: sbom4python-0.12.3"
+      "Tool: sbom4python-0.12.4"
     ],
-    "created": "2025-06-17T14:16:09Z",
-    "licenseListVersion": "3.25"
+    "created": "2025-07-03T03:29:04Z",
+    "licenseListVersion": "3.26"
   },
   "name": "Python-ribasim",
   "dataLicense": "CC0-1.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/Python-ribasim-cddc78c6-1752-4129-bf28-c802eebda75d",
+  "documentNamespace": "http://spdx.org/spdxdocs/Python-ribasim-15959213-16db-4ae2-9dca-19a4000ac006",
   "packages": [
     {
       "SPDXID": "SPDXRef-1-ribasim",
@@ -21,10 +21,17 @@
       "supplier": "Organization: Deltares and contributors (ribasim.info@deltares.nl)",
       "downloadLocation": "https://pypi.org/project/ribasim/2025.4.0/#files",
       "filesAnalyzed": false,
+      "checksums": [
+        {
+          "algorithm": "SHA256",
+          "checksumValue": "881bc5327b4962f71941682afcbec38a25373f51211eaf009c221c3aeab04d1d"
+        }
+      ],
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
       "copyrightText": "NOASSERTION",
       "summary": "Pre- and post-process Ribasim",
+      "releaseDate": "2025-06-16T17:02:19Z",
       "externalRefs": [
         {
           "referenceCategory": "OTHER",
@@ -51,16 +58,16 @@
     {
       "SPDXID": "SPDXRef-2-datacompy",
       "name": "datacompy",
-      "versionInfo": "0.16.7",
+      "versionInfo": "0.16.8",
       "primaryPackagePurpose": "LIBRARY",
       "supplier": "Organization: Ian Dan Coates Faisal Dosani (faisal.dosani@capitalone.com)",
-      "downloadLocation": "https://pypi.org/project/datacompy/0.16.7/#files",
+      "downloadLocation": "https://pypi.org/project/datacompy/0.16.8/#files",
       "filesAnalyzed": false,
       "homepage": "https://github.com/capitalone/datacompy",
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "42ba60bd5a82fa85db703b34c53e85d51f0ff5354edb9d1b18a63fea61ba5548"
+          "checksumValue": "ac521e5f95c8fa344af3ad8c553a1d0591677d14f45ad584bee36425edfb8f3e"
         }
       ],
       "licenseConcluded": "Apache-2.0",
@@ -68,7 +75,7 @@
       "licenseComments": "datacompy declares Apache Software License which is not currently a valid SPDX License identifier or expression.",
       "copyrightText": "NOASSERTION",
       "summary": "Dataframe comparison in Python",
-      "releaseDate": "2025-05-21T17:08:46Z",
+      "releaseDate": "2025-06-20T20:15:57Z",
       "externalRefs": [
         {
           "referenceCategory": "OTHER",
@@ -93,28 +100,28 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:pypi/datacompy@0.16.7"
+          "referenceLocator": "pkg:pypi/datacompy@0.16.8"
         },
         {
           "referenceCategory": "SECURITY",
           "referenceType": "cpe23Type",
-          "referenceLocator": "cpe:2.3:a:ian_dan_coates_faisal_dosani:datacompy:0.16.7:*:*:*:*:*:*:*"
+          "referenceLocator": "cpe:2.3:a:ian_dan_coates_faisal_dosani:datacompy:0.16.8:*:*:*:*:*:*:*"
         }
       ]
     },
     {
       "SPDXID": "SPDXRef-3-pandas",
       "name": "pandas",
-      "versionInfo": "2.2.3",
+      "versionInfo": "2.3.0",
       "primaryPackagePurpose": "LIBRARY",
       "supplier": "NOASSERTION",
-      "downloadLocation": "https://pypi.org/project/pandas/2.2.3/#files",
+      "downloadLocation": "https://pypi.org/project/pandas/2.3.0/#files",
       "filesAnalyzed": false,
       "homepage": "https://pandas.pydata.org",
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "1948ddde24197a0f7add2bdc4ca83bf2b1ef84a1bc8ccffd95eda17fd836ecb5"
+          "checksumValue": "625466edd01d43b75b1883a64d859168e4556261a5035b32f9d743b67ef44634"
         }
       ],
       "licenseConcluded": "NOASSERTION",
@@ -122,7 +129,7 @@
       "licenseComments": "pandas declares BSD 3-Clause License\n\n Copyright (c) 2008-2011, AQR Capital Management, LLC, Lambda Foundry, Inc. and PyData Development Team\n All rights reserved.\n\n Copyright (c) 2011-2023, Open source contributors.\n\n Redistribution and use in source and binary forms, with or without\n modification, are permitted provided that the following conditions are met:\n\n * Redistributions of source code must retain the above copyright notice, this\n   list of conditions and the following disclaimer.\n\n * Redistributions in binary form must reproduce the above copyright notice,\n   this list of conditions and the following disclaimer in the documentation\n   and/or other materials provided with the distribution.\n\n * Neither the name of the copyright holder nor the names of its\n   contributors may be used to endorse or promote products derived from\n   this software without specific prior written permission.\n\n THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\"\n AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE\n IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE\n DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE\n FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\n DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR\n SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER\n CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,\n OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE\n OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.\n which is not currently a valid SPDX License identifier or expression.",
       "copyrightText": "NOASSERTION",
       "summary": "Powerful data structures for data analysis, time series, and statistics",
-      "releaseDate": "2024-09-20T13:08:42Z",
+      "releaseDate": "2025-06-05T03:25:48Z",
       "externalRefs": [
         {
           "referenceCategory": "OTHER",
@@ -137,7 +144,7 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:pypi/pandas@2.2.3"
+          "referenceLocator": "pkg:pypi/pandas@2.3.0"
         }
       ]
     },
@@ -395,16 +402,16 @@
     {
       "SPDXID": "SPDXRef-10-polars",
       "name": "polars",
-      "versionInfo": "1.27.1",
+      "versionInfo": "1.31.0",
       "primaryPackagePurpose": "LIBRARY",
       "supplier": "Person: Ritchie Vink (ritchie46@gmail.com)",
-      "downloadLocation": "https://pypi.org/project/polars/1.27.1/#files",
+      "downloadLocation": "https://pypi.org/project/polars/1.31.0/#files",
       "filesAnalyzed": false,
       "homepage": "https://www.pola.rs/",
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "ba7ad4f8046d00dd97c1369e46a4b7e00ffcff5d38c0f847ee4b9b1bb182fb18"
+          "checksumValue": "ccc68cd6877deecd46b13cbd2663ca89ab2a2cb1fe49d5cfc66a9cef166566d9"
         }
       ],
       "licenseConcluded": "MIT",
@@ -412,7 +419,7 @@
       "licenseComments": "polars declares MIT License which is not currently a valid SPDX License identifier or expression.",
       "copyrightText": "NOASSERTION",
       "summary": "Blazingly fast DataFrame library",
-      "releaseDate": "2025-04-11T10:25:19Z",
+      "releaseDate": "2025-06-18T11:59:40Z",
       "externalRefs": [
         {
           "referenceCategory": "OTHER",
@@ -432,12 +439,12 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:pypi/polars@1.27.1"
+          "referenceLocator": "pkg:pypi/polars@1.31.0"
         },
         {
           "referenceCategory": "SECURITY",
           "referenceType": "cpe23Type",
-          "referenceLocator": "cpe:2.3:a:ritchie_vink:polars:1.27.1:*:*:*:*:*:*:*"
+          "referenceLocator": "cpe:2.3:a:ritchie_vink:polars:1.31.0:*:*:*:*:*:*:*"
         }
       ]
     },
@@ -522,23 +529,23 @@
     {
       "SPDXID": "SPDXRef-13-certifi",
       "name": "certifi",
-      "versionInfo": "2025.4.26",
+      "versionInfo": "2025.6.15",
       "primaryPackagePurpose": "LIBRARY",
       "supplier": "Person: Kenneth Reitz (me@kennethreitz.com)",
-      "downloadLocation": "https://pypi.org/project/certifi/2025.4.26/#files",
+      "downloadLocation": "https://pypi.org/project/certifi/2025.6.15/#files",
       "filesAnalyzed": false,
       "homepage": "https://github.com/certifi/python-certifi",
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3"
+          "checksumValue": "2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057"
         }
       ],
       "licenseConcluded": "MPL-2.0",
       "licenseDeclared": "MPL-2.0",
       "copyrightText": "NOASSERTION",
       "summary": "Python package for providing Mozilla's CA Bundle.",
-      "releaseDate": "2025-04-26T02:12:27Z",
+      "releaseDate": "2025-06-15T02:45:49Z",
       "externalRefs": [
         {
           "referenceCategory": "OTHER",
@@ -548,12 +555,12 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:pypi/certifi@2025.4.26"
+          "referenceLocator": "pkg:pypi/certifi@2025.6.15"
         },
         {
           "referenceCategory": "SECURITY",
           "referenceType": "cpe23Type",
-          "referenceLocator": "cpe:2.3:a:kenneth_reitz:certifi:2025.4.26:*:*:*:*:*:*:*"
+          "referenceLocator": "cpe:2.3:a:kenneth_reitz:certifi:2025.6.15:*:*:*:*:*:*:*"
         }
       ]
     },
@@ -841,33 +848,33 @@
     {
       "SPDXID": "SPDXRef-20-fonttools",
       "name": "fonttools",
-      "versionInfo": "4.58.2",
+      "versionInfo": "4.58.4",
       "primaryPackagePurpose": "LIBRARY",
       "supplier": "Organization: Just van Rossum (just@letterror.com)",
-      "downloadLocation": "https://pypi.org/project/fonttools/4.58.2/#files",
+      "downloadLocation": "https://pypi.org/project/fonttools/4.58.4/#files",
       "filesAnalyzed": false,
       "homepage": "http://github.com/fonttools/fonttools",
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "4baaf34f07013ba9c2c3d7a95d0c391fcbb30748cb86c36c094fab8f168e49bb"
+          "checksumValue": "834542f13fee7625ad753b2db035edb674b07522fcbdd0ed9e9a9e2a1034467f"
         }
       ],
       "licenseConcluded": "MIT",
       "licenseDeclared": "MIT",
       "copyrightText": "NOASSERTION",
       "summary": "Tools to manipulate font files",
-      "releaseDate": "2025-06-06T14:49:33Z",
+      "releaseDate": "2025-06-13T17:23:49Z",
       "externalRefs": [
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:pypi/fonttools@4.58.2"
+          "referenceLocator": "pkg:pypi/fonttools@4.58.4"
         },
         {
           "referenceCategory": "SECURITY",
           "referenceType": "cpe23Type",
-          "referenceLocator": "cpe:2.3:a:just_van_rossum:fonttools:4.58.2:*:*:*:*:*:*:*"
+          "referenceLocator": "cpe:2.3:a:just_van_rossum:fonttools:4.58.4:*:*:*:*:*:*:*"
         }
       ]
     },
@@ -923,23 +930,23 @@
     {
       "SPDXID": "SPDXRef-22-pillow",
       "name": "pillow",
-      "versionInfo": "11.2.1",
+      "versionInfo": "11.3.0",
       "primaryPackagePurpose": "LIBRARY",
       "supplier": "Organization: Jeffrey A. (aclark@aclark.net)",
-      "downloadLocation": "https://pypi.org/project/pillow/11.2.1/#files",
+      "downloadLocation": "https://pypi.org/project/pillow/11.3.0/#files",
       "filesAnalyzed": false,
       "homepage": "https://python-pillow.github.io",
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "d57a75d53922fc20c165016a20d9c44f73305e67c351bbc60d1adaf662e74047"
+          "checksumValue": "1b9c17fd4ace828b3003dfd1e30bff24863e0eb59b535e8f80194d9cc7ecf860"
         }
       ],
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "NOASSERTION",
       "copyrightText": "NOASSERTION",
       "summary": "Python Imaging Library (Fork)",
-      "releaseDate": "2025-04-12T17:47:10Z",
+      "releaseDate": "2025-07-01T09:13:39Z",
       "externalRefs": [
         {
           "referenceCategory": "OTHER",
@@ -974,12 +981,12 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:pypi/pillow@11.2.1"
+          "referenceLocator": "pkg:pypi/pillow@11.3.0"
         },
         {
           "referenceCategory": "SECURITY",
           "referenceType": "cpe23Type",
-          "referenceLocator": "cpe:2.3:a:jeffrey_a.:pillow:11.2.1:*:*:*:*:*:*:*"
+          "referenceLocator": "cpe:2.3:a:jeffrey_a.:pillow:11.3.0:*:*:*:*:*:*:*"
         }
       ]
     },
@@ -1063,16 +1070,16 @@
     {
       "SPDXID": "SPDXRef-25-pydantic",
       "name": "pydantic",
-      "versionInfo": "2.11.4",
+      "versionInfo": "2.11.7",
       "primaryPackagePurpose": "LIBRARY",
       "supplier": "Organization: Samuel Colvin Eric Jolibois Hasan Ramezani Adrian Garcia Badaracco Terrence Dorsey David Montague Serge Matveenko Marcelo Trylesinski Sydney Runkle David Hewitt Alex Hall Victorien Plot (contact@vctrn.dev)",
-      "downloadLocation": "https://pypi.org/project/pydantic/2.11.4/#files",
+      "downloadLocation": "https://pypi.org/project/pydantic/2.11.7/#files",
       "filesAnalyzed": false,
       "homepage": "https://github.com/pydantic/pydantic",
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "d9615eaa9ac5a063471da949c8fc16376a84afb5024688b3ff885693506764eb"
+          "checksumValue": "dde5df002701f6de26248661f6835bbe296a47bf73990135c7d07ce741b9623b"
         }
       ],
       "licenseConcluded": "MIT",
@@ -1080,7 +1087,7 @@
       "licenseComments": "pydantic declares MIT License which is not currently a valid SPDX License identifier or expression.",
       "copyrightText": "NOASSERTION",
       "summary": "Data validation using Python type hints",
-      "releaseDate": "2025-04-29T20:38:52Z",
+      "releaseDate": "2025-06-14T08:33:14Z",
       "externalRefs": [
         {
           "referenceCategory": "OTHER",
@@ -1105,12 +1112,12 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:pypi/pydantic@2.11.4"
+          "referenceLocator": "pkg:pypi/pydantic@2.11.7"
         },
         {
           "referenceCategory": "SECURITY",
           "referenceType": "cpe23Type",
-          "referenceLocator": "cpe:2.3:a:samuel_colvin_eric_jolibois_hasan_ramezani_adrian_garcia_badaracco_terrence_dorsey_david_montague_serge_matveenko_marcelo_trylesinski_sydney_runkle_david_hewitt_alex_hall_victorien_plot:pydantic:2.11.4:*:*:*:*:*:*:*"
+          "referenceLocator": "cpe:2.3:a:samuel_colvin_eric_jolibois_hasan_ramezani_adrian_garcia_badaracco_terrence_dorsey_david_montague_serge_matveenko_marcelo_trylesinski_sydney_runkle_david_hewitt_alex_hall_victorien_plot:pydantic:2.11.7:*:*:*:*:*:*:*"
         }
       ]
     },
@@ -1304,22 +1311,22 @@
     {
       "SPDXID": "SPDXRef-30-typeguard",
       "name": "typeguard",
-      "versionInfo": "4.4.3",
+      "versionInfo": "4.4.4",
       "primaryPackagePurpose": "LIBRARY",
       "supplier": "Person: Alex Gronholm (alex.gronholm@nextday.fi)",
-      "downloadLocation": "https://pypi.org/project/typeguard/4.4.3/#files",
+      "downloadLocation": "https://pypi.org/project/typeguard/4.4.4/#files",
       "filesAnalyzed": false,
       "checksums": [
         {
           "algorithm": "SHA256",
-          "checksumValue": "7d8b4a3d280257fd1aa29023f22de64e29334bda0b172ff1040f05682223795e"
+          "checksumValue": "b5f562281b6bfa1f5492470464730ef001646128b180769880468bd84b68b09e"
         }
       ],
-      "licenseConcluded": "MIT",
-      "licenseDeclared": "MIT",
+      "licenseConcluded": "NOASSERTION",
+      "licenseDeclared": "NOASSERTION",
       "copyrightText": "NOASSERTION",
       "summary": "Run-time type checker for Python",
-      "releaseDate": "2025-06-04T21:47:03Z",
+      "releaseDate": "2025-06-18T09:56:05Z",
       "externalRefs": [
         {
           "referenceCategory": "OTHER",
@@ -1344,12 +1351,12 @@
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:pypi/typeguard@4.4.3"
+          "referenceLocator": "pkg:pypi/typeguard@4.4.4"
         },
         {
           "referenceCategory": "SECURITY",
           "referenceType": "cpe23Type",
-          "referenceLocator": "cpe:2.3:a:alex_gronholm:typeguard:4.4.3:*:*:*:*:*:*:*"
+          "referenceLocator": "cpe:2.3:a:alex_gronholm:typeguard:4.4.4:*:*:*:*:*:*:*"
         }
       ]
     },

--- a/diff.md
+++ b/diff.md
@@ -1,0 +1,236 @@
+# Dependencies
+
+<details>
+<summary>Explicit dependencies</summary>
+
+|Dependency[^1]|Before|After|Change|Environments|
+|-|-|-|-|-|
+|[**pandas**](https://prefix.dev/channels/conda-forge/packages/pandas)|2.2.3|2.3.0|Minor Upgrade|*all*|
+|[**plotly**](https://prefix.dev/channels/conda-forge/packages/plotly)|6.1.2|6.2.0|Minor Upgrade|*all*|
+|[**pydantic-settings**](https://prefix.dev/channels/conda-forge/packages/pydantic-settings)|2.9.1|2.10.1|Minor Upgrade|*all*|
+|[**pytest-cov**](https://prefix.dev/channels/conda-forge/packages/pytest-cov)|6.1.1|6.2.1|Minor Upgrade|*all*|
+|[**pytest-xdist**](https://prefix.dev/channels/conda-forge/packages/pytest-xdist)|3.7.0|3.8.0|Minor Upgrade|*all*|
+|[**qgis**](https://prefix.dev/channels/conda-forge/packages/qgis)|3.42.2|3.44.0|Minor Upgrade|*all envs* on linux-64|
+|[**ruff**](https://prefix.dev/channels/conda-forge/packages/ruff)|0.11.13|0.12.1|Minor Upgrade|*all*|
+|[**rust**](https://prefix.dev/channels/conda-forge/packages/rust)|1.87.0|1.88.0|Minor Upgrade|*all*|
+|[**xarray**](https://prefix.dev/channels/conda-forge/packages/xarray)|2025.4.0|2025.6.1|Minor Upgrade|*all*|
+|[**datacompy**](https://prefix.dev/channels/conda-forge/packages/datacompy)|0.16.7|0.16.8|Patch Upgrade|*all*|
+|[**gh**](https://prefix.dev/channels/conda-forge/packages/gh)|2.74.1|2.74.2|Patch Upgrade|*all*|
+|[**mypy**](https://prefix.dev/channels/conda-forge/packages/mypy)|1.16.0|1.16.1|Patch Upgrade|*all*|
+|[**pydantic**](https://prefix.dev/channels/conda-forge/packages/pydantic)|2.11.4|2.11.7|Patch Upgrade|*all*|
+|[**pytest**](https://prefix.dev/channels/conda-forge/packages/pytest)|8.4.0|8.4.1|Patch Upgrade|*all*|
+|[**qgis**](https://prefix.dev/channels/conda-forge/packages/qgis)|3.42.2|3.42.3|Patch Upgrade|*all envs* on win-64|
+|[**quarto**](https://prefix.dev/channels/conda-forge/packages/quarto)|1.7.31|1.7.32|Patch Upgrade|*all*|
+|[**quartodoc**](https://prefix.dev/channels/conda-forge/packages/quartodoc)|0.11.0|0.11.1|Patch Upgrade|*all*|
+|[**sbom4python**](https://pypi.org/project/sbom4python)|0.12.3|0.12.4|Patch Upgrade|*all*|
+|[**pyogrio**](https://prefix.dev/channels/conda-forge/packages/pyogrio)|py312h6e88f47_0|py312h8f0c04e_1|Only build string|default on win-64|
+|[**pyogrio**](https://prefix.dev/channels/conda-forge/packages/pyogrio)|py312h02b19dd_0|py312h5426b81_1|Only build string|default on linux-64|
+|[**pyogrio**](https://prefix.dev/channels/conda-forge/packages/pyogrio)|py311hf6089d3_0|py311h75bf2cc_1|Only build string|py311 on linux-64|
+|[**pyogrio**](https://prefix.dev/channels/conda-forge/packages/pyogrio)|py311haedb144_0|py311h2467ed7_1|Only build string|py311 on win-64|
+
+</details>
+
+<details>
+<summary>Implicit dependencies</summary>
+
+|Dependency[^1]|Before|After|Change|Environments|
+|-|-|-|-|-|
+|[elementpath](https://pypi.org/project/elementpath)||5.0.3|Added|*all*|
+|[libadbc-driver-manager](https://prefix.dev/channels/conda-forge/packages/libadbc-driver-manager)||1.6.0|Added|*all envs* on linux-64|
+|[libgdal-adbc](https://prefix.dev/channels/conda-forge/packages/libgdal-adbc)||3.11.1|Added|*all envs* on linux-64|
+|[libhwy](https://prefix.dev/channels/conda-forge/packages/libhwy)||1.2.0|Added|*all envs* on {linux-64, win-64}|
+|[libjxl](https://prefix.dev/channels/conda-forge/packages/libjxl)||0.11.1|Added|*all envs* on {linux-64, win-64}|
+|[muparser](https://prefix.dev/channels/conda-forge/packages/muparser)||2.3.5|Added|*all envs* on {linux-64, win-64}|
+|[polars-default](https://prefix.dev/channels/conda-forge/packages/polars-default)||1.31.0|Added|*all*|
+|[xmlschema](https://pypi.org/project/xmlschema)||4.1.0|Added|*all*|
+|[libre2-11](https://prefix.dev/channels/conda-forge/packages/libre2-11)|2024.07.02|2025.06.26|Major Upgrade|*all envs* on {linux-64, win-64}|
+|[lxml](https://prefix.dev/channels/conda-forge/packages/lxml)|5.4.0|6.0.0|Major Upgrade|*all*|
+|[opencl-headers](https://prefix.dev/channels/conda-forge/packages/opencl-headers)|2024.10.24|2025.06.13|Major Upgrade|*all*|
+|[pyzmq](https://prefix.dev/channels/conda-forge/packages/pyzmq)|26.4.0|27.0.0|Major Upgrade|*all*|
+|[re2](https://prefix.dev/channels/conda-forge/packages/re2)|2024.07.02|2025.06.26|Major Upgrade|*all envs* on {linux-64, win-64}|
+|[libgfortran](https://prefix.dev/channels/conda-forge/packages/libgfortran)[^2]|14.2.0|5.0.0|Major Downgrade|*all envs* on osx-arm64|
+|[aws-c-io](https://prefix.dev/channels/conda-forge/packages/aws-c-io)|0.19.1|0.20.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[ca-certificates](https://prefix.dev/channels/conda-forge/packages/ca-certificates)|2025.4.26|2025.6.15|Minor Upgrade|*all*|
+|[capnproto](https://prefix.dev/channels/conda-forge/packages/capnproto)|1.0.2|1.2.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[certifi](https://prefix.dev/channels/conda-forge/packages/certifi)|2025.4.26|2025.6.15|Minor Upgrade|*all*|
+|[coverage](https://prefix.dev/channels/conda-forge/packages/coverage)|7.8.2|7.9.1|Minor Upgrade|*all*|
+|[fmt](https://prefix.dev/channels/conda-forge/packages/fmt)|11.1.4|11.2.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[folium](https://prefix.dev/channels/conda-forge/packages/folium)|0.19.7|0.20.0|Minor Upgrade|*all*|
+|[gdal](https://prefix.dev/channels/conda-forge/packages/gdal)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[ipython](https://prefix.dev/channels/conda-forge/packages/ipython)|9.3.0|9.4.0|Minor Upgrade|*all*|
+|[libfabric](https://prefix.dev/channels/conda-forge/packages/libfabric)|2.1.0|2.2.0|Minor Upgrade|*all envs* on {linux-64, osx-arm64}|
+|[libfabric1](https://prefix.dev/channels/conda-forge/packages/libfabric1)|2.1.0|2.2.0|Minor Upgrade|*all envs* on {linux-64, osx-arm64}|
+|[libgdal](https://prefix.dev/channels/conda-forge/packages/libgdal)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[libgdal-arrow-parquet](https://prefix.dev/channels/conda-forge/packages/libgdal-arrow-parquet)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[libgdal-core](https://prefix.dev/channels/conda-forge/packages/libgdal-core)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[libgdal-fits](https://prefix.dev/channels/conda-forge/packages/libgdal-fits)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[libgdal-grib](https://prefix.dev/channels/conda-forge/packages/libgdal-grib)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[libgdal-hdf4](https://prefix.dev/channels/conda-forge/packages/libgdal-hdf4)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[libgdal-hdf5](https://prefix.dev/channels/conda-forge/packages/libgdal-hdf5)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[libgdal-jp2openjpeg](https://prefix.dev/channels/conda-forge/packages/libgdal-jp2openjpeg)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[libgdal-kea](https://prefix.dev/channels/conda-forge/packages/libgdal-kea)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[libgdal-netcdf](https://prefix.dev/channels/conda-forge/packages/libgdal-netcdf)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[libgdal-pdf](https://prefix.dev/channels/conda-forge/packages/libgdal-pdf)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[libgdal-pg](https://prefix.dev/channels/conda-forge/packages/libgdal-pg)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[libgdal-postgisraster](https://prefix.dev/channels/conda-forge/packages/libgdal-postgisraster)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[libgdal-tiledb](https://prefix.dev/channels/conda-forge/packages/libgdal-tiledb)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[libgdal-xls](https://prefix.dev/channels/conda-forge/packages/libgdal-xls)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[libpdal](https://prefix.dev/channels/conda-forge/packages/libpdal)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
+|[libpdal-arrow](https://prefix.dev/channels/conda-forge/packages/libpdal-arrow)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
+|[libpdal-core](https://prefix.dev/channels/conda-forge/packages/libpdal-core)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
+|[libpdal-cpd](https://prefix.dev/channels/conda-forge/packages/libpdal-cpd)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
+|[libpdal-draco](https://prefix.dev/channels/conda-forge/packages/libpdal-draco)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
+|[libpdal-e57](https://prefix.dev/channels/conda-forge/packages/libpdal-e57)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
+|[libpdal-hdf](https://prefix.dev/channels/conda-forge/packages/libpdal-hdf)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
+|[libpdal-icebridge](https://prefix.dev/channels/conda-forge/packages/libpdal-icebridge)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
+|[libpdal-nitf](https://prefix.dev/channels/conda-forge/packages/libpdal-nitf)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
+|[libpdal-pgpointcloud](https://prefix.dev/channels/conda-forge/packages/libpdal-pgpointcloud)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
+|[libpdal-tiledb](https://prefix.dev/channels/conda-forge/packages/libpdal-tiledb)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
+|[libpdal-trajectory](https://prefix.dev/channels/conda-forge/packages/libpdal-trajectory)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
+|[libsystemd0](https://prefix.dev/channels/conda-forge/packages/libsystemd0)|257.6|257.7|Minor Upgrade|*all envs* on linux-64|
+|[libudev1](https://prefix.dev/channels/conda-forge/packages/libudev1)|257.6|257.7|Minor Upgrade|*all envs* on linux-64|
+|[narwhals](https://prefix.dev/channels/conda-forge/packages/narwhals)|1.42.0|1.45.0|Minor Upgrade|*all*|
+|[nss](https://prefix.dev/channels/conda-forge/packages/nss)|3.112|3.113|Minor Upgrade|*all envs* on {linux-64, osx-arm64}|
+|[pillow](https://prefix.dev/channels/conda-forge/packages/pillow)|11.2.1|11.3.0|Minor Upgrade|*all*|
+|[polars](https://prefix.dev/channels/conda-forge/packages/polars)|1.27.1|1.31.0|Minor Upgrade|*all*|
+|[pyobjc-core](https://prefix.dev/channels/conda-forge/packages/pyobjc-core)|11.0|11.1|Minor Upgrade|*all envs* on osx-arm64|
+|[pyobjc-framework-cocoa](https://prefix.dev/channels/conda-forge/packages/pyobjc-framework-cocoa)|11.0|11.1|Minor Upgrade|*all envs* on osx-arm64|
+|[pyqt5-sip](https://prefix.dev/channels/conda-forge/packages/pyqt5-sip)|12.12.2|12.17.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[rpds-py](https://prefix.dev/channels/conda-forge/packages/rpds-py)|0.25.1|0.26.0|Minor Upgrade|*all*|
+|[rust-std-aarch64-apple-darwin](https://prefix.dev/channels/conda-forge/packages/rust-std-aarch64-apple-darwin)|1.87.0|1.88.0|Minor Upgrade|*all envs* on osx-arm64|
+|[rust-std-x86_64-pc-windows-msvc](https://prefix.dev/channels/conda-forge/packages/rust-std-x86_64-pc-windows-msvc)|1.87.0|1.88.0|Minor Upgrade|*all envs* on win-64|
+|[rust-std-x86_64-unknown-linux-gnu](https://prefix.dev/channels/conda-forge/packages/rust-std-x86_64-unknown-linux-gnu)|1.87.0|1.88.0|Minor Upgrade|*all envs* on linux-64|
+|[scipy](https://prefix.dev/channels/conda-forge/packages/scipy)|1.15.2|1.16.0|Minor Upgrade|*all*|
+|[sip](https://prefix.dev/channels/conda-forge/packages/sip)|6.7.12|6.10.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
+|[urllib3](https://prefix.dev/channels/conda-forge/packages/urllib3)|2.4.0|2.5.0|Minor Upgrade|*all*|
+|[vc14_runtime](https://prefix.dev/channels/conda-forge/packages/vc14_runtime)|14.42.34438|14.44.35208|Minor Upgrade|*all envs* on win-64|
+|[vs2015_runtime](https://prefix.dev/channels/conda-forge/packages/vs2015_runtime)|14.42.34438|14.44.35208|Minor Upgrade|*all envs* on win-64|
+|[aws-c-s3](https://prefix.dev/channels/conda-forge/packages/aws-c-s3)|0.8.1|0.8.3|Patch Upgrade|*all envs* on {linux-64, win-64}|
+|[aws-crt-cpp](https://prefix.dev/channels/conda-forge/packages/aws-crt-cpp)|0.32.8|0.32.10|Patch Upgrade|*all envs* on {linux-64, win-64}|
+|[cryptography](https://prefix.dev/channels/conda-forge/packages/cryptography)|45.0.4|45.0.5|Patch Upgrade|*all envs* on linux-64|
+|[cyrus-sasl](https://prefix.dev/channels/conda-forge/packages/cyrus-sasl)|2.1.27|2.1.28|Patch Upgrade|*all envs* on {linux-64, osx-arm64}|
+|[fonttools](https://prefix.dev/channels/conda-forge/packages/fonttools)|4.58.2|4.58.4|Patch Upgrade|*all*|
+|[graphite2](https://prefix.dev/channels/conda-forge/packages/graphite2)|1.3.13|1.3.14|Patch Upgrade|*all envs* on {linux-64, win-64}|
+|[jupyterlab](https://prefix.dev/channels/conda-forge/packages/jupyterlab)|4.4.3|4.4.4|Patch Upgrade|*all*|
+|[kiwisolver](https://prefix.dev/channels/conda-forge/packages/kiwisolver)|1.4.7|1.4.8|Patch Upgrade|py311 on *all platforms*|
+|[lib4package](https://pypi.org/project/lib4package)|0.3.2|0.3.3|Patch Upgrade|*all*|
+|[lib4sbom](https://pypi.org/project/lib4sbom)|0.8.4|0.8.6|Patch Upgrade|*all*|
+|[libaec](https://prefix.dev/channels/conda-forge/packages/libaec)|1.1.3|1.1.4|Patch Upgrade|*all*|
+|[libasprintf](https://prefix.dev/channels/conda-forge/packages/libasprintf)|0.24.1|0.24.2|Patch Upgrade|*all envs* on osx-arm64|
+|[libclang-cpp20.1](https://prefix.dev/channels/conda-forge/packages/libclang-cpp20.1)|20.1.6|20.1.7|Patch Upgrade|*all envs* on linux-64|
+|[libclang13](https://prefix.dev/channels/conda-forge/packages/libclang13)|20.1.6|20.1.7|Patch Upgrade|*all*|
+|[libcxx](https://prefix.dev/channels/conda-forge/packages/libcxx)|20.1.6|20.1.7|Patch Upgrade|*all envs* on osx-arm64|
+|[libdrm](https://prefix.dev/channels/conda-forge/packages/libdrm)|2.4.124|2.4.125|Patch Upgrade|*all envs* on linux-64|
+|[libgettextpo](https://prefix.dev/channels/conda-forge/packages/libgettextpo)|0.24.1|0.24.2|Patch Upgrade|*all envs* on osx-arm64|
+|[libintl](https://prefix.dev/channels/conda-forge/packages/libintl)|0.24.1|0.24.2|Patch Upgrade|*all envs* on osx-arm64|
+|[libintl-devel](https://prefix.dev/channels/conda-forge/packages/libintl-devel)|0.24.1|0.24.2|Patch Upgrade|*all envs* on osx-arm64|
+|[libllvm20](https://prefix.dev/channels/conda-forge/packages/libllvm20)|20.1.6|20.1.7|Patch Upgrade|*all envs* on {linux-64, osx-arm64}|
+|[libopenblas](https://prefix.dev/channels/conda-forge/packages/libopenblas)|0.3.29|0.3.30|Patch Upgrade|*all envs* on {linux-64, osx-arm64}|
+|[libpng](https://prefix.dev/channels/conda-forge/packages/libpng)|1.6.47|1.6.49|Patch Upgrade|*all*|
+|[libsqlite](https://prefix.dev/channels/conda-forge/packages/libsqlite)|3.50.1|3.50.2|Patch Upgrade|*all*|
+|[llvm-openmp](https://prefix.dev/channels/conda-forge/packages/llvm-openmp)|20.1.6|20.1.7|Patch Upgrade|*all envs* on osx-arm64|
+|[msgpack-python](https://prefix.dev/channels/conda-forge/packages/msgpack-python)|1.1.0|1.1.1|Patch Upgrade|*all*|
+|[notebook](https://prefix.dev/channels/conda-forge/packages/notebook)|7.4.3|7.4.4|Patch Upgrade|*all*|
+|[openmpi](https://prefix.dev/channels/conda-forge/packages/openmpi)|5.0.7|5.0.8|Patch Upgrade|*all envs* on osx-arm64|
+|[openssl](https://prefix.dev/channels/conda-forge/packages/openssl)|3.5.0|3.5.1|Patch Upgrade|*all*|
+|[owslib](https://prefix.dev/channels/conda-forge/packages/owslib)|0.34.0|0.34.1|Patch Upgrade|*all*|
+|[pygments](https://prefix.dev/channels/conda-forge/packages/pygments)|2.19.1|2.19.2|Patch Upgrade|*all*|
+|[pyqt](https://prefix.dev/channels/conda-forge/packages/pyqt)|5.15.9|5.15.11|Patch Upgrade|*all envs* on {linux-64, win-64}|
+|[pyqtwebkit](https://prefix.dev/channels/conda-forge/packages/pyqtwebkit)|5.15.9|5.15.11|Patch Upgrade|*all envs* on {linux-64, win-64}|
+|[python-dotenv](https://prefix.dev/channels/conda-forge/packages/python-dotenv)|1.1.0|1.1.1|Patch Upgrade|*all*|
+|[sqlite](https://prefix.dev/channels/conda-forge/packages/sqlite)|3.50.1|3.50.2|Patch Upgrade|*all*|
+|[typeguard](https://prefix.dev/channels/conda-forge/packages/typeguard)|4.4.3|4.4.4|Patch Upgrade|*all*|
+|[uv](https://prefix.dev/channels/conda-forge/packages/uv)|0.7.12|0.7.19|Patch Upgrade|*all*|
+|[aws-c-auth](https://prefix.dev/channels/conda-forge/packages/aws-c-auth)|h3537544_13|hd490b63_15|Only build string|*all envs* on win-64|
+|[aws-c-auth](https://prefix.dev/channels/conda-forge/packages/aws-c-auth)|hf280997_13|hbfa7f16_15|Only build string|*all envs* on linux-64|
+|[aws-c-event-stream](https://prefix.dev/channels/conda-forge/packages/aws-c-event-stream)|hf27a43c_10|ha416645_12|Only build string|*all envs* on win-64|
+|[aws-c-event-stream](https://prefix.dev/channels/conda-forge/packages/aws-c-event-stream)|haaa725d_10|h76f0014_12|Only build string|*all envs* on linux-64|
+|[aws-c-http](https://prefix.dev/channels/conda-forge/packages/aws-c-http)|h633db33_0|h81282ae_2|Only build string|*all envs* on win-64|
+|[aws-c-http](https://prefix.dev/channels/conda-forge/packages/aws-c-http)|hcfde5e4_0|h015de20_2|Only build string|*all envs* on linux-64|
+|[aws-c-mqtt](https://prefix.dev/channels/conda-forge/packages/aws-c-mqtt)|h6306086_1|h5c1ae27_3|Only build string|*all envs* on win-64|
+|[aws-c-mqtt](https://prefix.dev/channels/conda-forge/packages/aws-c-mqtt)|h08b274c_1|h1e5e6c0_3|Only build string|*all envs* on linux-64|
+|[aws-sdk-cpp](https://prefix.dev/channels/conda-forge/packages/aws-sdk-cpp)|h7deb975_10|hd13e2d4_12|Only build string|*all envs* on win-64|
+|[aws-sdk-cpp](https://prefix.dev/channels/conda-forge/packages/aws-sdk-cpp)|h4607db7_10|h937e755_12|Only build string|*all envs* on linux-64|
+|[binutils_impl_linux-64](https://prefix.dev/channels/conda-forge/packages/binutils_impl_linux-64)|h4bf12b8_4|h4bf12b8_5|Only build string|*all envs* on linux-64|
+|[gcc_impl_linux-64](https://prefix.dev/channels/conda-forge/packages/gcc_impl_linux-64)|h4393ad2_2|h4393ad2_3|Only build string|*all envs* on linux-64|
+|[kiwisolver](https://prefix.dev/channels/conda-forge/packages/kiwisolver)|py312hc790b64_0|py312hf90b1b7_1|Only build string|default on win-64|
+|[kiwisolver](https://prefix.dev/channels/conda-forge/packages/kiwisolver)|py312h2c4a281_0|py312hb23fbb9_1|Only build string|default on osx-arm64|
+|[kiwisolver](https://prefix.dev/channels/conda-forge/packages/kiwisolver)|py312h84d6215_0|py312h68727a3_1|Only build string|default on linux-64|
+|[ld_impl_linux-64](https://prefix.dev/channels/conda-forge/packages/ld_impl_linux-64)|h712a8e2_4|h712a8e2_5|Only build string|*all envs* on linux-64|
+|[libarrow](https://prefix.dev/channels/conda-forge/packages/libarrow)|hc090743_6_cpu|h3e40a90_8_cpu|Only build string|*all envs* on win-64|
+|[libarrow](https://prefix.dev/channels/conda-forge/packages/libarrow)|h314c690_6_cpu|h1b9301b_8_cpu|Only build string|*all envs* on linux-64|
+|[libarrow-acero](https://prefix.dev/channels/conda-forge/packages/libarrow-acero)|hcb10f89_6_cpu|hcb10f89_8_cpu|Only build string|*all envs* on linux-64|
+|[libarrow-acero](https://prefix.dev/channels/conda-forge/packages/libarrow-acero)|h7d8d6a5_6_cpu|h7d8d6a5_8_cpu|Only build string|*all envs* on win-64|
+|[libarrow-dataset](https://prefix.dev/channels/conda-forge/packages/libarrow-dataset)|hcb10f89_6_cpu|hcb10f89_8_cpu|Only build string|*all envs* on linux-64|
+|[libarrow-dataset](https://prefix.dev/channels/conda-forge/packages/libarrow-dataset)|h7d8d6a5_6_cpu|h7d8d6a5_8_cpu|Only build string|*all envs* on win-64|
+|[libarrow-substrait](https://prefix.dev/channels/conda-forge/packages/libarrow-substrait)|hb76e781_6_cpu|hb76e781_8_cpu|Only build string|*all envs* on win-64|
+|[libarrow-substrait](https://prefix.dev/channels/conda-forge/packages/libarrow-substrait)|h1bed206_6_cpu|h1bed206_8_cpu|Only build string|*all envs* on linux-64|
+|[libblas](https://prefix.dev/channels/conda-forge/packages/libblas)|31_h641d27c_mkl|32_h641d27c_mkl|Only build string|*all envs* on win-64|
+|[libblas](https://prefix.dev/channels/conda-forge/packages/libblas)|31_h59b9bed_openblas|32_h59b9bed_openblas|Only build string|*all envs* on linux-64|
+|[libblas](https://prefix.dev/channels/conda-forge/packages/libblas)|31_h10e41b3_openblas|32_h10e41b3_openblas|Only build string|*all envs* on osx-arm64|
+|[libcblas](https://prefix.dev/channels/conda-forge/packages/libcblas)|31_he106b2a_openblas|32_he106b2a_openblas|Only build string|*all envs* on linux-64|
+|[libcblas](https://prefix.dev/channels/conda-forge/packages/libcblas)|31_hb3479ef_openblas|32_hb3479ef_openblas|Only build string|*all envs* on osx-arm64|
+|[libcblas](https://prefix.dev/channels/conda-forge/packages/libcblas)|31_h5e41251_mkl|32_h5e41251_mkl|Only build string|*all envs* on win-64|
+|[libcups](https://prefix.dev/channels/conda-forge/packages/libcups)|h4637d8d_4|hb8b1518_5|Only build string|*all envs* on linux-64|
+|[libgcc](https://prefix.dev/channels/conda-forge/packages/libgcc)|h767d61c_2|h767d61c_3|Only build string|*all envs* on linux-64|
+|[libgcc](https://prefix.dev/channels/conda-forge/packages/libgcc)|h1383e82_2|h1383e82_3|Only build string|*all envs* on win-64|
+|[libgcc-devel_linux-64](https://prefix.dev/channels/conda-forge/packages/libgcc-devel_linux-64)|h4c094af_102|h4c094af_103|Only build string|*all envs* on linux-64|
+|[libgcc-ng](https://prefix.dev/channels/conda-forge/packages/libgcc-ng)|h69a702a_2|h69a702a_3|Only build string|*all envs* on linux-64|
+|[libgfortran](https://prefix.dev/channels/conda-forge/packages/libgfortran)|h69a702a_2|h69a702a_3|Only build string|*all envs* on linux-64|
+|[libgfortran-ng](https://prefix.dev/channels/conda-forge/packages/libgfortran-ng)|h69a702a_2|h69a702a_3|Only build string|*all envs* on linux-64|
+|[libgfortran5](https://prefix.dev/channels/conda-forge/packages/libgfortran5)|hcea5267_2|hcea5267_3|Only build string|*all envs* on linux-64|
+|[libgfortran5](https://prefix.dev/channels/conda-forge/packages/libgfortran5)|h2c44a93_105|h6c33f7e_103|Only build string|*all envs* on osx-arm64|
+|[libgomp](https://prefix.dev/channels/conda-forge/packages/libgomp)|h767d61c_2|h767d61c_3|Only build string|*all envs* on linux-64|
+|[libgomp](https://prefix.dev/channels/conda-forge/packages/libgomp)|h1383e82_2|h1383e82_3|Only build string|*all envs* on win-64|
+|[liblapack](https://prefix.dev/channels/conda-forge/packages/liblapack)|31_hc9a63f6_openblas|32_hc9a63f6_openblas|Only build string|*all envs* on osx-arm64|
+|[liblapack](https://prefix.dev/channels/conda-forge/packages/liblapack)|31_h7ac8fdf_openblas|32_h7ac8fdf_openblas|Only build string|*all envs* on linux-64|
+|[liblapack](https://prefix.dev/channels/conda-forge/packages/liblapack)|31_h1aa476e_mkl|32_h1aa476e_mkl|Only build string|*all envs* on win-64|
+|[libnsl](https://prefix.dev/channels/conda-forge/packages/libnsl)|hd590300_0|hb9d3cd8_1|Only build string|*all envs* on linux-64|
+|[libparquet](https://prefix.dev/channels/conda-forge/packages/libparquet)|ha850022_6_cpu|ha850022_8_cpu|Only build string|*all envs* on win-64|
+|[libparquet](https://prefix.dev/channels/conda-forge/packages/libparquet)|h081d1f1_6_cpu|h081d1f1_8_cpu|Only build string|*all envs* on linux-64|
+|[libpciaccess](https://prefix.dev/channels/conda-forge/packages/libpciaccess)|hd590300_0|hb9d3cd8_0|Only build string|*all envs* on linux-64|
+|[libpdal](https://prefix.dev/channels/conda-forge/packages/libpdal)|hb3590ec_6|hb3590ec_7|Only build string|*all envs* on win-64|
+|[libpdal-arrow](https://prefix.dev/channels/conda-forge/packages/libpdal-arrow)|h6c57e06_6|h6c57e06_7|Only build string|*all envs* on win-64|
+|[libpdal-core](https://prefix.dev/channels/conda-forge/packages/libpdal-core)|h6f06235_6|heefb544_7|Only build string|*all envs* on win-64|
+|[libpdal-draco](https://prefix.dev/channels/conda-forge/packages/libpdal-draco)|ha763671_6|ha763671_7|Only build string|*all envs* on win-64|
+|[libpdal-e57](https://prefix.dev/channels/conda-forge/packages/libpdal-e57)|h482c529_6|h482c529_7|Only build string|*all envs* on win-64|
+|[libpdal-hdf](https://prefix.dev/channels/conda-forge/packages/libpdal-hdf)|h2520430_6|h2520430_7|Only build string|*all envs* on win-64|
+|[libpdal-icebridge](https://prefix.dev/channels/conda-forge/packages/libpdal-icebridge)|h2520430_6|h2520430_7|Only build string|*all envs* on win-64|
+|[libpdal-nitf](https://prefix.dev/channels/conda-forge/packages/libpdal-nitf)|h1b836ec_6|h1b836ec_7|Only build string|*all envs* on win-64|
+|[libpdal-pgpointcloud](https://prefix.dev/channels/conda-forge/packages/libpdal-pgpointcloud)|hb7c6058_6|hb7c6058_7|Only build string|*all envs* on win-64|
+|[libpdal-tiledb](https://prefix.dev/channels/conda-forge/packages/libpdal-tiledb)|hc4b2a02_6|hc4b2a02_7|Only build string|*all envs* on win-64|
+|[libpdal-trajectory](https://prefix.dev/channels/conda-forge/packages/libpdal-trajectory)|h82545d7_6|hf542bf2_7|Only build string|*all envs* on win-64|
+|[libsanitizer](https://prefix.dev/channels/conda-forge/packages/libsanitizer)|h97b714f_2|h97b714f_3|Only build string|*all envs* on linux-64|
+|[libstdcxx](https://prefix.dev/channels/conda-forge/packages/libstdcxx)|h8f9b012_2|h8f9b012_3|Only build string|*all envs* on linux-64|
+|[libstdcxx-ng](https://prefix.dev/channels/conda-forge/packages/libstdcxx-ng)|h4852527_2|h4852527_3|Only build string|*all envs* on linux-64|
+|[munkres](https://prefix.dev/channels/conda-forge/packages/munkres)|pyh9f0ad1d_0|pyhd8ed1ab_1|Only build string|*all*|
+|[nh3](https://prefix.dev/channels/conda-forge/packages/nh3)|py39he870945_1|py39h81ceba4_2|Only build string|*all envs* on win-64|
+|[nh3](https://prefix.dev/channels/conda-forge/packages/nh3)|py39h77e2912_1|py39h7c48542_2|Only build string|*all envs* on linux-64|
+|[nh3](https://prefix.dev/channels/conda-forge/packages/nh3)|py39h52c9f89_1|py39h39b1003_2|Only build string|*all envs* on osx-arm64|
+|[psycopg2](https://prefix.dev/channels/conda-forge/packages/psycopg2)|py312hfaedaf9_0|py312hfaedaf9_1|Only build string|default on linux-64|
+|[psycopg2](https://prefix.dev/channels/conda-forge/packages/psycopg2)|py312h96c7839_0|py312h96c7839_1|Only build string|default on osx-arm64|
+|[psycopg2](https://prefix.dev/channels/conda-forge/packages/psycopg2)|py312h16142e3_0|py312h16142e3_1|Only build string|default on win-64|
+|[psycopg2](https://prefix.dev/channels/conda-forge/packages/psycopg2)|py311hd732c25_0|py311hd732c25_1|Only build string|py311 on win-64|
+|[psycopg2](https://prefix.dev/channels/conda-forge/packages/psycopg2)|py311h83e8966_0|py311h83e8966_1|Only build string|py311 on linux-64|
+|[psycopg2](https://prefix.dev/channels/conda-forge/packages/psycopg2)|py311h2c64ce4_0|py311h2c64ce4_1|Only build string|py311 on osx-arm64|
+|[python-dateutil](https://prefix.dev/channels/conda-forge/packages/python-dateutil)|pyhff2d567_1|pyhe01879c_2|Only build string|*all*|
+|[qscintilla2](https://prefix.dev/channels/conda-forge/packages/qscintilla2)|py312h14105d7_0|py312he8164c3_1|Only build string|default on osx-arm64|
+|[qscintilla2](https://prefix.dev/channels/conda-forge/packages/qscintilla2)|py312hca0710b_0|py312he11f4ca_1|Only build string|default on win-64|
+|[qscintilla2](https://prefix.dev/channels/conda-forge/packages/qscintilla2)|py312hc23280e_0|py312hcec5e1c_1|Only build string|default on linux-64|
+|[qscintilla2](https://prefix.dev/channels/conda-forge/packages/qscintilla2)|py311h4c6dc46_0|py311he22028a_1|Only build string|py311 on linux-64|
+|[qscintilla2](https://prefix.dev/channels/conda-forge/packages/qscintilla2)|py311h5a77453_0|py311h2d05f59_1|Only build string|py311 on win-64|
+|[qscintilla2](https://prefix.dev/channels/conda-forge/packages/qscintilla2)|py311h14ede98_0|py311h2146069_1|Only build string|py311 on osx-arm64|
+|[qt6-main](https://prefix.dev/channels/conda-forge/packages/qt6-main)|h0384650_0|h0384650_1|Only build string|*all envs* on linux-64|
+|[qt6-main](https://prefix.dev/channels/conda-forge/packages/qt6-main)|h02ddd7d_0|h02ddd7d_1|Only build string|*all envs* on win-64|
+|[spdlog](https://prefix.dev/channels/conda-forge/packages/spdlog)|h10b92b3_0|h6dc744f_1|Only build string|*all envs* on linux-64|
+|[spdlog](https://prefix.dev/channels/conda-forge/packages/spdlog)|ha881ca7_0|h430ee68_1|Only build string|*all envs* on win-64|
+|[tiledb](https://prefix.dev/channels/conda-forge/packages/tiledb)|h6f9ba5a_2|hccce5bd_6|Only build string|*all envs* on linux-64|
+|[tiledb](https://prefix.dev/channels/conda-forge/packages/tiledb)|h0cf81a9_2|h7c9f11d_6|Only build string|*all envs* on win-64|
+|[vc](https://prefix.dev/channels/conda-forge/packages/vc)|h2b53caa_26|h41ae7f8_26|Only build string|*all envs* on win-64|
+|[xcb-util](https://prefix.dev/channels/conda-forge/packages/xcb-util)|hb711507_2|h4f16b4b_2|Only build string|*all envs* on linux-64|
+
+</details>
+
+[^1]: **Bold** means explicit dependency.
+[^2]: Dependency got downgraded.
+

--- a/pixi.lock
+++ b/pixi.lock
@@ -20,19 +20,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.5-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.9.0-hf280997_13.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.9.0-hbfa7f16_15.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.2-h5e3027f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.12.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.1-hafb2847_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.4-haaa725d_10.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.10.2-hcfde5e4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.19.1-hdfce8c9_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.13.1-h08b274c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.8.1-hed81e95_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.4-h76f0014_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.10.2-h015de20_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.20.1-hdfce8c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.13.1-h1e5e6c0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.8.3-h5e174a9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.4-hafb2847_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.7-hafb2847_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.32.8-h5e43bac_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.510-h4607db7_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.32.10-hff780f1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.510-h937e755_12.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
@@ -43,7 +43,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beartype-0.21.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.13.4-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/black-25.1.0-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
@@ -56,13 +56,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h2ec8cdc_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.5-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.6.15-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/capnproto-1.0.2-h766bdaa_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/capnproto-1.2.0-hfc315d8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ceres-solver-2.2.0-cpuh39c81a5_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.4.26-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.6.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py312h06ac9bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.6.2-h44b4e7a_0.conda
@@ -74,17 +74,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.2-py312h68727a3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.8.2-py312h178313f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.9.1-py312h178313f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cpd-0.5.5-h434a139_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.11-py312hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-45.0.4-py312hda17c39_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-45.0.5-py312hda17c39_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.27-h54b06d7_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.1-py312h66e93f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dart-sass-1.59.1-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2025.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2025.5.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/datacompy-0.16.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datacompy-0.16.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h3c4dab8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.14-py312h2ec8cdc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
@@ -105,8 +105,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/exiv2-0.28.5-h653fe86_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fgt-0.4.11-h87365c0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.18.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.1.4-h07f6e7f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.19.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.2.0-h07f6e7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -114,14 +114,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.58.2-py312h178313f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.58.4-py312h178313f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.13.3-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/future-1.0.0-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.1.0-h4393ad2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.10.3-py312hf1b357c_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.1.0-h4393ad2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.11.1-py312hf1b357c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.1-h97f6797_0.conda
@@ -129,13 +129,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.24.1-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.24.1-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.74.1-h76a2195_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.74.2-h76a2195_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.84.2-h6287aef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.84.2-h4833e2c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.7.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.7-he838d99_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.11-h651a532_0.conda
@@ -162,7 +162,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.3.0-pyhfa0c392_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.4.0-pyhfa0c392_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
@@ -188,7 +188,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.16.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.15-pyhd8ed1ab_0.conda
@@ -196,129 +196,133 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-he073ed8_18.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.6.0-pyha804496_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.8-py312h84d6215_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.8-py312h68727a3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/laz-perf-3.4.0-h00ab1b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.17-h717163a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20250127.1-cxx17_hbbce691_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libadbc-driver-manager-1.6.0-h84d6215_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.4-h3f801dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libamd-3.3.3-h456b2da_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.1-gpl_h98cc613_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-20.0.0-h314c690_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-20.0.0-hcb10f89_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-20.0.0-hcb10f89_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-20.0.0-h1bed206_6_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-20.0.0-h1b9301b_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-20.0.0-hcb10f89_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-20.0.0-hcb10f89_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-20.0.0-h1bed206_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.24.1-h8e693c7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.24.1-h8e693c7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-31_h59b9bed_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-32_h59b9bed_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbtf-2.3.2-hf02c80a_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcamd-3.3.3-hf02c80a_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.75-h39aace5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-31_he106b2a_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-32_he106b2a_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libccolamd-3.3.4-hf02c80a_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcholmod-5.3.1-h9cf07ce_7100101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.6-default_h1df26ce_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-20.1.6-default_he06ed0a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.7-default_h1df26ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-20.1.7-default_he06ed0a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcolamd-3.3.4-hf02c80a_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-hb8b1518_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.14.1-h332b0f4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxsparse-4.4.1-hf02c80a_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.24-h86f0d12_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.124-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.0-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.1.0-ha770c72_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.1.0-hf45584d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.2.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.2.0-hf45584d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.13.3-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.13.3-h48d6fc4_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.1.0-h4c094af_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.1.0-h4c094af_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.11.1-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.10.3-h3b705f5_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-arrow-parquet-3.10.3-h8169c6c_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.10.3-hcac4edf_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.10.3-hbd53b90_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.10.3-h34a6268_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.10.3-hbe05c68_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.10.3-hc4e49b7_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.10.3-hb7814c2_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.10.3-he794564_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.10.3-h6b150f0_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.10.3-h962cb15_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.10.3-hfb06ed7_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.10.3-hfb06ed7_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.10.3-hd16f1d8_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.10.3-ha4d2dc7_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.11.1-h3b705f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-adbc-3.11.1-ha4d2dc7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-arrow-parquet-3.11.1-h8169c6c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.11.1-h5e6393a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.11.1-hbd53b90_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.11.1-h34a6268_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.11.1-hbe05c68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.11.1-hc4e49b7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.11.1-hb7814c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.11.1-he794564_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.11.1-h6b150f0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.11.1-h962cb15_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.11.1-hfb06ed7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.11.1-hfb06ed7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.11.1-hd16f1d8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.11.1-ha4d2dc7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.24.1-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.24.1-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.1.0-h69a702a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.1.0-h69a702a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.84.2-h3618099_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.36.0-hc4361e1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.36.0-h0121fbd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.55-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.71.0-h8e591d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.2-default_h0d58e46_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.2.0-hf40a0c7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.1-h7b0646d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libklu-2.3.5-h95ff59c_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hf539b9f_1021.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-31_h7ac8fdf_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-32_h7ac8fdf_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libldl-3.3.2-hf02c80a_7100101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.6-he9d0ab4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.7-he9d0ab4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h0134ee8_117.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.29-pthreads_h94d23a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.21.0-hd1b1c89_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.21.0-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.5.2-hd0c01bc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-20.0.0-h081d1f1_6_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-20.0.0-h081d1f1_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libparu-1.0.0-hc6afc67_7100101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-2.8.4-h453e6b4_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-arrow-2.8.4-hb7ef14c_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-core-2.8.4-h921c622_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-cpd-2.8.4-hbb46d0d_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-draco-2.8.4-hbb46d0d_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-e57-2.8.4-h0dda180_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-hdf-2.8.4-haa54232_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-icebridge-2.8.4-haa54232_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-nitf-2.8.4-h986040f_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-pgpointcloud-2.8.4-h5c7ba8f_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-tiledb-2.8.4-h68be023_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-trajectory-2.8.4-hb16f371_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-2.9.0-h453e6b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-arrow-2.9.0-hb7ef14c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-core-2.9.0-ha13eeb3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-cpd-2.9.0-hbb46d0d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-draco-2.9.0-hbb46d0d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-e57-2.9.0-h0dda180_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-hdf-2.9.0-haa54232_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-icebridge-2.9.0-haa54232_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-nitf-2.9.0-h986040f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-pgpointcloud-2.9.0-h5c7ba8f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-tiledb-2.9.0-h68be023_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-trajectory-2.9.0-h502ccf6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpmix-5.0.8-h658e747_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.47-h943b412_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.49-h943b412_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.5-h27ae623_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.29.3-h501fc15_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librbio-4.3.4-hf02c80a_7100101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hba17884_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.06.26-hba17884_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-hd718a1a_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.1.0-h97b714f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.1.0-h97b714f_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsecret-0.21.7-h1e2da66_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
@@ -326,15 +330,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-he17ca71_14.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libspex-3.2.3-h9226d62_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libspqr-4.3.4-h23b7119_7100101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.1-hee588c1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.2-h6cd9bfd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsuitesparseconfig-7.10.1-h901830b_7100101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.6-h4e0b6ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.7-h4e0b6ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-hf01ce69_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.6-hbe16f8c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.7-hbe16f8c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libumfpack-6.3.5-h873dde6_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.10.0-h202a827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
@@ -349,7 +353,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.44.0-py312h374181b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-5.4.0-py312h68d7fa5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.0.0-py312h68d7fa5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.4.4-py312hf0f0c11_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
@@ -369,11 +373,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.1-h90cbb55_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpi-1.0-openmpi.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py312h68727a3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.16.0-py312h66e93f0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.1-py312h68727a3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/muparser-2.3.5-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.16.1-py312h66e93f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.42.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.45.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
@@ -381,30 +386,30 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.2-nompi_py312h3805cb1_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nh3-0.2.21-py39h77e2912_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nh3-0.2.21-py39h7c48542_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nitro-2.7.dev8-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nose2-0.9.2-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.36-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.112-h159eef7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.113-h159eef7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.61.2-py312h7bcfee6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.3-py312h58c1407_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2024.10.24-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.3-h5fbd93e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openmpi-5.0.8-h41ff47f_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.0-h7b32b05_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.1-h7b32b05_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.1.2-h17f744e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ordered-set-4.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/owslib-0.34.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/owslib-0.34.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py312hf9745cd_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.3.0-py312hf9745cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.3.250527-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-0.22.1-hd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.22.1-pyhd8ed1ab_1.conda
@@ -416,15 +421,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.45-hc749103_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.2.1-py312h80c1187_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py312h80c1187_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.2-h29eaf8c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.5.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/polars-1.27.1-py39h2a4a510_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/polars-1.31.0-default_h1650462_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/polars-default-1.31.0-py39hfac2b71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.12.0-hd7b24de_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
@@ -436,7 +442,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.51-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.0.0-py312h66e93f0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/psycopg2-2.9.10-py312hfaedaf9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psycopg2-2.9.10-py312hfaedaf9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-hac146a9_1.conda
@@ -445,25 +451,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-20.0.0-py312h01725c0_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pycryptodome-3.23.0-py312h6368725_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.4-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.7-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.33.2-py312h680f630_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.9.1-pyh3cfb1c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.11.0-py312h02b19dd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.10.1-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.11.0-py312h5426b81_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.1-py312h03c6e1f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.9-py312h949fe66_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.11-py312hcec5e1c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-stubs-5.15.6.0-pyhb6d5dde_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.12.2-py312h30efb56_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqtwebkit-5.15.9-py312hc23280e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.17.0-py312h2ec8cdc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqtwebkit-5.15.11-py312hcec5e1c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.9.1-py312hdb827e4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.11-h9e4cc4f_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.12.11-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
@@ -471,22 +477,22 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-7_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py312h178313f_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.4.0-py312hbf22597_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.0.0-py312hbf22597_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qca-2.3.10-h71e8f01_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qgis-3.42.2-py312h9cdd117_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qgis-3.44.0-py312h47e9dea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/qgis-plugin-manager-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qjson-0.9.0-h0c700ba_1009.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qscintilla2-2.14.1-py312hc23280e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qscintilla2-2.14.1-py312hcec5e1c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-hea1682b_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.9.1-h0384650_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.9.1-h0384650_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qtkeychain-0.15.0-h518214a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qtwebkit-5.212-h0fbc989_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/quarto-1.7.31-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/quarto-1.7.32-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.11.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qwt-6.3.0-h7c222af_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-57.0-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h9925aae_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.06.26-h9925aae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/readme_renderer-44.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
@@ -496,27 +502,27 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.0.0-pyh29332c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.25.1-py312h680f630_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.11.13-py312h1d08497_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.87.0-h1a8d7c4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.87.0-h2c6d0dc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.26.0-py312h680f630_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.12.1-py312h1d2019f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.88.0-h1a8d7c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.88.0-h2c6d0dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.21-h7ab7c64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.7.0-py312h7a48858_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.15.2-py312ha707e6e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.0-py312hf734454_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.3.3-py312h7900ff3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.1.1-py312h21f5128_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sip-6.7.12-py312h30efb56_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sip-6.10.0-py312h2ec8cdc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-h8bd8927_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.7-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.15.3-h10b92b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.15.3-h6dc744f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphobjinv-2.3.1.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.50.1-h9eae976_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.50.2-hb7a22d2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/suitesparse-7.10.1-h5b2951e_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h0157908_18.conda
@@ -525,7 +531,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/teamcity-messages-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.28.0-h6f9ba5a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.28.0-hccce5bd_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
@@ -537,7 +543,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2025.5.9.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/twine-6.1.0-pyh29332c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20250516-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2025.2.0.20250516-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.14.0-h32cad80_0.conda
@@ -554,9 +560,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py312h66e93f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.7.12-h2f11bb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.7.19-h29fcd0c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.31.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/watchdog-6.0.0-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_1.conda
@@ -565,8 +571,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.14-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-hb711507_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.6.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.5-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
@@ -600,14 +606,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312h66e93f0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
-      - pypi: https://files.pythonhosted.org/packages/23/72/a6feae158a2188f457ca8f50d8d4d29a3affeed763227bd8b1bf2df0ce2c/lib4package-0.3.2-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/07/4d/4e98d47cbfca9a45e62ff86eab29eff770fd355df9452e48480d89ede7ef/lib4sbom-0.8.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f6/65/84a48ff419cb5f303be2eaa40a757a7860c777a1caf738738de489db69e0/elementpath-5.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/66/d7/2344419cb255399ff2253cdb81cb38827867f854f66e98a780478fc13c19/lib4package-0.3.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ed/bd/4c87f8f863a09cd8c2126f7c553d08742becbfa7abffe29d3720340e2acd/lib4sbom-0.8.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/5b/fa477e4fd8e62c722febdc52462d7b037a77aa963c3e400a8e90e8f0d2c0/ptvsd-4.3.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/fd/e5dae179943e631ae1d2b1903d73d7060ea9a82242e922abc685e33b6679/sbom2dot-0.3.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/6f/09acbe8b17a427e89f92ed03ae2b102aa77f911f094834214e82d0d36416/sbom4files-0.4.5-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/ab/ca69eca5d16b550d227df7616ab24f32d528903a3f1305953ad038adecaa/sbom4python-0.12.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/13/cbf8f3937c6bb9f59b19281998589097769057d38e5af894db78ae95386f/sbom4python-0.12.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/2c/3ba8f8aeb3cb566e88a61ab0b0b767d5398d1e7293a0f7a76df9051e2b08/xmlschema-4.1.0-py3-none-any.whl
       - pypi: ./python/ribasim
       - pypi: ./python/ribasim_api
       - pypi: ./python/ribasim_testmodels
@@ -658,13 +666,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py312hd8f9ff3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.5-h5505292_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.6.15-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.4-h6a3b0d2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/capnproto-1.0.2-h221ca0e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ceres-solver-2.2.0-cpuhb9536e5_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.4.26-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.6.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py312h0fad829_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cfitsio-4.5.0-hc017baa_0.conda
@@ -676,16 +684,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.2-py312hb23fbb9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.8.2-py312h998013c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.9.1-py312h998013c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cpd-0.5.5-h420ef59_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.11-py312hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cyrus-sasl-2.1.27-h60b93bd_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cyrus-sasl-2.1.28-ha1cbb27_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.0.1-py312hea69d52_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dart-sass-1.59.1-hce30654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2025.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2025.5.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/datacompy-0.16.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datacompy-0.16.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.14-py312hd8f9ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
@@ -706,7 +714,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fgt-0.4.11-h745860c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.18.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-11.0.2-h440487c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.19.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -714,7 +722,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.15.0-h1383a14_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.58.2-py312h998013c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.58.4-py312h998013c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.13.3-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
@@ -726,7 +734,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.13.0-hf9b8971_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.4-hbef4fa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gh-2.74.1-hd02bf31_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gh-2.74.2-hd02bf31_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.84.0-heee381b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.84.0-h1dc7a0c_0.conda
@@ -757,7 +765,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.3.0-pyhfa0c392_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.4.0-pyhfa0c392_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
@@ -782,52 +790,52 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.16.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kealib-1.6.1-hc1fecf1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.6.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/khronos-opencl-icd-loader-2024.10.24-h5505292_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.8-py312h2c4a281_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.8-py312hb23fbb9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/laz-perf-3.4.0-h1995070_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.17-h7eeda09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-hd64df32_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_h07bc746_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.4-h51d1e36_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libamd-3.3.3-h5087772_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.7-h3c2f2b0_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-17.0.0-h0b4cf59_51_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-17.0.0-hf07054f_51_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-17.0.0-hf07054f_51_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-17.0.0-h4239455_51_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.24.1-h493aca8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.24.2-h493aca8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.3.0-hf1e31eb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-31_h10e41b3_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-32_h10e41b3_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-h5505292_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-h5505292_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-h5505292_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbtf-2.3.2-h99b4a89_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcamd-3.3.3-h99b4a89_7100102.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-31_hb3479ef_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-32_hb3479ef_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libccolamd-3.3.4-h99b4a89_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcholmod-5.3.1-hbba04d7_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp17-17.0.6-default_hf90f093_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-20.1.6-default_hee4fbb3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-20.1.7-default_hee4fbb3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcolamd-3.3.4-h99b4a89_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.14.1-h73640d1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxsparse-4.4.1-h9e79f82_7100102.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-20.1.6-ha82da77_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-20.1.7-ha82da77_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libde265-1.0.15-h2ffa867_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.23-h5773f1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.0-h286801f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.1.0-hce30654_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.1.0-h5505292_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.2.0-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.2.0-h5505292_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.13.3-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.13.3-h1d14073_1.conda
@@ -846,9 +854,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-postgisraster-3.10.2-h98ad515_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-tiledb-3.10.2-h3b22183_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-xls-3.10.2-hcf353f7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.24.1-h493aca8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-14.2.0-heb5dd2a_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-14.2.0-h2c44a93_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.24.2-h493aca8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-14_2_0_h6c33f7e_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-14.2.0-h6c33f7e_103.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.84.0-hdff4504_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.36.0-hdbe95d5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.36.0-h7081f7f_0.conda
@@ -856,21 +864,21 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libheif-1.19.7-gpl_h79e6334_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.11.2-default_hbce5d74_1001.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-hfe07756_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.24.1-h493aca8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.24.1-h493aca8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.24.2-h493aca8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.24.2-h493aca8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.1.0-h5505292_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libklu-2.3.5-h4370aa4_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-he250239_1021.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-31_hc9a63f6_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-32_hc9a63f6_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libldl-3.3.2-h99b4a89_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm17-17.0.6-hc4b4ae8_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm20-20.1.6-h598bca7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm20-20.1.7-h598bca7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_h610d594_116.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libntlm-1.8-h5505292_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.5-h48c0fde_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.29-openmp_hf332438_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.30-openmp_hf332438_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.5.2-h48c0fde_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-17.0.0-h636d7b7_51_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparu-1.0.0-h317a14d_7100102.conda
@@ -887,7 +895,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpdal-tiledb-2.8.4-h96a401d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpdal-trajectory-2.8.4-hcb8ff9a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpmix-5.0.8-h6500a5a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.47-h3783ad8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.49-h3783ad8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-17.5-h6896619_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.3-h3bd63a1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librbio-4.3.4-h99b4a89_7100102.conda
@@ -898,7 +906,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.1.0-hf92fc0a_12.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspex-3.2.3-h15d103f_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspqr-4.3.4-h775d698_7100102.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.1-h3f77e49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.2-h6fb428d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsuitesparseconfig-7.10.1-h4a8fc20_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtasn1-4.20.0-h5505292_0.conda
@@ -913,10 +921,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxslt-1.1.39-h223e5b9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.11.2-h1336266_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-20.1.6-hdb05f8b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-20.1.7-hdb05f8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.44.0-py312h728bc31_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-5.4.0-py312hc2c121e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-6.0.0-py312hc2c121e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.4.4-py312hf263c89_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h93a5062_1001.conda
@@ -935,13 +943,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.1-hb693164_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpi-1.0-openmpi.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py312h6142ec9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.16.0-py312hea69d52_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.1-py312hb23fbb9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.16.1-py312hea69d52_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-common-9.0.1-hd7719f6_6.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-libs-9.0.1-ha8be5b7_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.42.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.45.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
@@ -949,28 +957,28 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.7.2-nompi_py312hf5de4ce_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nh3-0.2.21-py39h52c9f89_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nh3-0.2.21-py39h39b1003_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nitro-2.7.dev8-h13dd4ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nose2-0.9.2-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.36-h5833ebf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.112-ha3c76ea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.113-ha3c76ea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.61.2-py312h22bc582_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py312h94ee1e1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/opencl-headers-2024.10.24-h286801f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/opencl-headers-2025.06.13-h286801f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.3-h8a3d83b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openldap-2.6.10-hbe55e7a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openmpi-5.0.7-h31ce4ef_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.0-h81ee809_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openmpi-5.0.8-hc9a84be_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.1-h81ee809_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.1.1-h74f7c94_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ordered-set-4.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/owslib-0.34.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/owslib-0.34.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py312hcb1e3ce_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.3.0-py312hcb1e3ce_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.3.250527-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-0.22.1-hd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.22.1-pyhd8ed1ab_1.conda
@@ -982,15 +990,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-ha881caa_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.2.1-py312h50aef2c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.3.0-py312h50aef2c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.46.2-h2f9eb0b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.5.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/polars-1.27.1-py39h81794e1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/polars-1.31.0-default_h56a14c1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/polars-default-1.31.0-py39h6da47c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/poppler-24.12.0-ha29e788_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
@@ -1001,7 +1010,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.51-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.0.0-py312hea69d52_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psycopg2-2.9.10-py312h96c7839_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psycopg2-2.9.10-py312h96c7839_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
@@ -1009,12 +1018,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-17.0.0-py312hc40f475_2_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pycryptodome-3.23.0-py312ha135e06_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.4-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.7-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.33.2-py312hd3c0895_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.9.1-pyh3cfb1c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.0-py312hb9d441b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.0-py312hb9d441b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.10.1-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.1-py312h4c66426_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.1-py312hb9d441b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.10.0-py312hfd5e53c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.1-py312h4b98159_0.conda
@@ -1023,12 +1032,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqt5-sip-12.17.0-py312hd8f9ff3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqtwebkit-5.15.11-py312he8164c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.11-hc22306f_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.12.11-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
@@ -1036,18 +1045,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-7_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py312h998013c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.4.0-py312hf4875e0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.0.0-py312hf4875e0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qca-2.3.10-hfcce152_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qgis-3.40.3-py312h8b719f5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/qgis-plugin-manager-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qjson-0.9.0-haa19703_1009.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qscintilla2-2.14.1-py312h14105d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qscintilla2-2.14.1-py312he8164c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qt-main-5.15.15-h67564f6_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qtkeychain-0.15.0-haaf71b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qtwebkit-5.212-he16459a_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/quarto-1.7.31-hce30654_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/quarto-1.7.32-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.11.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qwt-6.3.0-h4ff56cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rav1e-0.7.1-h0716509_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2024.07.02-h6589ca4_2.conda
@@ -1060,12 +1069,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.0.0-pyh29332c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.25.1-py312hd3c0895_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.11.13-py312h846f395_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.87.0-h4ff7c5d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.87.0-hf6ec828_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.26.0-py312hd3c0895_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.12.1-h412e174_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.88.0-h4ff7c5d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.88.0-hf6ec828_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.7.0-py312h39203ce_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.15.2-py312h99a188d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.16.0-py312hcedbd36_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.7-py312ha6455e5_0.conda
@@ -1078,7 +1087,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.15.1-hed1c2b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphobjinv-2.3.1.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.50.1-hd7222ec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.50.2-hc23dd5f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/suitesparse-7.10.1-h3071b36_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-3.0.2-h8ab69cd_0.conda
@@ -1099,7 +1108,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2025.5.9.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/twine-6.1.0-pyh29332c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20250516-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2025.2.0.20250516-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.14.0-h32cad80_0.conda
@@ -1114,9 +1123,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-16.0.0-py312hea69d52_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.8-h00cdb27_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.7.12-hb4c02be_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.7.19-hcff7401_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.31.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/watchdog-6.0.0-py312hea69d52_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
@@ -1125,7 +1134,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.14-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.6.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.2.5-h92fc2f4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xmipy-1.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-h5505292_0.conda
@@ -1139,14 +1148,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py312hea69d52_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
-      - pypi: https://files.pythonhosted.org/packages/23/72/a6feae158a2188f457ca8f50d8d4d29a3affeed763227bd8b1bf2df0ce2c/lib4package-0.3.2-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/07/4d/4e98d47cbfca9a45e62ff86eab29eff770fd355df9452e48480d89ede7ef/lib4sbom-0.8.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f6/65/84a48ff419cb5f303be2eaa40a757a7860c777a1caf738738de489db69e0/elementpath-5.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/66/d7/2344419cb255399ff2253cdb81cb38827867f854f66e98a780478fc13c19/lib4package-0.3.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ed/bd/4c87f8f863a09cd8c2126f7c553d08742becbfa7abffe29d3720340e2acd/lib4sbom-0.8.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/5b/fa477e4fd8e62c722febdc52462d7b037a77aa963c3e400a8e90e8f0d2c0/ptvsd-4.3.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/fd/e5dae179943e631ae1d2b1903d73d7060ea9a82242e922abc685e33b6679/sbom2dot-0.3.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/6f/09acbe8b17a427e89f92ed03ae2b102aa77f911f094834214e82d0d36416/sbom4files-0.4.5-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/ab/ca69eca5d16b550d227df7616ab24f32d528903a3f1305953ad038adecaa/sbom4python-0.12.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/13/cbf8f3937c6bb9f59b19281998589097769057d38e5af894db78ae95386f/sbom4python-0.12.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/2c/3ba8f8aeb3cb566e88a61ab0b0b767d5398d1e7293a0f7a76df9051e2b08/xmlschema-4.1.0-py3-none-any.whl
       - pypi: ./python/ribasim
       - pypi: ./python/ribasim_api
       - pypi: ./python/ribasim_testmodels
@@ -1161,19 +1172,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.5-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.9.0-h3537544_13.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.9.0-hd490b63_15.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.9.2-hd8a8e38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.12.3-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.1-h5d0e663_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.4-hf27a43c_10.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.10.2-h633db33_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.19.1-hddf4d6c_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.13.1-h6306086_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.8.1-h046fb53_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.4-ha416645_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.10.2-h81282ae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.20.1-hddf4d6c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.13.1-h5c1ae27_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.8.3-h1e843c7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.4-h5d0e663_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.7-h5d0e663_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.32.8-h04c53c4_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.510-h7deb975_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.32.10-h1aa98f0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.510-hd13e2d4_12.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/azure-core-cpp-1.14.0-haf5610f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/azure-identity-cpp-1.10.0-hd6deed7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-blobs-cpp-12.13.0-h3241184_1.conda
@@ -1195,13 +1206,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py312h275cf98_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.34.5-h2466b09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-h4c7d964_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.6.15-h4c7d964_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.4-h5782bbf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/capnproto-1.0.2-hb5d7e06_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/capnproto-1.2.0-h3a793f1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ceres-solver-2.2.0-cpuhc26068e_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.4.26-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.6.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.6.2-h2b45a09_0.conda
@@ -1213,14 +1224,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.2-py312hd5eb7cc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.8.2-py312h31fea79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.9.1-py312h31fea79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.11-py312hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.0.1-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/dart-sass-1.59.1-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2025.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2025.5.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/datacompy-0.16.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datacompy-0.16.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.14-py312h275cf98_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
@@ -1239,8 +1250,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/exiv2-0.28.5-h29f99b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.18.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-11.1.4-h5f12afc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.19.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-11.2.0-h1d4551f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -1248,24 +1259,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.15.0-h765892d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.58.2-py312h31fea79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.58.4-py312h31fea79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.13.3-h57928b3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/future-1.0.0-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.10.3-py312h97c3f2a_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.11.1-py312h07de9ea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.13.1-h9ea8674_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.4-h86c3423_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gflags-2.2.2-he0c23c2_1005.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gh-2.74.1-h36e2d1d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gh-2.74.2-h36e2d1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.84.2-he8f994d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.84.2-h4394cf3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glog-0.7.1-h3ff59bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gmp-6.3.0-hfeafd45_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-h63175ca_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.14-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.7.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gsl-2.7-hdfb1a43_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.24.11-h3fe0a9e_0.conda
@@ -1293,7 +1304,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.3.0-pyh6be1c34_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.4.0-pyh6be1c34_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
@@ -1317,36 +1328,36 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.16.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/kealib-1.6.2-h9df79d9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.6.0-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2024.10.24-h2466b09_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.8-py312hc790b64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.8-py312hf90b1b7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/laz-perf-3.4.0-h91493d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.17-hbcf6048_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h6470a55_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20250127.1-cxx17_h4eb7d71_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.4-h20038f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libamd-3.3.3-h60129d2_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.8.1-gpl_h1ca5a36_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-20.0.0-hc090743_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-20.0.0-h7d8d6a5_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-20.0.0-h7d8d6a5_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-20.0.0-hb76e781_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-31_h641d27c_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-20.0.0-h3e40a90_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-20.0.0-h7d8d6a5_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-20.0.0-h7d8d6a5_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-20.0.0-hb76e781_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-32_h641d27c_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbtf-2.3.2-h8c1c262_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcamd-3.3.3-h8c1c262_7100102.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-31_h5e41251_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-32_h5e41251_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libccolamd-3.3.4-h8c1c262_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcholmod-5.3.1-hdf2ebef_7100102.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-20.1.6-default_h6e92b77_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-20.1.7-default_h6e92b77_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcolamd-3.3.4-h8c1c262_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.14.1-h88aaa65_0.conda
@@ -1357,64 +1368,66 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.6-h537db12_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype-2.13.3-h57928b3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype6-2.13.3-h0b5ce68_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-15.1.0-h1383e82_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.10.3-hafd5c6c_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-arrow-parquet-3.10.3-h24452f8_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.10.3-h7d16cc0_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.10.3-hd840048_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.10.3-h79060df_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.10.3-h0de24e7_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.10.3-h527b061_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.10.3-h95c5499_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.10.3-h6b3a253_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.10.3-h1b8416b_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.10.3-ha9b9ad8_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.10.3-h38d3678_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.10.3-h38d3678_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.10.3-h6c2f05d_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.10.3-hc931c72_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-15.1.0-h1383e82_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.11.1-hafd5c6c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-arrow-parquet-3.11.1-h2345e04_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.11.1-hddc0a0b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.11.1-hcff14e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.11.1-h8ff101f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.11.1-ha47b6c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.11.1-h0f01001_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.11.1-hf58e487_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.11.1-hea5172e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.11.1-hcb0e93c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.11.1-h75c24f8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.11.1-h103a44d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.11.1-h103a44d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.11.1-h88e1fbc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.11.1-h93cc17c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.84.2-hbc94333_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-15.1.0-h1383e82_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-15.1.0-h1383e82_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.36.0-hf249c01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.36.0-he5eb982_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.71.0-h8c3449c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.2.0-h1d1702c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-h135ad9c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.1.0-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjxl-0.11.1-ha161b08_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libklu-2.3.5-h77a2eaa_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1021.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-31_h1aa476e_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-32_h1aa476e_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libldl-3.3.2-h8c1c262_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_he045f6b_117.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-20.0.0-ha850022_6_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-20.0.0-ha850022_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libparu-1.0.0-hd80212b_7100102.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-2.8.4-hb3590ec_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-arrow-2.8.4-h6c57e06_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-core-2.8.4-h6f06235_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-draco-2.8.4-ha763671_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-e57-2.8.4-h482c529_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-hdf-2.8.4-h2520430_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-icebridge-2.8.4-h2520430_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-nitf-2.8.4-h1b836ec_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-pgpointcloud-2.8.4-hb7c6058_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-tiledb-2.8.4-hc4b2a02_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-trajectory-2.8.4-h82545d7_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.47-h7a4582a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-2.8.4-hb3590ec_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-arrow-2.8.4-h6c57e06_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-core-2.8.4-heefb544_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-draco-2.8.4-ha763671_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-e57-2.8.4-h482c529_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-hdf-2.8.4-h2520430_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-icebridge-2.8.4-h2520430_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-nitf-2.8.4-h1b836ec_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-pgpointcloud-2.8.4-hb7c6058_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-tiledb-2.8.4-hc4b2a02_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-trajectory-2.8.4-hf542bf2_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.49-h7a4582a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libpq-17.5-h9087029_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.29.3-he9d8c4a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/librbio-4.3.4-h8c1c262_7100102.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-hd248061_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2025.06.26-habfad5f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-hbfc9ebc_18.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialindex-2.1.0-h518811d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-h378fb81_14.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libspex-3.2.3-h2f847cc_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libspqr-4.3.4-h60c7c62_7100102.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.50.1-h67fdade_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.50.2-hf5d6505_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-h9aa295b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsuitesparseconfig-7.10.1-h0795de7_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.21.0-hbe90ef8_0.conda
@@ -1431,7 +1444,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.44.0-py312h1f7db74_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/lxml-5.4.0-py312hef2e38f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lxml-6.0.0-py312hc85b015_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.4.4-py312h032eceb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.10.0-h2466b09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-hcfcfb64_1001.conda
@@ -1450,35 +1463,36 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mock-5.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/mpfr-4.2.1-hbc20e70_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.0-py312hd5eb7cc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.16.0-py312h4389bb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.1-py312hd5eb7cc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/muparser-2.3.5-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.16.1-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.42.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.45.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/netcdf4-1.7.2-nompi_py312hf8617a8_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/nh3-0.2.21-py39he870945_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/nh3-0.2.21-py39h81ceba4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/nitro-2.7.dev8-h1537add_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nose2-0.9.2-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.61.2-py312hdcac391_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.3-py312h49bc9c5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/opencl-headers-2024.10.24-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/opencl-headers-2025.06.13-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.3-h4d64b90_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.5.0-ha4e3fda_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.5.1-h725018a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.1.2-h35764e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ordered-set-4.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/owslib-0.34.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/owslib-0.34.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py312h72972c8_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.3.0-py312h72972c8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.3.250527-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-0.22.1-hd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.22.1-pyhd8ed1ab_1.conda
@@ -1490,15 +1504,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.45-h99c9b8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.2.1-py312h078707f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.3.0-py312hfb502af_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.46.2-had0cd8c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.5.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/polars-1.27.1-py39h9b97169_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/polars-1.31.0-default_hc01efcc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/polars-default-1.31.0-py39h4d7386a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/poppler-24.12.0-heaa0bce_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
@@ -1509,7 +1524,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.51-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.0.0-py312h4389bb4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/psycopg2-2.9.10-py312h16142e3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psycopg2-2.9.10-py312h16142e3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
@@ -1517,25 +1532,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-20.0.0-py312h6a9c419_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pycryptodome-3.23.0-py312h4389bb4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.4-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.7-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.33.2-py312h8422cdd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.9.1-pyh3cfb1c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.11.0-py312h6e88f47_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.10.1-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.11.0-py312h8f0c04e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.7.1-py312h5ea471a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.9-py312he09f080_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.11-py312he11f4ca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-stubs-5.15.6.0-pyhb6d5dde_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.12.2-py312h53d5487_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyqtwebkit-5.15.9-py312hca0710b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.17.0-py312h275cf98_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyqtwebkit-5.15.11-py312he11f4ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.9.1-py312h0ba07f7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.11-h3f84c4b_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.12.11-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
@@ -1546,22 +1561,22 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-ctypes-0.2.3-py312h2e8e312_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.15-py312h275cf98_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py312h31fea79_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.4.0-py312hd7027bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-27.0.0-py312hd7027bb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qca-2.3.10-hcfd1de8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/qgis-3.42.2-py312h20a3e66_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qgis-3.42.3-py312h8977587_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/qgis-plugin-manager-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qjson-0.9.0-h04a78d6_1009.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/qscintilla2-2.14.1-py312hca0710b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qscintilla2-2.14.1-py312he11f4ca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.15-h9151539_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.9.1-h02ddd7d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.9.1-h02ddd7d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qtkeychain-0.15.0-hc9563df_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qtwebkit-5.212-hbc9c816_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/quarto-1.7.31-h57928b3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/quarto-1.7.32-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.11.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qwt-6.3.0-h9417a65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rcedit-1.1.1-h63175ca_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-haf4117d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2025.06.26-h3dd2b4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/readme_renderer-44.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.4-pyhd8ed1ab_0.conda
@@ -1570,25 +1585,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.0.0-pyh29332c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.25.1-py312h8422cdd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.11.13-py312h24a9d25_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.87.0-hf8d6059_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.87.0-h17fc481_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.26.0-py312hdabe01f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.12.1-hd40eec1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.88.0-hf8d6059_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.88.0-h17fc481_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.7.0-py312h816cc57_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.15.2-py312h451d5c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.16.0-py312h1416ca1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.1.1-py312h3f81574_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/sip-6.7.12-py312h53d5487_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sip-6.10.0-py312h275cf98_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h500f7fa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.7-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.15.3-ha881ca7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.15.3-h430ee68_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphobjinv-2.3.1.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.50.1-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.50.2-hdb435a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/suitesparse-7.10.1-hfa24a04_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_2.conda
@@ -1597,7 +1612,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/teamcity-messages-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.28.0-h0cf81a9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.28.0-h7c9f11d_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
@@ -1609,7 +1624,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2025.5.9.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/twine-6.1.0-pyh29332c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20250516-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2025.2.0.20250516-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.14.0-h32cad80_0.conda
@@ -1624,13 +1639,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-16.0.0-py312h4389bb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/uv-0.7.12-he6717ee_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h2b53caa_26.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34438-hfd919c2_26.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/uv-0.7.19-h579f82e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_26.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_26.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.31.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34438-h7142326_26.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_26.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/watchdog-6.0.0-py312h2e8e312_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
@@ -1639,7 +1654,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.14-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.6.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.5-he0c23c2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xmipy-1.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.12-h0e40799_0.conda
@@ -1653,15 +1668,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py312h4389bb4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
-      - pypi: https://files.pythonhosted.org/packages/23/72/a6feae158a2188f457ca8f50d8d4d29a3affeed763227bd8b1bf2df0ce2c/lib4package-0.3.2-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/07/4d/4e98d47cbfca9a45e62ff86eab29eff770fd355df9452e48480d89ede7ef/lib4sbom-0.8.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f6/65/84a48ff419cb5f303be2eaa40a757a7860c777a1caf738738de489db69e0/elementpath-5.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/66/d7/2344419cb255399ff2253cdb81cb38827867f854f66e98a780478fc13c19/lib4package-0.3.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ed/bd/4c87f8f863a09cd8c2126f7c553d08742becbfa7abffe29d3720340e2acd/lib4sbom-0.8.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/5b/fa477e4fd8e62c722febdc52462d7b037a77aa963c3e400a8e90e8f0d2c0/ptvsd-4.3.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/c2/094e3d62b906d952537196603a23aec4bcd7c6126bf80eb14e6f9f4be3a2/python_magic_bin-0.4.14-py2.py3-none-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/3a/fd/e5dae179943e631ae1d2b1903d73d7060ea9a82242e922abc685e33b6679/sbom2dot-0.3.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/6f/09acbe8b17a427e89f92ed03ae2b102aa77f911f094834214e82d0d36416/sbom4files-0.4.5-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/ab/ca69eca5d16b550d227df7616ab24f32d528903a3f1305953ad038adecaa/sbom4python-0.12.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/13/cbf8f3937c6bb9f59b19281998589097769057d38e5af894db78ae95386f/sbom4python-0.12.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/2c/3ba8f8aeb3cb566e88a61ab0b0b767d5398d1e7293a0f7a76df9051e2b08/xmlschema-4.1.0-py3-none-any.whl
       - pypi: ./python/ribasim
       - pypi: ./python/ribasim_api
       - pypi: ./python/ribasim_testmodels
@@ -1685,19 +1702,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.5-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.9.0-hf280997_13.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.9.0-hbfa7f16_15.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.2-h5e3027f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.12.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.3.1-hafb2847_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.4-haaa725d_10.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.10.2-hcfde5e4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.19.1-hdfce8c9_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.13.1-h08b274c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.8.1-hed81e95_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.4-h76f0014_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.10.2-h015de20_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.20.1-hdfce8c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.13.1-h1e5e6c0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.8.3-h5e174a9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.4-hafb2847_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.2.7-hafb2847_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.32.8-h5e43bac_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.510-h4607db7_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.32.10-hff780f1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.510-h937e755_12.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-identity-cpp-1.10.0-h113e628_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.13.0-h3cf044e_1.conda
@@ -1708,7 +1725,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.tarfile-1.2.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beartype-0.21.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.13.4-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/black-25.1.0-py311h38be061_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.2.0-pyh29332c3_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.2.0-h82add2a_4.conda
@@ -1721,13 +1738,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.5-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.6.15-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/capnproto-1.0.2-h766bdaa_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/capnproto-1.2.0-hfc315d8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ceres-solver-2.2.0-cpuh39c81a5_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.4.26-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.6.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.6.2-h44b4e7a_0.conda
@@ -1739,17 +1756,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.2-py311hd18a35c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.8.2-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.9.1-py311h2dc5d0c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cpd-0.5.5-h434a139_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.13-py311hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-45.0.4-py311hafd3f86_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-45.0.5-py311hafd3f86_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.27-h54b06d7_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.1-py311h9ecbd09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dart-sass-1.59.1-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2025.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2025.5.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/datacompy-0.16.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datacompy-0.16.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h3c4dab8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.14-py311hfdbb021_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
@@ -1770,8 +1787,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/exiv2-0.28.5-h653fe86_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fgt-0.4.11-h87365c0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.18.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.1.4-h07f6e7f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.19.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.2.0-h07f6e7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -1779,14 +1796,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.58.2-py311h2dc5d0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.58.4-py311h2dc5d0c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.13.3-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/future-1.0.0-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.1.0-h4393ad2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.10.3-py311hbeb1d84_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.1.0-h4393ad2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.11.1-py311hbeb1d84_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.1-h97f6797_0.conda
@@ -1794,13 +1811,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.24.1-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.24.1-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.74.1-h76a2195_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.74.2-h76a2195_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.84.2-h6287aef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.84.2-h4833e2c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.7.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.7-he838d99_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.24.11-h651a532_0.conda
@@ -1827,7 +1844,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh3099207_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.3.0-pyhfa0c392_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.4.0-pyhfa0c392_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
@@ -1853,7 +1870,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.16.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.15-pyhd8ed1ab_0.conda
@@ -1861,129 +1878,133 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-3.10.0-he073ed8_18.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.6.0-pyha804496_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.8-py311hd18a35c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/laz-perf-3.4.0-h00ab1b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.17-h717163a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20250127.1-cxx17_hbbce691_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libadbc-driver-manager-1.6.0-h84d6215_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.4-h3f801dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libamd-3.3.3-h456b2da_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libarchive-3.8.1-gpl_h98cc613_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-20.0.0-h314c690_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-20.0.0-hcb10f89_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-20.0.0-hcb10f89_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-20.0.0-h1bed206_6_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-20.0.0-h1b9301b_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-20.0.0-hcb10f89_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-20.0.0-hcb10f89_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-20.0.0-h1bed206_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.24.1-h8e693c7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.24.1-h8e693c7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-31_h59b9bed_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-32_h59b9bed_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbtf-2.3.2-hf02c80a_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcamd-3.3.3-hf02c80a_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.75-h39aace5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-31_he106b2a_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-32_he106b2a_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libccolamd-3.3.4-hf02c80a_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcholmod-5.3.1-h9cf07ce_7100101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.6-default_h1df26ce_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-20.1.6-default_he06ed0a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.7-default_h1df26ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-20.1.7-default_he06ed0a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcolamd-3.3.4-hf02c80a_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-hb8b1518_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.14.1-h332b0f4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcxsparse-4.4.1-hf02c80a_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.24-h86f0d12_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.124-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.0-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.1.0-ha770c72_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.1.0-hf45584d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.2.0-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.2.0-hf45584d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.13.3-ha770c72_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.13.3-h48d6fc4_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.1.0-h4c094af_102.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.1.0-h4c094af_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.11.1-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.10.3-h3b705f5_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-arrow-parquet-3.10.3-h8169c6c_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.10.3-hcac4edf_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.10.3-hbd53b90_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.10.3-h34a6268_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.10.3-hbe05c68_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.10.3-hc4e49b7_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.10.3-hb7814c2_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.10.3-he794564_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.10.3-h6b150f0_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.10.3-h962cb15_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.10.3-hfb06ed7_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.10.3-hfb06ed7_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.10.3-hd16f1d8_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.10.3-ha4d2dc7_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.11.1-h3b705f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-adbc-3.11.1-ha4d2dc7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-arrow-parquet-3.11.1-h8169c6c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.11.1-h5e6393a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.11.1-hbd53b90_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.11.1-h34a6268_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.11.1-hbe05c68_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.11.1-hc4e49b7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.11.1-hb7814c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.11.1-he794564_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.11.1-h6b150f0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.11.1-h962cb15_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.11.1-hfb06ed7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.11.1-hfb06ed7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.11.1-hd16f1d8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.11.1-ha4d2dc7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.24.1-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.24.1-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.1.0-h69a702a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.1.0-h69a702a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.84.2-h3618099_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.36.0-hc4361e1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.36.0-h0121fbd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.55-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.71.0-h8e591d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.11.2-default_h0d58e46_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.2.0-hf40a0c7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.0-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.1-h7b0646d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libklu-2.3.5-h95ff59c_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libkml-1.3.0-hf539b9f_1021.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-31_h7ac8fdf_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-32_h7ac8fdf_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libldl-3.3.2-hf02c80a_7100101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.6-he9d0ab4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.7-he9d0ab4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnetcdf-4.9.2-nompi_h0134ee8_117.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.11.0-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.29-pthreads_h94d23a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-1.21.0-hd1b1c89_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.21.0-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.5.2-hd0c01bc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-20.0.0-h081d1f1_6_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-20.0.0-h081d1f1_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libparu-1.0.0-hc6afc67_7100101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-2.8.4-h453e6b4_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-arrow-2.8.4-hb7ef14c_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-core-2.8.4-h921c622_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-cpd-2.8.4-hbb46d0d_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-draco-2.8.4-hbb46d0d_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-e57-2.8.4-h0dda180_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-hdf-2.8.4-haa54232_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-icebridge-2.8.4-haa54232_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-nitf-2.8.4-h986040f_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-pgpointcloud-2.8.4-h5c7ba8f_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-tiledb-2.8.4-h68be023_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-trajectory-2.8.4-hb16f371_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-2.9.0-h453e6b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-arrow-2.9.0-hb7ef14c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-core-2.9.0-ha13eeb3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-cpd-2.9.0-hbb46d0d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-draco-2.9.0-hbb46d0d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-e57-2.9.0-h0dda180_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-hdf-2.9.0-haa54232_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-icebridge-2.9.0-haa54232_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-nitf-2.9.0-h986040f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-pgpointcloud-2.9.0-h5c7ba8f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-tiledb-2.9.0-h68be023_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-trajectory-2.9.0-h502ccf6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpmix-5.0.8-h658e747_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.47-h943b412_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.49-h943b412_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.5-h27ae623_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-5.29.3-h501fc15_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librbio-4.3.4-hf02c80a_7100101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hba17884_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.06.26-hba17884_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-hd718a1a_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.1.0-h97b714f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.1.0-h97b714f_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsecret-0.21.7-h1e2da66_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.20-h4ab18f5_0.conda
@@ -1991,15 +2012,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-he17ca71_14.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libspex-3.2.3-h9226d62_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libspqr-4.3.4-h23b7119_7100101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.1-hee588c1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.2-h6cd9bfd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsuitesparseconfig-7.10.1-h901830b_7100101.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.6-h4e0b6ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.7-h4e0b6ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.21.0-h0e7cc3e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-hf01ce69_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.6-hbe16f8c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.7-hbe16f8c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libumfpack-6.3.5-h873dde6_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.10.0-h202a827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
@@ -2014,7 +2035,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.44.0-py311h9c9ff8c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-5.4.0-py311hbd2c71b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.0.0-py311hbd2c71b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.4.4-py311h8c6ae76_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
@@ -2034,11 +2055,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpfr-4.2.1-h90cbb55_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/mpi-1.0-openmpi.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py311hd18a35c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.16.0-py311h9ecbd09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.1-py311hd18a35c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/muparser-2.3.5-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.16.1-py311h9ecbd09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.42.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.45.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
@@ -2046,30 +2068,30 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/netcdf4-1.7.2-nompi_py311h8b974bf_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nh3-0.2.21-py39h77e2912_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nh3-0.2.21-py39h7c48542_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nitro-2.7.dev8-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.12.0-h3f2d84a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nose2-0.9.2-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.36-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.112-h159eef7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.113-h159eef7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.61.2-py311h9806782_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.1.3-py311h71ddf71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2024.10.24-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.3-h5fbd93e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openldap-2.6.10-he970967_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openmpi-5.0.8-h41ff47f_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.0-h7b32b05_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.1-h7b32b05_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.1.2-h17f744e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ordered-set-4.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/owslib-0.34.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/owslib-0.34.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.3.0-py311h7db5c69_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.3.250527-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-0.22.1-hd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.22.1-pyhd8ed1ab_1.conda
@@ -2081,15 +2103,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.45-hc749103_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.2.1-py311h1322bbf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py311h1322bbf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.2-h29eaf8c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.5.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/polars-1.27.1-py39h2a4a510_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/polars-1.31.0-default_h1650462_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/polars-default-1.31.0-py39hfac2b71_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.12.0-hd7b24de_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
@@ -2101,7 +2124,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.51-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.0.0-py311h9ecbd09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/psycopg2-2.9.10-py311h83e8966_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psycopg2-2.9.10-py311h83e8966_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-hac146a9_1.conda
@@ -2110,25 +2133,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-20.0.0-py311h4854187_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pycryptodome-3.23.0-py311h35130b2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.4-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.7-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.33.2-py311hdae7d1d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.9.1-pyh3cfb1c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.11.0-py311hf6089d3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.10.1-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.11.0-py311h75bf2cc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.1-py311h0960b38_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.9-py311hf0fb5b6_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.11-py311he22028a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-stubs-5.15.6.0-pyhb6d5dde_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.12.2-py311hb755f60_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqtwebkit-5.15.9-py311h4c6dc46_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.17.0-py311hfdbb021_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqtwebkit-5.15.11-py311he22028a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.9.1-py311h846acb3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.13-h9e4cc4f_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.11.13-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
@@ -2136,22 +2159,22 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-7_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h2dc5d0c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.4.0-py311h7deb3e3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.0.0-py311h7deb3e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qca-2.3.10-h71e8f01_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qgis-3.42.2-py311hfd6a7af_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qgis-3.44.0-py311hf085377_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/qgis-plugin-manager-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qjson-0.9.0-h0c700ba_1009.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qscintilla2-2.14.1-py311h4c6dc46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qscintilla2-2.14.1-py311he22028a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-hea1682b_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.9.1-h0384650_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.9.1-h0384650_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qtkeychain-0.15.0-h518214a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qtwebkit-5.212-h0fbc989_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/quarto-1.7.31-ha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/quarto-1.7.32-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.11.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qwt-6.3.0-h7c222af_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-57.0-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h9925aae_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.06.26-h9925aae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/readme_renderer-44.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
@@ -2161,27 +2184,27 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.0.0-pyh29332c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.25.1-py311hdae7d1d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.11.13-py311h82b16fd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.87.0-h1a8d7c4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.87.0-h2c6d0dc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.26.0-py311hdae7d1d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.12.1-py311h4b9d5fb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.88.0-h1a8d7c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.88.0-h2c6d0dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.21-h7ab7c64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.7.0-py311h57cc02b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.15.2-py311h8f841c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.0-py311h2d3ef60_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.3.3-py311h38be061_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh0d859eb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.1.1-py311h3dc67b8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sip-6.7.12-py311hb755f60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sip-6.10.0-py311hfdbb021_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.1-h8bd8927_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.7-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.15.3-h10b92b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.15.3-h6dc744f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphobjinv-2.3.1.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.50.1-h9eae976_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.50.2-hb7a22d2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/suitesparse-7.10.1-h5b2951e_7100101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.17-h0157908_18.conda
@@ -2190,7 +2213,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/teamcity-messages-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh0d859eb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.28.0-h6f9ba5a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.28.0-hccce5bd_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
@@ -2202,7 +2225,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2025.5.9.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/twine-6.1.0-pyh29332c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20250516-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2025.2.0.20250516-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.14.0-h32cad80_0.conda
@@ -2219,9 +2242,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py311h9ecbd09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.7.12-h2f11bb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.7.19-h29fcd0c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.31.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/watchdog-6.0.0-py311h38be061_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.23.1-h3e06ad9_1.conda
@@ -2230,8 +2253,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.14-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-hb711507_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.6.1-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.5-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-hb711507_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.1-hb711507_0.conda
@@ -2265,14 +2288,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py311h9ecbd09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb8e6e7a_2.conda
-      - pypi: https://files.pythonhosted.org/packages/23/72/a6feae158a2188f457ca8f50d8d4d29a3affeed763227bd8b1bf2df0ce2c/lib4package-0.3.2-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/07/4d/4e98d47cbfca9a45e62ff86eab29eff770fd355df9452e48480d89ede7ef/lib4sbom-0.8.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f6/65/84a48ff419cb5f303be2eaa40a757a7860c777a1caf738738de489db69e0/elementpath-5.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/66/d7/2344419cb255399ff2253cdb81cb38827867f854f66e98a780478fc13c19/lib4package-0.3.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ed/bd/4c87f8f863a09cd8c2126f7c553d08742becbfa7abffe29d3720340e2acd/lib4sbom-0.8.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/5b/fa477e4fd8e62c722febdc52462d7b037a77aa963c3e400a8e90e8f0d2c0/ptvsd-4.3.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/fd/e5dae179943e631ae1d2b1903d73d7060ea9a82242e922abc685e33b6679/sbom2dot-0.3.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/6f/09acbe8b17a427e89f92ed03ae2b102aa77f911f094834214e82d0d36416/sbom4files-0.4.5-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/ab/ca69eca5d16b550d227df7616ab24f32d528903a3f1305953ad038adecaa/sbom4python-0.12.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/13/cbf8f3937c6bb9f59b19281998589097769057d38e5af894db78ae95386f/sbom4python-0.12.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/2c/3ba8f8aeb3cb566e88a61ab0b0b767d5398d1e7293a0f7a76df9051e2b08/xmlschema-4.1.0-py3-none-any.whl
       - pypi: ./python/ribasim
       - pypi: ./python/ribasim_api
       - pypi: ./python/ribasim_testmodels
@@ -2323,13 +2348,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h155a34a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.5-h5505292_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.6.15-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.4-h6a3b0d2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/capnproto-1.0.2-h221ca0e_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ceres-solver-2.2.0-cpuhb9536e5_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.4.26-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.6.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cfitsio-4.5.0-hc017baa_0.conda
@@ -2341,16 +2366,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.2-py311h210dab8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.8.2-py311h4921393_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.9.1-py311h4921393_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cpd-0.5.5-h420ef59_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.13-py311hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cyrus-sasl-2.1.27-h60b93bd_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cyrus-sasl-2.1.28-ha1cbb27_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.0.1-py311h917b07b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dart-sass-1.59.1-hce30654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2025.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2025.5.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/datacompy-0.16.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datacompy-0.16.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.14-py311h155a34a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
@@ -2371,7 +2396,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fgt-0.4.11-h745860c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.18.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-11.0.2-h440487c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.19.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -2379,7 +2404,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.15.0-h1383a14_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.58.2-py311h4921393_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.58.4-py311h4921393_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.13.3-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
@@ -2391,7 +2416,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.13.0-hf9b8971_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.4-hbef4fa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gh-2.74.1-hd02bf31_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gh-2.74.2-hd02bf31_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.84.0-heee381b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.84.0-h1dc7a0c_0.conda
@@ -2422,7 +2447,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.5.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh57ce528_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.3.0-pyhfa0c392_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.4.0-pyhfa0c392_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
@@ -2447,52 +2472,52 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.16.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kealib-1.6.1-hc1fecf1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.6.0-pyh534df25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/khronos-opencl-icd-loader-2024.10.24-h5505292_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.7-py311h2c37856_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.8-py311h210dab8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/laz-perf-3.4.0-h1995070_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.17-h7eeda09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-hd64df32_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240722.0-cxx17_h07bc746_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.4-h51d1e36_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libamd-3.3.3-h5087772_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarchive-3.7.7-h3c2f2b0_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-17.0.0-h0b4cf59_51_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-17.0.0-hf07054f_51_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-17.0.0-hf07054f_51_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-17.0.0-h4239455_51_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.24.1-h493aca8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.24.2-h493aca8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif16-1.3.0-hf1e31eb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-31_h10e41b3_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-32_h10e41b3_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-h5505292_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-h5505292_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-h5505292_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbtf-2.3.2-h99b4a89_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcamd-3.3.3-h99b4a89_7100102.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-31_hb3479ef_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-32_hb3479ef_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libccolamd-3.3.4-h99b4a89_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcholmod-5.3.1-hbba04d7_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp17-17.0.6-default_hf90f093_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-20.1.6-default_hee4fbb3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-20.1.7-default_hee4fbb3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcolamd-3.3.4-h99b4a89_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.14.1-h73640d1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxsparse-4.4.1-h9e79f82_7100102.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-20.1.6-ha82da77_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-20.1.7-ha82da77_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libde265-1.0.15-h2ffa867_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.23-h5773f1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20250104-pl5321hafb1f1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h93a5062_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.7.0-h286801f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.1.0-hce30654_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.1.0-h5505292_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.2.0-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.2.0-h5505292_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.6-h1da3d7d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype-2.13.3-hce30654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfreetype6-2.13.3-h1d14073_1.conda
@@ -2511,9 +2536,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-postgisraster-3.10.2-h98ad515_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-tiledb-3.10.2-h3b22183_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-xls-3.10.2-hcf353f7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.24.1-h493aca8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-14.2.0-heb5dd2a_105.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-14.2.0-h2c44a93_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.24.2-h493aca8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-14_2_0_h6c33f7e_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-14.2.0-h6c33f7e_103.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.84.0-hdff4504_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.36.0-hdbe95d5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.36.0-h7081f7f_0.conda
@@ -2521,21 +2546,21 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libheif-1.19.7-gpl_h79e6334_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.11.2-default_hbce5d74_1001.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-hfe07756_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.24.1-h493aca8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.24.1-h493aca8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.24.2-h493aca8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.24.2-h493aca8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.1.0-h5505292_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libklu-2.3.5-h4370aa4_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libkml-1.3.0-he250239_1021.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-31_hc9a63f6_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-32_hc9a63f6_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libldl-3.3.2-h99b4a89_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm17-17.0.6-hc4b4ae8_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm20-20.1.6-h598bca7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm20-20.1.7-h598bca7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.1-h39f12f2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnetcdf-4.9.2-nompi_h610d594_116.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.64.0-h6d7220d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libntlm-1.8-h5505292_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libogg-1.3.5-h48c0fde_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.29-openmp_hf332438_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.30-openmp_hf332438_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.5.2-h48c0fde_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-17.0.0-h636d7b7_51_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparu-1.0.0-h317a14d_7100102.conda
@@ -2552,7 +2577,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpdal-tiledb-2.8.4-h96a401d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpdal-trajectory-2.8.4-hcb8ff9a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpmix-5.0.8-h6500a5a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.47-h3783ad8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.49-h3783ad8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-17.5-h6896619_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-5.28.3-h3bd63a1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librbio-4.3.4-h99b4a89_7100102.conda
@@ -2563,7 +2588,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.1.0-hf92fc0a_12.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspex-3.2.3-h15d103f_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspqr-4.3.4-h775d698_7100102.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.1-h3f77e49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.2-h6fb428d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.1-h1590b86_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsuitesparseconfig-7.10.1-h4a8fc20_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtasn1-4.20.0-h5505292_0.conda
@@ -2578,10 +2603,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxslt-1.1.39-h223e5b9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzip-1.11.2-h1336266_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-h8359307_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-20.1.6-hdb05f8b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-20.1.7-hdb05f8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvmlite-0.44.0-py311h55fc170_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-5.4.0-py311hfcb965d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-6.0.0-py311hfcb965d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-4.4.4-py311h3a49619_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h93a5062_1001.conda
@@ -2600,13 +2625,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpfr-4.2.1-hb693164_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mpi-1.0-openmpi.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py311h2c37856_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.16.0-py311h917b07b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.1-py311h210dab8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.16.1-py311h917b07b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-common-9.0.1-hd7719f6_6.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mysql-libs-9.0.1-ha8be5b7_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.42.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.45.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
@@ -2614,28 +2639,28 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/netcdf4-1.7.2-nompi_py311h4102914_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nh3-0.2.21-py39h52c9f89_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nh3-0.2.21-py39h39b1003_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nitro-2.7.dev8-h13dd4ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nose2-0.9.2-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nspr-4.36-h5833ebf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.112-ha3c76ea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.113-ha3c76ea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numba-0.61.2-py311hdc76553_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-2.1.3-py311h649a571_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/opencl-headers-2024.10.24-h286801f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/opencl-headers-2025.06.13-h286801f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.3-h8a3d83b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openldap-2.6.10-hbe55e7a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openmpi-5.0.7-h31ce4ef_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.0-h81ee809_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openmpi-5.0.8-hc9a84be_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.1-h81ee809_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.1.1-h74f7c94_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ordered-set-4.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/owslib-0.34.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/owslib-0.34.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311hca32420_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.3.0-py311hca32420_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.3.250527-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-0.22.1-hd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.22.1-pyhd8ed1ab_1.conda
@@ -2647,15 +2672,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.44-ha881caa_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.2.1-py311hb9ba9e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.3.0-py311hb9ba9e9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.46.2-h2f9eb0b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.5.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/polars-1.27.1-py39h81794e1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/polars-1.31.0-default_h56a14c1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/polars-default-1.31.0-py39h6da47c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/poppler-24.12.0-ha29e788_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
@@ -2666,7 +2692,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.51-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.0.0-py311h917b07b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psycopg2-2.9.10-py311h2c64ce4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psycopg2-2.9.10-py311h2c64ce4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-hd74edd7_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
@@ -2674,12 +2700,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-17.0.0-py311he04fa90_2_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pycryptodome-3.23.0-py311h5f4a806_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.4-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.7-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pydantic-core-2.33.2-py311hf245fc6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.9.1-pyh3cfb1c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.0-py311hab620ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.0-py311hab620ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.10.1-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.1-py311hf0763de_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.1-py311hab620ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.10.0-py311h595b8b0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.1-py311hfe9757e_0.conda
@@ -2688,12 +2714,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqt5-sip-12.17.0-py311h155a34a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqtwebkit-5.15.11-py311h2146069_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.13-hc22306f_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.11.13-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
@@ -2701,18 +2727,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.11-7_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h4921393_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.4.0-py311h01f2145_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.0.0-py311h01f2145_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qca-2.3.10-hfcce152_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qgis-3.40.3-py311ha25bd51_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/qgis-plugin-manager-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qjson-0.9.0-haa19703_1009.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qscintilla2-2.14.1-py311h14ede98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qscintilla2-2.14.1-py311h2146069_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qt-main-5.15.15-h67564f6_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qtkeychain-0.15.0-haaf71b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qtwebkit-5.212-he16459a_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/quarto-1.7.31-hce30654_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/quarto-1.7.32-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.11.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qwt-6.3.0-h4ff56cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rav1e-0.7.1-h0716509_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2024.07.02-h6589ca4_2.conda
@@ -2725,12 +2751,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.0.0-pyh29332c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.25.1-py311hf245fc6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.11.13-py311hb8aca82_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.87.0-h4ff7c5d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.87.0-hf6ec828_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.26.0-py311hf245fc6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.12.1-h412e174_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.88.0-h4ff7c5d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.88.0-hf6ec828_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.7.0-py311h47fa2fb_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.15.2-py311h0675101_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.16.0-py311h53b02f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh31c8845_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.7-py311h50ea49b_0.conda
@@ -2743,7 +2769,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.15.1-hed1c2b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphobjinv-2.3.1.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.50.1-hd7222ec_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.50.2-hc23dd5f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/suitesparse-7.10.1-h3071b36_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-3.0.2-h8ab69cd_0.conda
@@ -2764,7 +2790,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2025.5.9.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/twine-6.1.0-pyh29332c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20250516-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2025.2.0.20250516-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.14.0-h32cad80_0.conda
@@ -2779,9 +2805,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-16.0.0-py311h917b07b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.8-h00cdb27_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.7.12-hb4c02be_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.7.19-hcff7401_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.31.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/watchdog-6.0.0-py311h917b07b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
@@ -2790,7 +2816,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.8.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.14-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.6.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.2.5-h92fc2f4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xmipy-1.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-h5505292_0.conda
@@ -2804,14 +2830,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.1-h8359307_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py311h917b07b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-h6491c7d_2.conda
-      - pypi: https://files.pythonhosted.org/packages/23/72/a6feae158a2188f457ca8f50d8d4d29a3affeed763227bd8b1bf2df0ce2c/lib4package-0.3.2-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/07/4d/4e98d47cbfca9a45e62ff86eab29eff770fd355df9452e48480d89ede7ef/lib4sbom-0.8.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f6/65/84a48ff419cb5f303be2eaa40a757a7860c777a1caf738738de489db69e0/elementpath-5.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/66/d7/2344419cb255399ff2253cdb81cb38827867f854f66e98a780478fc13c19/lib4package-0.3.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ed/bd/4c87f8f863a09cd8c2126f7c553d08742becbfa7abffe29d3720340e2acd/lib4sbom-0.8.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/5b/fa477e4fd8e62c722febdc52462d7b037a77aa963c3e400a8e90e8f0d2c0/ptvsd-4.3.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3a/fd/e5dae179943e631ae1d2b1903d73d7060ea9a82242e922abc685e33b6679/sbom2dot-0.3.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/6f/09acbe8b17a427e89f92ed03ae2b102aa77f911f094834214e82d0d36416/sbom4files-0.4.5-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/ab/ca69eca5d16b550d227df7616ab24f32d528903a3f1305953ad038adecaa/sbom4python-0.12.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/13/cbf8f3937c6bb9f59b19281998589097769057d38e5af894db78ae95386f/sbom4python-0.12.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/2c/3ba8f8aeb3cb566e88a61ab0b0b767d5398d1e7293a0f7a76df9051e2b08/xmlschema-4.1.0-py3-none-any.whl
       - pypi: ./python/ribasim
       - pypi: ./python/ribasim_api
       - pypi: ./python/ribasim_testmodels
@@ -2826,19 +2854,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-3.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.5-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.9.0-h3537544_13.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.9.0-hd490b63_15.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.9.2-hd8a8e38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.12.3-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.3.1-h5d0e663_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.4-hf27a43c_10.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.10.2-h633db33_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.19.1-hddf4d6c_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.13.1-h6306086_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.8.1-h046fb53_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.4-ha416645_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.10.2-h81282ae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.20.1-hddf4d6c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.13.1-h5c1ae27_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.8.3-h1e843c7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.2.4-h5d0e663_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.2.7-h5d0e663_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.32.8-h04c53c4_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.510-h7deb975_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.32.10-h1aa98f0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.510-hd13e2d4_12.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/azure-core-cpp-1.14.0-haf5610f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/azure-identity-cpp-1.10.0-hd6deed7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/azure-storage-blobs-cpp-12.13.0-h3241184_1.conda
@@ -2860,13 +2888,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311hda3d55a_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h2466b09_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.34.5-h2466b09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-h4c7d964_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.6.15-h4c7d964_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.4-h5782bbf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/capnproto-1.0.2-hb5d7e06_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/capnproto-1.2.0-h3a793f1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ceres-solver-2.2.0-cpuhc26068e_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.4.26-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.6.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cfgv-3.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.6.2-h2b45a09_0.conda
@@ -2878,14 +2906,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/contourpy-1.3.2-py311h3257749_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.8.2-py311h5082efb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.9.1-py311h5082efb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.13-py311hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.0.1-py311he736701_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/dart-sass-1.59.1-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-2025.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dask-core-2025.5.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/datacompy-0.16.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/datacompy-0.16.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.14-py311hda3d55a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
@@ -2904,8 +2932,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/exiv2-0.28.5-h29f99b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.18.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-11.1.4-h5f12afc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.19.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fmt-11.2.0-h1d4551f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -2913,24 +2941,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.15.0-h765892d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.58.2-py311h5082efb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.58.4-py311h5082efb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.13.3-h57928b3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2025.5.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/future-1.0.0-pyhd8ed1ab_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.10.3-py311h8d72537_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.11.1-py311ha7b5f94_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.0.1-pyha770c72_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.13.1-h9ea8674_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geotiff-1.7.4-h86c3423_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gflags-2.2.2-he0c23c2_1005.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gh-2.74.1-h36e2d1d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gh-2.74.2-h36e2d1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.84.2-he8f994d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.84.2-h4394cf3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/glog-0.7.1-h3ff59bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gmp-6.3.0-hfeafd45_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-h63175ca_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.14-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.7.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gsl-2.7-hdfb1a43_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.24.11-h3fe0a9e_0.conda
@@ -2958,7 +2986,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2024.2.1-h57928b3_1083.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.5-pyh4bbf305_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.3.0-pyh6be1c34_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.4.0-pyh6be1c34_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_1.conda
@@ -2982,36 +3010,36 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.12.0-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.16.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.15-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/kealib-1.6.2-h9df79d9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/keyring-25.6.0-pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2024.10.24-h2466b09_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.8-py311h3fd045d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/laz-perf-3.4.0-h91493d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.17-hbcf6048_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h6470a55_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20250127.1-cxx17_h4eb7d71_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.4-h20038f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libamd-3.3.3-h60129d2_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libarchive-3.8.1-gpl_h1ca5a36_100.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-20.0.0-hc090743_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-20.0.0-h7d8d6a5_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-20.0.0-h7d8d6a5_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-20.0.0-hb76e781_6_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-31_h641d27c_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-20.0.0-h3e40a90_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-20.0.0-h7d8d6a5_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-20.0.0-h7d8d6a5_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-20.0.0-hb76e781_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-32_h641d27c_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-h2466b09_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-h2466b09_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-h2466b09_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbtf-2.3.2-h8c1c262_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcamd-3.3.3-h8c1c262_7100102.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-31_h5e41251_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-32_h5e41251_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libccolamd-3.3.4-h8c1c262_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcholmod-5.3.1-hdf2ebef_7100102.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-20.1.6-default_h6e92b77_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-20.1.7-default_h6e92b77_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcolamd-3.3.4-h8c1c262_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.14.1-h88aaa65_0.conda
@@ -3022,64 +3050,66 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.6-h537db12_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype-2.13.3-h57928b3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype6-2.13.3-h0b5ce68_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-15.1.0-h1383e82_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.10.3-hafd5c6c_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-arrow-parquet-3.10.3-h24452f8_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.10.3-h7d16cc0_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.10.3-hd840048_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.10.3-h79060df_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.10.3-h0de24e7_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.10.3-h527b061_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.10.3-h95c5499_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.10.3-h6b3a253_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.10.3-h1b8416b_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.10.3-ha9b9ad8_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.10.3-h38d3678_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.10.3-h38d3678_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.10.3-h6c2f05d_11.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.10.3-hc931c72_11.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-15.1.0-h1383e82_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.11.1-hafd5c6c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-arrow-parquet-3.11.1-h2345e04_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.11.1-hddc0a0b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.11.1-hcff14e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.11.1-h8ff101f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.11.1-ha47b6c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.11.1-h0f01001_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.11.1-hf58e487_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.11.1-hea5172e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.11.1-hcb0e93c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.11.1-h75c24f8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.11.1-h103a44d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.11.1-h103a44d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.11.1-h88e1fbc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.11.1-h93cc17c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.84.2-hbc94333_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-15.1.0-h1383e82_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-15.1.0-h1383e82_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.36.0-hf249c01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.36.0-he5eb982_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.71.0-h8c3449c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.11.2-default_ha69328c_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.2.0-h1d1702c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-h135ad9c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.1.0-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjxl-0.11.1-ha161b08_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libklu-2.3.5-h77a2eaa_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libkml-1.3.0-h538826c_1021.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-31_h1aa476e_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-32_h1aa476e_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libldl-3.3.2-h8c1c262_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libnetcdf-4.9.2-nompi_he045f6b_117.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-20.0.0-ha850022_6_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-20.0.0-ha850022_8_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libparu-1.0.0-hd80212b_7100102.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-2.8.4-hb3590ec_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-arrow-2.8.4-h6c57e06_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-core-2.8.4-h6f06235_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-draco-2.8.4-ha763671_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-e57-2.8.4-h482c529_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-hdf-2.8.4-h2520430_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-icebridge-2.8.4-h2520430_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-nitf-2.8.4-h1b836ec_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-pgpointcloud-2.8.4-hb7c6058_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-tiledb-2.8.4-hc4b2a02_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-trajectory-2.8.4-h82545d7_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.47-h7a4582a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-2.8.4-hb3590ec_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-arrow-2.8.4-h6c57e06_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-core-2.8.4-heefb544_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-draco-2.8.4-ha763671_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-e57-2.8.4-h482c529_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-hdf-2.8.4-h2520430_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-icebridge-2.8.4-h2520430_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-nitf-2.8.4-h1b836ec_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-pgpointcloud-2.8.4-hb7c6058_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-tiledb-2.8.4-hc4b2a02_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-trajectory-2.8.4-hf542bf2_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.49-h7a4582a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libpq-17.5-h9087029_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-5.29.3-he9d8c4a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/librbio-4.3.4-h8c1c262_7100102.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-hd248061_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2025.06.26-habfad5f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-hbfc9ebc_18.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialindex-2.1.0-h518811d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-h378fb81_14.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libspex-3.2.3-h2f847cc_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libspqr-4.3.4-h60c7c62_7100102.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.50.1-h67fdade_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.50.2-hf5d6505_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.1-h9aa295b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsuitesparseconfig-7.10.1-h0795de7_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.21.0-hbe90ef8_0.conda
@@ -3096,7 +3126,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/llvmlite-0.44.0-py311h7deaa30_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/locket-1.0.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/lxml-5.4.0-py311h590fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lxml-6.0.0-py311hea5fcc3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-4.4.4-py311h0476921_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.10.0-h2466b09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lzo-2.10-hcfcfb64_1001.conda
@@ -3115,35 +3145,36 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mock-5.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.7.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/mpfr-4.2.1-hbc20e70_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.0-py311h3257749_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.16.0-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.1-py311h3257749_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/muparser-2.3.5-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.16.1-py311he736701_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.42.0-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.45.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.6-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.10.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/netcdf4-1.7.2-nompi_py311hc0e63eb_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.5-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/nh3-0.2.21-py39he870945_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/nh3-0.2.21-py39h81ceba4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/nitro-2.7.dev8-h1537add_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nodeenv-1.9.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nose2-0.9.2-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numba-0.61.2-py311h7afb941_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/numba_celltree-0.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.3-py311h35ffc71_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/opencl-headers-2024.10.24-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/opencl-headers-2025.06.13-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.3-h4d64b90_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.5.0-ha4e3fda_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.5.1-h725018a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/orc-2.1.2-h35764e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ordered-set-4.1.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/owslib-0.34.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/owslib-0.34.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.3.0-py311hcf9f919_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.3.250527-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-0.22.1-hd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandera-base-0.22.1-pyhd8ed1ab_1.conda
@@ -3155,15 +3186,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.45-h99c9b8b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-pyhd8ed1ab_1004.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.2.1-py311h43e43bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.3.0-py311h0f9b5fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.46.2-had0cd8c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.3.8-pyhe01879c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.1.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/plum-dispatch-2.5.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ply-3.11-pyhd8ed1ab_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/polars-1.27.1-py39h9b97169_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/polars-1.31.0-default_hc01efcc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/polars-default-1.31.0-py39h4d7386a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/poppler-24.12.0-heaa0bce_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/poppler-data-0.4.12-hd8ed1ab_0.conda
@@ -3174,7 +3206,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.51-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.51-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.0.0-py311he736701_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/psycopg2-2.9.10-py311hd732c25_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psycopg2-2.9.10-py311hd732c25_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-h0e40799_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
@@ -3182,25 +3214,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-20.0.0-py311hdea38fa_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pycryptodome-3.23.0-py311he736701_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.4-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.7-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pydantic-core-2.33.2-py311hc4022dc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.9.1-pyh3cfb1c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.11.0-py311haedb144_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.10.1-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.11.0-py311h2467ed7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyproj-3.7.1-py311h91919fb_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.9-py311h125bc19_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.11-py311h2d05f59_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-stubs-5.15.6.0-pyhb6d5dde_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.12.2-py311h12c1d0e_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyqtwebkit-5.15.9-py311h5a77453_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.17.0-py311hda3d55a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyqtwebkit-5.15.11-py311h2d05f59_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.9.1-py311h5d1a980_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.1.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.7.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.2.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.13-h3f84c4b_0_cpython.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.0-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-gil-3.11.13-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
@@ -3211,22 +3243,22 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-ctypes-0.2.3-py311h1ea47a8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.15-py311hda3d55a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311h5082efb_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.4.0-py311h484c95c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-27.0.0-py311h484c95c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qca-2.3.10-hcfd1de8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/qgis-3.42.2-py311h1440119_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qgis-3.42.3-py311he4d1a5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/qgis-plugin-manager-1.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qhull-2020.2-hc790b64_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qjson-0.9.0-h04a78d6_1009.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/qscintilla2-2.14.1-py311h5a77453_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qscintilla2-2.14.1-py311h2d05f59_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.15-h9151539_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.9.1-h02ddd7d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.9.1-h02ddd7d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qtkeychain-0.15.0-hc9563df_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qtwebkit-5.212-hbc9c816_18.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/quarto-1.7.31-h57928b3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.11.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/quarto-1.7.32-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.11.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qwt-6.3.0-h9417a65_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rcedit-1.1.1-h63175ca_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-haf4117d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2025.06.26-h3dd2b4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/readme_renderer-44.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.36.2-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.4-pyhd8ed1ab_0.conda
@@ -3235,25 +3267,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.0.0-pyh29332c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.25.1-py311hc4022dc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.11.13-py311hfc2f1ad_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.87.0-hf8d6059_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.87.0-h17fc481_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.26.0-py311hf51aa87_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.12.1-hd40eec1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.88.0-hf8d6059_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.88.0-h17fc481_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.7.0-py311hdcb8d17_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.15.2-py311h99d06ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.16.0-py311h0e21e1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.3-pyh5737063_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/shapely-2.1.1-py311hef32bf2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/shellingham-1.5.4-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/sip-6.7.12-py311h12c1d0e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sip-6.10.0-py311hda3d55a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h500f7fa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.7-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.15.3-ha881ca7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.15.3-h430ee68_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sphobjinv-2.3.1.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.50.1-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.50.2-hdb435a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/suitesparse-7.10.1-hfa24a04_7100102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tabulate-0.9.0-pyhd8ed1ab_2.conda
@@ -3262,7 +3294,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/teamcity-messages-1.33-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.1-pyh5737063_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.6.0-pyhecae5ae_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.28.0-h0cf81a9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.28.0-h7c9f11d_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
@@ -3274,7 +3306,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2025.5.9.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/twine-6.1.0-pyh29332c3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20250516-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-pytz-2025.2.0.20250516-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.14.0-h32cad80_0.conda
@@ -3289,13 +3321,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/unicodedata2-16.0.0-py311he736701_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/uv-0.7.12-he6717ee_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h2b53caa_26.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34438-hfd919c2_26.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/uv-0.7.19-h579f82e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_26.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_26.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.31.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34438-h7142326_26.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_26.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/watchdog-6.0.0-py311h1ea47a8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-24.11.1-pyhd8ed1ab_0.conda
@@ -3304,7 +3336,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.14-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.6.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.2.5-he0c23c2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/xmipy-1.3.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.12-h0e40799_0.conda
@@ -3318,15 +3350,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py311he736701_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-hbeecb71_2.conda
-      - pypi: https://files.pythonhosted.org/packages/23/72/a6feae158a2188f457ca8f50d8d4d29a3affeed763227bd8b1bf2df0ce2c/lib4package-0.3.2-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/07/4d/4e98d47cbfca9a45e62ff86eab29eff770fd355df9452e48480d89ede7ef/lib4sbom-0.8.4-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f6/65/84a48ff419cb5f303be2eaa40a757a7860c777a1caf738738de489db69e0/elementpath-5.0.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/66/d7/2344419cb255399ff2253cdb81cb38827867f854f66e98a780478fc13c19/lib4package-0.3.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ed/bd/4c87f8f863a09cd8c2126f7c553d08742becbfa7abffe29d3720340e2acd/lib4sbom-0.8.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/44/5b/fa477e4fd8e62c722febdc52462d7b037a77aa963c3e400a8e90e8f0d2c0/ptvsd-4.3.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/07/c2/094e3d62b906d952537196603a23aec4bcd7c6126bf80eb14e6f9f4be3a2/python_magic_bin-0.4.14-py2.py3-none-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/3a/fd/e5dae179943e631ae1d2b1903d73d7060ea9a82242e922abc685e33b6679/sbom2dot-0.3.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/6f/09acbe8b17a427e89f92ed03ae2b102aa77f911f094834214e82d0d36416/sbom4files-0.4.5-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/ab/ca69eca5d16b550d227df7616ab24f32d528903a3f1305953ad038adecaa/sbom4python-0.12.3-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/18/13/cbf8f3937c6bb9f59b19281998589097769057d38e5af894db78ae95386f/sbom4python-0.12.4-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6a/23/8146aad7d88f4fcb3a6218f41a60f6c2d4e3a72de72da1825dc7c8f7877c/semantic_version-2.10.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c5/2c/3ba8f8aeb3cb566e88a61ab0b0b767d5398d1e7293a0f7a76df9051e2b08/xmlschema-4.1.0-py3-none-any.whl
       - pypi: ./python/ribasim
       - pypi: ./python/ribasim_api
       - pypi: ./python/ribasim_testmodels
@@ -3439,7 +3473,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/appnope?source=compressed-mapping
+  - pkg:pypi/appnope?source=hash-mapping
   size: 10076
   timestamp: 1733332433806
 - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-25.1.0-pyhd8ed1ab_0.conda
@@ -3609,22 +3643,22 @@ packages:
   - pkg:pypi/attrs?source=compressed-mapping
   size: 57181
   timestamp: 1741918625732
-- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.9.0-hf280997_13.conda
-  sha256: f0e6ff4b85f5dc1efa657d7d60d714895d0654da89dea0de6a8e76f38a65d3f9
-  md5: 74e5106396d857db3f4d781423ba2b89
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.9.0-hbfa7f16_15.conda
+  sha256: 85086df9b358450196a13fc55bab1c552227df78cafddbe2d15caaea458b41a6
+  md5: 16baa9bb7f70a1e457a82023898314a7
   depends:
   - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-c-io >=0.20.1,<0.20.2.0a0
   - aws-c-http >=0.10.2,<0.10.3.0a0
+  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
   - aws-c-common >=0.12.3,<0.12.4.0a0
-  - aws-c-io >=0.19.1,<0.19.2.0a0
   - aws-c-cal >=0.9.2,<0.9.3.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 122963
-  timestamp: 1749566011782
+  size: 122993
+  timestamp: 1750291448852
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.8.6-h660070d_4.conda
   sha256: eb91bac831eb0746e53e3f32d7c8cced7b2aa42c07b4f1fe8de8eb1c8a6e55f9
   md5: 53121e315ec35a689a761646d761af14
@@ -3640,26 +3674,26 @@ packages:
   purls: []
   size: 94653
   timestamp: 1742078887945
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.9.0-h3537544_13.conda
-  sha256: 1884123b95e983ab7ea92485df0ec94d6b7fdd5e2124db4831773e472b98d5cc
-  md5: 2eb10b784333fe9ede4d58ec0a61fd23
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.9.0-hd490b63_15.conda
+  sha256: 27b1557a502890992950db65ba9414277baec74130042034ba449e71d4b36275
+  md5: 41c6aba02d07f6419a01210b5c7398bc
   depends:
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34438
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34438
   - ucrt >=10.0.20348.0
-  - aws-c-cal >=0.9.2,<0.9.3.0a0
-  - aws-c-http >=0.10.2,<0.10.3.0a0
-  - aws-c-io >=0.19.1,<0.19.2.0a0
-  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-c-io >=0.20.1,<0.20.2.0a0
   - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-http >=0.10.2,<0.10.3.0a0
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 114580
-  timestamp: 1749566075996
+  size: 115868
+  timestamp: 1750291419402
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.2-h5e3027f_0.conda
   sha256: d61cce967e6d97d03aa2828458f7344cdc93422fd2c1126976ab8f475a313363
   md5: 0ead3ab65460d51efb27e5186f50f8e4
@@ -3769,22 +3803,21 @@ packages:
   purls: []
   size: 22690
   timestamp: 1747145057422
-- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.4-haaa725d_10.conda
-  sha256: 68c3bd54d4297d9d5550dff5afd83eaa89885313d5d7f781c055d824a3ae1800
-  md5: ed15f12bd23f3861d61e3d71c0e639ee
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.5.4-h76f0014_12.conda
+  sha256: 7b89ed99ac73c863bea4479f1f1af6ce250f9f1722d2804e07cf05d3630c7e08
+  md5: f978f2a3032952350d0036c4c4a63bd6
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
   - libstdcxx >=13
   - libgcc >=13
+  - aws-c-io >=0.20.1,<0.20.2.0a0
   - aws-checksums >=0.2.7,<0.2.8.0a0
-  - aws-c-io >=0.19.1,<0.19.2.0a0
   - aws-c-common >=0.12.3,<0.12.4.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 57198
-  timestamp: 1748301243050
+  size: 57252
+  timestamp: 1750287878861
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.5.4-h3c33643_2.conda
   sha256: 450fc3b89751fe6ff9003c9ca6e151c362f1139a7e478d3ee80b35c90743ab0f
   md5: 0117e1dbf8de18d6caae49a5df075d0f
@@ -3799,39 +3832,39 @@ packages:
   purls: []
   size: 50753
   timestamp: 1741998303028
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.4-hf27a43c_10.conda
-  sha256: e590f11dddd9c364caddb23646d7cd2b14faad7c186ec64de6aa549676e189fd
-  md5: 4167af8471885f55b1f784c11e81461c
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.5.4-ha416645_12.conda
+  sha256: 89efca036d37a8392f3220ef65e5205f03eae6330dcc121d258b298eae4b2795
+  md5: 51269fa3c4b226f6b40aacb72dedb195
   depends:
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34438
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34438
   - ucrt >=10.0.20348.0
+  - aws-c-io >=0.20.1,<0.20.2.0a0
   - aws-checksums >=0.2.7,<0.2.8.0a0
   - aws-c-common >=0.12.3,<0.12.4.0a0
-  - aws-c-io >=0.19.1,<0.19.2.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 55592
-  timestamp: 1748301324176
-- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.10.2-hcfde5e4_0.conda
-  sha256: 245ddf0717a69f66d2a7b1140fe8236fee5e237183947f5a3b0732c60d76fe11
-  md5: ac05e5472ffc91118cc473816bdf61ca
+  size: 55990
+  timestamp: 1750287899566
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.10.2-h015de20_2.conda
+  sha256: ca0268cead19e985f9b153613f0f6cdb46e0ca32e1647466c506f256269bcdd9
+  md5: ad05d594704926ba7c0c894a02ea98f1
   depends:
-  - libgcc >=13
   - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - aws-c-io >=0.20.1,<0.20.2.0a0
   - aws-c-common >=0.12.3,<0.12.4.0a0
-  - aws-c-compression >=0.3.1,<0.3.2.0a0
-  - aws-c-io >=0.19.1,<0.19.2.0a0
   - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-compression >=0.3.1,<0.3.2.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 223040
-  timestamp: 1749494375983
+  size: 223038
+  timestamp: 1750289165728
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.9.4-hedcc1e3_4.conda
   sha256: 9f6ad8a261d256111b9e3f60761034441d8103260b89ce21194ca7863d90d48e
   md5: 99852aaf483001b174f251c7052f92e9
@@ -3846,39 +3879,39 @@ packages:
   purls: []
   size: 168914
   timestamp: 1742074952187
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.10.2-h633db33_0.conda
-  sha256: 951868797914c0cbcf1216dbcbab63d1f4f5f07c5903f3c9648489ae9ca9adbc
-  md5: ff11a26afe7824c6df1f93e549ee8e98
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.10.2-h81282ae_2.conda
+  sha256: e01c76ce10e3e8350bdcd1ffcefabf1fa5e170f42e4d654827635d3784fcce27
+  md5: 2fa3bbfd5a7e0ac1ec8571c71ca495e2
   depends:
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34438
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34438
   - ucrt >=10.0.20348.0
-  - aws-c-cal >=0.9.2,<0.9.3.0a0
-  - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-io >=0.20.1,<0.20.2.0a0
   - aws-c-compression >=0.3.1,<0.3.2.0a0
-  - aws-c-io >=0.19.1,<0.19.2.0a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 202827
-  timestamp: 1749494449739
-- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.19.1-hdfce8c9_3.conda
-  sha256: 3599fe63b7240854269e5109d180b515ad41c1cc4bdd537c943574a150ce56cb
-  md5: 012df4026887e82115796d4e664abe2d
+  size: 204438
+  timestamp: 1750289208536
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.20.1-hdfce8c9_0.conda
+  sha256: c6bd4f067a7829795e1c44e4536b71d46f55f69569216aed34a7b375815fa046
+  md5: dd2d3530296d75023a19bc9dfb0a1d59
   depends:
   - libgcc >=13
   - __glibc >=2.17,<3.0.a0
   - s2n >=1.5.21,<1.5.22.0a0
-  - aws-c-cal >=0.9.2,<0.9.3.0a0
   - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 179227
-  timestamp: 1749124519797
+  size: 179223
+  timestamp: 1749844480175
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.17.0-ha705ebb_6.conda
   sha256: d354bb7cd6122b8a74fd543dec6f726f748372425e38641e54a5ae9200611155
   md5: 1567e388e63dd0fe5418045380f69f26
@@ -3891,9 +3924,9 @@ packages:
   purls: []
   size: 151425
   timestamp: 1742070916672
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.19.1-hddf4d6c_3.conda
-  sha256: 104021a99b5eb12c37e8c1a9e7963e7900e01655824912a57fcf1bbafa7fe94a
-  md5: f91e5e0146d629fc29664117c3643765
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.20.1-hddf4d6c_0.conda
+  sha256: f494ad2f99ab6a5b5bec2beb92c914ba2f51c01ffe092f4322c42c5fdafe09fe
+  md5: 43b20ab02a0ad5a0f2069868579f8f3c
   depends:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -3901,27 +3934,27 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - ucrt >=10.0.20348.0
-  - aws-c-cal >=0.9.2,<0.9.3.0a0
   - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 177785
-  timestamp: 1749124597669
-- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.13.1-h08b274c_1.conda
-  sha256: e5d6a3c80fc143ba5588815c8ec4b6b748c669b75142270b40ccbac76c3c42f3
-  md5: 8e55f7979cd36f9c5e2ed53216102101
+  size: 179601
+  timestamp: 1749844514070
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.13.1-h1e5e6c0_3.conda
+  sha256: f9e63492d5dd17f361878ce7efa1878de27225216b4e07990a6cb18c378014dc
+  md5: d55921ca3469224f689f974278107308
   depends:
   - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - aws-c-io >=0.19.1,<0.19.2.0a0
   - aws-c-http >=0.10.2,<0.10.3.0a0
+  - aws-c-io >=0.20.1,<0.20.2.0a0
   - aws-c-common >=0.12.3,<0.12.4.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 215842
-  timestamp: 1749566612156
+  size: 215867
+  timestamp: 1750291920145
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.12.2-h82c6c6a_2.conda
   sha256: ea9191d1c51ba693f712991ff3de253c674eb469b5cf01e415bf7b94a75da53a
   md5: 1545c6b828a1c4a6eb720e10368a6734
@@ -3935,42 +3968,42 @@ packages:
   purls: []
   size: 149358
   timestamp: 1742003783130
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.13.1-h6306086_1.conda
-  sha256: 4f2e2aa3b27691f25ce5c60e7e98b4ece371bf97155ec71e74bd066bc97088d1
-  md5: 93e43ee76185fa7ba71e49be9c3f176f
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.13.1-h5c1ae27_3.conda
+  sha256: 6d8ec3659cc03c02ce90e83f0818686f013f3190ec5b82bf5f6c1977902c2c34
+  md5: b45b5124b91147887f4670e2e9b017b8
   depends:
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34438
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.42.34438
   - ucrt >=10.0.20348.0
-  - aws-c-common >=0.12.3,<0.12.4.0a0
-  - aws-c-io >=0.19.1,<0.19.2.0a0
+  - aws-c-io >=0.20.1,<0.20.2.0a0
   - aws-c-http >=0.10.2,<0.10.3.0a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 203456
-  timestamp: 1749566656269
-- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.8.1-hed81e95_1.conda
-  sha256: 2863e326670bd7b164e36b4e9399227db27a237e0793dfd7a79e04840687a92b
-  md5: 3936bcee2aa446f262e6320ae06aabcf
+  size: 206081
+  timestamp: 1750291938128
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.8.3-h5e174a9_0.conda
+  sha256: f4e7b200da5df7135cd087618fa30b2cd60cec0eebbd5570fb4c1e9a789dd9aa
+  md5: dea2540e57e8c1b949ca58ff4c7c0cbf
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - aws-c-common >=0.12.3,<0.12.4.0a0
-  - aws-c-io >=0.19.1,<0.19.2.0a0
+  - aws-c-io >=0.20.1,<0.20.2.0a0
+  - openssl >=3.5.0,<4.0a0
+  - aws-c-auth >=0.9.0,<0.9.1.0a0
   - aws-c-http >=0.10.2,<0.10.3.0a0
   - aws-checksums >=0.2.7,<0.2.8.0a0
-  - aws-c-auth >=0.9.0,<0.9.1.0a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
   - aws-c-cal >=0.9.2,<0.9.3.0a0
-  - openssl >=3.5.0,<4.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 133883
-  timestamp: 1749571677251
+  size: 133960
+  timestamp: 1750831815089
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.7.13-hb857f95_2.conda
   sha256: 71a58a3c50c7f1a787807f0bc6f1b443b52c2816e66d3747bf21312912b18a90
   md5: 2aeb64dc221ddd7ab1e13dddc22e94f2
@@ -3987,27 +4020,27 @@ packages:
   purls: []
   size: 113119
   timestamp: 1742083799050
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.8.1-h046fb53_1.conda
-  sha256: 546fef8dde6b91adcbf22a55114f51c81aaeaa36c5729bed2bfa0e43a08eebd3
-  md5: c513185d4421588a8ee0a5844c1cc6c8
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.8.3-h1e843c7_0.conda
+  sha256: cf3d2a87289e1d16504fd6908ddd067c16d7b08a893b753d690cc745f79cc462
+  md5: e36c53272fa10d95afead65623efa261
   depends:
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - aws-c-http >=0.10.2,<0.10.3.0a0
-  - aws-c-io >=0.19.1,<0.19.2.0a0
-  - aws-c-auth >=0.9.0,<0.9.1.0a0
   - aws-checksums >=0.2.7,<0.2.8.0a0
+  - aws-c-auth >=0.9.0,<0.9.1.0a0
   - aws-c-cal >=0.9.2,<0.9.3.0a0
+  - aws-c-http >=0.10.2,<0.10.3.0a0
   - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-io >=0.20.1,<0.20.2.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 125997
-  timestamp: 1749571731773
+  size: 126871
+  timestamp: 1750831846697
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.2.4-hafb2847_0.conda
   sha256: 18c588c386e21e2a926c6f3c1ba7aaf69059ce1459a134f7c8c1ebfc68cf67ec
   md5: 65853df44b7e4029d978c50be888ed89
@@ -4086,28 +4119,27 @@ packages:
   purls: []
   size: 92710
   timestamp: 1747141831325
-- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.32.8-h5e43bac_4.conda
-  sha256: 236b1c60d1e404e614a76805e8a65f29c1655acc9f515265cdcd43541fd56012
-  md5: a5da364952828df10b67781059dfb36c
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.32.10-hff780f1_1.conda
+  sha256: 9602a5199dccf257709afdef326abfde6e84c63862b7cee59979803c4d636840
+  md5: 843f52366658086c4f0b0654afbf3730
   depends:
-  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
   - libstdcxx >=13
   - libgcc >=13
-  - __glibc >=2.17,<3.0.a0
-  - aws-c-event-stream >=0.5.4,<0.5.5.0a0
   - aws-c-mqtt >=0.13.1,<0.13.2.0a0
+  - aws-c-event-stream >=0.5.4,<0.5.5.0a0
   - aws-c-auth >=0.9.0,<0.9.1.0a0
-  - aws-c-cal >=0.9.2,<0.9.3.0a0
-  - aws-c-io >=0.19.1,<0.19.2.0a0
+  - aws-c-s3 >=0.8.3,<0.8.4.0a0
   - aws-c-http >=0.10.2,<0.10.3.0a0
-  - aws-c-s3 >=0.8.1,<0.8.2.0a0
   - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-c-cal >=0.9.2,<0.9.3.0a0
   - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-io >=0.20.1,<0.20.2.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 395116
-  timestamp: 1749578123783
+  size: 399987
+  timestamp: 1750855462459
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.31.0-h7378f02_4.conda
   sha256: 4c6e71cf695e4624ff23830be1775e95146bada392a440d179bf0aad679b7b76
   md5: 1f8955a9e1a8ac37938143e0d298d54e
@@ -4128,48 +4160,47 @@ packages:
   purls: []
   size: 259854
   timestamp: 1742087132545
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.32.8-h04c53c4_4.conda
-  sha256: 2af3c4b72cc621dc7140981b31c7dcc1b43dc014ba6e428ac5ae74ff3c7e69b5
-  md5: 1accd7849d0fe7a021907aa9acb18d1c
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.32.10-h1aa98f0_1.conda
+  sha256: 19a13db5eb2d73fd528f02d5f45732cfb6d6048cede06ea9008a24dacbd43c1b
+  md5: e8d9e6d7f3c8539783de298728b776c6
   depends:
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - aws-c-s3 >=0.8.1,<0.8.2.0a0
-  - aws-c-common >=0.12.3,<0.12.4.0a0
-  - aws-c-auth >=0.9.0,<0.9.1.0a0
-  - aws-c-mqtt >=0.13.1,<0.13.2.0a0
-  - aws-c-io >=0.19.1,<0.19.2.0a0
   - aws-c-cal >=0.9.2,<0.9.3.0a0
   - aws-c-sdkutils >=0.2.4,<0.2.5.0a0
+  - aws-c-mqtt >=0.13.1,<0.13.2.0a0
   - aws-c-http >=0.10.2,<0.10.3.0a0
+  - aws-c-io >=0.20.1,<0.20.2.0a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
   - aws-c-event-stream >=0.5.4,<0.5.5.0a0
+  - aws-c-auth >=0.9.0,<0.9.1.0a0
+  - aws-c-s3 >=0.8.3,<0.8.4.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 290875
-  timestamp: 1749578167887
-- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.510-h4607db7_10.conda
-  sha256: b340651ca85500d9adc2ac639bc484a500f1ba8eb8a1e8e224799e3f1b4cfca7
-  md5: 96f240f245fe2e031ec59dbb3044bd6c
+  size: 296560
+  timestamp: 1750855483621
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.510-h937e755_12.conda
+  sha256: 8fa640da0d7223c3d120e8d222d4b4cb519f05b628f60764192d08a937229cec
+  md5: f4e09870ecaceb4594574e515bb04747
   depends:
   - libstdcxx >=13
   - libgcc >=13
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libcurl >=8.14.0,<9.0a0
-  - aws-c-event-stream >=0.5.4,<0.5.5.0a0
-  - libzlib >=1.3.1,<2.0a0
-  - aws-crt-cpp >=0.32.8,<0.32.9.0a0
+  - libcurl >=8.14.1,<9.0a0
   - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-c-event-stream >=0.5.4,<0.5.5.0a0
+  - aws-crt-cpp >=0.32.10,<0.32.11.0a0
+  - libzlib >=1.3.1,<2.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 3401506
-  timestamp: 1748938911866
+  size: 3401464
+  timestamp: 1751089137364
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.510-hf067f9e_3.conda
   sha256: 19a25bfb6202ca635ca68d88e1f46a11bee573d2a3d8a6ea58548ef8e3f3cbfc
   md5: 01d5e5a0269c8f0dfe3b31e0353de4f3
@@ -4186,25 +4217,25 @@ packages:
   purls: []
   size: 3065899
   timestamp: 1742061757216
-- conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.510-h7deb975_10.conda
-  sha256: cd95067d30c6fbe2422110e9571665e29c1f66cab443ef061f40094ef7974e2b
-  md5: 89c6fd396eba3b89a776a35c11e7d1b9
+- conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.510-hd13e2d4_12.conda
+  sha256: 537f2c0751c7b7e59fb55b69ce736fb203f510ea0b9761917ed8256a52753140
+  md5: c65de3f2c8364602aab241e735ca516e
   depends:
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - aws-c-common >=0.12.3,<0.12.4.0a0
-  - aws-c-event-stream >=0.5.4,<0.5.5.0a0
-  - aws-crt-cpp >=0.32.8,<0.32.9.0a0
   - libzlib >=1.3.1,<2.0a0
+  - aws-c-event-stream >=0.5.4,<0.5.5.0a0
+  - aws-c-common >=0.12.3,<0.12.4.0a0
+  - aws-crt-cpp >=0.32.10,<0.32.11.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 3222678
-  timestamp: 1748939023256
+  size: 3225542
+  timestamp: 1751089155688
 - conda: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.14.0-h5cfcd09_0.conda
   sha256: fe07debdb089a3db17f40a7f20d283d75284bb4fc269ef727b8ba6fc93f7cb5a
   md5: 0a8838771cc2e985cd295e01ae83baf1
@@ -4455,17 +4486,17 @@ packages:
   - pkg:pypi/beautifulsoup4?source=compressed-mapping
   size: 146613
   timestamp: 1744783307123
-- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_4.conda
-  sha256: 194d771be287dc973f6057c0747010ce28adf960f38d6e03ce3e828d7b74833e
-  md5: ef67db625ad0d2dce398837102f875ed
+- conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.43-h4bf12b8_5.conda
+  sha256: 27ae158d415ff2942214b32ac7952e642f0f4c2a45ab683691e2a9a9159f868c
+  md5: 18852d82df8e5737e320a8731ace51b9
   depends:
-  - ld_impl_linux-64 2.43 h712a8e2_4
+  - ld_impl_linux-64 2.43 h712a8e2_5
   - sysroot_linux-64
   license: GPL-3.0-only
   license_family: GPL
   purls: []
-  size: 6111717
-  timestamp: 1740155471052
+  size: 6376971
+  timestamp: 1749852878015
 - conda: https://conda.anaconda.org/conda-forge/linux-64/black-25.1.0-py311h38be061_0.conda
   sha256: 04b6c4bb324cfb8cf5cffd7ff38657eaf7a4ff741e1c416778987c1783761456
   md5: c042fe701ae57ff9686c56e02306f54a
@@ -4884,24 +4915,24 @@ packages:
   purls: []
   size: 194147
   timestamp: 1744128507613
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-h4c7d964_0.conda
-  sha256: 1454f3f53a3b828d3cb68a3440cb0fa9f1cc0e3c8c26e9e023773dc19d88cc06
-  md5: 23c7fd5062b48d8294fc7f61bf157fba
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.6.15-h4c7d964_0.conda
+  sha256: 065241ba03ef3ee8200084c075cbff50955a7e711765395ff34876dbc51a6bb9
+  md5: b01649832f7bc7ff94f8df8bd2ee6457
   depends:
   - __win
   license: ISC
   purls: []
-  size: 152945
-  timestamp: 1745653639656
-- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
-  sha256: 2a70ed95ace8a3f8a29e6cd1476a943df294a7111dfb3e152e3478c4c889b7ac
-  md5: 95db94f75ba080a22eb623590993167b
+  size: 151351
+  timestamp: 1749990170707
+- conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.6.15-hbd8a1cb_0.conda
+  sha256: 7cfec9804c84844ea544d98bda1d9121672b66ff7149141b8415ca42dfcd44f6
+  md5: 72525f07d72806e3b639ad4504c30ce5
   depends:
   - __unix
   license: ISC
   purls: []
-  size: 152283
-  timestamp: 1745653616541
+  size: 151069
+  timestamp: 1749990087500
 - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
   noarch: python
   sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
@@ -4989,20 +5020,20 @@ packages:
   purls: []
   size: 1524254
   timestamp: 1741555212198
-- conda: https://conda.anaconda.org/conda-forge/linux-64/capnproto-1.0.2-h766bdaa_3.conda
-  sha256: fecb35e58b73a3dcb50725305964839ad08c0973592ba4d4ee0964360609fd12
-  md5: 7ea5f8afe8041beee8bad281dee62414
+- conda: https://conda.anaconda.org/conda-forge/linux-64/capnproto-1.2.0-hfc315d8_0.conda
+  sha256: 8ee933c82ff95e1db22c86bf8249166f549cb6b3e44d7e7c1ea48bf215807e89
+  md5: 6c5d994da0f456c829637846ea1bd945
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libstdcxx >=13
   - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
+  - openssl >=3.5.0,<4.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 4037969
-  timestamp: 1730914760842
+  size: 4071892
+  timestamp: 1750171402150
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/capnproto-1.0.2-h221ca0e_3.conda
   sha256: 41e81f2d739d968b6166a723ed3f15372562c0ae4af32f9315ad0d3c15c6c5b2
   md5: 77b5500817183990757074a1fdc106c0
@@ -5016,20 +5047,20 @@ packages:
   purls: []
   size: 2862262
   timestamp: 1730914758286
-- conda: https://conda.anaconda.org/conda-forge/win-64/capnproto-1.0.2-hb5d7e06_3.conda
-  sha256: 3f105d2e1591543cb3749e4f6d256d539783eb88231852d05fd431da521df109
-  md5: c40f782e2c06150a1da3d690eae2c480
+- conda: https://conda.anaconda.org/conda-forge/win-64/capnproto-1.2.0-h3a793f1_0.conda
+  sha256: 68d03e9fa7a99d07ec482dc9846e9e6217bf0526726444ad2e4ceac4bc2f8312
+  md5: c17f27064ac3449424a46404bcfa4b11
   depends:
   - libzlib >=1.3.1,<2.0a0
-  - openssl >=3.3.2,<4.0a0
+  - openssl >=3.5.0,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
   purls: []
-  size: 8491858
-  timestamp: 1730915546343
+  size: 8464981
+  timestamp: 1750171713872
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ceres-solver-2.2.0-cpuh39c81a5_6.conda
   sha256: 48fe5a83e18b4375aa93943dc7c98688cc9430a91fa37493bda372a17d3bb7ea
   md5: ac532e6667fdb48dac8aa8e65237d257
@@ -5125,16 +5156,16 @@ packages:
   purls: []
   size: 955771
   timestamp: 1749481603894
-- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.4.26-pyhd8ed1ab_0.conda
-  sha256: 52aa837642fd851b3f7ad3b1f66afc5366d133c1d452323f786b0378a391915c
-  md5: c33eeaaa33f45031be34cda513df39b6
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2025.6.15-pyhd8ed1ab_0.conda
+  sha256: d71c85835813072cd6d7ce4b24be34215cd90c104785b15a5d58f4cd0cb50778
+  md5: 781d068df0cc2407d4db0ecfbb29225b
   depends:
   - python >=3.9
   license: ISC
   purls:
   - pkg:pypi/certifi?source=hash-mapping
-  size: 157200
-  timestamp: 1746569627830
+  size: 155377
+  timestamp: 1749972291158
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
   sha256: bc47aa39c8254e9e487b8bcd74cfa3b4a3de3648869eb1a0b89905986b668e35
   md5: 55553ecd5328336368db611f350b7039
@@ -5392,7 +5423,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/click?source=compressed-mapping
+  - pkg:pypi/click?source=hash-mapping
   size: 87749
   timestamp: 1747811451319
 - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.2.1-pyh7428d3b_0.conda
@@ -5630,9 +5661,9 @@ packages:
   - pkg:pypi/contourpy?source=hash-mapping
   size: 217491
   timestamp: 1744743749434
-- conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.8.2-py311h2dc5d0c_0.conda
-  sha256: 1da68668a274d87003cb1c3281269fa930e952cda1711426c4240517d98177c8
-  md5: 21c1ef48cc2bf485e6d38c5611e91da2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.9.1-py311h2dc5d0c_0.conda
+  sha256: 09245391f91135f4eea87d64107e82d4fb4b7d4fbd6596ea6cc126645191220c
+  md5: f524bd18889f169f2fa8dc70df1c53c3
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -5643,11 +5674,11 @@ packages:
   license_family: APACHE
   purls:
   - pkg:pypi/coverage?source=hash-mapping
-  size: 382340
-  timestamp: 1748049052047
-- conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.8.2-py312h178313f_0.conda
-  sha256: 29d1b0ff196f8cb9c65d9ce4a355c3b1037698b5a0f4cc4590472ed38de182c3
-  md5: 141e4480d38281c3988f3a9aa917b07d
+  size: 383591
+  timestamp: 1749833491301
+- conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.9.1-py312h178313f_0.conda
+  sha256: bef32c5830b7701705660ef18d5d6ad7c597ebab196954c012e8a1cb4af0d3bc
+  md5: 4c18b79fa2a3371557ed3663876e5dcc
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -5658,11 +5689,11 @@ packages:
   license_family: APACHE
   purls:
   - pkg:pypi/coverage?source=hash-mapping
-  size: 371986
-  timestamp: 1748048993905
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.8.2-py311h4921393_0.conda
-  sha256: df880fad177ea357ae8966feb0b202950b58195b705b87e48185592836bd4c00
-  md5: 311c172fc9c5431f784cc0c33da21ba9
+  size: 371371
+  timestamp: 1749833562595
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.9.1-py311h4921393_0.conda
+  sha256: 43c3fc41a6c790a4f88cc7f59358ecca06d1f7e32f75fcddfc3d4347403f058c
+  md5: d05861abb8d6097acd60e08d79cd1c4d
   depends:
   - __osx >=11.0
   - python >=3.11,<3.12.0a0
@@ -5673,11 +5704,11 @@ packages:
   license_family: APACHE
   purls:
   - pkg:pypi/coverage?source=hash-mapping
-  size: 381814
-  timestamp: 1748048943371
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.8.2-py312h998013c_0.conda
-  sha256: 035ae3cf6def1c9164bc9b6298a6e9193a77d55533289d5584e40700eedf2d66
-  md5: f9c677fdd72c932b44436eb3f8242c86
+  size: 380898
+  timestamp: 1749833551848
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.9.1-py312h998013c_0.conda
+  sha256: 0f8ed3cb0b702c6a9df9fafd31a45023c3c6ca1c66d85453cde7a0e2e5812c05
+  md5: 738b5ae0d38352a804fba9750bca81a0
   depends:
   - __osx >=11.0
   - python >=3.12,<3.13.0a0
@@ -5688,11 +5719,11 @@ packages:
   license_family: APACHE
   purls:
   - pkg:pypi/coverage?source=hash-mapping
-  size: 371311
-  timestamp: 1748048981164
-- conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.8.2-py311h5082efb_0.conda
-  sha256: ca270ce3d6e450dd638d03cbbf532c7ba8ef9243279b00ff0c2e3e19be1b71fc
-  md5: dfd09752e23b9e8c1389ee8655c26f87
+  size: 373189
+  timestamp: 1749833686158
+- conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.9.1-py311h5082efb_0.conda
+  sha256: 821c280024834cdf88038452e3c131140c9e8bc310617349c0deecffca2c2196
+  md5: a12491bec053dd704f8e467127e20b6a
   depends:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
@@ -5704,11 +5735,11 @@ packages:
   license_family: APACHE
   purls:
   - pkg:pypi/coverage?source=hash-mapping
-  size: 407388
-  timestamp: 1748049048380
-- conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.8.2-py312h31fea79_0.conda
-  sha256: ccf00edc1b8f4f1c224f81a4a598d2e89f97c063ff3ffd8e0dc8b9f7213db6db
-  md5: 746283c1e8a793b7322b52514111456c
+  size: 407907
+  timestamp: 1749833673698
+- conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.9.1-py312h31fea79_0.conda
+  sha256: d8a7874de0cd78242cd24b592c41ca2fab7898eedf3b6aa9e7243027ee9aed22
+  md5: 05437668629deb7fdb7af513d43249c0
   depends:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -5720,8 +5751,8 @@ packages:
   license_family: APACHE
   purls:
   - pkg:pypi/coverage?source=hash-mapping
-  size: 397765
-  timestamp: 1748049227393
+  size: 399371
+  timestamp: 1749834041463
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cpd-0.5.5-h434a139_2.conda
   sha256: f8dcdac7e17d64e389ebb15bc2bed5f854981aadb82671913b4de7468ece161c
   md5: 2e99fbaf88b79533f22710d278b336be
@@ -5769,14 +5800,14 @@ packages:
   purls: []
   size: 45852
   timestamp: 1749047748072
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-45.0.4-py311hafd3f86_0.conda
-  sha256: 0832d1aff2f6606824a89aed2427da26bda9914b6d2ff34ec643f560f4560547
-  md5: 0cfa6cebbf4b3c8f16be9fba587d990a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-45.0.5-py311hafd3f86_0.conda
+  sha256: 82ed8218edcc664d5a9ce6dfe09e70c472d91ab59f56810c11ab4f8e2162e7fc
+  md5: d096f77b1dbfab3bcd58a1a9b4023673
   depends:
   - __glibc >=2.17,<3.0.a0
   - cffi >=1.12
   - libgcc >=13
-  - openssl >=3.5.0,<4.0a0
+  - openssl >=3.5.1,<4.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   constrains:
@@ -5784,17 +5815,17 @@ packages:
   license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
   license_family: BSD
   purls:
-  - pkg:pypi/cryptography?source=hash-mapping
-  size: 1662736
-  timestamp: 1749538948414
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-45.0.4-py312hda17c39_0.conda
-  sha256: 5d36a2f20b54f05341845ba19b909ed40ada50f1fd4f7b606282a4563e1a6a2c
-  md5: f56a043ace4885f37c8856a24447cd19
+  - pkg:pypi/cryptography?source=compressed-mapping
+  size: 1658005
+  timestamp: 1751491380121
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-45.0.5-py312hda17c39_0.conda
+  sha256: 4f0940ea061bc0194a447d1c571918e79ad834ef4d26fe4d17a4503bee71a49c
+  md5: b315b9ae992b31e65c59be8fac2e234a
   depends:
   - __glibc >=2.17,<3.0.a0
   - cffi >=1.12
   - libgcc >=13
-  - openssl >=3.5.0,<4.0a0
+  - openssl >=3.5.1,<4.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   constrains:
@@ -5802,9 +5833,9 @@ packages:
   license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
   license_family: BSD
   purls:
-  - pkg:pypi/cryptography?source=hash-mapping
-  size: 1658881
-  timestamp: 1749539059944
+  - pkg:pypi/cryptography?source=compressed-mapping
+  size: 1653383
+  timestamp: 1751491514393
 - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
   sha256: 9827efa891e507a91a8a2acf64e210d2aff394e1cde432ad08e1f8c66b12293c
   md5: 44600c4667a319d67dbe0681fc0bc833
@@ -5816,33 +5847,36 @@ packages:
   - pkg:pypi/cycler?source=hash-mapping
   size: 13399
   timestamp: 1733332563512
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.27-h54b06d7_7.conda
-  sha256: d2ea5e52da745c4249e1a818095a28f9c57bd4df22cbfc645352defa468e86c2
-  md5: dce22f70b4e5a407ce88f2be046f4ceb
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cyrus-sasl-2.1.28-hd9c7081_0.conda
+  sha256: ee09ad7610c12c7008262d713416d0b58bf365bc38584dce48950025850bdf3f
+  md5: cae723309a49399d2949362f4ab5c9e4
   depends:
-  - krb5 >=1.21.1,<1.22.0a0
-  - libgcc-ng >=12
-  - libntlm
-  - libstdcxx-ng >=12
-  - openssl >=3.1.1,<4.0a0
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libntlm >=1.8,<2.0a0
+  - libstdcxx >=13
+  - libxcrypt >=4.4.36
+  - openssl >=3.5.0,<4.0a0
   license: BSD-3-Clause-Attribution
   license_family: BSD
   purls: []
-  size: 219527
-  timestamp: 1690061203707
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cyrus-sasl-2.1.27-h60b93bd_7.conda
-  sha256: befd4d6e8b542d0c30aff47b098d43bbbe1bbf743ba6cd87a100d8a8731a6e03
-  md5: 80a3b015d05a7d235db1bf09911fe08e
+  size: 209774
+  timestamp: 1750239039316
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/cyrus-sasl-2.1.28-ha1cbb27_0.conda
+  sha256: 7de03254fa5421e7ec2347c830a59530fb5356022ee0dc26ec1cef0be1de0911
+  md5: 2867ea6551e97e53a81787fd967162b1
   depends:
-  - krb5 >=1.21.1,<1.22.0a0
-  - libcxx >=15.0.7
-  - libntlm
-  - openssl >=3.1.1,<4.0a0
+  - __osx >=11.0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libcxx >=18
+  - libntlm >=1.8,<2.0a0
+  - openssl >=3.5.0,<4.0a0
   license: BSD-3-Clause-Attribution
   license_family: BSD
   purls: []
-  size: 210957
-  timestamp: 1690061457834
+  size: 193732
+  timestamp: 1750239236574
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.0.1-py311h9ecbd09_0.conda
   sha256: fd5a8c7e613c3c538ca775951fd814ab10cfcdaed79e193c3bf7eb59c87cd114
   md5: 69a0a85acdcc5e6d0f1cc915c067ad4c
@@ -5999,21 +6033,21 @@ packages:
   - pkg:pypi/dask?source=hash-mapping
   size: 993940
   timestamp: 1747771723761
-- conda: https://conda.anaconda.org/conda-forge/noarch/datacompy-0.16.7-pyhd8ed1ab_0.conda
-  sha256: 18e87030b9957bc2f9efcd428fce117e422e362e67726cf0c412102deddc3854
-  md5: 9e26d91536aa5c59088b7f6645f98e09
+- conda: https://conda.anaconda.org/conda-forge/noarch/datacompy-0.16.8-pyhd8ed1ab_0.conda
+  sha256: ccf6d8e9b35f7e5b8bb3c9fef96f3faa969f850e953f1edcfa02eaae2e198c9e
+  md5: c07c1930498f1795c65ae2a0dd30564b
   depends:
-  - numpy <=2.2.5,>=1.22.0
+  - numpy <=2.2.6,>=1.22.0
   - ordered-set <=4.1.0,>=4.0.2
-  - pandas <=2.2.3,>=0.25.0
-  - polars <=1.27.1,>=0.20.4
+  - pandas <=2.3.0,>=0.25.0
+  - polars <=1.31.0,>=0.20.4
   - python >=3.10
   license: Apache-2.0
   license_family: APACHE
   purls:
   - pkg:pypi/datacompy?source=hash-mapping
-  size: 49939
-  timestamp: 1747920136671
+  size: 50307
+  timestamp: 1750527972096
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
   sha256: 93e077b880a85baec8227e8c72199220c7f87849ad32d02c14fb3807368260b8
   md5: 5a74cdee497e6b65173e10d94582fae6
@@ -6373,6 +6407,24 @@ packages:
   purls: []
   size: 1089706
   timestamp: 1690273089254
+- pypi: https://files.pythonhosted.org/packages/f6/65/84a48ff419cb5f303be2eaa40a757a7860c777a1caf738738de489db69e0/elementpath-5.0.3-py3-none-any.whl
+  name: elementpath
+  version: 5.0.3
+  sha256: 8c93540556f743835b3c682a7bdb2d97371ee1e151430ff35498b59f2c14e5a0
+  requires_dist:
+  - coverage ; extra == 'dev'
+  - flake8 ; extra == 'dev'
+  - lxml ; extra == 'dev'
+  - lxml-stubs ; extra == 'dev'
+  - memray ; extra == 'dev'
+  - mypy ; extra == 'dev'
+  - psutil ; extra == 'dev'
+  - sphinx ; extra == 'dev'
+  - tox ; extra == 'dev'
+  - xmlschema>=4.0.1 ; extra == 'dev'
+  - sphinx ; extra == 'docs'
+  - readthedocs-sphinx-search ; extra == 'docs'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/esbuild-0.25.5-ha770c72_0.conda
   sha256: 18cf2bccbfa5dd1a04d733e49f3ac02d771fe06be1b1b1dcc78f16fb1fbbc3f6
   md5: 2bc4e89a4df56b765e7166aceca7c621
@@ -6523,9 +6575,9 @@ packages:
   - pkg:pypi/filelock?source=hash-mapping
   size: 17887
   timestamp: 1741969612334
-- conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.1.4-h07f6e7f_1.conda
-  sha256: 2db2a6a1629bc2ac649b31fd990712446394ce35930025e960e1765a9249af5d
-  md5: 288a90e722fd7377448b00b2cddcb90d
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fmt-11.2.0-h07f6e7f_0.conda
+  sha256: e0f53b7801d0bcb5d61a1ddcb873479bfe8365e56fd3722a232fbcc372a9ac52
+  md5: 0c2f855a88fab6afa92a7aa41217dc8e
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -6533,8 +6585,8 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 191161
-  timestamp: 1742833273257
+  size: 192721
+  timestamp: 1751277120358
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-11.0.2-h440487c_1.conda
   sha256: afc3d556845e42112953279d3703c603c00bf6e139658778ea6b904c4fc1f50a
   md5: f90a1a21cef4c1e11f421ba29538d704
@@ -6546,21 +6598,21 @@ packages:
   purls: []
   size: 180080
   timestamp: 1743030842101
-- conda: https://conda.anaconda.org/conda-forge/win-64/fmt-11.1.4-h5f12afc_1.conda
-  sha256: fd88cd4796572d649da4d249ffb91bd387558c75ab14ad344b7ac45f714079b6
-  md5: 65be2289e596e757fc03a5383072a2e7
+- conda: https://conda.anaconda.org/conda-forge/win-64/fmt-11.2.0-h1d4551f_0.conda
+  sha256: 890f2789e55b509ff1f14592a5b20a0d0ec19f6da463eff96e378a5d70f882da
+  md5: 15b63c3fb5b7d67b1cb63553a33e6090
   depends:
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
   purls: []
-  size: 184746
-  timestamp: 1742833874774
-- conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.19.7-pyhd8ed1ab_0.conda
-  sha256: 01adf2e15fa6eb352e869951f6f5e3e94ab5e6d3bb8b08db88dbf1603a9a767c
-  md5: 1a0ace71ddcbb17aa146f5f9b0746dd3
+  size: 185995
+  timestamp: 1751277236879
+- conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.20.0-pyhd8ed1ab_0.conda
+  sha256: 782fa186d7677fd3bc1ff7adb4cc3585f7d2c7177c30bcbce21f8c177135c520
+  md5: a6997a7dcd6673c0692c61dfeaea14ab
   depends:
   - branca >=0.6.0
   - jinja2 >=2.9
@@ -6572,8 +6624,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/folium?source=hash-mapping
-  size: 82083
-  timestamp: 1748944963776
+  size: 82665
+  timestamp: 1750113928159
 - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
   md5: 0c96522c6bdaed4b1566d11387caaf45
@@ -6673,9 +6725,9 @@ packages:
   purls: []
   size: 4102
   timestamp: 1566932280397
-- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.58.2-py311h2dc5d0c_0.conda
-  sha256: 50a028c44427d51c467905d01129f0ca234007359331282aac374370e1e2e158
-  md5: c58ce3ab3833471964d7ee6b83203425
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.58.4-py311h2dc5d0c_0.conda
+  sha256: f57df9d0573fa04b53afdaa5253bc4f1902357cca9265951f9d6ebe46567a40e
+  md5: dd3ef31d2bf022668f30859d5e11c83e
   depends:
   - __glibc >=2.17,<3.0.a0
   - brotli
@@ -6687,12 +6739,12 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/fonttools?source=compressed-mapping
-  size: 2877123
-  timestamp: 1749229277815
-- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.58.2-py312h178313f_0.conda
-  sha256: aa2dbfcc173c1fe4e0e1c54ff07e98f36edfc6bbbd7e49ea9ff60541d37e648d
-  md5: 286068e5706fa6eacce413a594cf0d4b
+  - pkg:pypi/fonttools?source=hash-mapping
+  size: 2919952
+  timestamp: 1749848724761
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.58.4-py312h178313f_0.conda
+  sha256: aa29952ac29ab4c4dad091794513241c1f732c55c58ba109f02550bc83081dc9
+  md5: 223a4616e3db7336569eafefac04ebbf
   depends:
   - __glibc >=2.17,<3.0.a0
   - brotli
@@ -6705,11 +6757,11 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/fonttools?source=hash-mapping
-  size: 2826545
-  timestamp: 1749229412185
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.58.2-py311h4921393_0.conda
-  sha256: a47e8a4bf8e088797cd75429d4f809ec996cedf847f8da80ba5611c62d3fa28a
-  md5: bc17b768409f0c65cf9dd9bd6109fb7e
+  size: 2864513
+  timestamp: 1749848613494
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.58.4-py311h4921393_0.conda
+  sha256: 27135a2600d0c42ad58cf339e2cd0df597a534af7c51e826ceae60219706a62c
+  md5: af71168d44a74216ba42fe39fef624ff
   depends:
   - __osx >=11.0
   - brotli
@@ -6721,12 +6773,12 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/fonttools?source=compressed-mapping
-  size: 2790717
-  timestamp: 1749228926697
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.58.2-py312h998013c_0.conda
-  sha256: 821fb407cb405788269666f06882debacac667b9fda6f49bbb9dea32c2574b9e
-  md5: d48837815b6461517024e1594db9af4c
+  - pkg:pypi/fonttools?source=hash-mapping
+  size: 2804047
+  timestamp: 1749848663496
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.58.4-py312h998013c_0.conda
+  sha256: 293362bd29aea655ab5ccbc42b1c3d339bae0b0b46066045f5d96b501d476614
+  md5: 1e5f0e1b9196f7d6bb6e80d1251b2b8e
   depends:
   - __osx >=11.0
   - brotli
@@ -6738,12 +6790,12 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/fonttools?source=hash-mapping
-  size: 2755217
-  timestamp: 1749229214675
-- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.58.2-py311h5082efb_0.conda
-  sha256: 40d319bdb90178680e91046dce7cbdb1764489e7ba7efad4ecc2d9cd00690f18
-  md5: b2aa1abdfadfdf8deb04ac6a9b64e11d
+  - pkg:pypi/fonttools?source=compressed-mapping
+  size: 2773078
+  timestamp: 1749848775165
+- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.58.4-py311h5082efb_0.conda
+  sha256: 0381a0b6c32cddbeaab39750590205a97604b52faae1c7db7d7891ac4710be60
+  md5: 0619fa68408637bbfb263aa8396a61a9
   depends:
   - brotli
   - munkres
@@ -6756,12 +6808,12 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/fonttools?source=compressed-mapping
-  size: 2484501
-  timestamp: 1749229161621
-- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.58.2-py312h31fea79_0.conda
-  sha256: a314886c4a0baaf00526ded33104fd09fd7044393395f24fd33696beee601c4d
-  md5: 300dfab2dac1c966c6fc52c2ee442287
+  - pkg:pypi/fonttools?source=hash-mapping
+  size: 2486946
+  timestamp: 1749848727487
+- conda: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.58.4-py312h31fea79_0.conda
+  sha256: 4d3d830517f29e43e87e7f6998fd63c64a9bab504ee4441ab7c86ef49af3cb6b
+  md5: ea00f492c19ac1799f510617ef502e0e
   depends:
   - brotli
   - munkres
@@ -6775,8 +6827,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/fonttools?source=hash-mapping
-  size: 2427072
-  timestamp: 1749229563092
+  size: 2426491
+  timestamp: 1749848699287
 - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_1.conda
   sha256: 2509992ec2fd38ab27c7cdb42cf6cadc566a1cc0d1021a2673475d9fa87c6276
   md5: d3549fd50d450b6d9e7dddff25dd2110
@@ -6883,56 +6935,56 @@ packages:
   - pkg:pypi/future?source=hash-mapping
   size: 364561
   timestamp: 1738926525117
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.1.0-h4393ad2_2.conda
-  sha256: 99c545b842edd356d907c51ccd6f894ef6db042c6ebebefd14eb844f53ff8f73
-  md5: 240c2af59f95792f60193c1cb9ee42c5
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-15.1.0-h4393ad2_3.conda
+  sha256: fed91c71f8e7b3f0970f883c589d7dd74a3503b7020d0be273cea301a64ee3af
+  md5: f39f96280dd8b1ec8cbd395a3d3fdd1e
   depends:
   - binutils_impl_linux-64 >=2.40
   - libgcc >=15.1.0
-  - libgcc-devel_linux-64 15.1.0 h4c094af_102
+  - libgcc-devel_linux-64 15.1.0 h4c094af_103
   - libgomp >=15.1.0
-  - libsanitizer 15.1.0 h97b714f_2
+  - libsanitizer 15.1.0 h97b714f_3
   - libstdcxx >=15.1.0
   - sysroot_linux-64
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 76467375
-  timestamp: 1746642316078
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.10.3-py311hbeb1d84_11.conda
-  sha256: 09dcfa793dd468b8df580ae5ab4998f5d841e2736329c3b9f1e0059be6e0a9c7
-  md5: 9932cf8b1160ffa5d53ded7a5f8a07cf
+  size: 76098052
+  timestamp: 1750808341511
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.11.1-py311hbeb1d84_0.conda
+  sha256: dffd69c26f298baa71a532399ccb29d765b2a676fa17e456ce05fa21a985d1d4
+  md5: 23ff62bb8ee6c11c4681d0aafc2b9e11
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libgdal-core 3.10.3.*
+  - libgdal-core 3.11.1.*
   - libstdcxx >=13
-  - numpy >=1.21,<3
+  - numpy >=1.23,<3
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 1799223
-  timestamp: 1749423008054
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.10.3-py312hf1b357c_11.conda
-  sha256: 4b39cc4ae9067471224f0b1b82b72945b042f29b66866c2c4ba6529daece0eee
-  md5: 5daf10db494d9925fb225afe61aab8db
+  size: 1846329
+  timestamp: 1751395808964
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.11.1-py312hf1b357c_0.conda
+  sha256: ae62368906bd4abeadcbb3596839ee00cdf00eb29174899385130eb1a5de36dd
+  md5: 25e6d46ff056599f40013aa3df8377b1
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libgdal-core 3.10.3.*
+  - libgdal-core 3.11.1.*
   - libstdcxx >=13
-  - numpy >=1.21,<3
+  - numpy >=1.23,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 1777588
-  timestamp: 1749422928019
+  size: 1830601
+  timestamp: 1751395604693
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.10.2-py311h32e851c_5.conda
   sha256: 6ab9c2f81b972184b1e1f1299daa6992b65ee72afeb9f12d4c5bfc32f1283641
   md5: 0a7633f7f886acdc97e257d996b34602
@@ -6973,40 +7025,40 @@ packages:
   - pkg:pypi/gdal?source=hash-mapping
   size: 1710856
   timestamp: 1742976793856
-- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.10.3-py311h8d72537_11.conda
-  sha256: 4c70ccf07e97549355d4ac6252f97a0817f5797731523ae276d2b6b84282f518
-  md5: 1ac511cc43819b87a8dc2a4a8c5c0f46
+- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.11.1-py311ha7b5f94_0.conda
+  sha256: 4833f7540f78742dfb99dc2d518c7776892e68a9d037fc13ed75721766af5803
+  md5: 08dd1ddc043841cad7baa1149ccdf81f
   depends:
-  - libgdal-core 3.10.3.*
-  - numpy >=1.21,<3
+  - libgdal-core 3.11.1.*
+  - numpy >=1.23,<3
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 1682434
-  timestamp: 1749426368408
-- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.10.3-py312h97c3f2a_11.conda
-  sha256: 08f6baf8ff3cbc9ab3c8666d4c57977ceffa1a597253b6e575dc94df9332c213
-  md5: f43c04fd92b544300f2339654083abaf
+  size: 1751351
+  timestamp: 1751397574522
+- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.11.1-py312h07de9ea_0.conda
+  sha256: 96ec9ee6d40212e09a112934e41b5e5aff5caf942f1e2e9a393481e275824d8b
+  md5: 3acff5054d4033f39618824a217eddb0
   depends:
-  - libgdal-core 3.10.3.*
-  - numpy >=1.21,<3
+  - libgdal-core 3.11.1.*
+  - numpy >=1.23,<3
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 1669868
-  timestamp: 1749425517037
+  size: 1727295
+  timestamp: 1751397948976
 - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.0.1-pyhd8ed1ab_3.conda
   sha256: 04f7e616ebbf6352ff852b53c57901e43f14e2b3c92411f99b5547f106bc192e
   md5: 1baca589eb35814a392eaad6d152447e
@@ -7183,29 +7235,29 @@ packages:
   purls: []
   size: 76765
   timestamp: 1726600357514
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.74.1-h76a2195_0.conda
-  sha256: 519080155b56dac094ce84d3caffc84723c803f510f59ee5f7fccb443764b357
-  md5: bd5da738a4b6ea6ff4d5a569c71ef647
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gh-2.74.2-h76a2195_0.conda
+  sha256: e2b23f35eb471092a55b89512e8305974b8ad1b594e8f75b6f179ef9adafb896
+  md5: 14bd3f0d831f726a70744abd07eb63da
   depends:
   - __glibc >=2.17,<3.0.a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 23854816
-  timestamp: 1749576612792
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gh-2.74.1-hd02bf31_0.conda
-  sha256: 8a3afe49d73d429141eb03f70a77b4bf3f45919c4de37bedb057e39c93fae41c
-  md5: f96fafdb08cc666085cdffa2ae7e8894
+  size: 23868292
+  timestamp: 1750292011271
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gh-2.74.2-hd02bf31_0.conda
+  sha256: 96eaf01ae063292a6c434ed5dc220879daebf7410b9b9ea6b809edd2949dd08f
+  md5: 4fcccaf573accc84e75cf3e2cd456529
   depends:
   - __osx >=11.0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 21787865
-  timestamp: 1749576794134
-- conda: https://conda.anaconda.org/conda-forge/win-64/gh-2.74.1-h36e2d1d_0.conda
-  sha256: 417d6234c2e3b91c0b74dda4da185dfdf5e630152dba05e1ff3506ec2c9fe50c
-  md5: b5a704ab7a7343b49f251937e6da6784
+  size: 21775616
+  timestamp: 1750292355203
+- conda: https://conda.anaconda.org/conda-forge/win-64/gh-2.74.2-h36e2d1d_0.conda
+  sha256: 211d7ed7a31d839f806ef7ce44d0e3ab2d74111545b924451f5e87a1ecbe39c4
+  md5: e3c77eb055871e956173d109fbd6a971
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
@@ -7213,8 +7265,8 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 23221718
-  timestamp: 1749577033131
+  size: 23232059
+  timestamp: 1750292283657
 - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
   sha256: aac402a8298f0c0cc528664249170372ef6b37ac39fdc92b40601a6aed1e32ff
   md5: 3bf7b9fd5a7136126e0234db4b87c8b6
@@ -7384,20 +7436,21 @@ packages:
   purls: []
   size: 567053
   timestamp: 1718982076982
-- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
-  sha256: 0595b009f20f8f60f13a6398e7cdcbd2acea5f986633adcf85f5a2283c992add
-  md5: f87c7b7c2cb45f323ffbce941c78ab7c
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-h5888daf_0.conda
+  sha256: cac69f3ff7756912bbed4c28363de94f545856b35033c0b86193366b95f5317d
+  md5: 951ff8d9e5536896408e89d63230b8d5
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
   license: LGPL-2.0-or-later
   license_family: LGPL
   purls: []
-  size: 96855
-  timestamp: 1711634169756
-- conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-h63175ca_1003.conda
-  sha256: 25040a4f371b9b51663f546bac620122c237fa1d5d32968e21b0751af9b7f56f
-  md5: 3194499ee7d1a67404a87d0eefdd92c6
+  size: 98419
+  timestamp: 1750079957535
+- conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.14-he0c23c2_0.conda
+  sha256: bcbcece7719f2a14ede6bfead8f5fdbb65ed102d47769c817b375e4e9d43be39
+  md5: 692bc31c646f7e221af07ccc924e1ae4
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -7405,8 +7458,8 @@ packages:
   license: LGPL-2.0-or-later
   license_family: LGPL
   purls: []
-  size: 95406
-  timestamp: 1711634622644
+  size: 95862
+  timestamp: 1750080330012
 - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.7.3-pyhd8ed1ab_0.conda
   sha256: c1e4039c9b6d613e8e9feafa21fae58db5eebeaa5f8bece5d8610154ae6ebf80
   md5: aafe052f140a58b1afaf8ab473f5ac0d
@@ -7851,7 +7904,8 @@ packages:
   - python
   license: MIT
   license_family: MIT
-  purls: []
+  purls:
+  - pkg:pypi/hyperlink?source=hash-mapping
   size: 74751
   timestamp: 1733319972207
 - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
@@ -8054,9 +8108,9 @@ packages:
   - pkg:pypi/ipykernel?source=hash-mapping
   size: 119568
   timestamp: 1719845667420
-- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.3.0-pyh6be1c34_0.conda
-  sha256: b6189de4e9f3d007a11e6e1df023c2bb73cf1864f63ca154c5ff8f0cdf601a50
-  md5: 73e4ba4c8247f744be670f4da4f132e2
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.4.0-pyh6be1c34_0.conda
+  sha256: 8fb441c9f4b50e38b6059e8984e49208a4e2a4ec4e41b543ebaa894f8261d4c9
+  md5: b551e25e4fb27ccb51aff2c5dcf178f4
   depends:
   - __win
   - colorama
@@ -8077,11 +8131,11 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/ipython?source=hash-mapping
-  size: 621095
-  timestamp: 1748711232331
-- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.3.0-pyhfa0c392_0.conda
-  sha256: ee5d526cba0c0a5981cbcbcadc37a76d257627a904ed2cd2db45821735c93ebd
-  md5: 270dbfb30fe759b39ce0c9fdbcd7be10
+  size: 627419
+  timestamp: 1751470649672
+- conda: https://conda.anaconda.org/conda-forge/noarch/ipython-9.4.0-pyhfa0c392_0.conda
+  sha256: ff5138bf6071ca01d84e1329f6baa96f0723df6fe183cfa1ab3ebc96240e6d8f
+  md5: cb7706b10f35e7507917cefa0978a66d
   depends:
   - __unix
   - pexpect >4.3
@@ -8102,8 +8156,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/ipython?source=compressed-mapping
-  size: 621859
-  timestamp: 1748713870748
+  size: 628259
+  timestamp: 1751465044469
 - conda: https://conda.anaconda.org/conda-forge/noarch/ipython_pygments_lexers-1.1.1-pyhd8ed1ab_0.conda
   sha256: 894682a42a7d659ae12878dbcb274516a7031bbea9104e92f8e88c1f2765a104
   md5: bd80ba060603cc228d9d81c257093119
@@ -8223,7 +8277,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/joblib?source=compressed-mapping
+  - pkg:pypi/joblib?source=hash-mapping
   size: 224437
   timestamp: 1748019237972
 - conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
@@ -8576,9 +8630,9 @@ packages:
   - pkg:pypi/jupyter-server-terminals?source=hash-mapping
   size: 19711
   timestamp: 1733428049134
-- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.3-pyhd8ed1ab_0.conda
-  sha256: fc0235a71d852734fe92183a78cb91827367573450eba82465ae522c64230736
-  md5: 4861a0c2a5a5d0481a450a9dfaf9febe
+- conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.4.4-pyhd8ed1ab_0.conda
+  sha256: a6efcdbe973e12bc8bd61aa26af77f733364975000c8fdaa0d6374338018e0db
+  md5: dbd991d0080c48dae5113a27ab6d0d70
   depends:
   - async-lru >=1.0.0
   - httpx >=0.25.0
@@ -8599,9 +8653,9 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jupyterlab?source=hash-mapping
-  size: 8236973
-  timestamp: 1748273017680
+  - pkg:pypi/jupyterlab?source=compressed-mapping
+  size: 8316249
+  timestamp: 1751119910935
 - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_2.conda
   sha256: dc24b900742fdaf1e077d9a3458fd865711de80bca95fe3c6d46610c532c6ef0
   md5: fd312693df06da3578383232528c468d
@@ -8785,9 +8839,9 @@ packages:
   purls: []
   size: 46768
   timestamp: 1732916943523
-- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.7-py311hd18a35c_0.conda
-  sha256: 4af11cbc063096a284fe1689b33424e7e49732a27fd396d74c7dee03d1e788ee
-  md5: be34c90cce87090d24da64a7c239ca96
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.8-py311hd18a35c_1.conda
+  sha256: 1a1f73000796c0429ecbcc8a869b9f64e6e95baa49233c0777bfab8fb26cd75a
+  md5: bb17b97b0c0d86e052134bf21af5c03d
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -8798,11 +8852,11 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/kiwisolver?source=hash-mapping
-  size: 72393
-  timestamp: 1725459421768
-- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.8-py312h84d6215_0.conda
-  sha256: 3ce99d721c1543f6f8f5155e53eef11be47b2f5942a8d1060de6854f9d51f246
-  md5: 6713467dc95509683bfa3aca08524e8a
+  size: 73699
+  timestamp: 1751493971471
+- conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.8-py312h68727a3_1.conda
+  sha256: 34814cea4b92d17237211769f2ec5b739a328849b152a2f5736183c52d48cafc
+  md5: a8ea818e46addfa842348701a9dbe8f8
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -8812,15 +8866,15 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/kiwisolver?source=hash-mapping
-  size: 71649
-  timestamp: 1736908364705
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.7-py311h2c37856_0.conda
-  sha256: 8ffc46f6e99c95c48426cf34c033d16cde3bcf100cd74d1d74a33943a85a6ec8
-  md5: ee572d19da1346db8e78cb8e7d5d2330
+  - pkg:pypi/kiwisolver?source=compressed-mapping
+  size: 72166
+  timestamp: 1751493973594
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.8-py311h210dab8_1.conda
+  sha256: 5c29528bce81092860551ed0e7849c1bfd76def81d094999cea9c0d431d62fe0
+  md5: d29f957f5ce0b0e5d0df58d146e0888a
   depends:
   - __osx >=11.0
-  - libcxx >=17
+  - libcxx >=18
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
@@ -8828,11 +8882,11 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/kiwisolver?source=hash-mapping
-  size: 59357
-  timestamp: 1725459504453
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.8-py312h2c4a281_0.conda
-  sha256: 01366fa9d65bedb4069266d08c8a7a2ebbe6f25cedf60eebeeb701067f162f68
-  md5: a94f3ac940c391e7716b6ffd332d7463
+  size: 60414
+  timestamp: 1751494205171
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.8-py312hb23fbb9_1.conda
+  sha256: f75e00ed3fe2db218fa58d37148c437c5852ce0a4e3f08563e24ab98045ddc5e
+  md5: aebb58801a162a0a0ed75df72a9bbeb1
   depends:
   - __osx >=11.0
   - libcxx >=18
@@ -8843,38 +8897,38 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/kiwisolver?source=hash-mapping
-  size: 61368
-  timestamp: 1736908431125
-- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.7-py311h3257749_0.conda
-  sha256: a2079e13d1345a5dd61df6be933e828e805051256e7260009ba93fce55aebd75
-  md5: 18fd1ac3d79a8d6550eaea5ceaa00036
+  size: 61937
+  timestamp: 1751494129774
+- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.8-py311h3fd045d_1.conda
+  sha256: 223c426ba94e58f9e7b283403e4cd8b2388a88104914b4f22129ca2cb643c634
+  md5: b6946e850c2df74a0b0aede30c85fbee
   depends:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/kiwisolver?source=hash-mapping
-  size: 55867
-  timestamp: 1725459681416
-- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.8-py312hc790b64_0.conda
-  sha256: 2cce3d9bcc95c68069e3032cda25b732f69be7b025f94685ee4783d7b54588dd
-  md5: 7ef59428fc0dcb8a78a5e23dc4f50aa3
+  size: 71997
+  timestamp: 1751494127833
+- conda: https://conda.anaconda.org/conda-forge/win-64/kiwisolver-1.4.8-py312hf90b1b7_1.conda
+  sha256: 91e452fca2de7cc94374c99d09e3e984adc48eb90f41f69be0716b20015a55a3
+  md5: c3b0a086ab765183c024e0f4001fd8bc
   depends:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/kiwisolver?source=hash-mapping
-  size: 71318
-  timestamp: 1736908754898
+  size: 72289
+  timestamp: 1751494614759
 - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
   sha256: 99df692f7a8a5c27cd14b5fb1374ee55e756631b9c3d659ed3ee60830249b238
   md5: 3f43953b7d3fb3aaa1d0d0723d91e368
@@ -8999,9 +9053,9 @@ packages:
   purls: []
   size: 510641
   timestamp: 1739161381270
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_4.conda
-  sha256: db73f38155d901a610b2320525b9dd3b31e4949215c870685fd92ea61b5ce472
-  md5: 01f8d123c96816249efd255a31ad7712
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.43-h712a8e2_5.conda
+  sha256: de097284f497b391fe9d000c75b684583c30aad172d9508ed05df23ce39d75cb
+  md5: acd9213a63cb62521290e581ef82de80
   depends:
   - __glibc >=2.17,<3.0.a0
   constrains:
@@ -9009,8 +9063,8 @@ packages:
   license: GPL-3.0-only
   license_family: GPL
   purls: []
-  size: 671240
-  timestamp: 1740155456116
+  size: 670525
+  timestamp: 1749852860076
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
   sha256: 412381a43d5ff9bbed82cd52a0bbca5b90623f62e41007c9c42d3870c60945ff
   md5: 9344155d33912347b37f0ae6c410a835
@@ -9046,21 +9100,23 @@ packages:
   purls: []
   size: 164701
   timestamp: 1745264384716
-- pypi: https://files.pythonhosted.org/packages/23/72/a6feae158a2188f457ca8f50d8d4d29a3affeed763227bd8b1bf2df0ce2c/lib4package-0.3.2-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/66/d7/2344419cb255399ff2253cdb81cb38827867f854f66e98a780478fc13c19/lib4package-0.3.3-py2.py3-none-any.whl
   name: lib4package
-  version: 0.3.2
-  sha256: 6466d7274ab94f0ec7a15aaa5620752ce483b3aff887ec745214f72897ef469e
+  version: 0.3.3
+  sha256: 1a5c371aa0cb3b128b17a5afe1740bb6e8448a86c02b2711fefa2835268e5104
   requires_dist:
   - requests
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/07/4d/4e98d47cbfca9a45e62ff86eab29eff770fd355df9452e48480d89ede7ef/lib4sbom-0.8.4-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/ed/bd/4c87f8f863a09cd8c2126f7c553d08742becbfa7abffe29d3720340e2acd/lib4sbom-0.8.6-py2.py3-none-any.whl
   name: lib4sbom
-  version: 0.8.4
-  sha256: 380d123426348ece43cae8976b49e6ebc4e85bccd6db02dc394a2fa97cf6776c
+  version: 0.8.6
+  sha256: 853a5ea7f789ecd6b47dc7a3c8bb1d588f29592f1ae7de69753b33dba83017a9
   requires_dist:
   - pyyaml>=5.4
   - semantic-version
   - defusedxml
+  - jsonschema
+  - xmlschema
   requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20250127.1-cxx17_hbbce691_0.conda
   sha256: 65d5ca837c3ee67b9d769125c21dc857194d7f6181bb0e7bd98ae58597b457d0
@@ -9106,30 +9162,44 @@ packages:
   purls: []
   size: 1836732
   timestamp: 1742370096247
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
-  sha256: 2ef420a655528bca9d269086cf33b7e90d2f54ad941b437fb1ed5eca87cee017
-  md5: 5e97e271911b8b2001a8b71860c32faa
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libadbc-driver-manager-1.6.0-h84d6215_2.conda
+  sha256: 392e64e11c71ba492e04667853f1e623c3cc047a9fdafeba00002a39a9549efa
+  md5: 3100fb48dfe3fa49c8af832fdca8d69e
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 65638
+  timestamp: 1748476749560
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.4-h3f801dc_0.conda
+  sha256: 410ab78fe89bc869d435de04c9ffa189598ac15bb0fe1ea8ace8fb1b860a2aa3
+  md5: 01ba04e414e47f95c03d6ddd81fd37be
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 35446
-  timestamp: 1711021212685
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
-  sha256: 896189b7b48a194c46a3556ea04943ef81cbe0498521231f8eb25816a68bc8ed
-  md5: 6f0b8e56d2e7bae12a18fc5b2cd9f310
+  size: 36825
+  timestamp: 1749993532943
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.4-h51d1e36_0.conda
+  sha256: 0ea6b73b3fb1511615d9648186a7409e73b7a8d9b3d890d39df797730e3d1dbb
+  md5: 8ed0f86b7a5529b98ec73b43a53ce800
   depends:
-  - libcxx >=16
+  - __osx >=11.0
+  - libcxx >=18
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 28451
-  timestamp: 1711021498493
-- conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
-  sha256: f5c293d3cfc00f71dfdb64bd65ab53625565f8778fc2d5790575bef238976ebf
-  md5: 8723000f6ffdbdaef16025f0a01b64c5
+  size: 30173
+  timestamp: 1749993648288
+- conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.4-h20038f6_0.conda
+  sha256: 0be89085effce9fdcbb6aea7acdb157b18793162f68266ee0a75acf615d4929b
+  md5: 85a2bed45827d77d5b308cb2b165404f
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -9137,8 +9207,8 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls: []
-  size: 32567
-  timestamp: 1711021603471
+  size: 33847
+  timestamp: 1749993666162
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libamd-3.3.3-h456b2da_7100101.conda
   sha256: 5fc32a5497c9919ffde729a604b0acfa97c403ce5b2b27b28ca261cf0c4643aa
   md5: a067596d679bcde85375143e7c374738
@@ -9240,13 +9310,13 @@ packages:
   purls: []
   size: 1098688
   timestamp: 1749386269743
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-20.0.0-h314c690_6_cpu.conda
-  build_number: 6
-  sha256: bff6870341dd9310b6626eb50832e517bd02c3ce295fc9f994b762a29b6e89a4
-  md5: 36f91dcd71682a790981f59b1f25e81a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-20.0.0-h1b9301b_8_cpu.conda
+  build_number: 8
+  sha256: e218ae6165e6243d8850352640cee57f06a8d05743647918a0370cc5fcc8b602
+  md5: 31fc3235e7c84fe61575041cad3756a8
   depends:
   - __glibc >=2.17,<3.0.a0
-  - aws-crt-cpp >=0.32.8,<0.32.9.0a0
+  - aws-crt-cpp >=0.32.10,<0.32.11.0a0
   - aws-sdk-cpp >=1.11.510,<1.11.511.0a0
   - azure-core-cpp >=1.14.0,<1.14.1.0a0
   - azure-identity-cpp >=1.10.0,<1.10.1.0a0
@@ -9273,14 +9343,14 @@ packages:
   - snappy >=1.2.1,<1.3.0a0
   - zstd >=1.5.7,<1.6.0a0
   constrains:
-  - apache-arrow-proc =*=cpu
-  - arrow-cpp <0.0a0
   - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 9205546
-  timestamp: 1748962326597
+  size: 9203820
+  timestamp: 1750865083349
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-17.0.0-h0b4cf59_51_cpu.conda
   build_number: 51
   sha256: a4ce599e5030d53b8701c95be90d256bd8820020b10b46f0a3eddfe9d7d692bd
@@ -9319,12 +9389,12 @@ packages:
   purls: []
   size: 5300906
   timestamp: 1741905858028
-- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-20.0.0-hc090743_6_cpu.conda
-  build_number: 6
-  sha256: 8c8dc1ba377d738c6147503a3b0fce7d41ad5a86614cae5bb1d99db5eb310cc0
-  md5: c621302ce70567aadf11010a409cfb7f
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-20.0.0-h3e40a90_8_cpu.conda
+  build_number: 8
+  sha256: 84d91117892abfdd4ca600139c1ab8b5b6c49fae4c6f76a3cede5673ce016ca0
+  md5: a9e7a615567570b4d6825ed65bf98078
   depends:
-  - aws-crt-cpp >=0.32.8,<0.32.9.0a0
+  - aws-crt-cpp >=0.32.10,<0.32.11.0a0
   - aws-sdk-cpp >=1.11.510,<1.11.511.0a0
   - bzip2 >=1.0.8,<2.0a0
   - libabseil * cxx17*
@@ -9332,7 +9402,7 @@ packages:
   - libbrotlidec >=1.1.0,<1.2.0a0
   - libbrotlienc >=1.1.0,<1.2.0a0
   - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl >=8.14.0,<9.0a0
+  - libcurl >=8.14.1,<9.0a0
   - libgoogle-cloud >=2.36.0,<2.37.0a0
   - libgoogle-cloud-storage >=2.36.0,<2.37.0a0
   - libprotobuf >=5.29.3,<5.29.4.0a0
@@ -9345,31 +9415,31 @@ packages:
   - snappy >=1.2.1,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
-  - vc14_runtime >=14.42.34438
+  - vc14_runtime >=14.44.35208
   - zstd >=1.5.7,<1.6.0a0
   constrains:
-  - arrow-cpp <0.0a0
-  - parquet-cpp <0.0a0
   - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 5392882
-  timestamp: 1748964154335
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-20.0.0-hcb10f89_6_cpu.conda
-  build_number: 6
-  sha256: fbcc2ea6ee31759486a98a4f5d254c63594564ea803663b8f8b8c050531c67ea
-  md5: d30eef9d28672b910decb5c11b00e09e
+  size: 5455325
+  timestamp: 1750866095901
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-20.0.0-hcb10f89_8_cpu.conda
+  build_number: 8
+  sha256: 7be0682610864ec3866214b935c9bf8adeda2615e9a663e3bf4fe57ef203fa2d
+  md5: a9d337e1f407c5d92e609cb39c803343
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libarrow 20.0.0 h314c690_6_cpu
+  - libarrow 20.0.0 h1b9301b_8_cpu
   - libgcc >=13
   - libstdcxx >=13
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 641644
-  timestamp: 1748962396834
+  size: 642522
+  timestamp: 1750865165581
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-17.0.0-hf07054f_51_cpu.conda
   build_number: 51
   sha256: c7073fb720d214d21da3ff80ba73e6cd8503bff91086af7ff24a6d472566d756
@@ -9383,36 +9453,36 @@ packages:
   purls: []
   size: 483156
   timestamp: 1741906000402
-- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-20.0.0-h7d8d6a5_6_cpu.conda
-  build_number: 6
-  sha256: 5c671c6776044004bff4331a4a12c00343a6637e15a4300668c20934d82db812
-  md5: 0fb7a551ae206cd53e57df9f04a70562
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-20.0.0-h7d8d6a5_8_cpu.conda
+  build_number: 8
+  sha256: 09645cf16bb9953638e50d73b1111b41fdff3d56195109a17615cd4da2d17744
+  md5: 25734d200245f53c264c86f28fbb66cd
   depends:
-  - libarrow 20.0.0 hc090743_6_cpu
+  - libarrow 20.0.0 h3e40a90_8_cpu
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
-  - vc14_runtime >=14.42.34438
+  - vc14_runtime >=14.44.35208
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 461163
-  timestamp: 1748964266720
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-20.0.0-hcb10f89_6_cpu.conda
-  build_number: 6
-  sha256: 4c150bd27e743d72277cc3756e15767eac87c9095882113dd9b8f2e838cd2e57
-  md5: 528a0f333effc7e8b1ef1c40c6437bae
+  size: 461444
+  timestamp: 1750866232724
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-20.0.0-hcb10f89_8_cpu.conda
+  build_number: 8
+  sha256: 23f6a1dc75e8d12478aa683640169ac14baaeb086d1f0ed5bfe96a562a3c5bab
+  md5: 14bb8eeeff090f873056fa629d2d82b5
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libarrow 20.0.0 h314c690_6_cpu
-  - libarrow-acero 20.0.0 hcb10f89_6_cpu
+  - libarrow 20.0.0 h1b9301b_8_cpu
+  - libarrow-acero 20.0.0 hcb10f89_8_cpu
   - libgcc >=13
-  - libparquet 20.0.0 h081d1f1_6_cpu
+  - libparquet 20.0.0 h081d1f1_8_cpu
   - libstdcxx >=13
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 607827
-  timestamp: 1748962516941
+  size: 607588
+  timestamp: 1750865314449
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-17.0.0-hf07054f_51_cpu.conda
   build_number: 51
   sha256: 951a6981fcda7b47f8bd5a172bfb244b0f337f078f2c342e5aa5e5fc905c6af6
@@ -9428,41 +9498,41 @@ packages:
   purls: []
   size: 489633
   timestamp: 1741907326254
-- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-20.0.0-h7d8d6a5_6_cpu.conda
-  build_number: 6
-  sha256: 5607e011fa3f7c4e7ed9bd5c34ac71032aa908c169a0e8340e1690e9b4321338
-  md5: 8cbd3168733367acb7f72aad1794231a
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-20.0.0-h7d8d6a5_8_cpu.conda
+  build_number: 8
+  sha256: 262f7b267cabffb89991e1a0a753801f3edb61614e9ce83ef7b503824a7e68c0
+  md5: 3b8393cfa51bcef40ec5c9a3a92639c6
   depends:
-  - libarrow 20.0.0 hc090743_6_cpu
-  - libarrow-acero 20.0.0 h7d8d6a5_6_cpu
-  - libparquet 20.0.0 ha850022_6_cpu
+  - libarrow 20.0.0 h3e40a90_8_cpu
+  - libarrow-acero 20.0.0 h7d8d6a5_8_cpu
+  - libparquet 20.0.0 ha850022_8_cpu
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
-  - vc14_runtime >=14.42.34438
+  - vc14_runtime >=14.44.35208
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 440842
-  timestamp: 1748964476197
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-20.0.0-h1bed206_6_cpu.conda
-  build_number: 6
-  sha256: 774ee81de16c82a98268e5504982dc4f3a575add266ce5bbace326cd019418bc
-  md5: b051b8e680398c103567e331ce3a339c
+  size: 441111
+  timestamp: 1750866456893
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-20.0.0-h1bed206_8_cpu.conda
+  build_number: 8
+  sha256: 04f214b1f6d5b35fa89a17cce43f5c321167038d409d1775d7457015c6a26cba
+  md5: 8a98f2bf0cf61725f8842ec45dbd7986
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil * cxx17*
   - libabseil >=20250127.1,<20250128.0a0
-  - libarrow 20.0.0 h314c690_6_cpu
-  - libarrow-acero 20.0.0 hcb10f89_6_cpu
-  - libarrow-dataset 20.0.0 hcb10f89_6_cpu
+  - libarrow 20.0.0 h1b9301b_8_cpu
+  - libarrow-acero 20.0.0 hcb10f89_8_cpu
+  - libarrow-dataset 20.0.0 hcb10f89_8_cpu
   - libgcc >=13
   - libprotobuf >=5.29.3,<5.29.4.0a0
   - libstdcxx >=13
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 523328
-  timestamp: 1748962594816
+  size: 525599
+  timestamp: 1750865405214
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-17.0.0-h4239455_51_cpu.conda
   build_number: 51
   sha256: 7e471500fc7591654a003fcbf6351f6c64ea0376dd34e170a3a7b7d1d07f2498
@@ -9481,25 +9551,25 @@ packages:
   purls: []
   size: 450992
   timestamp: 1741907553928
-- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-20.0.0-hb76e781_6_cpu.conda
-  build_number: 6
-  sha256: 343ca7c05d1ba39e0c280cb4b3e2aac3394bceedf52672ffffdbff43611f559a
-  md5: 1d3511f1adf9a7221818ec1e190a68fd
+- conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-20.0.0-hb76e781_8_cpu.conda
+  build_number: 8
+  sha256: 214bd90128a0613fad2ca8d7e2cc6f0de3dcd2bbf1ee8cbd781ea8efdd263f45
+  md5: fd8326ff2331b30706a222e25434fa76
   depends:
   - libabseil * cxx17*
   - libabseil >=20250127.1,<20250128.0a0
-  - libarrow 20.0.0 hc090743_6_cpu
-  - libarrow-acero 20.0.0 h7d8d6a5_6_cpu
-  - libarrow-dataset 20.0.0 h7d8d6a5_6_cpu
+  - libarrow 20.0.0 h3e40a90_8_cpu
+  - libarrow-acero 20.0.0 h7d8d6a5_8_cpu
+  - libarrow-dataset 20.0.0 h7d8d6a5_8_cpu
   - libprotobuf >=5.29.3,<5.29.4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
-  - vc14_runtime >=14.42.34438
+  - vc14_runtime >=14.44.35208
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 367092
-  timestamp: 1748964612702
+  size: 367807
+  timestamp: 1750866609263
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.24.1-h8e693c7_0.conda
   sha256: e30733a729eb6efd9cb316db0202897c882d46f6c20a0e647b4de8ec921b7218
   md5: 57566a81dd1e5aa3d98ac7582e8bfe03
@@ -9511,16 +9581,16 @@ packages:
   purls: []
   size: 53115
   timestamp: 1746228856865
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.24.1-h493aca8_0.conda
-  sha256: 54293ab2ce43085ac424dc62804fd4d7ec62cce404a77f0c99a9a48857bca0a9
-  md5: b5a77d2b7c2013b3b1ffce193764302f
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.24.2-h493aca8_0.conda
+  sha256: 9f6f30978a900b956ef17bf12996a75107f97fda36a725a76e13f030dc723b48
+  md5: 5069fbe41758a0abf40b2464c9757ca7
   depends:
   - __osx >=11.0
   - libcxx >=18
   license: LGPL-2.1-or-later
   purls: []
-  size: 52180
-  timestamp: 1746229244376
+  size: 52013
+  timestamp: 1751465360319
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.24.1-h8e693c7_0.conda
   sha256: ccbfc465456133042eea3e8d69bae009893f57a47a786f772c0af382bda7ad99
   md5: 8f66ed2e34507b7ae44afa31c3e4ec79
@@ -9546,58 +9616,58 @@ packages:
   purls: []
   size: 111817
   timestamp: 1746836468929
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-31_h59b9bed_openblas.conda
-  build_number: 31
-  sha256: 9839fc4ac0cbb0aa3b9eea520adfb57311838959222654804e58f6f2d1771db5
-  md5: 728dbebd0f7a20337218beacffd37916
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-32_h59b9bed_openblas.conda
+  build_number: 32
+  sha256: 1540bf739feb446ff71163923e7f044e867d163c50b605c8b421c55ff39aa338
+  md5: 2af9f3d5c2e39f417ce040f5a35c40c6
   depends:
-  - libopenblas >=0.3.29,<0.3.30.0a0
-  - libopenblas >=0.3.29,<1.0a0
+  - libopenblas >=0.3.30,<0.3.31.0a0
+  - libopenblas >=0.3.30,<1.0a0
   constrains:
-  - liblapacke =3.9.0=31*_openblas
-  - liblapack =3.9.0=31*_openblas
-  - blas =2.131=openblas
+  - libcblas   3.9.0   32*_openblas
   - mkl <2025
-  - libcblas =3.9.0=31*_openblas
+  - liblapacke 3.9.0   32*_openblas
+  - blas 2.132   openblas
+  - liblapack  3.9.0   32*_openblas
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 16859
-  timestamp: 1740087969120
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-31_h10e41b3_openblas.conda
-  build_number: 31
-  sha256: 369586e7688b59b4f92c709b99d847d66d4d095425db327dd32ee5e6ab74697f
-  md5: 39b053da5e7035c6592102280aa7612a
+  size: 17330
+  timestamp: 1750388798074
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-32_h10e41b3_openblas.conda
+  build_number: 32
+  sha256: 2775472dd81d43dc20804b484028560bfecd5ab4779e39f1fb95684da3ff2029
+  md5: d4a1732d2b330c9d5d4be16438a0ac78
   depends:
-  - libopenblas >=0.3.29,<0.3.30.0a0
-  - libopenblas >=0.3.29,<1.0a0
+  - libopenblas >=0.3.30,<0.3.31.0a0
+  - libopenblas >=0.3.30,<1.0a0
   constrains:
-  - liblapacke =3.9.0=31*_openblas
-  - libcblas =3.9.0=31*_openblas
-  - blas =2.131=openblas
+  - blas 2.132   openblas
+  - liblapack  3.9.0   32*_openblas
   - mkl <2025
-  - liblapack =3.9.0=31*_openblas
+  - libcblas   3.9.0   32*_openblas
+  - liblapacke 3.9.0   32*_openblas
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 17123
-  timestamp: 1740088119350
-- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-31_h641d27c_mkl.conda
-  build_number: 31
-  sha256: 7bb4d5b591e98fe607279520ee78e3571a297b5720aa789a2536041ad5540de8
-  md5: d05563c577fe2f37693a554b3f271e8f
+  size: 17520
+  timestamp: 1750388963178
+- conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-32_h641d27c_mkl.conda
+  build_number: 32
+  sha256: 809d78b096e70fed7ebb17c867dd5dde2f9f4ed8564967a6e10c65b3513b0c31
+  md5: 49b36a01450e96c516bbc5486d4a0ea0
   depends:
   - mkl 2024.2.2 h66d3029_15
   constrains:
-  - libcblas =3.9.0=31*_mkl
-  - blas =2.131=mkl
-  - liblapacke =3.9.0=31*_mkl
-  - liblapack =3.9.0=31*_mkl
+  - libcblas   3.9.0   32*_mkl
+  - liblapack  3.9.0   32*_mkl
+  - liblapacke 3.9.0   32*_mkl
+  - blas 2.132   mkl
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 3733728
-  timestamp: 1740088452830
+  size: 3735390
+  timestamp: 1750389080409
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_3.conda
   sha256: 462a8ed6a7bb9c5af829ec4b90aab322f8bcd9d8987f793e6986ea873bbd05cf
   md5: cb98af5db26e3f482bebb80ce9d947d3
@@ -9790,51 +9860,51 @@ packages:
   purls: []
   size: 120375
   timestamp: 1741176638215
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-31_he106b2a_openblas.conda
-  build_number: 31
-  sha256: ede8545011f5b208b151fe3e883eb4e31d495ab925ab7b9ce394edca846e0c0d
-  md5: abb32c727da370c481a1c206f5159ce9
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-32_he106b2a_openblas.conda
+  build_number: 32
+  sha256: 92a001fc181e6abe4f4a672b81d9413ca2f22609f8a95327dfcc6eee593ffeb9
+  md5: 3d3f9355e52f269cd8bc2c440d8a5263
   depends:
-  - libblas 3.9.0 31_h59b9bed_openblas
+  - libblas 3.9.0 32_h59b9bed_openblas
   constrains:
-  - liblapacke =3.9.0=31*_openblas
-  - liblapack =3.9.0=31*_openblas
-  - blas =2.131=openblas
+  - blas 2.132   openblas
+  - liblapack  3.9.0   32*_openblas
+  - liblapacke 3.9.0   32*_openblas
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 16796
-  timestamp: 1740087984429
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-31_hb3479ef_openblas.conda
-  build_number: 31
-  sha256: f237486cc9118d09d0f3ff8820280de34365f98ee7b7dc5ab923b04c7cbf25a5
-  md5: 7353c2bf0e90834cb70545671996d871
+  size: 17308
+  timestamp: 1750388809353
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-32_hb3479ef_openblas.conda
+  build_number: 32
+  sha256: 25d46ace14c3ac45d4aa18b5f7a0d3d30cec422297e900f8b97a66334232061c
+  md5: d8e8ba717ae863b13a7495221f2b5a71
   depends:
-  - libblas 3.9.0 31_h10e41b3_openblas
+  - libblas 3.9.0 32_h10e41b3_openblas
   constrains:
-  - liblapacke =3.9.0=31*_openblas
-  - blas =2.131=openblas
-  - liblapack =3.9.0=31*_openblas
+  - blas 2.132   openblas
+  - liblapack  3.9.0   32*_openblas
+  - liblapacke 3.9.0   32*_openblas
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 17032
-  timestamp: 1740088127097
-- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-31_h5e41251_mkl.conda
-  build_number: 31
-  sha256: 609f455b099919bd4d15d4a733f493dc789e02da73fe4474f1cca73afafb95b8
-  md5: 43c100b94ad2607382b0cf0f3a6b0bf3
+  size: 17485
+  timestamp: 1750388970626
+- conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-32_h5e41251_mkl.conda
+  build_number: 32
+  sha256: d0f81145ae795592f3f3b5d7ff641c1019a99d6b308bfaf2a4cc5ba24b067bb0
+  md5: 054b9b4b48296e4413cf93e6ece7b27d
   depends:
-  - libblas 3.9.0 31_h641d27c_mkl
+  - libblas 3.9.0 32_h641d27c_mkl
   constrains:
-  - blas =2.131=mkl
-  - liblapacke =3.9.0=31*_mkl
-  - liblapack =3.9.0=31*_mkl
+  - liblapack  3.9.0   32*_mkl
+  - liblapacke 3.9.0   32*_mkl
+  - blas 2.132   mkl
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 3733549
-  timestamp: 1740088502127
+  size: 3735392
+  timestamp: 1750389122586
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libccolamd-3.3.4-hf02c80a_7100101.conda
   sha256: cc90aa5e0ad1f7ae9a29d9a42aacd7f7f02aba0bf5467513bfda7e6b18a4cbc8
   md5: e5107e02dc4c2f9f41eef72d72c23517
@@ -9945,47 +10015,47 @@ packages:
   purls: []
   size: 12785300
   timestamp: 1738083576490
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.6-default_h1df26ce_0.conda
-  sha256: c2194ccfd8e6ef422a7fcf21b9b72efd8859f84d3792f54ff6be87574751b913
-  md5: 99ead3b974685e44df8b1e3953503cfc
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp20.1-20.1.7-default_h1df26ce_0.conda
+  sha256: 4194c75a91a9c790cbe96c3c33fc2f388274d1be85ec884ce7c88d7e8f9d96f2
+  md5: f9ef7bce54a7673cdbc2fadd8bca1956
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libllvm20 >=20.1.6,<20.2.0a0
+  - libllvm20 >=20.1.7,<20.2.0a0
   - libstdcxx >=13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 20859825
-  timestamp: 1748541570131
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-20.1.6-default_he06ed0a_0.conda
-  sha256: 5d40dc0cf929532ba4337bf1c7dbe1abb5f7c19ceb76397406006e9946a73fd4
-  md5: cc6c469d9d7fc0ac106cef5f45d973a9
+  size: 20925717
+  timestamp: 1749876303353
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-20.1.7-default_he06ed0a_0.conda
+  sha256: 6541d19a1659062dbf8823d6a1206e28f788369bcf7af9171d7c9069c1d35932
+  md5: 846875a174de6b6ff19e205a7d90eb74
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libllvm20 >=20.1.6,<20.2.0a0
+  - libllvm20 >=20.1.7,<20.2.0a0
   - libstdcxx >=13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 12111337
-  timestamp: 1748541871797
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-20.1.6-default_hee4fbb3_0.conda
-  sha256: f45bd3e794b0a1707f3b6a0544f5d0af457770399795cb5e3539d1be36a0b68d
-  md5: 15ea5ee1f9e7a30adc425ebeb3ed8a25
+  size: 12116245
+  timestamp: 1749876520951
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-20.1.7-default_hee4fbb3_0.conda
+  sha256: f783b27bd7afbc140b67b02f45c0ce7c61f57f5f30a46b9bae0c1751af1991de
+  md5: 202c01a92d050e5d22b4010ea8e7c1d7
   depends:
   - __osx >=11.0
-  - libcxx >=20.1.6
-  - libllvm20 >=20.1.6,<20.2.0a0
+  - libcxx >=20.1.7
+  - libllvm20 >=20.1.7,<20.2.0a0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 8435223
-  timestamp: 1748534559012
-- conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-20.1.6-default_h6e92b77_0.conda
-  sha256: 6ac6dc226a2fe5af61730224d89cd32f88123623bf35995a2c42d53a077e0427
-  md5: 3920536319b052a9a49639e02fda2db7
+  size: 8437862
+  timestamp: 1749873096061
+- conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-20.1.7-default_h6e92b77_0.conda
+  sha256: 41e4efe4300b429e0d05b98f3b31147311790b929d4aabdc1e64589c09342a69
+  md5: 173d6b2a9225623e20edab8921815314
   depends:
   - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
@@ -9995,8 +10065,8 @@ packages:
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 28337445
-  timestamp: 1748541917495
+  size: 28343316
+  timestamp: 1749881763774
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcolamd-3.3.4-hf02c80a_7100101.conda
   sha256: 00d1b976b914f0c20ae6f81f4e4713fa87717542eba8757b9a3c9e8abcc29858
   md5: 56d4c5542887e8955f21f8546ad75d9d
@@ -10068,19 +10138,20 @@ packages:
   purls: []
   size: 25694
   timestamp: 1633684287072
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
-  sha256: bc67b9b21078c99c6bd8595fe7e1ed6da1f721007726e717f0449de7032798c4
-  md5: d4529f4dff3057982a7617c7ac58fde3
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-hb8b1518_5.conda
+  sha256: cb83980c57e311783ee831832eb2c20ecb41e7dee6e86e8b70b8cef0e43eab55
+  md5: d4a250da4737ee127fb1fa6452a9002e
   depends:
-  - krb5 >=1.21.1,<1.22.0a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - libzlib >=1.3.1,<2.0a0
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 4519402
-  timestamp: 1689195353551
+  size: 4523621
+  timestamp: 1749905341688
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.14.1-h332b0f4_0.conda
   sha256: b6c5cf340a4f80d70d64b3a29a7d9885a5918d16a5cb952022820e6d3e79dc8b
   md5: 45f6713cb00f124af300342512219182
@@ -10167,16 +10238,16 @@ packages:
   purls: []
   size: 70656
   timestamp: 1742288893863
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-20.1.6-ha82da77_0.conda
-  sha256: b74ec832ec05571f8747c9bd5f96b93d76489909b4f6f37d99d576dc955f21e9
-  md5: 95c1830841844ef54e07efed1654b47f
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-20.1.7-ha82da77_0.conda
+  sha256: a3fd34773f1252a4f089e74a075ff5f0f6b878aede097e83a405f35687c36f24
+  md5: 881de227abdddbe596239fa9e82eb3ab
   depends:
   - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 567539
-  timestamp: 1748495055530
+  size: 567189
+  timestamp: 1749847129529
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libde265-1.0.15-h2ffa867_0.conda
   sha256: 13747fa634f7f16d7f222b7d3869e3c1aab9d3a2791edeb2fc632a87663950e0
   md5: 7c718ee6d8497702145612fa0898a12d
@@ -10220,9 +10291,9 @@ packages:
   purls: []
   size: 156292
   timestamp: 1747040812624
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.124-hb9d3cd8_0.conda
-  sha256: f0d5ffbdf3903a7840184d14c14154b503e1a96767c328f61d99ad24b6963e52
-  md5: 8bc89311041d7fcb510238cf0848ccae
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb9d3cd8_0.conda
+  sha256: f53458db897b93b4a81a6dbfd7915ed8fa4a54951f97c698dde6faa028aadfd2
+  md5: 4c0ab57463117fbb8df85268415082f5
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -10230,8 +10301,8 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 242533
-  timestamp: 1733424409299
+  size: 246161
+  timestamp: 1749904704373
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
   sha256: d789471216e7aba3c184cd054ed61ce3f6dac6f87a50ec69291b9297f8c18724
   md5: c277e0a4d549b03ac1e9d6cbbe3d017b
@@ -10358,29 +10429,29 @@ packages:
   purls: []
   size: 140896
   timestamp: 1743432122520
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.1.0-ha770c72_1.conda
-  sha256: d07cdd0613bae31ec30410a419078cd8ba60be4727563f863cc39e7cd81620c8
-  md5: a3419b2895a32e0748a254be58efb7a8
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric-2.2.0-ha770c72_0.conda
+  sha256: c5c1ba63ebfb938b0c0e626fa8e0378aec5dfcfed45f94cb579b4c14b3bb05d0
+  md5: 4ca41e052fa65c946a5205f0d8c95c9a
   depends:
-  - libfabric1 2.1.0 hf45584d_1
+  - libfabric1 2.2.0 hf45584d_0
   license: BSD-2-Clause OR GPL-2.0-only
   license_family: BSD
   purls: []
-  size: 14083
-  timestamp: 1745592773785
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.1.0-hce30654_1.conda
-  sha256: fa960d18dc106067b67b4cea52a43841ee1fde349faf3c7115ed1e0d8641d537
-  md5: 8c66e8467206187201628cc7ef4264e3
+  size: 14073
+  timestamp: 1751278347690
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric-2.2.0-hce30654_0.conda
+  sha256: 4794160d94dc1aac6946f65d887fe187efad0f880ca7e7a890048bb16e5a3fe9
+  md5: a7b9ab9125299c08dc9561b9e551d058
   depends:
-  - libfabric1 2.1.0 h5505292_1
+  - libfabric1 2.2.0 h5505292_0
   license: BSD-2-Clause OR GPL-2.0-only
   license_family: BSD
   purls: []
-  size: 14181
-  timestamp: 1745592890895
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.1.0-hf45584d_1.conda
-  sha256: 58e16e12e254454582044ca3109afad814fc6419ed4475a2bb5244fffd4728c2
-  md5: 8530ead81bc02442ce5fe2c07deb85ea
+  size: 14175
+  timestamp: 1751278650863
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfabric1-2.2.0-hf45584d_0.conda
+  sha256: 64734fad375212f3310d037a455d7bf75aad081fe10e60cfa61cdbfa20a348c4
+  md5: 75da439aaa61fff0dccf38362dcf0097
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -10389,18 +10460,18 @@ packages:
   license: BSD-2-Clause OR GPL-2.0-only
   license_family: BSD
   purls: []
-  size: 673866
-  timestamp: 1745592772949
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.1.0-h5505292_1.conda
-  sha256: b84755a4a6e82bbc81207e9023e23304aa9f05f177b8e6f0fff5fd97e2919f61
-  md5: 7884e705e35375739ee5afc97a8fd793
+  size: 678202
+  timestamp: 1751278347006
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libfabric1-2.2.0-h5505292_0.conda
+  sha256: 56b1ee3643eff9a73acf0053955edf93db240cec93102d7537b475d9de82aaba
+  md5: e290471d23f56b5fffcee2244fcac2da
   depends:
   - __osx >=11.0
   license: BSD-2-Clause OR GPL-2.0-only
   license_family: BSD
   purls: []
-  size: 325469
-  timestamp: 1745592889193
+  size: 330314
+  timestamp: 1751278648826
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.6-h2dba641_1.conda
   sha256: 764432d32db45466e87f10621db5b74363a9f847d2b8b1f9743746cd160f06ab
   md5: ede4673863426c0883c0063d853bbd85
@@ -10517,55 +10588,55 @@ packages:
   purls: []
   size: 337007
   timestamp: 1745370226578
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_2.conda
-  sha256: 0024f9ab34c09629621aefd8603ef77bf9d708129b0dd79029e502c39ffc2195
-  md5: ea8ac52380885ed41c1baa8f1d6d2b93
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.1.0-h767d61c_3.conda
+  sha256: 59a87161212abe8acc57d318b0cc8636eb834cdfdfddcf1f588b5493644b39a3
+  md5: 9e60c55e725c20d23125a5f0dd69af5d
   depends:
   - __glibc >=2.17,<3.0.a0
   - _openmp_mutex >=4.5
   constrains:
-  - libgcc-ng ==15.1.0=*_2
-  - libgomp 15.1.0 h767d61c_2
+  - libgcc-ng ==15.1.0=*_3
+  - libgomp 15.1.0 h767d61c_3
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 829108
-  timestamp: 1746642191935
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-15.1.0-h1383e82_2.conda
-  sha256: c0288596ac58366d96a56c57e4088fe1c6dd4194fdcaeacf5862f47fb1e1e5be
-  md5: 9bedb24480136bfeb81ebc81d4285e70
+  size: 824921
+  timestamp: 1750808216066
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgcc-15.1.0-h1383e82_3.conda
+  sha256: 05978c4e8c826dd3b727884e009a19ceee75b0a530c18fc14f0ba56b090f2ea3
+  md5: d8314be93c803e2e2b430f6389d6ce6a
   depends:
   - _openmp_mutex >=4.5
   - libwinpthread >=12.0.0.r4.gg4f2fc60ca
   constrains:
+  - libgomp 15.1.0 h1383e82_3
   - msys2-conda-epoch <0.0a0
-  - libgcc-ng ==15.1.0=*_2
-  - libgomp 15.1.0 h1383e82_2
+  - libgcc-ng ==15.1.0=*_3
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 673459
-  timestamp: 1746656621653
-- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.1.0-h4c094af_102.conda
-  sha256: f379980c3d48ceabf8ade0ebc5bdb4acd41e4b1c89023b673deb212e51b7a7f6
-  md5: c49792270935d4024aef12f8e49f0f9c
+  size: 669602
+  timestamp: 1750808309041
+- conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-64-15.1.0-h4c094af_103.conda
+  sha256: 770a59a79f83dbd8ada4565b08633b429c0c54040b2b1f78c4db4648c7c7a805
+  md5: ea67e87d658d31dc33818f9574563269
   depends:
   - __unix
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 2733483
-  timestamp: 1746642098272
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_2.conda
-  sha256: 0ab5421a89f090f3aa33841036bb3af4ed85e1f91315b528a9d75fab9aad51ae
-  md5: ddca86c7040dd0e73b2b69bd7833d225
+  size: 2728790
+  timestamp: 1750808123770
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.1.0-h69a702a_3.conda
+  sha256: b0b0a5ee6ce645a09578fc1cb70c180723346f8a45fdb6d23b3520591c6d6996
+  md5: e66f2b8ad787e7beb0f846e4bd7e8493
   depends:
-  - libgcc 15.1.0 h767d61c_2
+  - libgcc 15.1.0 h767d61c_3
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 34586
-  timestamp: 1746642200749
+  size: 29033
+  timestamp: 1750808224854
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-lib-1.11.1-hb9d3cd8_0.conda
   sha256: dc9c7d7a6c0e6639deee6fde2efdc7e119e7739a6b229fa5f9049a449bae6109
   md5: 8504a291085c9fb809b66cabd5834307
@@ -10577,28 +10648,29 @@ packages:
   purls: []
   size: 590353
   timestamp: 1747060639058
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.10.3-h3b705f5_11.conda
-  sha256: 32428a45115d5e29e2ff8823d90aef3176d8e0ff3b6520511ef915847e8c2004
-  md5: 786a7e6468df9604d008e9fab44fdfd2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.11.1-h3b705f5_0.conda
+  sha256: 07924b4805214fa634ce8512102d4814a85ea02d2af52406630524cd292f97d0
+  md5: f435fcf9464cb788600f2c9fea11e23a
   depends:
-  - libgdal-core 3.10.3.*
-  - libgdal-fits 3.10.3.*
-  - libgdal-grib 3.10.3.*
-  - libgdal-hdf4 3.10.3.*
-  - libgdal-hdf5 3.10.3.*
-  - libgdal-jp2openjpeg 3.10.3.*
-  - libgdal-kea 3.10.3.*
-  - libgdal-netcdf 3.10.3.*
-  - libgdal-pdf 3.10.3.*
-  - libgdal-pg 3.10.3.*
-  - libgdal-postgisraster 3.10.3.*
-  - libgdal-tiledb 3.10.3.*
-  - libgdal-xls 3.10.3.*
+  - libgdal-adbc 3.11.1.*
+  - libgdal-core 3.11.1.*
+  - libgdal-fits 3.11.1.*
+  - libgdal-grib 3.11.1.*
+  - libgdal-hdf4 3.11.1.*
+  - libgdal-hdf5 3.11.1.*
+  - libgdal-jp2openjpeg 3.11.1.*
+  - libgdal-kea 3.11.1.*
+  - libgdal-netcdf 3.11.1.*
+  - libgdal-pdf 3.11.1.*
+  - libgdal-pg 3.11.1.*
+  - libgdal-postgisraster 3.11.1.*
+  - libgdal-tiledb 3.11.1.*
+  - libgdal-xls 3.11.1.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 425518
-  timestamp: 1749424649290
+  size: 426543
+  timestamp: 1751397232842
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-3.10.2-h828714d_5.conda
   sha256: 1a066b8e0c5bf6dd90f75430bd9fa084ee135f71fd8369da8d3d577124c41205
   md5: 7ab5b0e171d177c92823f39345070d2b
@@ -10621,44 +10693,58 @@ packages:
   purls: []
   size: 424127
   timestamp: 1742980898590
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.10.3-hafd5c6c_11.conda
-  sha256: df625982da9b841825da61cc0f6534eea6e155f274fa2a16fd0b6d9d64f0b07e
-  md5: 7a4d125db53cb70b5cfd68016284464a
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.11.1-hafd5c6c_0.conda
+  sha256: b37b8cc4c307bdfc6857c1858551d50b766a0498f77d7dfa24cd7c691f5b9764
+  md5: 3acf4f4506b279ac4efc4598390618e5
   depends:
-  - libgdal-core 3.10.3.*
-  - libgdal-fits 3.10.3.*
-  - libgdal-grib 3.10.3.*
-  - libgdal-hdf4 3.10.3.*
-  - libgdal-hdf5 3.10.3.*
-  - libgdal-jp2openjpeg 3.10.3.*
-  - libgdal-kea 3.10.3.*
-  - libgdal-netcdf 3.10.3.*
-  - libgdal-pdf 3.10.3.*
-  - libgdal-pg 3.10.3.*
-  - libgdal-postgisraster 3.10.3.*
-  - libgdal-tiledb 3.10.3.*
-  - libgdal-xls 3.10.3.*
+  - libgdal-core 3.11.1.*
+  - libgdal-fits 3.11.1.*
+  - libgdal-grib 3.11.1.*
+  - libgdal-hdf4 3.11.1.*
+  - libgdal-hdf5 3.11.1.*
+  - libgdal-jp2openjpeg 3.11.1.*
+  - libgdal-kea 3.11.1.*
+  - libgdal-netcdf 3.11.1.*
+  - libgdal-pdf 3.11.1.*
+  - libgdal-pg 3.11.1.*
+  - libgdal-postgisraster 3.11.1.*
+  - libgdal-tiledb 3.11.1.*
+  - libgdal-xls 3.11.1.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 425598
-  timestamp: 1749431093403
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-arrow-parquet-3.10.3-h8169c6c_11.conda
-  sha256: e1f746dbff5567c7839a114380001d81efca881d515d8fca3ba0027f44f78015
-  md5: fb916ed13e7d59682ccbfbe6768d78e9
+  size: 427361
+  timestamp: 1751401228152
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-adbc-3.11.1-ha4d2dc7_0.conda
+  sha256: 58e2b1f92be9fbbc333fa275e00fb10300d5917630a16b84036a867d51abdd0d
+  md5: 33a1a996aa5fe9b9aa74c6caabe62868
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libadbc-driver-manager >=1.6.0,<1.7.0a0
+  - libgcc >=13
+  - libgdal-core 3.11.1 h5e6393a_0
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 478711
+  timestamp: 1751395984839
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-arrow-parquet-3.11.1-h8169c6c_0.conda
+  sha256: 1deb9eabf4aa9fb512f088f31056e9a0c7de4123c0036fab0c8f2915e1323607
+  md5: 241a27b325013d32eeca38f45608d2f8
   depends:
   - __glibc >=2.17,<3.0.a0
   - libarrow >=20.0.0,<20.1.0a0
   - libarrow-dataset >=20.0.0,<20.1.0a0
   - libgcc >=13
-  - libgdal-core 3.10.3 hcac4edf_11
+  - libgdal-core 3.11.1 h5e6393a_0
   - libparquet >=20.0.0,<20.1.0a0
   - libstdcxx >=13
   license: MIT
   license_family: MIT
   purls: []
-  size: 827402
-  timestamp: 1749423760182
+  size: 830901
+  timestamp: 1751396338617
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-arrow-parquet-3.10.2-h1cd521e_0.conda
   sha256: f5bba68fb67d4d399633ddbecd528b6dd5db9d3900f597f4cf7fafd57b4e1a70
   md5: ead5892c0e21c46c8c5fd8653cd4f01a
@@ -10676,30 +10762,29 @@ packages:
   purls: []
   size: 730477
   timestamp: 1739627718861
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-arrow-parquet-3.10.3-h24452f8_11.conda
-  sha256: 62414cc47afa7dd91804b4b44f9fc0b40526c5819ac801d3e7cbb62b03ccec25
-  md5: 74f448ffeddec0ecc768b2de3fd224ca
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-arrow-parquet-3.11.1-h2345e04_0.conda
+  sha256: d1e1c6e4988085d88314884eeca42123401c59e9d3fe7f61982d903592940fa5
+  md5: 175492d4969e74b3bed279cbc39e821b
   depends:
   - libarrow >=20.0.0,<20.1.0a0
   - libarrow-dataset >=20.0.0,<20.1.0a0
-  - libgdal-core 3.10.3 h7d16cc0_11
+  - libgdal-core 3.11.1 hddc0a0b_0
   - libparquet >=20.0.0,<20.1.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
   purls: []
-  size: 738014
-  timestamp: 1749427486764
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.10.3-hcac4edf_11.conda
-  sha256: df4173e4a0a07e582056bf3bedef37e8a265f2e7307ee770568955de49f8d477
-  md5: 06b6788794c786c9944e0ebfc3762da7
+  size: 744121
+  timestamp: 1751398710646
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.11.1-h5e6393a_0.conda
+  sha256: a28d3ee16e652144234785e4c5e8a83f9624f6d96246fe2ed6a34490d845146f
+  md5: 87682ef87cb7f0e02f759eec2cd50150
   depends:
   - __glibc >=2.17,<3.0.a0
   - blosc >=1.21.6,<2.0a0
   - geos >=3.13.1,<3.13.2.0a0
-  - geotiff >=1.7.4,<1.8.0a0
   - giflib >=5.2.2,<5.3.0a0
   - json-c >=0.18,<0.19.0a0
   - lerc >=4.0.0,<5.0a0
@@ -10710,29 +10795,30 @@ packages:
   - libgcc >=13
   - libiconv >=1.18,<2.0a0
   - libjpeg-turbo >=3.1.0,<4.0a0
+  - libjxl >=0.11,<0.12.0a0
   - libkml >=1.3.0,<1.4.0a0
   - liblzma >=5.8.1,<6.0a0
-  - libpng >=1.6.47,<1.7.0a0
+  - libpng >=1.6.49,<1.7.0a0
   - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.50.1,<4.0a0
+  - libsqlite >=3.50.2,<4.0a0
   - libstdcxx >=13
-  - libtiff >=4.7.0,<4.8.0a0
   - libwebp-base >=1.5.0,<2.0a0
   - libxml2 >=2.13.8,<2.14.0a0
   - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.10.0,<1.11.0a0
-  - openssl >=3.5.0,<4.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - openssl >=3.5.1,<4.0a0
   - pcre2 >=10.45,<10.46.0a0
   - proj >=9.6.2,<9.7.0a0
   - xerces-c >=3.2.5,<3.3.0a0
   - zstd >=1.5.7,<1.6.0a0
   constrains:
-  - libgdal 3.10.3.*
+  - libgdal 3.11.1.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 10818698
-  timestamp: 1749422719368
+  size: 11879410
+  timestamp: 1751395444211
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.10.2-h9ef0d2d_0.conda
   sha256: bb72a3c879eddcb0e7e01e662245ec3f9fe07c53cf287217a200e52a39115014
   md5: 5982d6c652d39c9cef709bf22cbbb94d
@@ -10774,13 +10860,12 @@ packages:
   purls: []
   size: 8463050
   timestamp: 1739626559515
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.10.3-h7d16cc0_11.conda
-  sha256: e15d6914792b8d1652a5dbbdc517d7e24b0986c7eb729c70920cbea1f2863688
-  md5: 542d5e00058ef9a7833f690c3c077a70
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.11.1-hddc0a0b_0.conda
+  sha256: 47660785161800a008fa2aa31a9b27a806fce52ae17b4f0b0113d5860ba830ce
+  md5: 848fe95ee484e88f003b71cfb51f2e61
   depends:
   - blosc >=1.21.6,<2.0a0
   - geos >=3.13.1,<3.13.2.0a0
-  - geotiff >=1.7.4,<1.8.0a0
   - lerc >=4.0.0,<5.0a0
   - libarchive >=3.8.1,<3.9.0a0
   - libcurl >=8.14.1,<9.0a0
@@ -10788,45 +10873,46 @@ packages:
   - libexpat >=2.7.0,<3.0a0
   - libiconv >=1.18,<2.0a0
   - libjpeg-turbo >=3.1.0,<4.0a0
+  - libjxl >=0.11,<0.12.0a0
   - libkml >=1.3.0,<1.4.0a0
   - liblzma >=5.8.1,<6.0a0
-  - libpng >=1.6.47,<1.7.0a0
+  - libpng >=1.6.49,<1.7.0a0
   - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.50.1,<4.0a0
-  - libtiff >=4.7.0,<4.8.0a0
+  - libsqlite >=3.50.2,<4.0a0
   - libwebp-base >=1.5.0,<2.0a0
   - libxml2 >=2.13.8,<2.14.0a0
   - libzlib >=1.3.1,<2.0a0
   - lz4-c >=1.10.0,<1.11.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - openssl >=3.5.0,<4.0a0
   - pcre2 >=10.45,<10.46.0a0
   - proj >=9.6.2,<9.7.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - xerces-c >=3.2.5,<3.3.0a0
   - zstd >=1.5.7,<1.6.0a0
   constrains:
-  - libgdal 3.10.3.*
+  - libgdal 3.11.1.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 8431773
-  timestamp: 1749424900728
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.10.3-hbd53b90_11.conda
-  sha256: 722267f0ec5d7f07df51043a70a35852005b7b2ae129773ece14257a4f4751ff
-  md5: 18f637866200bc30feaa19371d95ea38
+  size: 9153877
+  timestamp: 1751397156707
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-fits-3.11.1-hbd53b90_0.conda
+  sha256: c3594407696e7c9ddf4e74ee6624dcccfc489d6534dd79d23cb52854c7becffe
+  md5: 059f4074408a03ed7fdacc5d96978d57
   depends:
   - __glibc >=2.17,<3.0.a0
   - cfitsio >=4.6.2,<4.6.3.0a0
   - libgcc >=13
-  - libgdal-core 3.10.3 hcac4edf_11
+  - libgdal-core 3.11.1 h5e6393a_0
   - libstdcxx >=13
   license: MIT
   license_family: MIT
   purls: []
-  size: 480264
-  timestamp: 1749423868366
+  size: 481290
+  timestamp: 1751396538897
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-fits-3.10.2-hae9ebd6_0.conda
   sha256: d10f6eedc889da67ffc5bd05ed78a1abd0524ba0edcbc21dc8085161270bbf3e
   md5: 2dfc38f9cbbbc95bd6e5a058480f13b9
@@ -10842,34 +10928,34 @@ packages:
   purls: []
   size: 466114
   timestamp: 1739628441530
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.10.3-hd840048_11.conda
-  sha256: b1c5be78e32ceb0805a834a7ae2a07f2b448da07c67f3f00996bbf0fd5e78b64
-  md5: b3026d2816c8e427bf3f96b34e3a168d
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-fits-3.11.1-hcff14e6_0.conda
+  sha256: 343aec9a850a2eb15a459cc17416a606220df50bbb152e8b34ec2b025b9e4d1d
+  md5: a5cc2b21a2e13a8b2a64e2d141ff50f7
   depends:
   - cfitsio >=4.6.2,<4.6.3.0a0
-  - libgdal-core 3.10.3 h7d16cc0_11
+  - libgdal-core 3.11.1 hddc0a0b_0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
   purls: []
-  size: 506966
-  timestamp: 1749428247602
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.10.3-h34a6268_11.conda
-  sha256: 53d2c5aa05265d320313da11ec0487510ffe741dd53fe705dcef43e29a5df03c
-  md5: 52bea376dee739c5e1b37dd7b101da1f
+  size: 508706
+  timestamp: 1751399431678
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.11.1-h34a6268_0.conda
+  sha256: fdb358a9e7c7a1ea9c09b014480f560cb10f6f678ca7ec11117642b62e9fa9e2
+  md5: 414622ec464f8962eaeae51c64910a4e
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libaec >=1.1.3,<2.0a0
+  - libaec >=1.1.4,<2.0a0
   - libgcc >=13
-  - libgdal-core 3.10.3 hcac4edf_11
+  - libgdal-core 3.11.1 h5e6393a_0
   - libstdcxx >=13
   license: MIT
   license_family: MIT
   purls: []
-  size: 725452
-  timestamp: 1749423933188
+  size: 729397
+  timestamp: 1751396589150
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.10.2-ha6ee725_0.conda
   sha256: 88a5962f6ae1f17c0ad18762d161884cc4409a69a9d6c9378bbe8b471e4aa739
   md5: 843f6470ba5ee47b2cf66946e8dd1e9d
@@ -10885,35 +10971,35 @@ packages:
   purls: []
   size: 654404
   timestamp: 1739628593408
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.10.3-h79060df_11.conda
-  sha256: 505cb7d2d27a7a2e3e2c4a95803c2db6fee150be2de832645e4b3bcdc124d8dd
-  md5: 5ff07b4a5aa0cb372ab40fb390e46779
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.11.1-h8ff101f_0.conda
+  sha256: aed7a0a410eeb32c3bab5bf93d382fa7fb63971cb1b167269d6d44db850d8522
+  md5: d76b2a10cdc5a948ae73849c170150f6
   depends:
-  - libaec >=1.1.3,<2.0a0
-  - libgdal-core 3.10.3 h7d16cc0_11
+  - libaec >=1.1.4,<2.0a0
+  - libgdal-core 3.11.1 hddc0a0b_0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
   purls: []
-  size: 687713
-  timestamp: 1749428486557
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.10.3-hbe05c68_11.conda
-  sha256: 303ab7eb36ad3dddcf830b2d6f276ed4b493dcf4e0fae4faf8c24fbf047ababe
-  md5: e0ebb527882649e6a4ea9c246194fb96
+  size: 692794
+  timestamp: 1751399572120
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.11.1-hbe05c68_0.conda
+  sha256: 67c43fa52d5044abdc6bf6113f6beb9599fe2c66f989adaabf90560cdfe7b073
+  md5: 8fc3dc9d11dcac9835141745ba7bf357
   depends:
   - __glibc >=2.17,<3.0.a0
   - hdf4 >=4.2.15,<4.2.16.0a0
-  - libaec >=1.1.3,<2.0a0
+  - libaec >=1.1.4,<2.0a0
   - libgcc >=13
-  - libgdal-core 3.10.3 hcac4edf_11
+  - libgdal-core 3.11.1 h5e6393a_0
   - libstdcxx >=13
   license: MIT
   license_family: MIT
   purls: []
-  size: 561039
-  timestamp: 1749423992559
+  size: 561520
+  timestamp: 1751396636886
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.10.2-hd589a83_0.conda
   sha256: 98098a344028a8eb2480782f418378ca7cf4b4a3df47ad230acf0d8abfe748c1
   md5: fe6c1896078d288d5668cab3fd4df219
@@ -10930,35 +11016,35 @@ packages:
   purls: []
   size: 540368
   timestamp: 1739628740306
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.10.3-h0de24e7_11.conda
-  sha256: 3712734635de73b7805e75ffb8c5f83953fbd36a6eae336914a585796e27c159
-  md5: 9783f51a19bcc3d98ac606d575e64913
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.11.1-ha47b6c4_0.conda
+  sha256: 251f6f0188d496e3dce5eecaaf663155e02befbcde49b6e832baf47fe9222685
+  md5: c3b803d3f7ba7fca61c7eadf04f07cf5
   depends:
   - hdf4 >=4.2.15,<4.2.16.0a0
-  - libaec >=1.1.3,<2.0a0
-  - libgdal-core 3.10.3 h7d16cc0_11
+  - libaec >=1.1.4,<2.0a0
+  - libgdal-core 3.11.1 hddc0a0b_0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
   purls: []
-  size: 564767
-  timestamp: 1749428703453
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.10.3-hc4e49b7_11.conda
-  sha256: d39005fbd44978d630edc21539be55436ea0b888719323438b1b2cbce077a475
-  md5: 533ce281f3155a2436b01a100a0d9abe
+  size: 566763
+  timestamp: 1751399704122
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.11.1-hc4e49b7_0.conda
+  sha256: 4c684dbc062ccb727b43d9f17f43de3233e85f6599ab251c639d17eb1ffddcd2
+  md5: a94837385b2581bfb3aa91971b430f22
   depends:
   - __glibc >=2.17,<3.0.a0
   - hdf5 >=1.14.6,<1.14.7.0a0
   - libgcc >=13
-  - libgdal-core 3.10.3 hcac4edf_11
+  - libgdal-core 3.11.1 h5e6393a_0
   - libstdcxx >=13
   license: MIT
   license_family: MIT
   purls: []
-  size: 648023
-  timestamp: 1749424075615
+  size: 651923
+  timestamp: 1751396693901
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.10.2-h8e86020_0.conda
   sha256: 2788fb56979ba9aba12537af8cf4fb3edc8011feb8f0aad60480389a1a70bf58
   md5: fe2463e0cef65e5c7424ebea8b0d4214
@@ -10974,34 +11060,34 @@ packages:
   purls: []
   size: 595006
   timestamp: 1739628904365
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.10.3-h527b061_11.conda
-  sha256: 00cf031a703060b86464d4fe9518ce40198b93b7ae666c1cc47ef03effad4719
-  md5: f9ae39af3b4457ae48e3f9750fc5932a
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.11.1-h0f01001_0.conda
+  sha256: 982b53975fb03c00fe02dffe1f33f4a11338603fb066c7b4dace9c6fb9cc6699
+  md5: 50f6709d160b9d4bbdd457a9e61a341d
   depends:
   - hdf5 >=1.14.6,<1.14.7.0a0
-  - libgdal-core 3.10.3 h7d16cc0_11
+  - libgdal-core 3.11.1 hddc0a0b_0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
   purls: []
-  size: 623501
-  timestamp: 1749428949379
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.10.3-hb7814c2_11.conda
-  sha256: 6dab1c8c2b291e7fe757ecf904a336fdab0a6a639f815d3f37fe76ef14f61c4c
-  md5: b64bfc4b1b718acdcad2fdcf2bc6de62
+  size: 625958
+  timestamp: 1751399879650
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.11.1-hb7814c2_0.conda
+  sha256: 419e4146006440243d7cce7967ed5ff475df2f34aef9e6dc11c9712d1f926ea0
+  md5: 1db44f6380d7b09f5bcb25ae17f3013b
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libgdal-core 3.10.3 hcac4edf_11
+  - libgdal-core 3.11.1 h5e6393a_0
   - libstdcxx >=13
   - openjpeg >=2.5.3,<3.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 471226
-  timestamp: 1749424181710
+  size: 472227
+  timestamp: 1751396845145
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.10.2-h5de94d9_0.conda
   sha256: c0a3607c1da91c194b6caa01496ae9d2cba1bd45e9c128cf23b51662e61a910a
   md5: 2452e1d690808c0f5a83350df894476b
@@ -11017,36 +11103,36 @@ packages:
   purls: []
   size: 464220
   timestamp: 1739629183560
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.10.3-h95c5499_11.conda
-  sha256: 38bfcab103d24cbf01322813cd56e71309ae7c6550863a7af6e9313748b53cb7
-  md5: 175920dc07734e631f2a1c1b9966382e
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.11.1-hf58e487_0.conda
+  sha256: 77b12d9489ac85aff3a3b97fdfb584abf9838ae03827d09060b52370a0257b0d
+  md5: f7191d120d12ada4f23450a5126c155b
   depends:
-  - libgdal-core 3.10.3 h7d16cc0_11
+  - libgdal-core 3.11.1 hddc0a0b_0
   - openjpeg >=2.5.3,<3.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
   purls: []
-  size: 507175
-  timestamp: 1749429358339
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.10.3-he794564_11.conda
-  sha256: 2612351ae2bb3e492248e73d7b050251740c8a5a31e94b17d9abda3059480172
-  md5: 97f93490aea9a789385bfcfadb543572
+  size: 511283
+  timestamp: 1751400124151
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-kea-3.11.1-he794564_0.conda
+  sha256: 2caca52cb6ea1a1b1fe07fb5bff2669a2af6dd69ab1f9c64666a5b2b152ffd59
+  md5: bea7ace74de59589c58857a768ab50d2
   depends:
   - __glibc >=2.17,<3.0.a0
   - hdf5 >=1.14.6,<1.14.7.0a0
   - kealib >=1.6.2,<1.7.0a0
   - libgcc >=13
-  - libgdal-core 3.10.3 hcac4edf_11
-  - libgdal-hdf5 3.10.3.*
+  - libgdal-core 3.11.1 h5e6393a_0
+  - libgdal-hdf5 3.11.1.*
   - libstdcxx >=13
   license: MIT
   license_family: MIT
   purls: []
-  size: 483425
-  timestamp: 1749424574016
+  size: 484306
+  timestamp: 1751397167713
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-kea-3.10.2-h54bfe2d_0.conda
   sha256: f4c758b8d13cab5db7e2e05a0e8b377766f9ac229dad6e290db84f9051fad682
   md5: e469804500d5ff44ca446c3e715d1c65
@@ -11064,40 +11150,40 @@ packages:
   purls: []
   size: 470369
   timestamp: 1739630116988
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.10.3-h6b3a253_11.conda
-  sha256: cefcc2b71f5a2cec6b7d62e3af8850036862248831697e45f97184511f5943d3
-  md5: 36fcbec3cb1b68f57ba32c6923ef6710
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-kea-3.11.1-hea5172e_0.conda
+  sha256: 57b26ac3c820eadb8c3d0aff824636909fc2739870fd06ccdf9cec4a37f56634
+  md5: 22915174ad40d33bc7fc34464c0c7c75
   depends:
   - hdf5 >=1.14.6,<1.14.7.0a0
   - kealib >=1.6.2,<1.7.0a0
-  - libgdal-core 3.10.3 h7d16cc0_11
-  - libgdal-hdf5 3.10.3.*
+  - libgdal-core 3.11.1 hddc0a0b_0
+  - libgdal-hdf5 3.11.1.*
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
   purls: []
-  size: 527552
-  timestamp: 1749430836745
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.10.3-h6b150f0_11.conda
-  sha256: 61361e84bd63cc5a8c945b0b4cf7d4474ac31165def33b272fc3d65bf44bb506
-  md5: 6e63e077177389a3ae4c509469bec7e1
+  size: 529170
+  timestamp: 1751401054020
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.11.1-h6b150f0_0.conda
+  sha256: f8c5ff8448b8d4c35a2f2ef0abdcec287a8b892bde64932a8582c330d10df7f9
+  md5: 3356d1f17d74333f2f277c3585e1aaf3
   depends:
   - __glibc >=2.17,<3.0.a0
   - hdf4 >=4.2.15,<4.2.16.0a0
   - hdf5 >=1.14.6,<1.14.7.0a0
   - libgcc >=13
-  - libgdal-core 3.10.3 hcac4edf_11
-  - libgdal-hdf4 3.10.3.*
-  - libgdal-hdf5 3.10.3.*
+  - libgdal-core 3.11.1 h5e6393a_0
+  - libgdal-hdf4 3.11.1.*
+  - libgdal-hdf5 3.11.1.*
   - libnetcdf >=4.9.2,<4.9.3.0a0
   - libstdcxx >=13
   license: MIT
   license_family: MIT
   purls: []
-  size: 740126
-  timestamp: 1749424647388
+  size: 742788
+  timestamp: 1751397231358
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.10.2-h3ef4abb_0.conda
   sha256: 89e6ab13620226053cf33ae30441e5c22dc7a1b8c517fdce87bb04d40427b293
   md5: 139d8322ebf86f329be896d13f83f457
@@ -11117,38 +11203,38 @@ packages:
   purls: []
   size: 670087
   timestamp: 1739630272867
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.10.3-h1b8416b_11.conda
-  sha256: 2d687d79378eeb4e4f24e0194ecd56b84a1f0c50204a2fc40f70d0291d2fcb94
-  md5: c3abfd3eb5f867262e14211b61af4871
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.11.1-hcb0e93c_0.conda
+  sha256: 3524ca30534c9230415fac80ef8e282faadc451715b3e563433377f5ad113830
+  md5: 661eb12a5c5ae32c04aeb4d30dbc6971
   depends:
   - hdf4 >=4.2.15,<4.2.16.0a0
   - hdf5 >=1.14.6,<1.14.7.0a0
-  - libgdal-core 3.10.3 h7d16cc0_11
-  - libgdal-hdf4 3.10.3.*
-  - libgdal-hdf5 3.10.3.*
+  - libgdal-core 3.11.1 hddc0a0b_0
+  - libgdal-hdf4 3.11.1.*
+  - libgdal-hdf5 3.11.1.*
   - libnetcdf >=4.9.2,<4.9.3.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
   purls: []
-  size: 675960
-  timestamp: 1749431088212
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.10.3-h962cb15_11.conda
-  sha256: ce534d174bd11705790cbc6af6800daca33673e52e58b3c98be2eb3dc19c445c
-  md5: 8a957aaa3f8fef443af94160c7122b7c
+  size: 680059
+  timestamp: 1751401225462
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pdf-3.11.1-h962cb15_0.conda
+  sha256: 9e0fca7f500d9e96d230285f784ba249bd14458a2863cdd9ca3cb413fe25d2fe
+  md5: d1037f9cdd5ef700717e86d4a151615a
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libgdal-core 3.10.3 hcac4edf_11
+  - libgdal-core 3.11.1 h5e6393a_0
   - libstdcxx >=13
   - poppler >=24.12.0,<24.13.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 672403
-  timestamp: 1749424263066
+  size: 671932
+  timestamp: 1751396914444
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-pdf-3.10.2-hb9cf988_0.conda
   sha256: 4b7263d278e92cb24a69f9892e96e4092155130f6d4a4f9d0f1438006e819d30
   md5: 100c14015f36cd0419835db922a1ba8a
@@ -11164,35 +11250,35 @@ packages:
   purls: []
   size: 603160
   timestamp: 1739629355948
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.10.3-ha9b9ad8_11.conda
-  sha256: 3296df3cbb663f7c9eafebda4c81fee818c0e5583cbb1e396b8b3ad29ef75640
-  md5: 1ddc101bf5117d009eaeff318e466f90
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pdf-3.11.1-h75c24f8_0.conda
+  sha256: 603cf5f65de13672129f0301c8e959857ea8afedaeb9ea154a0731e62129df35
+  md5: d6d117bcac69c6a3b947fc82db385d90
   depends:
-  - libgdal-core 3.10.3 h7d16cc0_11
+  - libgdal-core 3.11.1 hddc0a0b_0
   - poppler >=24.12.0,<24.13.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
   purls: []
-  size: 636181
-  timestamp: 1749429642894
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.10.3-hfb06ed7_11.conda
-  sha256: f2a0de5552096dacd948eec5d6486d4acf9133f7aad52debe692f455c6714d46
-  md5: 6da6c1107583fdedec30b875b5360845
+  size: 650904
+  timestamp: 1751400296153
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-pg-3.11.1-hfb06ed7_0.conda
+  sha256: 7dac716d037fc1f7a412462ae5995fddd1af7a6e11db0f9a9ef438d3548fc6f8
+  md5: 3c435b889597891a39414c5c8d19f48b
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libgdal-core 3.10.3 hcac4edf_11
+  - libgdal-core 3.11.1 h5e6393a_0
   - libpq >=17.5,<18.0a0
   - libstdcxx >=13
   - postgresql
   license: MIT
   license_family: MIT
   purls: []
-  size: 530131
-  timestamp: 1749424320985
+  size: 528537
+  timestamp: 1751396962972
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-pg-3.10.2-h98ad515_0.conda
   sha256: 12b72c8cc5ae4f11319c4282ee715d73bc5e7197df5ed334f1ecbccd56cd51e2
   md5: 455267bd0343f2db81b98ef58a4ae05f
@@ -11209,36 +11295,36 @@ packages:
   purls: []
   size: 504722
   timestamp: 1739629503499
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.10.3-h38d3678_11.conda
-  sha256: 8e6f5917d8d3dca5c137d8eb25bfab3642d9e26e31e6e5a65572a1be56a5c9ae
-  md5: b1d117ee3aa22db41b4b96370e37ca2a
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-pg-3.11.1-h103a44d_0.conda
+  sha256: e32e5ad2e2503bb4be6198cba97e706e3f3b5ec1224f800e5cf0e9baeb0cd7ab
+  md5: d3ccf50ac303f373a6a7f91a198d8cb4
   depends:
-  - libgdal-core 3.10.3 h7d16cc0_11
+  - libgdal-core 3.11.1 hddc0a0b_0
   - libpq >=17.5,<18.0a0
   - postgresql
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
   purls: []
-  size: 541877
-  timestamp: 1749429872686
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.10.3-hfb06ed7_11.conda
-  sha256: 40a92be7f811c2cc3b34bbe555f86096574a76e24c1d138d4bcfd616f9897c05
-  md5: c620c02a36c1897621f54e19d014d1db
+  size: 544173
+  timestamp: 1751400435169
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-postgisraster-3.11.1-hfb06ed7_0.conda
+  sha256: 0faac968085b16ba5b0affa93fe940d1d26cdfd289282300d707cadec4f0cadd
+  md5: 13e9d9852749805f7b58070b872345e7
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libgdal-core 3.10.3 hcac4edf_11
+  - libgdal-core 3.11.1 h5e6393a_0
   - libpq >=17.5,<18.0a0
   - libstdcxx >=13
   - postgresql
   license: MIT
   license_family: MIT
   purls: []
-  size: 482513
-  timestamp: 1749424379884
+  size: 483838
+  timestamp: 1751397009837
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-postgisraster-3.10.2-h98ad515_0.conda
   sha256: e5c6ba2ef94f485816a287ee6015f1c641e5287fa58d6db42bfcb69d9602c171
   md5: 5dc68cf82ec18f7af58132a13f32c286
@@ -11255,35 +11341,35 @@ packages:
   purls: []
   size: 469443
   timestamp: 1739629649102
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.10.3-h38d3678_11.conda
-  sha256: 42ff151d3f9a0e030e2df5d8d883d038506a0379c7a07dc7ee7821f97b14fba4
-  md5: b8b1fb063ca6761a1bf80132940f2be9
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-postgisraster-3.11.1-h103a44d_0.conda
+  sha256: a1563ba9b481346820958296866bb678466413b5df1e5f09cb84521af118016d
+  md5: f598f8c8e3f62209c79678a2b3e7138d
   depends:
-  - libgdal-core 3.10.3 h7d16cc0_11
+  - libgdal-core 3.11.1 hddc0a0b_0
   - libpq >=17.5,<18.0a0
   - postgresql
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
   purls: []
-  size: 514635
-  timestamp: 1749430119758
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.10.3-hd16f1d8_11.conda
-  sha256: d6ac02bdde4be81275601d77a859c2604bad6ff8432439f859e3c30b32bf3a91
-  md5: 600998d1ea75a59b3c98b6a1f79ed65a
+  size: 516761
+  timestamp: 1751400588100
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-tiledb-3.11.1-hd16f1d8_0.conda
+  sha256: d49b730a571c2f8cdbb9e33289579ed6eb057fcc6819e3752d9cc86da4ef9e0c
+  md5: fec465d9bb610f10c3a71f76a7652dbe
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libgdal-core 3.10.3 hcac4edf_11
+  - libgdal-core 3.11.1 h5e6393a_0
   - libstdcxx >=13
   - tiledb >=2.28.0,<2.29.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 697435
-  timestamp: 1749424461754
+  size: 698215
+  timestamp: 1751397080498
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-tiledb-3.10.2-h3b22183_0.conda
   sha256: bcc974d4adcb98149dd963be7c746965d9ac178625560cd4062ff2f598141aa7
   md5: 82daafdd29a335bb350387053e704b06
@@ -11299,34 +11385,34 @@ packages:
   purls: []
   size: 625406
   timestamp: 1739629817158
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.10.3-h6c2f05d_11.conda
-  sha256: 0c31eaa7f81ce41167a18adb20900737983c867b25b4d09ccdc3788c694046b5
-  md5: 993effc5d72ca288842d687803456f8a
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-tiledb-3.11.1-h88e1fbc_0.conda
+  sha256: fe7ec2a8c8761d9a4934d8ebe14c86108608439235d85a7a603615c10c1fec7d
+  md5: 5fc6ab3948ab2a22ffe2ad327d655df4
   depends:
-  - libgdal-core 3.10.3 h7d16cc0_11
+  - libgdal-core 3.11.1 hddc0a0b_0
   - tiledb >=2.28.0,<2.29.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
   purls: []
-  size: 647178
-  timestamp: 1749430392383
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.10.3-ha4d2dc7_11.conda
-  sha256: 3095e505e88a2ab902a3681e27a0602a26f184f22a8b459c74561db01b77dc2f
-  md5: 8e82d79c57f0de4f25b07ec62ec108a0
+  size: 646980
+  timestamp: 1751400767880
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-xls-3.11.1-ha4d2dc7_0.conda
+  sha256: 65be21dbb80e0a810ef1876f46806ae706932d093ba6276c6f2eb4cc2c1b64fb
+  md5: 20ae673e0903c7ac07c8ca1d2af943fc
   depends:
   - __glibc >=2.17,<3.0.a0
   - freexl >=2.0.0,<3.0a0
   - libgcc >=13
-  - libgdal-core 3.10.3 hcac4edf_11
+  - libgdal-core 3.11.1 h5e6393a_0
   - libstdcxx >=13
   license: MIT
   license_family: MIT
   purls: []
-  size: 436143
-  timestamp: 1749424515682
+  size: 437285
+  timestamp: 1751397120234
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-xls-3.10.2-hcf353f7_0.conda
   sha256: 03a6d3815a162ca11ac509dd71a7e4f463763a83b64054fefe57b2a6c4eb58f3
   md5: 3e6cb0759e5af459b1d66b735f99552c
@@ -11342,20 +11428,20 @@ packages:
   purls: []
   size: 433439
   timestamp: 1739629956429
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.10.3-hc931c72_11.conda
-  sha256: 79a74fb115185c7c14f59db66379e41150cb831f9d79eeb085c4d800bb35f31c
-  md5: caeb77b2102bc12d27abbeb54984ef00
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-xls-3.11.1-h93cc17c_0.conda
+  sha256: 5d84436e7c8c21a28c953fbdc343cf775c979db76dce4c3db2a7d1fd09dfc8d8
+  md5: 962b313bdac2ff71f3c006ce9affa543
   depends:
   - freexl >=2.0.0,<3.0a0
-  - libgdal-core 3.10.3 h7d16cc0_11
+  - libgdal-core 3.11.1 hddc0a0b_0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
   purls: []
-  size: 475536
-  timestamp: 1749430618759
+  size: 476348
+  timestamp: 1751400901223
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.24.1-h5888daf_0.conda
   sha256: 104f2341546e295d1136ab3010e81391bd3fd5be0f095db59266e8eba2082d37
   md5: 2ee6d71b72f75d50581f2f68e965efdb
@@ -11367,18 +11453,18 @@ packages:
   purls: []
   size: 171165
   timestamp: 1746228870846
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.24.1-h493aca8_0.conda
-  sha256: 0f380fee5d5dc870b6b9d3134cca344965d68bbf454f6ac741907fee4cc3e07a
-  md5: 218a45f477876644cf75c7ed0b5158c7
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.24.2-h493aca8_0.conda
+  sha256: 4079a10fda101f2f7307bf5888974c5ea4a6328d8e497c394523a117b90d3439
+  md5: 8f2557940b6b035f79cc113d63d32397
   depends:
   - __osx >=11.0
   - libiconv >=1.18,<2.0a0
-  - libintl 0.24.1 h493aca8_0
+  - libintl 0.24.2 h493aca8_0
   license: GPL-3.0-or-later
   license_family: GPL
   purls: []
-  size: 176982
-  timestamp: 1746229282723
+  size: 177322
+  timestamp: 1751465402808
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.24.1-h5888daf_0.conda
   sha256: a9a0cba030778eb2944a1f235dba51e503b66f8be0ce6f55f745173a515c3644
   md5: 8f04c7aae6a46503bc36d1ed5abc8c7c
@@ -11391,41 +11477,41 @@ packages:
   purls: []
   size: 37234
   timestamp: 1746228897993
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_2.conda
-  sha256: 914daa4f632b786827ea71b5e07cd00d25fc6e67789db2f830dc481eec660342
-  md5: f92e6e0a3c0c0c85561ef61aa59d555d
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.1.0-h69a702a_3.conda
+  sha256: 77dd1f1efd327e6991e87f09c7c97c4ae1cfbe59d9485c41d339d6391ac9c183
+  md5: bfbca721fd33188ef923dfe9ba172f29
   depends:
-  - libgfortran5 15.1.0 hcea5267_2
+  - libgfortran5 15.1.0 hcea5267_3
   constrains:
-  - libgfortran-ng ==15.1.0=*_2
+  - libgfortran-ng ==15.1.0=*_3
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 34541
-  timestamp: 1746642233221
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-14.2.0-heb5dd2a_105.conda
-  sha256: 6ca48762c330d1cdbdaa450f197ccc16ffb7181af50d112b4ccf390223d916a1
-  md5: ad35937216e65cfeecd828979ee5e9e6
+  size: 29057
+  timestamp: 1750808257258
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-14_2_0_h6c33f7e_103.conda
+  sha256: 8628746a8ecd311f1c0d14bb4f527c18686251538f7164982ccbe3b772de58b5
+  md5: 044a210bc1d5b8367857755665157413
   depends:
-  - libgfortran5 14.2.0 h2c44a93_105
+  - libgfortran5 14.2.0 h6c33f7e_103
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 155474
-  timestamp: 1743913530958
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.1.0-h69a702a_2.conda
-  sha256: 0665170a98c8ec586352929d45a9c833c0dcdbead38b0b8f3af7a0deee2af755
-  md5: a483a87b71e974bb75d1b9413d4436dd
+  size: 156291
+  timestamp: 1743863532821
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-15.1.0-h69a702a_3.conda
+  sha256: 2d961f9748d994a4dc9891feae60e182ae9cdce4b0780caaa643e9e3757c7b43
+  md5: 6e5d0574e57a38c36e674e9a18eee2b4
   depends:
-  - libgfortran 15.1.0 h69a702a_2
+  - libgfortran 15.1.0 h69a702a_3
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 34616
-  timestamp: 1746642441079
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_2.conda
-  sha256: be23750f3ca1a5cb3ada858c4f633effe777487d1ea35fddca04c0965c073350
-  md5: 01de444988ed960031dbe84cf4f9b1fc
+  size: 29089
+  timestamp: 1750808529101
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.1.0-hcea5267_3.conda
+  sha256: eea6c3cf22ad739c279b4d665e6cf20f8081f483b26a96ddd67d4df3c88dfa0a
+  md5: 530566b68c3b8ce7eec4cd047eae19fe
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=15.1.0
@@ -11434,20 +11520,20 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 1569986
-  timestamp: 1746642212331
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-14.2.0-h2c44a93_105.conda
-  sha256: de09987e1080f71e2285deec45ccb949c2620a672b375029534fbb878e471b22
-  md5: 06f35a3b1479ec55036e1c9872f97f2c
+  size: 1565627
+  timestamp: 1750808236464
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-14.2.0-h6c33f7e_103.conda
+  sha256: 8599453990bd3a449013f5fa3d72302f1c68f0680622d419c3f751ff49f01f17
+  md5: 69806c1e957069f1d515830dcc9f6cbb
   depends:
   - llvm-openmp >=8.0.0
   constrains:
-  - libgfortran 14.2.0
+  - libgfortran 5.0.0 14_2_0_*_103
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 806283
-  timestamp: 1743913488925
+  size: 806566
+  timestamp: 1743863491726
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
   sha256: dc2752241fa3d9e40ce552c1942d0a4b5eeb93740c9723873f6fcf8d39ef8d2d
   md5: 928b8be80851f5d8ffb016f9c81dae7a
@@ -11529,19 +11615,19 @@ packages:
   purls: []
   size: 75504
   timestamp: 1731330988898
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_2.conda
-  sha256: 05fff3dc7e80579bc28de13b511baec281c4343d703c406aefd54389959154fb
-  md5: fbe7d535ff9d3a168c148e07358cd5b1
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.1.0-h767d61c_3.conda
+  sha256: 43710ab4de0cd7ff8467abff8d11e7bb0e36569df04ce1c099d48601818f11d1
+  md5: 3cd1a7238a0dd3d0860fdefc496cc854
   depends:
   - __glibc >=2.17,<3.0.a0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 452635
-  timestamp: 1746642113092
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-15.1.0-h1383e82_2.conda
-  sha256: 4316316097ce5fde2608b6fccd18709cf647dce52e230f5ac66f5c524dfad791
-  md5: 5fbacaa9b41e294a6966602205b99747
+  size: 447068
+  timestamp: 1750808138400
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgomp-15.1.0-h1383e82_3.conda
+  sha256: 2e6e286c817d2274b109c448f63d804dcc85610c5abf97e183440aa2d84b8c72
+  md5: 94545e52b3d21a7ab89961f7bda3da0d
   depends:
   - libwinpthread >=12.0.0.r4.gg4f2fc60ca
   constrains:
@@ -11549,8 +11635,8 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 540903
-  timestamp: 1746656563815
+  size: 535456
+  timestamp: 1750808243424
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.36.0-hc4361e1_1.conda
   sha256: 3a56c653231d6233de5853dc01f07afad6a332799a39c3772c0948d2e68547e4
   md5: ae36e6296a8dd8e8a9a8375965bf6398
@@ -11793,6 +11879,30 @@ packages:
   purls: []
   size: 2390021
   timestamp: 1731375651179
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.2.0-hf40a0c7_0.conda
+  sha256: 2834859c2216f26d9e024c22a0654267d582173bc93b1c44bf6c6416fecb5fd9
+  md5: 2f433d593a66044c3f163cb25f0a09de
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 1326964
+  timestamp: 1744841715208
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.2.0-h1d1702c_0.conda
+  sha256: 57b744e1cd1316ebda141a2abc39d6deae6d2d6833b7fb00d1212bdef8750a16
+  md5: f9c48717ec26b7102445719bac1bdba8
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 456913
+  timestamp: 1744841708967
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
   sha256: 18a4afe14f731bfb9cf388659994263904d20111e42f841e9eea1bb6f91f4ab4
   md5: e796ff8ddc598affdf7c173d6145f087
@@ -11823,16 +11933,16 @@ packages:
   purls: []
   size: 638142
   timestamp: 1740128665984
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.24.1-h493aca8_0.conda
-  sha256: fb6d211d9e75e6becfbf339d255ea01f7bd3a61fe6237b3dad740de1b74b3b81
-  md5: 0dca9914f2722b773c863508723dfe6e
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.24.2-h493aca8_0.conda
+  sha256: aebb3357d4b6e00996b15917d9a4061c3c17e1ee191b7226d2c1317ac049a62a
+  md5: 2dc5359f33b7038d3a35a2d2defeb608
   depends:
   - __osx >=11.0
   - libiconv >=1.18,<2.0a0
   license: LGPL-2.1-or-later
   purls: []
-  size: 90547
-  timestamp: 1746229257769
+  size: 90769
+  timestamp: 1751465374263
 - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
   sha256: c7e4600f28bcada8ea81456a6530c2329312519efcf0c886030ada38976b0511
   md5: 2cf0cf76cc15d360dfa2f17fd6cf9772
@@ -11842,17 +11952,17 @@ packages:
   purls: []
   size: 95568
   timestamp: 1723629479451
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.24.1-h493aca8_0.conda
-  sha256: 5e71abebd1340f3051bcd441bbd23e97c65d6f1de1738b71aef455dde7253c65
-  md5: 42ce4a88aa2fd300aa128c9c599f9676
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.24.2-h493aca8_0.conda
+  sha256: 1e5f0f5ba34ac085fdb7453dd73404e10706c3d44949c2d237014362cceca72e
+  md5: f8bfc03eb84a19b82d9f056125d63b0c
   depends:
   - __osx >=11.0
   - libiconv >=1.18,<2.0a0
-  - libintl 0.24.1 h493aca8_0
+  - libintl 0.24.2 h493aca8_0
   license: LGPL-2.1-or-later
   purls: []
-  size: 40167
-  timestamp: 1746229294880
+  size: 40105
+  timestamp: 1751465417290
 - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_3.conda
   sha256: be1f3c48bc750bca7e68955d57180dfd826d6f9fa7eb32994f6cb61b813f9a6a
   md5: 7537784e9e35399234d4007f45cdb744
@@ -11899,6 +12009,36 @@ packages:
   purls: []
   size: 838154
   timestamp: 1745268437136
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.1-h7b0646d_2.conda
+  sha256: 586e007075e79b9aea4c4f9cf5bcf517ac38cefec353c5a14d49bf52d423683a
+  md5: 7b7baf93533744be2c0228bfa7149e2d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libgcc >=13
+  - libhwy >=1.2.0,<1.3.0a0
+  - libstdcxx >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1504320
+  timestamp: 1749125999597
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjxl-0.11.1-ha161b08_2.conda
+  sha256: 7bb0fb033e2386ead1957f6aa1a93e2f328fbd38fdd5b9a20d176bbfd51a9fa1
+  md5: 5fc376d36949612948f1191a0e276a3c
+  depends:
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libhwy >=1.2.0,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1022654
+  timestamp: 1749126610763
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libklu-2.3.5-h95ff59c_7100101.conda
   sha256: 6b4d462642c240dc3671af74f7705b23f34eea0f71e0d9dbcf14b4ed008311ff
   md5: efaa5e7dc6989363585fbb591480b256
@@ -12011,51 +12151,51 @@ packages:
   purls: []
   size: 1651104
   timestamp: 1724667610262
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-31_h7ac8fdf_openblas.conda
-  build_number: 31
-  sha256: f583661921456e798aba10972a8abbd9d33571c655c1f66eff450edc9cbefcf3
-  md5: 452b98eafe050ecff932f0ec832dd03f
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-32_h7ac8fdf_openblas.conda
+  build_number: 32
+  sha256: 5b55a30ed1b3f8195dad9020fe1c6d0f514829bfaaf0cf5e393e93682af009f2
+  md5: 6c3f04ccb6c578138e9f9899da0bd714
   depends:
-  - libblas 3.9.0 31_h59b9bed_openblas
+  - libblas 3.9.0 32_h59b9bed_openblas
   constrains:
-  - libcblas =3.9.0=31*_openblas
-  - liblapacke =3.9.0=31*_openblas
-  - blas =2.131=openblas
+  - libcblas   3.9.0   32*_openblas
+  - blas 2.132   openblas
+  - liblapacke 3.9.0   32*_openblas
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 16790
-  timestamp: 1740087997375
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-31_hc9a63f6_openblas.conda
-  build_number: 31
-  sha256: fe55b9aaf82c6c0192c3d1fcc9b8e884f97492dda9a8de5dae29334b3135fab5
-  md5: ff57a55a2cbce171ef5707fb463caf19
+  size: 17316
+  timestamp: 1750388820745
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-32_hc9a63f6_openblas.conda
+  build_number: 32
+  sha256: 5e1cfa3581d1dec6b07a75084ff6cfa4b4465c646c6884a71c78a28543f83b61
+  md5: bf9ead3fa92fd75ad473c6a1d255ffcb
   depends:
-  - libblas 3.9.0 31_h10e41b3_openblas
+  - libblas 3.9.0 32_h10e41b3_openblas
   constrains:
-  - liblapacke =3.9.0=31*_openblas
-  - libcblas =3.9.0=31*_openblas
-  - blas =2.131=openblas
+  - blas 2.132   openblas
+  - libcblas   3.9.0   32*_openblas
+  - liblapacke 3.9.0   32*_openblas
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 17033
-  timestamp: 1740088134988
-- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-31_h1aa476e_mkl.conda
-  build_number: 31
-  sha256: 9415e807aa6f8968322bbd756aab8f487379d809c74266d37c697b8d85c534ad
-  md5: 40b47ee720a185289760960fc6185750
+  size: 17507
+  timestamp: 1750388977861
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-32_h1aa476e_mkl.conda
+  build_number: 32
+  sha256: 5629e592137114b24bfdea71e1c4b6bee11379631409ed91dfe2f83b32a8b298
+  md5: 1652285573db93afc3ba9b3b9356e3d3
   depends:
-  - libblas 3.9.0 31_h641d27c_mkl
+  - libblas 3.9.0 32_h641d27c_mkl
   constrains:
-  - libcblas =3.9.0=31*_mkl
-  - blas =2.131=mkl
-  - liblapacke =3.9.0=31*_mkl
+  - libcblas   3.9.0   32*_mkl
+  - liblapacke 3.9.0   32*_mkl
+  - blas 2.132   mkl
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 3732648
-  timestamp: 1740088548986
+  size: 3735534
+  timestamp: 1750389164366
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libldl-3.3.2-hf02c80a_7100101.conda
   sha256: 590232cd302047023ab31b80458833a71b10aeabee7474304dc65db322b5cd70
   md5: 19b71122fea7f6b1c4815f385b2da419
@@ -12106,9 +12246,9 @@ packages:
   purls: []
   size: 24849265
   timestamp: 1737798197048
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.6-he9d0ab4_0.conda
-  sha256: 1f446c261c98794c4f4430513065637dfaaacaf00b6d5d41b3f90e9d9f8cb631
-  md5: bf8ccdd2c1c1a54a3fa25bb61f26460e
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm20-20.1.7-he9d0ab4_0.conda
+  sha256: 5c51416c10e84ac6a73560c82e20f99788b1395ce431c450391966d07a444fa6
+  md5: 63f1accca4913e6b66a2d546c30ff4db
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -12119,11 +12259,11 @@ packages:
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 43023023
-  timestamp: 1748507316454
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm20-20.1.6-h598bca7_0.conda
-  sha256: 8513d01f6e52bca09f95854f0e98d67f4bfd21534523036d6d3a9b6efb9cf431
-  md5: a69ea59e6f3141d46cfaf4bf234544d5
+  size: 43026762
+  timestamp: 1749836200754
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm20-20.1.7-h598bca7_0.conda
+  sha256: 6f482bf800d10ef3a48bed8f4eccd1184f3138ce3a6df2fe46c06bd1405bec56
+  md5: f42b39a37cee6ef028610803851b4c47
   depends:
   - __osx >=11.0
   - libcxx >=18
@@ -12133,8 +12273,8 @@ packages:
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   purls: []
-  size: 28900564
-  timestamp: 1748501902946
+  size: 28901840
+  timestamp: 1749828576903
 - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
   sha256: f2591c0069447bbe28d4d696b7fcb0c5bd0b4ac582769b89addbcf26fb3430d8
   md5: 1a580f7796c7bf6393fddb8bbbde58dc
@@ -12285,16 +12425,17 @@ packages:
   purls: []
   size: 741323
   timestamp: 1731846827427
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
-  sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
-  md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+  sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
+  md5: d864d34357c3b65a4b731f78c0801dc4
   depends:
-  - libgcc-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
   license: LGPL-2.1-only
   license_family: GPL
   purls: []
-  size: 33408
-  timestamp: 1697359010159
+  size: 33731
+  timestamp: 1750274110928
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libntlm-1.8-hb9d3cd8_0.conda
   sha256: 3b3f19ced060013c2dd99d9d46403be6d319d4601814c772a3472fe2955612b0
   md5: 7c7927b404672409d9917d49bff5f2d6
@@ -12350,36 +12491,36 @@ packages:
   purls: []
   size: 35040
   timestamp: 1745826086628
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.29-pthreads_h94d23a6_0.conda
-  sha256: cc5389ea254f111ef17a53df75e8e5209ef2ea6117e3f8aced88b5a8e51f11c4
-  md5: 0a4d0252248ef9a0f88f2ba8b8a08e12
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.30-pthreads_h94d23a6_0.conda
+  sha256: 225f4cfdb06b3b73f870ad86f00f49a9ca0a8a2d2afe59440521fafe2b6c23d9
+  md5: 323dc8f259224d13078aaf7ce96c3efe
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
   - libgfortran
-  - libgfortran5 >=14.2.0
+  - libgfortran5 >=14.3.0
   constrains:
-  - openblas >=0.3.29,<0.3.30.0a0
+  - openblas >=0.3.30,<0.3.31.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 5919288
-  timestamp: 1739825731827
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.29-openmp_hf332438_0.conda
-  sha256: 8989d9e01ec8c9b2d48dbb5efbe70b356fcd15990fb53b64fcb84798982c0343
-  md5: 0cd1148c68f09027ee0b0f0179f77c30
+  size: 5916819
+  timestamp: 1750379877844
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.30-openmp_hf332438_0.conda
+  sha256: 501c8c64f1a6e6b671e49835e6c483bc25f0e7147f3eb4bbb19a4c3673dcaf28
+  md5: 5d7dbaa423b4c253c476c24784286e4b
   depends:
   - __osx >=11.0
-  - libgfortran >=5
-  - libgfortran5 >=13.2.0
+  - libgfortran 5.*
+  - libgfortran5 >=13.3.0
   - llvm-openmp >=18.1.8
   constrains:
-  - openblas >=0.3.29,<0.3.30.0a0
+  - openblas >=0.3.30,<0.3.31.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 4168442
-  timestamp: 1739825514918
+  size: 4163399
+  timestamp: 1750378829050
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libopengl-1.7.0-ha4b6fd6_2.conda
   sha256: 215086c108d80349e96051ad14131b751d17af3ed2cb5a34edd62fa89bfe8ead
   md5: 7df50d44d4a14d6c31a2c54f2cd92157
@@ -12439,13 +12580,13 @@ packages:
   purls: []
   size: 299498
   timestamp: 1744330988108
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-20.0.0-h081d1f1_6_cpu.conda
-  build_number: 6
-  sha256: 01cb0015a91523ce788fdd4fe5e300fa2d71694976498eb2464501c7cba27af4
-  md5: 640b79f7a2c691ab4101345c5d87a540
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-20.0.0-h081d1f1_8_cpu.conda
+  build_number: 8
+  sha256: c3bc9454b25f8d32db047c282645ae33fe96b5d4d9bde66099fb49cf7a6aa90c
+  md5: d64065a5ab0a8d466b7431049e531995
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libarrow 20.0.0 h314c690_6_cpu
+  - libarrow 20.0.0 h1b9301b_8_cpu
   - libgcc >=13
   - libstdcxx >=13
   - libthrift >=0.21.0,<0.21.1.0a0
@@ -12453,8 +12594,8 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 1243790
-  timestamp: 1748962490331
+  size: 1244187
+  timestamp: 1750865279989
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-17.0.0-h636d7b7_51_cpu.conda
   build_number: 51
   sha256: b15c3684e54acf9e1af96cd8a0fd2af847aada79cb90158392870b1e4168252b
@@ -12470,22 +12611,22 @@ packages:
   purls: []
   size: 865262
   timestamp: 1741907250525
-- conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-20.0.0-ha850022_6_cpu.conda
-  build_number: 6
-  sha256: e225fb0ae4e7138a4a270553e48ac96566fac66166d96dc8b9c463db9ee68fa2
-  md5: 6e1b673c82847e5e6f4c842fbe4d9a0f
+- conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-20.0.0-ha850022_8_cpu.conda
+  build_number: 8
+  sha256: 3f8be5c7b1576ea97b24b247f149992a9ff1825ef322ab80318421be350b8fc1
+  md5: 78c04f9db52897dbfa71871a8a5818bf
   depends:
-  - libarrow 20.0.0 hc090743_6_cpu
+  - libarrow 20.0.0 h3e40a90_8_cpu
   - libthrift >=0.21.0,<0.21.1.0a0
   - openssl >=3.5.0,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
-  - vc14_runtime >=14.42.34438
+  - vc14_runtime >=14.44.35208
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 823138
-  timestamp: 1748964426266
+  size: 823920
+  timestamp: 1750866407836
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libparu-1.0.0-hc6afc67_7100101.conda
   sha256: 50144e87b95d1309d2043aa5bf02035b948b1ae9ec6ec44ee97b7aec1cccd70a
   md5: fd1d3e26c1b12c70f7449369ae3d9c1a
@@ -12536,37 +12677,38 @@ packages:
   purls: []
   size: 108991
   timestamp: 1742288893864
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
-  sha256: c0a30ac74eba66ea76a4f0a39acc7833f5ed783a632ca3bb6665b2d81aabd2fb
-  md5: 48f4330bfcd959c3cfb704d424903c82
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
+  sha256: 0bd91de9b447a2991e666f284ae8c722ffb1d84acb594dbd0c031bd656fa32b2
+  md5: 70e3400cbbfa03e96dcde7fc13e38c7b
   depends:
-  - libgcc-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
   license: MIT
   license_family: MIT
   purls: []
-  size: 28361
-  timestamp: 1707101388552
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-2.8.4-h453e6b4_6.conda
-  sha256: c0e1c6d00c1d2b8119cd991fbda7b3ea78e3cb5af8eed042594e430f09a0687f
-  md5: 09c57eda1579821376f1fd13572972ba
+  size: 28424
+  timestamp: 1749901812541
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-2.9.0-h453e6b4_0.conda
+  sha256: 9c4db76152dbc6c406e0b8746392e128544adf937b13776e940308cae9f99a51
+  md5: 5242cc2061d7cefa99dd6030eb796a4f
   depends:
-  - libpdal-arrow 2.8.4 hb7ef14c_6
-  - libpdal-cpd 2.8.4 hbb46d0d_6
-  - libpdal-draco 2.8.4 hbb46d0d_6
-  - libpdal-e57 2.8.4 h0dda180_6
-  - libpdal-hdf 2.8.4 haa54232_6
-  - libpdal-icebridge 2.8.4 haa54232_6
-  - libpdal-nitf 2.8.4 h986040f_6
-  - libpdal-pgpointcloud 2.8.4 h5c7ba8f_6
-  - libpdal-tiledb 2.8.4 h68be023_6
-  - libpdal-trajectory 2.8.4 hb16f371_6
+  - libpdal-arrow 2.9.0 hb7ef14c_0
+  - libpdal-cpd 2.9.0 hbb46d0d_0
+  - libpdal-draco 2.9.0 hbb46d0d_0
+  - libpdal-e57 2.9.0 h0dda180_0
+  - libpdal-hdf 2.9.0 haa54232_0
+  - libpdal-icebridge 2.9.0 haa54232_0
+  - libpdal-nitf 2.9.0 h986040f_0
+  - libpdal-pgpointcloud 2.9.0 h5c7ba8f_0
+  - libpdal-tiledb 2.9.0 h68be023_0
+  - libpdal-trajectory 2.9.0 h502ccf6_0
   constrains:
-  - pdal 2.8.4.*
+  - pdal 2.9.0.*
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 11780
-  timestamp: 1747451034998
+  size: 12026
+  timestamp: 1750441235368
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpdal-2.8.4-h7656b53_1.conda
   sha256: c6a94e62f12240e0cc02e5069122428615747a4e9e45caf2d8201c515432b302
   md5: f302d9d4841d9dc57fa2770f497c06d6
@@ -12588,29 +12730,29 @@ packages:
   purls: []
   size: 11509
   timestamp: 1738875551919
-- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-2.8.4-hb3590ec_6.conda
-  sha256: 921e6296a05f8a84a25b098387eb1ef28064f5903387c39c23c14fc2f1e3278e
-  md5: 30dccf7bbdfcd32328cb7c405af9ecf1
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-2.8.4-hb3590ec_7.conda
+  sha256: 3f174403088f8dd96497a54d55692121545ec62904ed218cb8aa28f96d281964
+  md5: f55969d5ddddb31d05ffa88e36773129
   depends:
-  - libpdal-arrow 2.8.4 h6c57e06_6
-  - libpdal-draco 2.8.4 ha763671_6
-  - libpdal-e57 2.8.4 h482c529_6
-  - libpdal-hdf 2.8.4 h2520430_6
-  - libpdal-icebridge 2.8.4 h2520430_6
-  - libpdal-nitf 2.8.4 h1b836ec_6
-  - libpdal-pgpointcloud 2.8.4 hb7c6058_6
-  - libpdal-tiledb 2.8.4 hc4b2a02_6
-  - libpdal-trajectory 2.8.4 h82545d7_6
+  - libpdal-arrow 2.8.4 h6c57e06_7
+  - libpdal-draco 2.8.4 ha763671_7
+  - libpdal-e57 2.8.4 h482c529_7
+  - libpdal-hdf 2.8.4 h2520430_7
+  - libpdal-icebridge 2.8.4 h2520430_7
+  - libpdal-nitf 2.8.4 h1b836ec_7
+  - libpdal-pgpointcloud 2.8.4 hb7c6058_7
+  - libpdal-tiledb 2.8.4 hc4b2a02_7
+  - libpdal-trajectory 2.8.4 hf542bf2_7
   constrains:
   - pdal 2.8.4.*
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 12203
-  timestamp: 1747452619850
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-arrow-2.8.4-hb7ef14c_6.conda
-  sha256: 61b61eff5d3bd6eef3855479452baf6c4811b2eca2d214bd870e5e56ce5f5747
-  md5: 5d380a33b5b13887917f626f8f883649
+  size: 12531
+  timestamp: 1748359613007
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-arrow-2.9.0-hb7ef14c_0.conda
+  sha256: 9831c4035aa368d61d140580974130e11212a586323924ab6d916e6b7ac45e85
+  md5: a10a7d92461f62e008ec6c81913cff7a
   depends:
   - __glibc >=2.17,<3.0.a0
   - libarrow >=20.0.0,<20.1.0a0
@@ -12618,15 +12760,15 @@ packages:
   - libgcc >=13
   - libgdal-arrow-parquet
   - libparquet >=20.0.0,<20.1.0a0
-  - libpdal-core 2.8.4 h921c622_6
+  - libpdal-core 2.9.0 ha13eeb3_0
   - libstdcxx >=13
   constrains:
-  - pdal 2.8.4.*
+  - pdal 2.9.0.*
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 186707
-  timestamp: 1747450708457
+  size: 199782
+  timestamp: 1750440881425
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpdal-arrow-2.8.4-h20b5a78_1.conda
   sha256: d4596981e369c1fe4b3956249130adf18788c8f419300dbb6203be3ae5816227
   md5: 160d7346dca6cb1f129f83b0baf147d5
@@ -12645,15 +12787,15 @@ packages:
   purls: []
   size: 146425
   timestamp: 1738874737183
-- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-arrow-2.8.4-h6c57e06_6.conda
-  sha256: 69bc00e718a70c0236e003ec973d1fa89a1ffe50b8b2faf98c9e7b0d39b0901d
-  md5: c19b3be2c1f305df74d59277ba950fec
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-arrow-2.8.4-h6c57e06_7.conda
+  sha256: 69a69e3ac966b15d018bacf40e159428a6a5146b514103c96bd7435c3489e689
+  md5: f2f6638fce30b4a7a1ddc28c227e682f
   depends:
   - libarrow >=20.0.0,<20.1.0a0
   - libarrow-dataset >=20.0.0,<20.1.0a0
   - libgdal-arrow-parquet
   - libparquet >=20.0.0,<20.1.0a0
-  - libpdal-core 2.8.4 h6f06235_6
+  - libpdal-core 2.8.4 heefb544_7
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -12662,31 +12804,31 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 236859
-  timestamp: 1747452082239
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-core-2.8.4-h921c622_6.conda
-  sha256: 3dfe4ea7b7c42402ec9b0dad394159206a91b5429f1dcc0db47c946748d79732
-  md5: 7ace78ca119e3e78d811a991a4401dea
+  size: 236286
+  timestamp: 1748358964218
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-core-2.9.0-ha13eeb3_0.conda
+  sha256: ed090abe795a244580542b14bb89648007b6ab5de1d01651aa4304d8f7760e0f
+  md5: c40776feedc4f3867825350a41ddb71c
   depends:
   - __glibc >=2.17,<3.0.a0
   - geotiff >=1.7.4,<1.8.0a0
   - icu *
-  - libcurl >=8.13.0,<9.0a0
+  - libcurl >=8.14.1,<9.0a0
   - libgcc >=13
-  - libgdal-core >=3.10.3,<3.11.0a0
+  - libgdal-core >=3.11.0,<3.12.0a0
   - libstdcxx >=13
   - libxml2 >=2.13.8,<2.14.0a0
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.5.0,<4.0a0
-  - proj >=9.6.0,<9.7.0a0
+  - proj >=9.6.2,<9.7.0a0
   - zstd >=1.5.7,<1.6.0a0
   constrains:
-  - pdal 2.8.4.*
+  - pdal 2.9.0.*
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 3562547
-  timestamp: 1747450564189
+  size: 3689283
+  timestamp: 1750440698700
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpdal-core-2.8.4-h920e52e_1.conda
   sha256: 4a31aa39615bc057d792995811594d00f21e82d93b4a061bc194af3f73eb3ad8
   md5: bef19500f7e741c8aa6c261ab4f1def3
@@ -12709,13 +12851,13 @@ packages:
   purls: []
   size: 2217662
   timestamp: 1738874072507
-- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-core-2.8.4-h6f06235_6.conda
-  sha256: c7ee36832b0f74bc3536624b02660a6ff3de963dfbf1fdac9c09b7711f5435e6
-  md5: 886baeef72e2473eb0a6f0d871f9b248
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-core-2.8.4-heefb544_7.conda
+  sha256: 1f4ec84c500bd5955be0d5e687b82df07120a3f771be815cd3fc205df0b99c11
+  md5: 802f58c15bc574f1edeac03faa054bc0
   depends:
   - geotiff >=1.7.4,<1.8.0a0
   - libcurl >=8.13.0,<9.0a0
-  - libgdal-core >=3.10.3,<3.11.0a0
+  - libgdal-core >=3.11.0,<3.12.0a0
   - libxml2 >=2.13.8,<2.14.0a0
   - libzlib >=1.3.1,<2.0a0
   - openssl >=3.5.0,<4.0a0
@@ -12729,25 +12871,25 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 2151805
-  timestamp: 1747451802820
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-cpd-2.8.4-hbb46d0d_6.conda
-  sha256: f46ab5dded97bad926033c836a4638a0b085a6782f8290eb38a279ab1b2593e3
-  md5: ff14fdf8033892078fb28362bc181c36
+  size: 2155789
+  timestamp: 1748358619828
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-cpd-2.9.0-hbb46d0d_0.conda
+  sha256: 9e482874b5717a61bd7d3cbab1bb09d90b6af3657a6af0ef23bc3851b15e98d8
+  md5: e7f182db393ce5694cd1e3b7f5f02e39
   depends:
   - __glibc >=2.17,<3.0.a0
   - cpd >=0.5.5,<0.6.0a0
   - fgt >=0.4.11,<0.5.0a0
   - libgcc >=13
-  - libpdal-core 2.8.4 h921c622_6
+  - libpdal-core 2.9.0 ha13eeb3_0
   - libstdcxx >=13
   constrains:
-  - pdal 2.8.4.*
+  - pdal 2.9.0.*
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 161534
-  timestamp: 1747450739667
+  size: 161973
+  timestamp: 1750440918789
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpdal-cpd-2.8.4-h5bc210e_1.conda
   sha256: c169f659afdbeca255324e9bb3cf225fbfc4332a1b1ac134e013133c64c06b74
   md5: 8d1d7f34f4bd483c261aadde8cbe0dfe
@@ -12764,22 +12906,22 @@ packages:
   purls: []
   size: 132619
   timestamp: 1738874817141
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-draco-2.8.4-hbb46d0d_6.conda
-  sha256: 630ee2313ac33d9ffa8a4f26e1bcdd9013d31b6910794e70379b9166d8a1d609
-  md5: c5615d0c4fa835ac577b4304ed498fdd
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-draco-2.9.0-hbb46d0d_0.conda
+  sha256: 5334a38961ad0e9cb9923cad1df32c1cfef174a5a98d42ad0ce7ac71fd460682
+  md5: 5e02b95ea2931ee5fac64766ccf18775
   depends:
   - __glibc >=2.17,<3.0.a0
   - draco 1.5.7 h00ab1b0_0
   - libgcc >=13
-  - libpdal-core 2.8.4 h921c622_6
+  - libpdal-core 2.9.0 ha13eeb3_0
   - libstdcxx >=13
   constrains:
-  - pdal 2.8.4.*
+  - pdal 2.9.0.*
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 135892
-  timestamp: 1747450777192
+  size: 136201
+  timestamp: 1750440959699
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpdal-draco-2.8.4-h5bc210e_1.conda
   sha256: 35a38c12578502dff507fa303bd088cbdd557cc52756c7f20cf93503105a81d9
   md5: adc7435865959fbfa31c6bc9e8ae01b2
@@ -12795,12 +12937,12 @@ packages:
   purls: []
   size: 102179
   timestamp: 1738874901798
-- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-draco-2.8.4-ha763671_6.conda
-  sha256: 8e215d1249e2aa8cf23b78f2dfbfa3fd52d9c3f83d5cd7170a9c0a699183da1d
-  md5: 396aa63a78427f780543252e47e1d993
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-draco-2.8.4-ha763671_7.conda
+  sha256: c9d97600b6fb9ce35c17bce42970058882f02e80a591f99f5e44f547f5bc042d
+  md5: 0cb0597d87ff8a70ea086d94f9a3260b
   depends:
   - draco 1.5.7 h181d51b_0
-  - libpdal-core 2.8.4 h6f06235_6
+  - libpdal-core 2.8.4 heefb544_7
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -12809,24 +12951,24 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 380658
-  timestamp: 1747452146272
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-e57-2.8.4-h0dda180_6.conda
-  sha256: a864a67b183c86a80f409df3c6926cdb5886debf2a680e9684e62bdda894b77a
-  md5: 59c9d0fc9d252f48cd5d19ba945bf210
+  size: 380638
+  timestamp: 1748359042321
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-e57-2.9.0-h0dda180_0.conda
+  sha256: e815a5e7051d4da2d7206b6c4f0424c8e56e8a4506c74fe4b9a5baf2c03770c3
+  md5: b16c88eeaa656a0e71353b145c74380e
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libpdal-core 2.8.4 h921c622_6
+  - libpdal-core 2.9.0 ha13eeb3_0
   - libstdcxx >=13
   - xerces-c >=3.2.5,<3.3.0a0
   constrains:
-  - pdal 2.8.4.*
+  - pdal 2.9.0.*
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 439159
-  timestamp: 1747450817402
+  size: 439301
+  timestamp: 1750441000292
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpdal-e57-2.8.4-hf47beff_1.conda
   sha256: e8084ea0996b0c9c1a1532a89a47b4bace1e95f29fc35766e645f0630dc5d66e
   md5: b51acbde05c14c4fa1b235481e44a3bd
@@ -12842,11 +12984,11 @@ packages:
   purls: []
   size: 313525
   timestamp: 1738875048443
-- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-e57-2.8.4-h482c529_6.conda
-  sha256: d36c3b9897d30c6898e4f04cbd17d33437a4ab5b34dc9a07b6d596bfe0577161
-  md5: d9df0d6a4fe07a3d712869d35af95d15
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-e57-2.8.4-h482c529_7.conda
+  sha256: 730828259c64e563a932689c4c9f5fc537869a746bca0416a33347b5e97349fa
+  md5: 534a3fa8e862e3fe4369fef9b5316d5c
   depends:
-  - libpdal-core 2.8.4 h6f06235_6
+  - libpdal-core 2.8.4 heefb544_7
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -12856,26 +12998,26 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 300418
-  timestamp: 1747452212364
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-hdf-2.8.4-haa54232_6.conda
-  sha256: 84495f3c33fb0edcc618c88d93b09f9643f6ffb0a284841986095a7f1ced3759
-  md5: aaecea202ae47c64e0b80b64539700cd
+  size: 300582
+  timestamp: 1748359125415
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-hdf-2.9.0-haa54232_0.conda
+  sha256: dd47225002cfaad9f6b135eb64832ba4a527c819575118f8a9b70312c61bb3cb
+  md5: 655df3ee7760024a9f95b55dbbf093c3
   depends:
   - __glibc >=2.17,<3.0.a0
   - hdf5 >=1.14.6,<1.14.7.0a0
   - libgcc >=13
   - libgdal-hdf5
-  - libpdal-core 2.8.4 h921c622_6
-  - libpdal-icebridge 2.8.4 haa54232_6
+  - libpdal-core 2.9.0 ha13eeb3_0
+  - libpdal-icebridge 2.9.0 haa54232_0
   - libstdcxx >=13
   constrains:
-  - pdal 2.8.4.*
+  - pdal 2.9.0.*
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 104676
-  timestamp: 1747451034155
+  size: 104761
+  timestamp: 1750441234440
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpdal-hdf-2.8.4-h1a002fd_1.conda
   sha256: 7a51b49c603ad8ff761cbce14f26a0f7562f2910ba989c07e55e2332093b4bb9
   md5: 9afed740abbd176f34cd1c15da056195
@@ -12893,14 +13035,14 @@ packages:
   purls: []
   size: 81582
   timestamp: 1738875548931
-- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-hdf-2.8.4-h2520430_6.conda
-  sha256: 89fc7fa8b288ed4793628fbd450404123a6708bc4d2bd4eacd5638e74a1c8131
-  md5: 3192b932d752a79c91b0359f255c91c5
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-hdf-2.8.4-h2520430_7.conda
+  sha256: 4b7a9287189b49ceeb40b152a7177e2ddb56f384cfda75d12d2149f9e0eab2db
+  md5: 4cfc9519491a17acf43da7d353338c2e
   depends:
   - hdf5 >=1.14.6,<1.14.7.0a0
   - libgdal-hdf5
-  - libpdal-core 2.8.4 h6f06235_6
-  - libpdal-icebridge 2.8.4 h2520430_6
+  - libpdal-core 2.8.4 heefb544_7
+  - libpdal-icebridge 2.8.4 h2520430_7
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -12909,24 +13051,24 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 148063
-  timestamp: 1747452618333
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-icebridge-2.8.4-haa54232_6.conda
-  sha256: 421dab2489c2e7db8e47918a839c62a8e3b152c42311fe7d59cd8be5d8147d1f
-  md5: f447dedf09e2dcf74f62bb6940217415
+  size: 148260
+  timestamp: 1748359611140
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-icebridge-2.9.0-haa54232_0.conda
+  sha256: 90bf64f87d9d8ccbc4faa65c9233549dbf15598cab37dee6b7d6c974a8b2cfbe
+  md5: 1d7973ffb3b295fac57c0d784164e5ab
   depends:
   - __glibc >=2.17,<3.0.a0
   - hdf5 >=1.14.6,<1.14.7.0a0
   - libgcc >=13
-  - libpdal-core 2.8.4 h921c622_6
+  - libpdal-core 2.9.0 ha13eeb3_0
   - libstdcxx >=13
   constrains:
-  - pdal 2.8.4.*
+  - pdal 2.9.0.*
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 54010
-  timestamp: 1747450853126
+  size: 54499
+  timestamp: 1750441038893
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpdal-icebridge-2.8.4-h1a002fd_1.conda
   sha256: 6a4a8389c57633978b6b09903b6ae988ad3ecd723c775c798d847f5b4e901070
   md5: 2318ef5158c0a530723a70435ec6b21d
@@ -12942,12 +13084,12 @@ packages:
   purls: []
   size: 42045
   timestamp: 1738875146808
-- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-icebridge-2.8.4-h2520430_6.conda
-  sha256: d8d3c4a40495bdd9cb1c4fc88a39538e79c017f71be25cb0912a2d323bb3f22e
-  md5: 741b8ef30dc44869c3831cc4acd38da4
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-icebridge-2.8.4-h2520430_7.conda
+  sha256: d1729f20f3ce85765ca15efb3cb7ef07a9b7dede0d50ec9f2ac2e3f7ff7cccdb
+  md5: 74d5420540e9efe4c06b0d039e4d43b5
   depends:
   - hdf5 >=1.14.6,<1.14.7.0a0
-  - libpdal-core 2.8.4 h6f06235_6
+  - libpdal-core 2.8.4 heefb544_7
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -12956,24 +13098,24 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 115166
-  timestamp: 1747452269831
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-nitf-2.8.4-h986040f_6.conda
-  sha256: d763ca7164cf580e07395d11a39ee78a742edfa0f3f156a95b899e63788141a8
-  md5: 5c48a619bdcd566cdb70ea07b197b614
+  size: 115860
+  timestamp: 1748359194725
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-nitf-2.9.0-h986040f_0.conda
+  sha256: 470e01fb5e7c65b4f8594abcfa027fa9e5686d7cd14f8b06cfb448df3951bd1c
+  md5: bd919c4fb2a5d253a5f45f241c1421a4
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libpdal-core 2.8.4 h921c622_6
+  - libpdal-core 2.9.0 ha13eeb3_0
   - libstdcxx >=13
   - nitro 2.7.dev8 h59595ed_0
   constrains:
-  - pdal 2.8.4.*
+  - pdal 2.9.0.*
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 153473
-  timestamp: 1747450889740
+  size: 153491
+  timestamp: 1750441079170
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpdal-nitf-2.8.4-hba6916d_1.conda
   sha256: c6c73acb1172d9ddd677668a7801301dfb0b892e53649fed485a8530b2560eed
   md5: 63e37ff3801c90db3445a9a42ecfc137
@@ -12989,11 +13131,11 @@ packages:
   purls: []
   size: 106068
   timestamp: 1738875248508
-- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-nitf-2.8.4-h1b836ec_6.conda
-  sha256: 5b6e717ae45f09edd02b6496c1e90f18d24133f7882b4af1ffa5ded965b1a970
-  md5: 0c0647e66e92e8856f9c783d791963fc
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-nitf-2.8.4-h1b836ec_7.conda
+  sha256: 7b9b79ce0f6b1a3684959ffdcab9972ce3bcfdd78620c9fc92df9cec6d645ab3
+  md5: 4b213a111a27836d349b25fc0fffa403
   depends:
-  - libpdal-core 2.8.4 h6f06235_6
+  - libpdal-core 2.8.4 heefb544_7
   - nitro 2.7.dev8 h1537add_0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -13003,27 +13145,27 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 201210
-  timestamp: 1747452342912
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-pgpointcloud-2.8.4-h5c7ba8f_6.conda
-  sha256: 3c4844dcc0eca7c0854a9552a571e5cd625f95911d2e961e4dfeb4468e2f4562
-  md5: 3b41d91bb582fa0e21396414e1d19f4e
+  size: 201284
+  timestamp: 1748359281045
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-pgpointcloud-2.9.0-h5c7ba8f_0.conda
+  sha256: 3bcb5d1e1568df8af4891487425bee113ff8d7d9d70f76336a338305825af000
+  md5: af226adc214c304077042ea57f04a7a9
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libgdal-pg
   - libgdal-postgisraster
-  - libpdal-core 2.8.4 h921c622_6
+  - libpdal-core 2.9.0 ha13eeb3_0
   - libpq >=17.5,<18.0a0
   - libstdcxx >=13
   - libxml2 >=2.13.8,<2.14.0a0
   constrains:
-  - pdal 2.8.4.*
+  - pdal 2.9.0.*
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 95571
-  timestamp: 1747450928277
+  size: 96005
+  timestamp: 1750441120126
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpdal-pgpointcloud-2.8.4-h16bec17_1.conda
   sha256: aebd8c18676a3a2ddb67f820ef0a68f6534f7900154fd1dd4dbaa50878297f0a
   md5: b2dd49a0b00e1dd22407de658225c9d8
@@ -13042,13 +13184,13 @@ packages:
   purls: []
   size: 66133
   timestamp: 1738875318334
-- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-pgpointcloud-2.8.4-hb7c6058_6.conda
-  sha256: f65edfb61dde3836926f5bc276fee34c32ebc269cd9128db2b8b2941a97dae78
-  md5: b81b1f5b80cb56bf17b126f3a5d677ed
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-pgpointcloud-2.8.4-hb7c6058_7.conda
+  sha256: de5409f6171e73ab37f81714cd17e52c3184f627d44b0de08baf0d4cae41eb12
+  md5: 6eff8508712bf55f52b8ae29f3b54b14
   depends:
   - libgdal-pg
   - libgdal-postgisraster
-  - libpdal-core 2.8.4 h6f06235_6
+  - libpdal-core 2.8.4 heefb544_7
   - libpq >=17.5,<18.0a0
   - libxml2 >=2.13.8,<2.14.0a0
   - ucrt >=10.0.20348.0
@@ -13059,25 +13201,25 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 175692
-  timestamp: 1747452406567
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-tiledb-2.8.4-h68be023_6.conda
-  sha256: 62d3119127b70e58a138a0b07e6152a63593030b0f5f9ca38c0a317eba9a4950
-  md5: 00deae3e5d89fb74720024aa7e3fae29
+  size: 175574
+  timestamp: 1748359357406
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-tiledb-2.9.0-h68be023_0.conda
+  sha256: 75c0a9e385135d900f7ffc126e2180714500724f8adbbee29575f85a2481d1dd
+  md5: 34f62b78b3a2f38500585c670d822af9
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libgdal-tiledb
-  - libpdal-core 2.8.4 h921c622_6
+  - libpdal-core 2.9.0 ha13eeb3_0
   - libstdcxx >=13
   - tiledb >=2.28.0,<2.29.0a0
   constrains:
-  - pdal 2.8.4.*
+  - pdal 2.9.0.*
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 263202
-  timestamp: 1747450965164
+  size: 262554
+  timestamp: 1750441160622
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpdal-tiledb-2.8.4-h96a401d_1.conda
   sha256: 75447f17f8ee45ba0d77c3606654bc334089f0b261c3201dd7959c78b901973d
   md5: 1fcc633dd1ab3637a8bea865bf1af5f0
@@ -13094,12 +13236,12 @@ packages:
   purls: []
   size: 204578
   timestamp: 1738875396894
-- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-tiledb-2.8.4-hc4b2a02_6.conda
-  sha256: 1adaa22e8fa731df1066ffd5831f0633a7a50f63480bffde97d80b133cc4cb34
-  md5: 8203bc0f8ff6bcee54280f1377809c69
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-tiledb-2.8.4-hc4b2a02_7.conda
+  sha256: f1fa16d8dc09b07d8ecf6ade7d4cdde561efdb5a0197ad32942ebd65bec4fda9
+  md5: 832a99f2801b6fc1b3204b91d2c6e853
   depends:
   - libgdal-tiledb
-  - libpdal-core 2.8.4 h6f06235_6
+  - libpdal-core 2.8.4 heefb544_7
   - tiledb >=2.28.0,<2.29.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -13109,11 +13251,11 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 268299
-  timestamp: 1747452482062
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-trajectory-2.8.4-hb16f371_6.conda
-  sha256: 8c34c69554b271cbcf02c67b3efd1847ca4963a90c898322f0b1c393a88e3c9d
-  md5: dee56ef796d75723fec7365d09775303
+  size: 268954
+  timestamp: 1748359447965
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpdal-trajectory-2.9.0-h502ccf6_0.conda
+  sha256: a970f2aa211747cbab677b919e446353bff875d5fab716d154b2f7751e2bba41
+  md5: 8afaf1d9cbf5f4ce52b1b4f69c023d2f
   depends:
   - __glibc >=2.17,<3.0.a0
   - ceres-solver >=2.2.0,<2.3.0a0
@@ -13121,16 +13263,16 @@ packages:
   - gflags >=2.2.2,<2.3.0a0
   - glog >=0.7.1,<0.8.0a0
   - libgcc >=13
-  - libgdal-core >=3.10.3,<3.11.0a0
-  - libpdal-core 2.8.4 h921c622_6
+  - libgdal-core >=3.11.0,<3.12.0a0
+  - libpdal-core 2.9.0 ha13eeb3_0
   - libstdcxx >=13
   constrains:
-  - pdal 2.8.4.*
+  - pdal 2.9.0.*
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 128820
-  timestamp: 1747450999458
+  size: 128745
+  timestamp: 1750441195868
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpdal-trajectory-2.8.4-hcb8ff9a_1.conda
   sha256: ad5ec7a02b9a0e82c4f11918dab195df12b798d1a2465f9d3bc5d35d6c537e59
   md5: 6a064f49d9694c079a5810c8224e8b63
@@ -13150,16 +13292,16 @@ packages:
   purls: []
   size: 102180
   timestamp: 1738875468740
-- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-trajectory-2.8.4-h82545d7_6.conda
-  sha256: 15aba46d973372b440e22204cd68ef8cd06c1248a0ba2fc4bbe854c89863d6d1
-  md5: 3195016405b1a63ff541f5fe0f4244d2
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpdal-trajectory-2.8.4-hf542bf2_7.conda
+  sha256: 40a63e685d2cee079ca54e6e8fec355ff962797ecf8af0412931ce3e90954575
+  md5: 5d183b5604b30dc78f5f62689af91d16
   depends:
   - ceres-solver >=2.2.0,<2.3.0a0
   - eigen >=3.4.0,<3.4.1.0a0
   - gflags >=2.2.2,<2.3.0a0
   - glog >=0.7.1,<0.8.0a0
-  - libgdal-core >=3.10.3,<3.11.0a0
-  - libpdal-core 2.8.4 h6f06235_6
+  - libgdal-core >=3.11.0,<3.12.0a0
+  - libpdal-core 2.8.4 heefb544_7
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -13168,8 +13310,8 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 172451
-  timestamp: 1747452555689
+  size: 173220
+  timestamp: 1748359535705
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libpmix-5.0.8-h658e747_0.conda
   sha256: 28c41a9dc992c2961c5b027a92f4f89bc1f5b6c97194dd15eb4e337b22c07654
   md5: dfcb13950dcdf35a5496035782dbaef9
@@ -13197,30 +13339,30 @@ packages:
   purls: []
   size: 532413
   timestamp: 1746901806284
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.47-h943b412_0.conda
-  sha256: 23367d71da58c9a61c8cbd963fcffb92768d4ae5ffbef9a47cdf1f54f98c5c36
-  md5: 55199e2ae2c3651f6f9b2a447b47bdc9
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.49-h943b412_0.conda
+  sha256: c8f5dc929ba5fcee525a66777498e03bbcbfefc05a0773e5163bb08ac5122f1a
+  md5: 37511c874cf3b8d0034c8d24e73c0884
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
   license: zlib-acknowledgement
   purls: []
-  size: 288701
-  timestamp: 1739952993639
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.47-h3783ad8_0.conda
-  sha256: dc93cc30f59b28e7812c6f14d2c2e590b509c38092cce7ababe6b23541b7ed8f
-  md5: 3550e05e3af94a3fa9cef2694417ccdf
+  size: 289506
+  timestamp: 1750095629466
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.49-h3783ad8_0.conda
+  sha256: b1050f6da51de507eec6902367cc2a3f381dd548eaaccb85673784543dcdee1a
+  md5: 90be56ffd1a6b1950268f88c12e17c69
   depends:
   - __osx >=11.0
   - libzlib >=1.3.1,<2.0a0
   license: zlib-acknowledgement
   purls: []
-  size: 259332
-  timestamp: 1739953032676
-- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.47-h7a4582a_0.conda
-  sha256: e12c46ca882080d901392ae45e0e5a1c96fc3e5acd5cd1a23c2632eb7f024f26
-  md5: ad620e92b82d2948bc019e029c574ebb
+  size: 259291
+  timestamp: 1750095759683
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.49-h7a4582a_0.conda
+  sha256: 8876a2d32d3538675e035b6560691471a1571835c0bcbf23816c24c460d31439
+  md5: 27269977c8f25d499727ceabc47cee3d
   depends:
   - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
@@ -13228,8 +13370,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: zlib-acknowledgement
   purls: []
-  size: 346511
-  timestamp: 1745771984515
+  size: 347727
+  timestamp: 1750096091724
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-17.5-h27ae623_0.conda
   sha256: 2dbcef0db82e0e7b6895b6c0dadd3d36c607044c40290c7ca10656f3fca3166f
   md5: 6458be24f09e1b034902ab44fe9de908
@@ -13354,22 +13496,22 @@ packages:
   purls: []
   size: 45026
   timestamp: 1742288893862
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2024.07.02-hba17884_3.conda
-  sha256: 392ec1e49370eb03270ffd4cc8d727f8e03e1e3a92b12f10c53f396ae4554668
-  md5: 545e93a513c10603327c76c15485e946
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.06.26-hba17884_0.conda
+  sha256: 89535af669f63e0dc4ae75a5fc9abb69b724b35e0f2ca0304c3d9744a55c8310
+  md5: f6881c04e6617ebba22d237c36f1b88e
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil * cxx17*
-  - libabseil >=20250127.0,<20250128.0a0
+  - libabseil >=20250127.1,<20250128.0a0
   - libgcc >=13
   - libstdcxx >=13
   constrains:
-  - re2 2024.07.02.*
+  - re2 2025.06.26.*
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 210073
-  timestamp: 1741121121238
+  size: 211720
+  timestamp: 1751053073521
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2024.07.02-h07bc746_2.conda
   sha256: 112a73ad483353751d4c5d63648c69a4d6fcebf5e1b698a860a3f5124fc3db96
   md5: 6b1e3624d3488016ca4f1ca0c412efaa
@@ -13385,22 +13527,22 @@ packages:
   purls: []
   size: 167155
   timestamp: 1735541067807
-- conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2024.07.02-hd248061_3.conda
-  sha256: 1e037dc1bc0fdaced4e103280f30d6f272ca15558a33d9f770ba64172eb699e8
-  md5: ba8d5530e951114fc3227780393d9ce2
+- conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2025.06.26-habfad5f_0.conda
+  sha256: ab65399d05be6d0e0733068b47d7d57e91e360ec46c7ced9e21d7f80ac8e05c3
+  md5: 38df4686fd7b22710a066faa749d9fa3
   depends:
   - libabseil * cxx17*
-  - libabseil >=20250127.0,<20250128.0a0
+  - libabseil >=20250127.1,<20250128.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   constrains:
-  - re2 2024.07.02.*
+  - re2 2025.06.26.*
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 263495
-  timestamp: 1741121665560
+  size: 267600
+  timestamp: 1751053268406
 - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-hd718a1a_18.conda
   sha256: 394cf4356e0e26c4c95c9681e01e4def77049374ac78b737193e38c1861e8042
   md5: 4f40dea96ff9935e7bd48893c24891b9
@@ -13439,9 +13581,9 @@ packages:
   purls: []
   size: 404655
   timestamp: 1741167186009
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.1.0-h97b714f_2.conda
-  sha256: 3f573329431523b2510b9374f4048d87bb603536bc63f66910cd47b5347ea37f
-  md5: 4de6cfe35a4736a63e4f59602a8ebeec
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-15.1.0-h97b714f_3.conda
+  sha256: 75fa45d8ea2344bfe96667b478fd00f1d038026f399cb680eceec836c90e67bc
+  md5: bbcff9bf972a0437bea8e431e4b327bb
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=15.1.0
@@ -13449,8 +13591,8 @@ packages:
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 4539916
-  timestamp: 1746642248624
+  size: 5224736
+  timestamp: 1750808272292
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsecret-0.21.7-h1e2da66_0.conda
   sha256: 2f4c634536ee8bccfb9f57b0248ef754d2ad4daa587673b76277cd515a2cbf1c
   md5: 70fc6d1bbf942b3d617646ac0359d9d8
@@ -13716,38 +13858,38 @@ packages:
   purls: []
   size: 181693
   timestamp: 1742288893864
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.1-hee588c1_0.conda
-  sha256: cd15ab1b9f0d53507e7ad7a01e52f6756ab3080bf623ab0e438973b6e4dba3c0
-  md5: 96a7e36bff29f1d0ddf5b771e0da373a
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.50.2-h6cd9bfd_0.conda
+  sha256: 07649c7c19b916179926006df5c38074618d35bf36cd33ab3fe8b22182bbd258
+  md5: b04c7eda6d7dab1e6503135e7fad4d25
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
   license: Unlicense
   purls: []
-  size: 919819
-  timestamp: 1749232795476
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.1-h3f77e49_0.conda
-  sha256: f39e22a00396c048dcfcb5d8c9dbedb2d69f06edcd8dba98b87f263eeb6d2049
-  md5: 73df23998b27dd6774d03db626d031d3
+  size: 918887
+  timestamp: 1751135622316
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.50.2-h6fb428d_0.conda
+  sha256: 6b51a9e7366d6cd26e50d1d0646331d457999ebb88af258f06a74f075e95bf68
+  md5: b2dc1707166040e738df2d514f8a1d22
   depends:
   - __osx >=11.0
   - libzlib >=1.3.1,<2.0a0
   license: Unlicense
   purls: []
-  size: 901258
-  timestamp: 1749232800279
-- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.50.1-h67fdade_0.conda
-  sha256: 0dda5b3f21ad2c7e823f21b0e173194347fbfccb73a06ddc9366da1877020bda
-  md5: 0e11a893eeeb46510520fd3fdd9c346a
+  size: 901519
+  timestamp: 1751135765345
+- conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.50.2-hf5d6505_0.conda
+  sha256: d136ecf423f83208156daa6a8c1de461a7e9780e8e4423c23c7e136be3c2ff0a
+  md5: e1e6cac409e95538acdc3d33a0f34d6a
   depends:
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: Unlicense
   purls: []
-  size: 1082758
-  timestamp: 1749233212790
+  size: 1285981
+  timestamp: 1751135695346
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
   sha256: fa39bfd69228a13e553bd24601332b7cfeb30ca11a3ca50bb028108fe90a7661
   md5: eecce068c7e4eddeb169591baac20ac4
@@ -13786,27 +13928,27 @@ packages:
   purls: []
   size: 292785
   timestamp: 1745608759342
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_2.conda
-  sha256: 6ae3d153e78f6069d503d9309f2cac6de5b93d067fc6433160a4c05226a5dad4
-  md5: 1cb1c67961f6dd257eae9e9691b341aa
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_3.conda
+  sha256: 7650837344b7850b62fdba02155da0b159cf472b9ab59eb7b472f7bd01dff241
+  md5: 6d11a5edae89fe413c0569f16d308f5a
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc 15.1.0 h767d61c_2
+  - libgcc 15.1.0 h767d61c_3
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 3902355
-  timestamp: 1746642227493
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_2.conda
-  sha256: 11bea86e11de7d6bce87589197a383344df3fa0a3552dab7e931785ff1159a5b
-  md5: 9d2072af184b5caa29492bf2344597bb
+  size: 3896407
+  timestamp: 1750808251302
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_3.conda
+  sha256: bbaea1ecf973a7836f92b8ebecc94d3c758414f4de39d2cc6818a3d10cb3216b
+  md5: 57541755b5a51691955012b8e197c06c
   depends:
-  - libstdcxx 15.1.0 h8f9b012_2
+  - libstdcxx 15.1.0 h8f9b012_3
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
   purls: []
-  size: 34647
-  timestamp: 1746642266826
+  size: 29093
+  timestamp: 1750808292700
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsuitesparseconfig-7.10.1-h901830b_7100101.conda
   sha256: d8f32a0b0ee17fbace7af4bd34ad554cc855b9c18e0aeccf8395e1478c161f37
   md5: 57ae1dd979da7aa88a9b38bfa2e1d6b2
@@ -13850,9 +13992,9 @@ packages:
   purls: []
   size: 44847
   timestamp: 1742288893861
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.6-h4e0b6ca_0.conda
-  sha256: 139b89421a651c004aba9c5e351e61674d98723f3f19d45cdbcde1fd6e8a59df
-  md5: 071409970083d0f99ab7b569352771c9
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.7-h4e0b6ca_0.conda
+  sha256: e26b22c0ae40fb6ad4356104d5fa4ec33fe8dd8a10e6aef36a9ab0c6a6f47275
+  md5: 1e12c8aa74fa4c3166a9bdc135bc4abf
   depends:
   - __glibc >=2.17,<3.0.a0
   - libcap >=2.75,<2.76.0a0
@@ -13863,8 +14005,8 @@ packages:
   - zstd >=1.5.7,<1.6.0a0
   license: LGPL-2.1-or-later
   purls: []
-  size: 489524
-  timestamp: 1748886391854
+  size: 487969
+  timestamp: 1750949895969
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtasn1-4.20.0-h5505292_0.conda
   sha256: 7b320516555ac9131aa2935c98d73364e8f5bdff2d17f37532881a3e3bd494af
   md5: 6e30ad12e566ed6f404be9af5a0f6751
@@ -13971,17 +14113,17 @@ packages:
   purls: []
   size: 979074
   timestamp: 1747067408877
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.6-hbe16f8c_0.conda
-  sha256: 742369b1203547dee69917c2af0c2bac6d1c1921203deaf7ef52c3283ec5c14a
-  md5: 2ddf4d040b58018f8ba3dfd464837827
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.7-hbe16f8c_0.conda
+  sha256: 3fca2655f4cf2ce6b618a2b52e3dce92f27f429732b88080567d5bbeea404c82
+  md5: 5a23e52bd654a5297bd3e247eebab5a3
   depends:
   - __glibc >=2.17,<3.0.a0
   - libcap >=2.75,<2.76.0a0
   - libgcc >=13
   license: LGPL-2.1-or-later
   purls: []
-  size: 144531
-  timestamp: 1748886400306
+  size: 143533
+  timestamp: 1750949902296
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libumfpack-6.3.5-h873dde6_7100101.conda
   sha256: 9a2c0049210c0223084c29b39404ad6da6538e7a4d1ed74ee8423212998fd686
   md5: 9626fc7667bc6c901c7a0a4004938c71
@@ -14384,18 +14526,18 @@ packages:
   purls: []
   size: 55476
   timestamp: 1727963768015
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-20.1.6-hdb05f8b_0.conda
-  sha256: 99c8aa89a77870d6ee16d62b858be67e30f2ad4fe13555570c7660cc38f9557b
-  md5: 7a3b28d59940a28e761e0a623241a832
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-20.1.7-hdb05f8b_0.conda
+  sha256: e7d95b50a90cdc9e0fc38bc37f493a61b9d08164114b562bbd9ff0034f45eca2
+  md5: 741e1da0a0798d32e13e3724f2ca2dcf
   depends:
   - __osx >=11.0
   constrains:
-  - openmp 20.1.6|20.1.6.*
+  - openmp 20.1.7|20.1.7.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
   purls: []
-  size: 282698
-  timestamp: 1748570308073
+  size: 281996
+  timestamp: 1749892286735
 - conda: https://conda.anaconda.org/conda-forge/linux-64/llvmlite-0.44.0-py311h9c9ff8c_1.conda
   sha256: 48e91296af21ce96ea4dc6adca6bd5528aeda3b717d9a3e72e63e4909a142ef2
   md5: eb6be2d03a0f5b259ae00427a6cb1b73
@@ -14503,13 +14645,13 @@ packages:
   - pkg:pypi/locket?source=hash-mapping
   size: 8250
   timestamp: 1650660473123
-- conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-5.4.0-py311hbd2c71b_0.conda
-  sha256: 87fb5cc03e97a21b353fea5400a9f2eeea239a68c83f1e674fcd365bbbb699b0
-  md5: 8f918de217abd92a1197cd0ef3b5ce16
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.0.0-py311hbd2c71b_0.conda
+  sha256: 0c8783524bd51f8e9d6ec1322e74fdd200036e994b331d8a37aa28759e15b595
+  md5: 3fee70825164281b54d6c3aba97e619c
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libxml2 >=2.13.7,<2.14.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
   - libxslt >=1.1.39,<2.0a0
   - libzlib >=1.3.1,<2.0a0
   - python >=3.11,<3.12.0a0
@@ -14517,15 +14659,15 @@ packages:
   license: BSD-3-Clause and MIT-CMU
   purls:
   - pkg:pypi/lxml?source=hash-mapping
-  size: 1390077
-  timestamp: 1745414121627
-- conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-5.4.0-py312h68d7fa5_0.conda
-  sha256: ee072aef31b8ec89bed4600ceb4c73aea81c2246c3244b2872571584b5dce045
-  md5: 9143d654930fa7d0ad1e351705419cb5
+  size: 1584583
+  timestamp: 1751021744404
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.0.0-py312h68d7fa5_0.conda
+  sha256: 7d0b6283aab071a83731021384f31a132db341e3d784757e3cc60b7500a1af37
+  md5: 5f672474eea97c1d115e9ddd28ab8076
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libxml2 >=2.13.7,<2.14.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
   - libxslt >=1.1.39,<2.0a0
   - libzlib >=1.3.1,<2.0a0
   - python >=3.12,<3.13.0a0
@@ -14533,14 +14675,14 @@ packages:
   license: BSD-3-Clause and MIT-CMU
   purls:
   - pkg:pypi/lxml?source=hash-mapping
-  size: 1404621
-  timestamp: 1745414227771
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-5.4.0-py311hfcb965d_0.conda
-  sha256: 174744465fea296d96d6289b5888c653f887e1365e9a4f22c853b08e873ca152
-  md5: 2dac514fa79912080deccce05becb5b3
+  size: 1593117
+  timestamp: 1751021703851
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-6.0.0-py311hfcb965d_0.conda
+  sha256: 1b66865e8eaefdd7eb56c8465c2549755426b916c983c6a24ace612cc6ec3e7d
+  md5: e5ec226447567badf5b4a91f72f39e35
   depends:
   - __osx >=11.0
-  - libxml2 >=2.13.7,<2.14.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
   - libxslt >=1.1.39,<2.0a0
   - libzlib >=1.3.1,<2.0a0
   - python >=3.11,<3.12.0a0
@@ -14549,14 +14691,14 @@ packages:
   license: BSD-3-Clause and MIT-CMU
   purls:
   - pkg:pypi/lxml?source=hash-mapping
-  size: 1196626
-  timestamp: 1745414265761
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-5.4.0-py312hc2c121e_0.conda
-  sha256: d9ea36f6b68ab73e7c65040f46bf6f1566d578fd2ae1f6e2fa4fc72c16f607a6
-  md5: 8bf1e82fa3bfb5905796c6e52d623903
+  size: 1346161
+  timestamp: 1751021901608
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-6.0.0-py312hc2c121e_0.conda
+  sha256: cc0d35b5a80ad4807020cfc66bc08e0ead887e85c624649911c761a3f58302b4
+  md5: 7bcb5ffb2f3b83bcb19049481c7b6c57
   depends:
   - __osx >=11.0
-  - libxml2 >=2.13.7,<2.14.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
   - libxslt >=1.1.39,<2.0a0
   - libzlib >=1.3.1,<2.0a0
   - python >=3.12,<3.13.0a0
@@ -14565,42 +14707,42 @@ packages:
   license: BSD-3-Clause and MIT-CMU
   purls:
   - pkg:pypi/lxml?source=hash-mapping
-  size: 1201897
-  timestamp: 1745414239165
-- conda: https://conda.anaconda.org/conda-forge/win-64/lxml-5.4.0-py311h590fa1f_0.conda
-  sha256: ddf5276b3ee8429de8f6e1aad283036988cf1ed67012805996ca27abb91ae452
-  md5: 63e4d329fdfc1bd71d96aee75c65fc1c
+  size: 1366081
+  timestamp: 1751021867744
+- conda: https://conda.anaconda.org/conda-forge/win-64/lxml-6.0.0-py311hea5fcc3_0.conda
+  sha256: d8bc0e00aac11cba7a608b02dcaaf4372513a177962173563afc618e3883123c
+  md5: c407f00017ac828c474dbfcdc3ebbd87
   depends:
-  - libxml2 >=2.13.7,<2.14.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
   - libxslt >=1.1.39,<2.0a0
   - libzlib >=1.3.1,<2.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: BSD-3-Clause and MIT-CMU
   purls:
   - pkg:pypi/lxml?source=hash-mapping
-  size: 1054755
-  timestamp: 1745414419745
-- conda: https://conda.anaconda.org/conda-forge/win-64/lxml-5.4.0-py312hef2e38f_0.conda
-  sha256: 18cc69c479da9d1298e74aa4eec9a4c93953d45dd2544be8bad837637d4ad34b
-  md5: ddec733582c0b0ab2a0dcf68d35a7dd5
+  size: 1238616
+  timestamp: 1751022037147
+- conda: https://conda.anaconda.org/conda-forge/win-64/lxml-6.0.0-py312hc85b015_0.conda
+  sha256: 5157d78fa900641be1d9508fff7ba61ffe0b4ee54602ae5fb1887ef7d21b5b25
+  md5: e7eaa37abe4d0e8a2fd56ecaac0f9d22
   depends:
-  - libxml2 >=2.13.7,<2.14.0a0
+  - libxml2 >=2.13.8,<2.14.0a0
   - libxslt >=1.1.39,<2.0a0
   - libzlib >=1.3.1,<2.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: BSD-3-Clause and MIT-CMU
   purls:
   - pkg:pypi/lxml?source=hash-mapping
-  size: 1047683
-  timestamp: 1745414493450
+  size: 1232795
+  timestamp: 1751021843977
 - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-4.4.4-py311h8c6ae76_0.conda
   sha256: cff970448fbb85da6b3083ad985a991f789df7905941904eb085003314aac725
   md5: cb99a4a8a0828c76d2869d807ef92f7a
@@ -14771,7 +14913,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/mapclassify?source=compressed-mapping
+  - pkg:pypi/mapclassify?source=hash-mapping
   size: 276836
   timestamp: 1748411918865
 - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_1.conda
@@ -15373,9 +15515,9 @@ packages:
   purls: []
   size: 4294
   timestamp: 1605464601195
-- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py311hd18a35c_0.conda
-  sha256: 9033fa7084cbfd10e1b7ed3b74cee17169a0731ec98244d05c372fc4a935d5c9
-  md5: 682f76920687f7d9283039eb542fdacf
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.1-py311hd18a35c_0.conda
+  sha256: f07aafd9e9adddf66b75630b4f68784e22ce63ae9e0887711a7386ceb2506fca
+  md5: d0898973440adc2ad25917028669126d
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -15386,11 +15528,11 @@ packages:
   license_family: Apache
   purls:
   - pkg:pypi/msgpack?source=hash-mapping
-  size: 104809
-  timestamp: 1725975116412
-- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.0-py312h68727a3_0.conda
-  sha256: 4bc53333774dea1330643b7e23aa34fd6880275737fc2e07491795872d3af8dd
-  md5: 5c9b020a3f86799cdc6115e55df06146
+  size: 103109
+  timestamp: 1749813330034
+- conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.1.1-py312h68727a3_0.conda
+  sha256: 969b8e50922b592228390c25ac417c0761fd6f98fccad870ac5cc84f35da301a
+  md5: 6998b34027ecc577efe4e42f4b022a98
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -15400,15 +15542,15 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/msgpack?source=hash-mapping
-  size: 105271
-  timestamp: 1725975182669
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py311h2c37856_0.conda
-  sha256: aafa8572c72283801148845772fd9d494765bdcf1b8ae6f435e1caff4f1c97f3
-  md5: 6c826762702474fb0def6cedd2db5316
+  - pkg:pypi/msgpack?source=compressed-mapping
+  size: 102924
+  timestamp: 1749813333354
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.1-py311h210dab8_0.conda
+  sha256: eb0cfc60f428cd4cd9f50f7764ee2c2910949b82893055cf29c0866c163e5c33
+  md5: f4f5b9fb201bfad3d0806d4a3af405b2
   depends:
   - __osx >=11.0
-  - libcxx >=17
+  - libcxx >=18
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
@@ -15416,26 +15558,26 @@ packages:
   license_family: Apache
   purls:
   - pkg:pypi/msgpack?source=hash-mapping
-  size: 91131
-  timestamp: 1725975234150
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.0-py312h6142ec9_0.conda
-  sha256: 2b8c22f8a4e0031c2d6fa81d32814c8afdaf7e7fe2e681bf2369a35ff3eab1fd
-  md5: 0dfc3750cc6bbc463d72c0b727e60d8a
+  size: 90646
+  timestamp: 1749813845551
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/msgpack-python-1.1.1-py312hb23fbb9_0.conda
+  sha256: 0cdc5fcdb75727a13cbcfc49e00b0fddf6705c7bd908aee1dd1e7a869de8dfe9
+  md5: 4ae8111ba5af53e50cb6f9d1705c408c
   depends:
   - __osx >=11.0
-  - libcxx >=17
+  - libcxx >=18
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/msgpack?source=hash-mapping
-  size: 90793
-  timestamp: 1725975279147
-- conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.0-py311h3257749_0.conda
-  sha256: 4e6a7979b434308ce5588970cb613952e3340bb2f9e63aaad7e5069ef1f08d1d
-  md5: 36562593204b081d0da8a8bfabfb278b
+  - pkg:pypi/msgpack?source=compressed-mapping
+  size: 91155
+  timestamp: 1749813638452
+- conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.1-py311h3257749_0.conda
+  sha256: a0ba6da7e31c406c39da1258d0c4304b58e791b3836529e51dc56d7d8f542de4
+  md5: 236c48eab3925b666eed26a3ba94bcb6
   depends:
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
@@ -15446,11 +15588,11 @@ packages:
   license_family: Apache
   purls:
   - pkg:pypi/msgpack?source=hash-mapping
-  size: 89472
-  timestamp: 1725975909671
-- conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.0-py312hd5eb7cc_0.conda
-  sha256: 3fd45d9c0830e931e34990cb90e88ba53cc7f89fce69fc7d1a8289639d363e85
-  md5: ff4f1e63a6438a06d1ab259936e5c2ac
+  size: 88144
+  timestamp: 1749814077794
+- conda: https://conda.anaconda.org/conda-forge/win-64/msgpack-python-1.1.1-py312hd5eb7cc_0.conda
+  sha256: 41d9b229e0654400d81bfe417675b4603e4cd7d13ffc1b1aa9c748c67d5bd39f
+  md5: 732a1b46ab8c8ee0dce4aac014e66006
   depends:
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -15461,22 +15603,46 @@ packages:
   license_family: Apache
   purls:
   - pkg:pypi/msgpack?source=hash-mapping
-  size: 88169
-  timestamp: 1725975418157
-- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
-  sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
-  md5: 2ba8498c1018c1e9c61eb99b973dfe19
+  size: 87498
+  timestamp: 1749813960284
+- conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyhd8ed1ab_1.conda
+  sha256: d09c47c2cf456de5c09fa66d2c3c5035aa1fa228a1983a433c47b876aa16ce90
+  md5: 37293a85a0f4f77bbd9cf7aaefc62609
   depends:
-  - python
+  - python >=3.9
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/munkres?source=hash-mapping
-  size: 12452
-  timestamp: 1600387789153
-- conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.16.0-py311h9ecbd09_0.conda
-  sha256: e6a5b2d6f79cf34c171f633e3d0972f410ed5c927a6825a62cbe44dd24c0ba21
-  md5: 72f1d298d27aced6463aacad8d437432
+  - pkg:pypi/munkres?source=compressed-mapping
+  size: 15851
+  timestamp: 1749895533014
+- conda: https://conda.anaconda.org/conda-forge/linux-64/muparser-2.3.5-h5888daf_0.conda
+  sha256: 320dfc59a94cb9e3635bda71b9e62278b34aa2fdaea0caa6832ddb9b37e9ccd5
+  md5: ab3e3db511033340e75e7002e80ce8c0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 203174
+  timestamp: 1747116762269
+- conda: https://conda.anaconda.org/conda-forge/win-64/muparser-2.3.5-he0c23c2_0.conda
+  sha256: 57f78d8cd9a282d03cd7a7ffb1f42d570e1bbfb42d606e99de5c16e089067185
+  md5: 013aabb169d59009bdf7d70319360e9b
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 148557
+  timestamp: 1747117340968
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.16.1-py311h9ecbd09_0.conda
+  sha256: 74c465c69a356d5bb8fe37b5623a64601a75c2053b1c1b2287d07b2152498fa8
+  md5: 6756b9d36dbd989470dd73cce7c04495
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -15490,11 +15656,11 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/mypy?source=hash-mapping
-  size: 18753001
-  timestamp: 1748547630128
-- conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.16.0-py312h66e93f0_0.conda
-  sha256: 2a1d7b66b6abf0d2b72ae881612f60c5953244eaa3a2326f07dc0e176b432531
-  md5: af65ec3f748ca1e4c4bec26e2844f7e3
+  size: 18754430
+  timestamp: 1750118676430
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.16.1-py312h66e93f0_0.conda
+  sha256: 2d1dca2a580374470e8a108565356e13aec8598c83eec17d888a4cc0b014cddd
+  md5: d52e9cc0c93e47a87e1024158ed2bcd3
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -15508,11 +15674,11 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/mypy?source=hash-mapping
-  size: 18824892
-  timestamp: 1748547279249
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.16.0-py311h917b07b_0.conda
-  sha256: 41f11c8ac88494eadc9c8d3918776a34de2bb194f983dcdb6530487071628f67
-  md5: fe7c8f573c3c9fbfde74ea1b53712472
+  size: 18860143
+  timestamp: 1750118219318
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.16.1-py311h917b07b_0.conda
+  sha256: c5c68e725bf143456c58eacc066328e8dc46c3a7069f1e83b1d3ce71f36ce639
+  md5: fc2af37ec54335ef65448e85b44d6edd
   depends:
   - __osx >=11.0
   - mypy_extensions >=1.0.0
@@ -15526,11 +15692,11 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/mypy?source=hash-mapping
-  size: 10010442
-  timestamp: 1748547285392
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.16.0-py312hea69d52_0.conda
-  sha256: 61e12ef4bc5ae300dacaa9de924a674d86bc53caa928d98e57c9d94955c7e918
-  md5: 9ffa6d710bc1ba7eb6fa54c3db40b5e2
+  size: 9996661
+  timestamp: 1750118375356
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.16.1-py312hea69d52_0.conda
+  sha256: 32920a7074b450a15f0f7b1ba48e5246484c44c167d38311db85ca9d7b100eac
+  md5: ab4b5c37bfdd0002491a92239a580af7
   depends:
   - __osx >=11.0
   - mypy_extensions >=1.0.0
@@ -15543,12 +15709,12 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/mypy?source=compressed-mapping
-  size: 10338262
-  timestamp: 1748547448199
-- conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.16.0-py311he736701_0.conda
-  sha256: 1c5746a543393519d905f18c5fb6ec238bf17eca4a832b5e07867c787cfec1b8
-  md5: 21440d57d03c6ac465676e2bb5b96b40
+  - pkg:pypi/mypy?source=hash-mapping
+  size: 10320816
+  timestamp: 1750118464722
+- conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.16.1-py311he736701_0.conda
+  sha256: 6b7148b5c95ee79d4d158a8cf2e7700d2418fa2cdafbca506f9071940668d064
+  md5: ed9b934ee2a74a302c712395f0247d2d
   depends:
   - mypy_extensions >=1.0.0
   - pathspec >=0.9.0
@@ -15563,11 +15729,11 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/mypy?source=hash-mapping
-  size: 10243038
-  timestamp: 1748547307314
-- conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.16.0-py312h4389bb4_0.conda
-  sha256: 6cb935cbf31373bf453105750f6e62f19adf9d89e99516ffa7c12b89edd0dd96
-  md5: 3d4be3acdd2c610c58ad18b83805f631
+  size: 10334010
+  timestamp: 1750118527547
+- conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.16.1-py312h4389bb4_0.conda
+  sha256: 5bb00863b7a736e5bfdabc576af1ff93bb95ab78b3f35e5d800feda57148ba1d
+  md5: 749b32d06a926c492bc48de440fc6919
   depends:
   - mypy_extensions >=1.0.0
   - pathspec >=0.9.0
@@ -15582,8 +15748,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/mypy?source=hash-mapping
-  size: 9929836
-  timestamp: 1748547482790
+  size: 10100093
+  timestamp: 1750118435536
 - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
   sha256: 6ed158e4e5dd8f6a10ad9e525631e35cee8557718f83de7a4e3966b1f772c4b1
   md5: e9c622e0d00fa24a6292279af3ab6d06
@@ -15622,18 +15788,18 @@ packages:
   purls: []
   size: 1352817
   timestamp: 1744125034041
-- conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.42.0-pyhe01879c_0.conda
-  sha256: 24e38798d37b14ab2e9bdf03a7d60da647805f535798883f511308d822e986ad
-  md5: 59ac95d874bc29d352fb4554fea14789
+- conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.45.0-pyhe01879c_0.conda
+  sha256: 8f0fe3d641a48b2da4573eba41f4acd2e5631714a56b574a3c44e6024636fe17
+  md5: 482ef8fa195fd3119846e080e6233b1a
   depends:
   - python >=3.9
   - python
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/narwhals?source=hash-mapping
-  size: 226893
-  timestamp: 1749494642346
+  - pkg:pypi/narwhals?source=compressed-mapping
+  size: 234102
+  timestamp: 1751393316636
 - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.10.2-pyhd8ed1ab_0.conda
   sha256: a20cff739d66c2f89f413e4ba4c6f6b59c50d5c30b5f0d840c13e8c9c2df9135
   md5: 6bb0d77277061742744176ab555b723c
@@ -15863,58 +16029,58 @@ packages:
   - pkg:pypi/networkx?source=hash-mapping
   size: 1564462
   timestamp: 1749078300258
-- conda: https://conda.anaconda.org/conda-forge/linux-64/nh3-0.2.21-py39h77e2912_1.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nh3-0.2.21-py39h7c48542_2.conda
   noarch: python
-  sha256: 05b2fcbc831ea2936108ba1ebdb249d310d710c7880a98a25817510cf8a41d2a
-  md5: 5547559fdb8becc558147c0183e5eebe
+  sha256: 2b03aae2181c6f3569f41dfd5781caeedb98a6a91ebe294e36a596cf1184570f
+  md5: 2f8c58a98e37736ba86a32ed29cf6210
   depends:
   - python
   - libgcc >=13
   - __glibc >=2.17,<3.0.a0
   - _python_abi3_support 1.*
-  - python >=3.9
+  - cpython >=3.9
   constrains:
   - __glibc >=2.17
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/nh3?source=hash-mapping
-  size: 621078
-  timestamp: 1741652643562
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nh3-0.2.21-py39h52c9f89_1.conda
+  size: 624208
+  timestamp: 1750895927138
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nh3-0.2.21-py39h39b1003_2.conda
   noarch: python
-  sha256: 688bef40252a2c51f5c4b556ea0e0a8ea9116606e2e523a9d2a25146d973f3a6
-  md5: 2528bab75df4b8b9307807dc4ef76796
+  sha256: 5c2486ac075e31ea57f63bd21923cea2752e19d8bd8301e954e80660376cfd68
+  md5: 25cfdef3322dd7e87c4fcc14cd9610cd
   depends:
   - python
   - __osx >=11.0
   - _python_abi3_support 1.*
-  - python >=3.9
+  - cpython >=3.9
   constrains:
   - __osx >=11.0
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/nh3?source=hash-mapping
-  size: 560146
-  timestamp: 1741652707931
-- conda: https://conda.anaconda.org/conda-forge/win-64/nh3-0.2.21-py39he870945_1.conda
+  size: 565436
+  timestamp: 1750895986983
+- conda: https://conda.anaconda.org/conda-forge/win-64/nh3-0.2.21-py39h81ceba4_2.conda
   noarch: python
-  sha256: c441efc437deeafa37d37120fb8d671238427e926279db9ca22315352ccf5065
-  md5: d07edf27dc51778b81a9a9748f3a9356
+  sha256: d2756c3b23a40838bb63d207d6b839a34e2cf80e555d84f4a40a005ff3d2694b
+  md5: 689dbe3db34eb3e476347e0c8cc54ee9
   depends:
   - python
   - vc >=14.3,<15
-  - vc14_runtime >=14.42.34438
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - _python_abi3_support 1.*
-  - python >=3.9
+  - cpython >=3.9
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/nh3?source=hash-mapping
-  size: 513432
-  timestamp: 1741652669968
+  size: 514007
+  timestamp: 1750895927355
 - conda: https://conda.anaconda.org/conda-forge/linux-64/nitro-2.7.dev8-h59595ed_0.conda
   sha256: 80b125f82b1553ed00550a642dcaefb5f046d69f6d1eefa9ee3ac8d5b273e029
   md5: 5fad8a0083974b2f9e6ff64b8ca426a0
@@ -15981,12 +16147,12 @@ packages:
   - pkg:pypi/nose2?source=hash-mapping
   size: 92820
   timestamp: 1580623268425
-- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.4.3-pyhd8ed1ab_0.conda
-  sha256: aea1b33b734e809bd090f0bae47f4bca5da406f7bc7dd65a67b565f03c740866
-  md5: f0b767b717cab652712d29f5e4699b2a
+- conda: https://conda.anaconda.org/conda-forge/noarch/notebook-7.4.4-pyhd8ed1ab_0.conda
+  sha256: 6d7e522a91dcc6f7b8b119da86534f9ad021cd9094c5db7dbfd16e48efd02857
+  md5: dcbb5c47f5dffa7637c05df5d4068181
   depends:
   - jupyter_server >=2.4.0,<3
-  - jupyterlab >=4.4.3,<4.5
+  - jupyterlab >=4.4.4,<4.5
   - jupyterlab_server >=2.27.1,<3
   - notebook-shim >=0.2,<0.3
   - python >=3.9
@@ -15995,8 +16161,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/notebook?source=hash-mapping
-  size: 10538691
-  timestamp: 1748278796079
+  size: 10511848
+  timestamp: 1751290903603
 - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.4-pyhd8ed1ab_1.conda
   sha256: 7b920e46b9f7a2d2aa6434222e5c8d739021dbc5cc75f32d124a8191d86f9056
   md5: e7f89ea5f7ea9401642758ff50a2d9c1
@@ -16032,35 +16198,35 @@ packages:
   purls: []
   size: 202873
   timestamp: 1729545964601
-- conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.112-h159eef7_0.conda
-  sha256: fba790fc41c331878480fcc818a5bd76f58fd9f3ab273569994faf100d4e6013
-  md5: 688a8bc02e57e6b741a040c84e931a7d
+- conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.113-h159eef7_0.conda
+  sha256: ceef2b561cc92f00bac1263562f8fd9c17ff11de710fc27370572adee1b34b1c
+  md5: 47fbbbda15a2a03bae2b3d2cd3735b30
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libsqlite >=3.49.2,<4.0a0
+  - libsqlite >=3.50.1,<4.0a0
   - libstdcxx >=13
   - libzlib >=1.3.1,<2.0a0
   - nspr >=4.36,<5.0a0
   license: MPL-2.0
   license_family: MOZILLA
   purls: []
-  size: 2005432
-  timestamp: 1748362992069
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.112-ha3c76ea_0.conda
-  sha256: e0c5ad991f3305bc39aef185138422fa0c490c645a543ab327fadcf600bbcec9
-  md5: 0a1c593b7349a50bbefcbf67a017d927
+  size: 2009636
+  timestamp: 1750369586316
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.113-ha3c76ea_0.conda
+  sha256: f2067d241d6a414cdbf5022ff15ccb9e22f26722259a4498608253bd20bc098f
+  md5: 9b750a217ce07a584ac593391a710dc1
   depends:
   - __osx >=11.0
   - libcxx >=18
-  - libsqlite >=3.49.2,<4.0a0
+  - libsqlite >=3.50.1,<4.0a0
   - libzlib >=1.3.1,<2.0a0
   - nspr >=4.36,<5.0a0
   license: MPL-2.0
   license_family: MOZILLA
   purls: []
-  size: 1826617
-  timestamp: 1748363082435
+  size: 1828206
+  timestamp: 1750370138279
 - conda: https://conda.anaconda.org/conda-forge/linux-64/numba-0.61.2-py311h9806782_1.conda
   sha256: e822e0cb85a54d51d321897c5da3039788406f80d21e62a7bce01d1cade7c2f3
   md5: 9b72f3bfefed2f5fa1cdb01e8110b571
@@ -16362,9 +16528,9 @@ packages:
   purls: []
   size: 106742
   timestamp: 1743700382939
-- conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2024.10.24-h5888daf_0.conda
-  sha256: 7e1d3ad55d4ad3ddf826e205d4603b9ed40c5e655a9dfd66b56f459d7ba14db3
-  md5: 3ba02cce423fdac1a8582bd6bb189359
+- conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-h5888daf_0.conda
+  sha256: 2b6ce54174ec19110e1b3c37455f7cd138d0e228a75727a9bba443427da30a36
+  md5: 45c3d2c224002d6d0d7769142b29f986
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -16372,22 +16538,22 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 54060
-  timestamp: 1732912937444
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/opencl-headers-2024.10.24-h286801f_0.conda
-  sha256: 1823731a3816de7cc1a362981c74af0f83d91fd0d316b6eb8db0b5d51620404a
-  md5: 6971ff5b26af17c5dff51e22226426f7
+  size: 55357
+  timestamp: 1749853464518
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/opencl-headers-2025.06.13-h286801f_0.conda
+  sha256: 5c6269546780749ad5f4e780f0c7d7dcaaf6c20961ebd4588d82fdcda6cdf386
+  md5: f4d4d97714ae85265e4299b8e56ca6eb
   depends:
   - __osx >=11.0
   - libcxx >=18
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 54246
-  timestamp: 1732914373137
-- conda: https://conda.anaconda.org/conda-forge/win-64/opencl-headers-2024.10.24-he0c23c2_0.conda
-  sha256: b2e9546765727152eb4eed7e89d230757e60dbe368f4e62e49132bf7caa92355
-  md5: 20248dbb7d4a877ba783a2e06ecc2d02
+  size: 55476
+  timestamp: 1749853726041
+- conda: https://conda.anaconda.org/conda-forge/win-64/opencl-headers-2025.06.13-he0c23c2_0.conda
+  sha256: 1958dd489d32c3635e411e1802607e04a42ec685f1b2d63292211383447cecd3
+  md5: 25b288eda332180bba67ef785a20ae45
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
@@ -16395,8 +16561,8 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls: []
-  size: 54172
-  timestamp: 1732913057999
+  size: 55411
+  timestamp: 1749853655608
 - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.3-h5fbd93e_0.conda
   sha256: 5bee706ea5ba453ed7fd9da7da8380dd88b865c8d30b5aaec14d2b6dd32dbc39
   md5: 9e5816bc95d285c115a3ebc2f8563564
@@ -16500,19 +16666,20 @@ packages:
   purls: []
   size: 3564407
   timestamp: 1748705001931
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openmpi-5.0.7-h31ce4ef_100.conda
-  sha256: 10b802876fcb0210fb7bbeb85032c67224edbaf3d7cddc47a054283bcbfc3778
-  md5: cc1927fe2db684db106de1d001be81d9
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openmpi-5.0.8-hc9a84be_100.conda
+  sha256: 286c3da1493d43feed2ab6806477706bce5b6343f2d706dcfcc7a4be91c1933d
+  md5: bc87585958dd4adcbd93f0726c153c7b
   depends:
   - __osx >=11.0
   - libcxx >=18
   - libevent >=2.1.12,<2.1.13.0a0
   - libfabric
   - libfabric1 >=1.14.0
-  - libgfortran >=5
-  - libgfortran5 >=13.2.0
+  - libgfortran 5.*
+  - libgfortran5 >=13.3.0
+  - libgfortran5 >=14.2.0
   - libhwloc >=2.11.2,<2.11.3.0a0
-  - libpmix >=5.0.6,<6.0a0
+  - libpmix >=5.0.8,<6.0a0
   - libzlib >=1.3.1,<2.0a0
   - mpi 1.0 openmpi
   constrains:
@@ -16520,11 +16687,11 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 2354221
-  timestamp: 1739780210946
-- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.0-h7b32b05_1.conda
-  sha256: b4491077c494dbf0b5eaa6d87738c22f2154e9277e5293175ec187634bd808a0
-  md5: de356753cfdbffcde5bb1e86e3aa6cd0
+  size: 2349281
+  timestamp: 1748704985121
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.1-h7b32b05_0.conda
+  sha256: 942347492164190559e995930adcdf84e2fea05307ec8012c02a505f5be87462
+  md5: c87df2ab1448ba69169652ab9547082d
   depends:
   - __glibc >=2.17,<3.0.a0
   - ca-certificates
@@ -16532,32 +16699,32 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 3117410
-  timestamp: 1746223723843
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.0-h81ee809_1.conda
-  sha256: 73d366c1597a10bcd5f3604b5f0734b31c23225536e03782c6a13f9be9d01bff
-  md5: 5c7aef00ef60738a14e0e612cfc5bcde
+  size: 3131002
+  timestamp: 1751390382076
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.5.1-h81ee809_0.conda
+  sha256: f94fde0f096fa79794c8aa0a2665630bbf9026cc6438e8253f6555fc7281e5a8
+  md5: a8ac77e7c7e58d43fa34d60bd4361062
   depends:
   - __osx >=11.0
   - ca-certificates
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 3064197
-  timestamp: 1746223530698
-- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.5.0-ha4e3fda_1.conda
-  sha256: 02846553d2a4c9bde850c60824d0f02803eb9c9b674d5c1a8cce25bc387e748f
-  md5: 72c07e46b6766bb057018a9a74861b89
+  size: 3071649
+  timestamp: 1751390309393
+- conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.5.1-h725018a_0.conda
+  sha256: 2b2eb73b0661ff1aed55576a3d38614852b5d857c2fa9205ac115820c523306c
+  md5: d124fc2fd7070177b5e2450627f8fc1a
   depends:
   - ca-certificates
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: Apache-2.0
   license_family: Apache
   purls: []
-  size: 9025176
-  timestamp: 1746227349882
+  size: 9327033
+  timestamp: 1751392489008
 - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-2.1.2-h17f744e_0.conda
   sha256: f6ff644e27f42f2beb877773ba3adc1228dbb43530dbe9426dd672f3b847c7c5
   md5: ef7f9897a244b2023a066c22a1089ce4
@@ -16634,9 +16801,9 @@ packages:
   - pkg:pypi/overrides?source=hash-mapping
   size: 30139
   timestamp: 1734587755455
-- conda: https://conda.anaconda.org/conda-forge/noarch/owslib-0.34.0-pyhd8ed1ab_0.conda
-  sha256: 76d3739d08358e282474f653bfc8528033b2092889e44a40cef7a50a1158a635
-  md5: ec12af2750b04ef51f3c7364887d071a
+- conda: https://conda.anaconda.org/conda-forge/noarch/owslib-0.34.1-pyhd8ed1ab_0.conda
+  sha256: bd1dc309ec0d161cd1f65279cfc548c2b9dda7dc8cf44277b303923cfdf40386
+  md5: 819c0171e7092a83806a7ef9158f9158
   depends:
   - lxml
   - python >=3.10
@@ -16647,8 +16814,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/owslib?source=hash-mapping
-  size: 154579
-  timestamp: 1748876579108
+  size: 155181
+  timestamp: 1750176397327
 - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
   sha256: 289861ed0c13a15d7bbb408796af4de72c2fe67e2bcb0de98f4c3fce259d7991
   md5: 58335b26c38bf4a20f399384c33cbcf9
@@ -16661,9 +16828,9 @@ packages:
   - pkg:pypi/packaging?source=compressed-mapping
   size: 62477
   timestamp: 1745345660407
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py311h7db5c69_3.conda
-  sha256: 98cd49bfc4b803d950f9dbc4799793903aec1eaacd388c244a0b46d644159831
-  md5: c9f8fe78840d5c04e61666474bd739b2
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.3.0-py311h7db5c69_0.conda
+  sha256: 402602238308e04062e599b2df0984ed77beca8f9fe49cc78559cc716d816e2d
+  md5: 805040d254f51cb15df55eff6e213d09
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -16676,46 +16843,46 @@ packages:
   - python_abi 3.11.* *_cp311
   - pytz >=2020.1
   constrains:
-  - odfpy >=1.4.1
-  - numba >=0.56.4
-  - qtpy >=2.3.0
-  - pyarrow >=10.0.1
-  - matplotlib >=3.6.3
+  - pyqt5 >=5.15.9
   - beautifulsoup4 >=4.11.2
-  - gcsfs >=2022.11.0
+  - odfpy >=1.4.1
+  - s3fs >=2022.11.0
   - lxml >=4.9.2
   - bottleneck >=1.3.6
-  - tabulate >=0.9.0
-  - s3fs >=2022.11.0
-  - zstandard >=0.19.0
-  - sqlalchemy >=2.0.0
-  - xlrd >=2.0.1
-  - fastparquet >=2022.12.0
-  - numexpr >=2.8.4
-  - pyqt5 >=5.15.9
-  - pytables >=3.8.0
-  - pyreadstat >=1.2.0
-  - fsspec >=2022.11.0
-  - html5lib >=1.1
-  - xarray >=2022.12.0
-  - blosc >=1.21.3
-  - openpyxl >=3.1.0
-  - pandas-gbq >=0.19.0
   - tzdata >=2022.7
-  - pyxlsb >=1.0.10
-  - psycopg2 >=2.9.6
+  - numba >=0.56.4
+  - xarray >=2022.12.0
   - scipy >=1.10.0
+  - xlrd >=2.0.1
+  - matplotlib >=3.6.3
+  - pandas-gbq >=0.19.0
+  - zstandard >=0.19.0
+  - psycopg2 >=2.9.6
+  - sqlalchemy >=2.0.0
+  - pyxlsb >=1.0.10
   - python-calamine >=0.1.7
+  - tabulate >=0.9.0
   - xlsxwriter >=3.0.5
+  - openpyxl >=3.1.0
+  - blosc >=1.21.3
+  - pytables >=3.8.0
+  - qtpy >=2.3.0
+  - html5lib >=1.1
+  - fsspec >=2022.11.0
+  - numexpr >=2.8.4
+  - gcsfs >=2022.11.0
+  - fastparquet >=2022.12.0
+  - pyreadstat >=1.2.0
+  - pyarrow >=10.0.1
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/pandas?source=hash-mapping
-  size: 15689443
-  timestamp: 1744430942431
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.3-py312hf9745cd_3.conda
-  sha256: b0bed36b95757bbd269d30b2367536b802158bdf7947800ee7ae55089cfa8b9c
-  md5: 2979458c23c7755683a0598fb33e7666
+  size: 15299103
+  timestamp: 1749100113269
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.3.0-py312hf9745cd_0.conda
+  sha256: 44f5587c1e1a9f0257387dd18735bcf65a67a6089e723302dc7947be09d9affe
+  md5: ac82ac336dbe61106e21fb2e11704459
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -16728,46 +16895,46 @@ packages:
   - python_abi 3.12.* *_cp312
   - pytz >=2020.1
   constrains:
-  - tabulate >=0.9.0
-  - pytables >=3.8.0
-  - html5lib >=1.1
-  - lxml >=4.9.2
-  - gcsfs >=2022.11.0
-  - odfpy >=1.4.1
-  - numexpr >=2.8.4
-  - psycopg2 >=2.9.6
-  - fsspec >=2022.11.0
-  - qtpy >=2.3.0
-  - tzdata >=2022.7
-  - pyarrow >=10.0.1
-  - pyqt5 >=5.15.9
-  - xlrd >=2.0.1
-  - sqlalchemy >=2.0.0
-  - xarray >=2022.12.0
-  - scipy >=1.10.0
-  - fastparquet >=2022.12.0
-  - pyreadstat >=1.2.0
-  - matplotlib >=3.6.3
   - bottleneck >=1.3.6
-  - s3fs >=2022.11.0
-  - zstandard >=0.19.0
-  - openpyxl >=3.1.0
   - blosc >=1.21.3
-  - beautifulsoup4 >=4.11.2
-  - pandas-gbq >=0.19.0
-  - xlsxwriter >=3.0.5
   - numba >=0.56.4
-  - pyxlsb >=1.0.10
+  - pyqt5 >=5.15.9
+  - pyarrow >=10.0.1
+  - gcsfs >=2022.11.0
+  - xlsxwriter >=3.0.5
+  - scipy >=1.10.0
+  - beautifulsoup4 >=4.11.2
+  - numexpr >=2.8.4
+  - fastparquet >=2022.12.0
+  - lxml >=4.9.2
+  - xlrd >=2.0.1
+  - openpyxl >=3.1.0
+  - qtpy >=2.3.0
+  - s3fs >=2022.11.0
+  - pandas-gbq >=0.19.0
+  - pytables >=3.8.0
   - python-calamine >=0.1.7
+  - fsspec >=2022.11.0
+  - psycopg2 >=2.9.6
+  - xarray >=2022.12.0
+  - matplotlib >=3.6.3
+  - pyxlsb >=1.0.10
+  - tabulate >=0.9.0
+  - odfpy >=1.4.1
+  - pyreadstat >=1.2.0
+  - html5lib >=1.1
+  - zstandard >=0.19.0
+  - sqlalchemy >=2.0.0
+  - tzdata >=2022.7
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/pandas?source=hash-mapping
-  size: 15392153
-  timestamp: 1744430987175
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py311hca32420_3.conda
-  sha256: 2fedf5cec20945d5ce1a5264f06a8adf23bc6b355cef365e92241a3f1f6a6d11
-  md5: 29ae2c4e0ee3c65fa8520cafbf479ff7
+  size: 14958450
+  timestamp: 1749100123120
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.3.0-py311hca32420_0.conda
+  sha256: dc90abbeaa1b73b77c47269aec1faac72f2bf71c55e6a51a523ac92b53f09a53
+  md5: ea3aa0995e65698bd1d59999c1482d15
   depends:
   - __osx >=11.0
   - libcxx >=18
@@ -16780,46 +16947,46 @@ packages:
   - python_abi 3.11.* *_cp311
   - pytz >=2020.1
   constrains:
-  - python-calamine >=0.1.7
-  - pytables >=3.8.0
-  - s3fs >=2022.11.0
-  - openpyxl >=3.1.0
-  - pyarrow >=10.0.1
-  - tzdata >=2022.7
-  - xarray >=2022.12.0
-  - fastparquet >=2022.12.0
-  - pyqt5 >=5.15.9
-  - numba >=0.56.4
-  - pyxlsb >=1.0.10
-  - xlrd >=2.0.1
-  - bottleneck >=1.3.6
-  - matplotlib >=3.6.3
-  - xlsxwriter >=3.0.5
-  - zstandard >=0.19.0
-  - odfpy >=1.4.1
-  - qtpy >=2.3.0
-  - numexpr >=2.8.4
-  - gcsfs >=2022.11.0
-  - tabulate >=0.9.0
-  - pyreadstat >=1.2.0
-  - pandas-gbq >=0.19.0
-  - blosc >=1.21.3
-  - scipy >=1.10.0
-  - beautifulsoup4 >=4.11.2
-  - lxml >=4.9.2
   - html5lib >=1.1
+  - tabulate >=0.9.0
+  - bottleneck >=1.3.6
   - fsspec >=2022.11.0
+  - beautifulsoup4 >=4.11.2
+  - pytables >=3.8.0
+  - gcsfs >=2022.11.0
+  - scipy >=1.10.0
+  - python-calamine >=0.1.7
+  - numba >=0.56.4
+  - numexpr >=2.8.4
   - psycopg2 >=2.9.6
+  - lxml >=4.9.2
+  - pyxlsb >=1.0.10
   - sqlalchemy >=2.0.0
+  - fastparquet >=2022.12.0
+  - xarray >=2022.12.0
+  - zstandard >=0.19.0
+  - matplotlib >=3.6.3
+  - odfpy >=1.4.1
+  - openpyxl >=3.1.0
+  - xlsxwriter >=3.0.5
+  - tzdata >=2022.7
+  - pyreadstat >=1.2.0
+  - pyqt5 >=5.15.9
+  - s3fs >=2022.11.0
+  - blosc >=1.21.3
+  - pyarrow >=10.0.1
+  - pandas-gbq >=0.19.0
+  - xlrd >=2.0.1
+  - qtpy >=2.3.0
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/pandas?source=hash-mapping
-  size: 14820281
-  timestamp: 1744430962289
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.3-py312hcb1e3ce_3.conda
-  sha256: 57beb95a8c5c3c35a87d0c5a6c3235fb3673618445e60be952a2502781534613
-  md5: 63af5cccfa8b67825d8358b149e96466
+  size: 14290986
+  timestamp: 1749100100341
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.3.0-py312hcb1e3ce_0.conda
+  sha256: 3105a94036f37429ed292763d3034008fd0b4911bd565bdf86c33e898655dcdf
+  md5: d95b29a40430115d6aa817f70be5b5b1
   depends:
   - __osx >=11.0
   - libcxx >=18
@@ -16832,46 +16999,46 @@ packages:
   - python_abi 3.12.* *_cp312
   - pytz >=2020.1
   constrains:
-  - zstandard >=0.19.0
-  - pyreadstat >=1.2.0
-  - blosc >=1.21.3
-  - fastparquet >=2022.12.0
-  - qtpy >=2.3.0
-  - openpyxl >=3.1.0
-  - psycopg2 >=2.9.6
-  - xlsxwriter >=3.0.5
-  - lxml >=4.9.2
-  - xarray >=2022.12.0
-  - pyxlsb >=1.0.10
-  - matplotlib >=3.6.3
-  - python-calamine >=0.1.7
-  - gcsfs >=2022.11.0
-  - numba >=0.56.4
-  - pandas-gbq >=0.19.0
-  - odfpy >=1.4.1
-  - fsspec >=2022.11.0
-  - numexpr >=2.8.4
   - xlrd >=2.0.1
-  - scipy >=1.10.0
-  - bottleneck >=1.3.6
-  - pyqt5 >=5.15.9
+  - pyxlsb >=1.0.10
+  - pyreadstat >=1.2.0
+  - fsspec >=2022.11.0
+  - matplotlib >=3.6.3
   - s3fs >=2022.11.0
-  - html5lib >=1.1
-  - pytables >=3.8.0
+  - pyqt5 >=5.15.9
+  - lxml >=4.9.2
+  - blosc >=1.21.3
   - tabulate >=0.9.0
+  - fastparquet >=2022.12.0
+  - numba >=0.56.4
+  - scipy >=1.10.0
+  - xlsxwriter >=3.0.5
+  - gcsfs >=2022.11.0
+  - html5lib >=1.1
+  - odfpy >=1.4.1
+  - bottleneck >=1.3.6
+  - numexpr >=2.8.4
   - beautifulsoup4 >=4.11.2
   - pyarrow >=10.0.1
-  - sqlalchemy >=2.0.0
+  - openpyxl >=3.1.0
+  - qtpy >=2.3.0
+  - pytables >=3.8.0
   - tzdata >=2022.7
+  - zstandard >=0.19.0
+  - psycopg2 >=2.9.6
+  - xarray >=2022.12.0
+  - sqlalchemy >=2.0.0
+  - python-calamine >=0.1.7
+  - pandas-gbq >=0.19.0
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/pandas?source=hash-mapping
-  size: 14442730
-  timestamp: 1744431003090
-- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py311hcf9f919_3.conda
-  sha256: 7aabb8d23a6817844a7f1b402e7e147e341cade5f470a908b8239f969c7b681c
-  md5: 84c8b4aab176baefd352cd34f7e69469
+  size: 14054660
+  timestamp: 1749100309197
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.3.0-py311hcf9f919_0.conda
+  sha256: b785d7a6d3146b4b9b13d200bb410ba2db31fa69da500e47be8e9f617e34d170
+  md5: 5856ab7c6cd759b51b7d80ad0b7b92e7
   depends:
   - numpy >=1.19,<3
   - numpy >=1.22.4
@@ -16884,46 +17051,46 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
+  - pytables >=3.8.0
+  - pyreadstat >=1.2.0
+  - numexpr >=2.8.4
+  - blosc >=1.21.3
+  - html5lib >=1.1
+  - tzdata >=2022.7
+  - numba >=0.56.4
+  - python-calamine >=0.1.7
+  - fastparquet >=2022.12.0
+  - xlrd >=2.0.1
+  - beautifulsoup4 >=4.11.2
+  - zstandard >=0.19.0
+  - fsspec >=2022.11.0
+  - xlsxwriter >=3.0.5
+  - s3fs >=2022.11.0
+  - openpyxl >=3.1.0
+  - odfpy >=1.4.1
+  - matplotlib >=3.6.3
+  - scipy >=1.10.0
+  - qtpy >=2.3.0
+  - bottleneck >=1.3.6
+  - xarray >=2022.12.0
   - lxml >=4.9.2
   - pandas-gbq >=0.19.0
+  - sqlalchemy >=2.0.0
+  - pyarrow >=10.0.1
+  - tabulate >=0.9.0
   - psycopg2 >=2.9.6
   - pyxlsb >=1.0.10
-  - python-calamine >=0.1.7
-  - html5lib >=1.1
-  - sqlalchemy >=2.0.0
-  - fastparquet >=2022.12.0
-  - xarray >=2022.12.0
-  - matplotlib >=3.6.3
-  - numexpr >=2.8.4
-  - pyqt5 >=5.15.9
-  - openpyxl >=3.1.0
-  - tzdata >=2022.7
-  - bottleneck >=1.3.6
-  - tabulate >=0.9.0
-  - numba >=0.56.4
-  - scipy >=1.10.0
-  - beautifulsoup4 >=4.11.2
-  - s3fs >=2022.11.0
   - gcsfs >=2022.11.0
-  - qtpy >=2.3.0
-  - odfpy >=1.4.1
-  - pyreadstat >=1.2.0
-  - xlrd >=2.0.1
-  - pyarrow >=10.0.1
-  - zstandard >=0.19.0
-  - blosc >=1.21.3
-  - fsspec >=2022.11.0
-  - pytables >=3.8.0
-  - xlsxwriter >=3.0.5
+  - pyqt5 >=5.15.9
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/pandas?source=hash-mapping
-  size: 14530915
-  timestamp: 1744431484551
-- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.3-py312h72972c8_3.conda
-  sha256: 86fe04c5f0dcae3644e3d2d892ddf6760d89eeb8fe1a31ef30290ac5a6a9f125
-  md5: 08b4650b022c9f3233d45f231fb9471f
+  size: 14178063
+  timestamp: 1749100482385
+- conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.3.0-py312h72972c8_0.conda
+  sha256: e4c8a685cfa1334a566b642523c9584d79ba78ed05888c7b7809d9116b6e9e25
+  md5: e2ab2d8cc52281c9ebe19451936802eb
   depends:
   - numpy >=1.19,<3
   - numpy >=1.22.4
@@ -16936,43 +17103,43 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - pyxlsb >=1.0.10
-  - psycopg2 >=2.9.6
-  - bottleneck >=1.3.6
-  - html5lib >=1.1
-  - openpyxl >=3.1.0
-  - python-calamine >=0.1.7
-  - tabulate >=0.9.0
-  - numexpr >=2.8.4
-  - beautifulsoup4 >=4.11.2
-  - odfpy >=1.4.1
+  - pyarrow >=10.0.1
   - gcsfs >=2022.11.0
-  - pytables >=3.8.0
-  - pyqt5 >=5.15.9
-  - zstandard >=0.19.0
-  - scipy >=1.10.0
-  - xarray >=2022.12.0
-  - blosc >=1.21.3
-  - qtpy >=2.3.0
-  - sqlalchemy >=2.0.0
-  - pyreadstat >=1.2.0
   - fsspec >=2022.11.0
   - lxml >=4.9.2
+  - tabulate >=0.9.0
+  - openpyxl >=3.1.0
+  - pyreadstat >=1.2.0
   - xlrd >=2.0.1
-  - tzdata >=2022.7
-  - fastparquet >=2022.12.0
+  - pyqt5 >=5.15.9
+  - pyxlsb >=1.0.10
   - s3fs >=2022.11.0
+  - zstandard >=0.19.0
+  - numexpr >=2.8.4
+  - python-calamine >=0.1.7
+  - beautifulsoup4 >=4.11.2
+  - fastparquet >=2022.12.0
+  - bottleneck >=1.3.6
+  - xarray >=2022.12.0
   - xlsxwriter >=3.0.5
-  - pandas-gbq >=0.19.0
-  - numba >=0.56.4
-  - pyarrow >=10.0.1
+  - sqlalchemy >=2.0.0
+  - psycopg2 >=2.9.6
   - matplotlib >=3.6.3
+  - blosc >=1.21.3
+  - pytables >=3.8.0
+  - html5lib >=1.1
+  - numba >=0.56.4
+  - tzdata >=2022.7
+  - pandas-gbq >=0.19.0
+  - qtpy >=2.3.0
+  - scipy >=1.10.0
+  - odfpy >=1.4.1
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/pandas?source=hash-mapping
-  size: 14150000
-  timestamp: 1744431235710
+  size: 13859642
+  timestamp: 1749100498003
 - conda: https://conda.anaconda.org/conda-forge/noarch/pandas-stubs-2.2.3.250527-pyhd8ed1ab_1.conda
   sha256: f36a5bc0b4551febcf8ce87cb7814c2d0ca8ef2c8f1606c924ca3f0bc1fd27ae
   md5: 50f3c512f3034ed6277043f36af5dcb2
@@ -17145,9 +17312,9 @@ packages:
   - pkg:pypi/pickleshare?source=hash-mapping
   size: 11748
   timestamp: 1733327448200
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.2.1-py311h1322bbf_0.conda
-  sha256: 35ad7e1a9fe8152d0bad51046490c3903d7c56e06a1ba2a0af5be4fd3bdc18c7
-  md5: 4c49bdabd1d4e09386dabc676fb6bd65
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py311h1322bbf_0.conda
+  sha256: cf296d5185090f27ac4e3d73177ff865ca87307c815d759f3baa0f9c8680a250
+  md5: 8b4568b1357f5ec5494e36b06076c3a1
   depends:
   - __glibc >=2.17,<3.0.a0
   - lcms2 >=2.17,<3.0a0
@@ -17166,11 +17333,11 @@ packages:
   license: HPND
   purls:
   - pkg:pypi/pillow?source=hash-mapping
-  size: 43489672
-  timestamp: 1746646364323
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.2.1-py312h80c1187_0.conda
-  sha256: 15f32ec89f3a7104fcb190546a2bc0fc279372d9073e5ec08a8d61a1c79af4c0
-  md5: ca438bf57e4f2423d261987fe423a0dd
+  size: 43054892
+  timestamp: 1751482121228
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-11.3.0-py312h80c1187_0.conda
+  sha256: 7c9a8f65a200587bf7a0135ca476f9c472348177338ed8b825ddcc08773fde68
+  md5: 7911e727a6c24db662193a960b81b6b2
   depends:
   - __glibc >=2.17,<3.0.a0
   - lcms2 >=2.17,<3.0a0
@@ -17188,12 +17355,12 @@ packages:
   - tk >=8.6.13,<8.7.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
-  size: 42506161
-  timestamp: 1746646366556
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.2.1-py311hb9ba9e9_0.conda
-  sha256: f2652d15d6a3c6f5e40d0e87fbc459e67778abe2319e7715196d45215805b0cb
-  md5: 5cdc7320584eedc6080df391668eaf41
+  - pkg:pypi/pillow?source=hash-mapping
+  size: 42964111
+  timestamp: 1751482158083
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.3.0-py311hb9ba9e9_0.conda
+  sha256: 6eb85c7828cd28f79980dff822a2acac74c8edaa186a9dfef53bc2bf7421cd26
+  md5: afcdff84f6b7dd35ba49f3fe55dcc90f
   depends:
   - __osx >=11.0
   - lcms2 >=2.17,<3.0a0
@@ -17212,11 +17379,11 @@ packages:
   license: HPND
   purls:
   - pkg:pypi/pillow?source=hash-mapping
-  size: 42632596
-  timestamp: 1746646647318
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.2.1-py312h50aef2c_0.conda
-  sha256: ba5a9a7c431e4efe5e718779702f31835618ab87bef839fcfde51123993a04c9
-  md5: cdf747c54075674962f2662b0d059efa
+  size: 42028662
+  timestamp: 1751482509684
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-11.3.0-py312h50aef2c_0.conda
+  sha256: 3d60288e8cfd42e4548c9e5192a285e73f81df2869f69b9d3905849b45d9bd2a
+  md5: dddff48655b5cd24a5170a6df979943a
   depends:
   - __osx >=11.0
   - lcms2 >=2.17,<3.0a0
@@ -17235,11 +17402,11 @@ packages:
   license: HPND
   purls:
   - pkg:pypi/pillow?source=hash-mapping
-  size: 42678633
-  timestamp: 1746646517184
-- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.2.1-py311h43e43bb_0.conda
-  sha256: 16cf0466ce3666ecb867bf5cd33fb5bb50ba766151dd698d6bfff6f6e5a334cf
-  md5: cfb76166a1a96819fadef74097ef9d87
+  size: 42514714
+  timestamp: 1751482419501
+- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.3.0-py311h0f9b5fc_0.conda
+  sha256: 91aa79f6a0894edf9c698251428f3bb175f274c476f6bc07eb9136ab10ba1e76
+  md5: feb1a7f0fa15a147350d2c7d477e72b3
   depends:
   - lcms2 >=2.17,<3.0a0
   - libfreetype >=2.13.3
@@ -17254,16 +17421,16 @@ packages:
   - python_abi 3.11.* *_cp311
   - tk >=8.6.13,<8.7.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: HPND
   purls:
   - pkg:pypi/pillow?source=hash-mapping
-  size: 42624917
-  timestamp: 1746646855016
-- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.2.1-py312h078707f_0.conda
-  sha256: e2e06c41da68943242c0c7181400781890fbc92fe0705ba312592b8cb1489c65
-  md5: 08d84254d64ef99ca6b718e6dae1c25d
+  size: 42754092
+  timestamp: 1751482299214
+- conda: https://conda.anaconda.org/conda-forge/win-64/pillow-11.3.0-py312hfb502af_0.conda
+  sha256: 7b523afc3ce71be4655c0d639c3fe2e4d0f2f6ce87e4bcc523163700995f2b3f
+  md5: 40dd6b8b814253a77c3297273bfb3701
   depends:
   - lcms2 >=2.17,<3.0a0
   - libfreetype >=2.13.3
@@ -17278,13 +17445,13 @@ packages:
   - python_abi 3.12.* *_cp312
   - tk >=8.6.13,<8.7.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: HPND
   purls:
   - pkg:pypi/pillow?source=hash-mapping
-  size: 42728944
-  timestamp: 1746646804195
+  size: 42787505
+  timestamp: 1751482431385
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.2-h29eaf8c_0.conda
   sha256: 6cb261595b5f0ae7306599f2bb55ef6863534b6d4d1bc0dcfdfa5825b0e4e53d
   md5: 39b4228a867772d610c02e06f939a5b8
@@ -17342,9 +17509,9 @@ packages:
   - pkg:pypi/platformdirs?source=compressed-mapping
   size: 23531
   timestamp: 1746710438805
-- conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.1.2-pyhd8ed1ab_0.conda
-  sha256: ae70322038e849c40a1fb701196c17b62a0b01907d7733a64f4f112e8ebbf39e
-  md5: f547ee092ef42452ddaffdfa59ff4987
+- conda: https://conda.anaconda.org/conda-forge/noarch/plotly-6.2.0-pyhd8ed1ab_0.conda
+  sha256: d72d601e09722c434871c29a102202178fe1fcf031c6290e10fb4a756c1944a3
+  md5: 8a9590843af49b36f37ac3dbcf5fc3d9
   depends:
   - narwhals >=1.15.1
   - packaging
@@ -17355,8 +17522,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/plotly?source=hash-mapping
-  size: 5906149
-  timestamp: 1748388709041
+  size: 5187885
+  timestamp: 1751025216667
 - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhd8ed1ab_0.conda
   sha256: a8eb555eef5063bbb7ba06a379fa7ea714f57d9741fe0efdb9442dbbc2cccbcc
   md5: 7da7ccd349dbf6487a7778579d2bb971
@@ -17392,18 +17559,46 @@ packages:
   - pkg:pypi/ply?source=hash-mapping
   size: 49052
   timestamp: 1733239818090
-- conda: https://conda.anaconda.org/conda-forge/linux-64/polars-1.27.1-py39h2a4a510_3.conda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/polars-1.31.0-default_h1650462_0.conda
+  sha256: abc9ccf364db4150efb629f58ad66315b76e71444636ebdeb4bc1ecbcf855dd0
+  md5: 2372c82ef3c85bc1cc94025b9bf4d329
+  depends:
+  - polars-default ==1.31.0 py39hfac2b71_0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 6065
+  timestamp: 1750271790427
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/polars-1.31.0-default_h56a14c1_0.conda
+  sha256: f598d5b75887c76abe15c3f3af392dac5455ecc394a39dbd1e805aec895f9112
+  md5: a52f4e0c368e3a6423f22ce8ab2cc4da
+  depends:
+  - polars-default ==1.31.0 py39h6da47c3_0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 6088
+  timestamp: 1750271608484
+- conda: https://conda.anaconda.org/conda-forge/win-64/polars-1.31.0-default_hc01efcc_0.conda
+  sha256: e6ca38e6eb1b34624a38130d04847586cf40d943e09d040908593929da142f74
+  md5: 4f8e5741c5a794cb9e93ede0101e55c1
+  depends:
+  - polars-default ==1.31.0 py39h4d7386a_0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 6090
+  timestamp: 1750271645336
+- conda: https://conda.anaconda.org/conda-forge/linux-64/polars-default-1.31.0-py39hfac2b71_0.conda
   noarch: python
-  sha256: 165b1b0f1d0d0cb34f06a800c2f813eb055b18f434d3167c10a85415b771034d
-  md5: fba08963eaa1f954480045d033d1221e
+  sha256: 45e7d8de1ed19ecfb72de47ea45ae29ea08ec355ea7f025944f2cce737bccb9d
+  md5: 412f48979db22009a89706d57384756e
   depends:
   - python
   - numpy >=1.16.0
-  - packaging
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
   - libstdcxx >=13
   - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
   - _python_abi3_support 1.*
   - cpython >=3.9
   constrains:
@@ -17412,16 +17607,15 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/polars?source=hash-mapping
-  size: 29576371
-  timestamp: 1745327133869
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/polars-1.27.1-py39h81794e1_3.conda
+  size: 29112336
+  timestamp: 1750271790427
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/polars-default-1.31.0-py39h6da47c3_0.conda
   noarch: python
-  sha256: 4fdb73b3d753469cbc23e4c126247cc40ab47ae343d68f29d144cdc850f66d68
-  md5: 147546993ae9bb1d9ab87b4e46d60acd
+  sha256: 5bb546f3e24b31c218c621dda093c82c6ae009fb7d22f2b3d3d36d821899c3b3
+  md5: c96cfae13458cfc05dbdd144b8bd6726
   depends:
   - python
   - numpy >=1.16.0
-  - packaging
   - libcxx >=18
   - __osx >=11.0
   - _python_abi3_support 1.*
@@ -17432,16 +17626,15 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/polars?source=hash-mapping
-  size: 26770774
-  timestamp: 1745326969707
-- conda: https://conda.anaconda.org/conda-forge/win-64/polars-1.27.1-py39h9b97169_3.conda
+  size: 26658197
+  timestamp: 1750271608483
+- conda: https://conda.anaconda.org/conda-forge/win-64/polars-default-1.31.0-py39h4d7386a_0.conda
   noarch: python
-  sha256: 539db2d9d4499da64f72e4ce8a3cdcc025343f412879c665f078767c50d4eb51
-  md5: 581b395c489dcccd64071f4f259045f8
+  sha256: 9f6490452bee8aeef5b6ef1dbc1cfa6b21d4a5eef36ad94b97a4521bb3726766
+  md5: b7faec3925da45e2e73b19e3f2426a7d
   depends:
   - python
   - numpy >=1.16.0
-  - packaging
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - ucrt >=10.0.20348.0
@@ -17454,8 +17647,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/polars?source=hash-mapping
-  size: 32210305
-  timestamp: 1745327051297
+  size: 31780922
+  timestamp: 1750271645335
 - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.8.2-pyhd8ed1ab_1.conda
   sha256: bedda6b36e8e42b0255179446699a0cf08051e6d9d358dd0dd0e787254a3620e
   md5: b3e783e8e8ed7577cf0b6dee37d1fbac
@@ -17830,9 +18023,9 @@ packages:
   - pkg:pypi/psutil?source=hash-mapping
   size: 484682
   timestamp: 1740663813103
-- conda: https://conda.anaconda.org/conda-forge/linux-64/psycopg2-2.9.10-py311h83e8966_0.conda
-  sha256: 675de3772fdb9b04f2646b3dce0016dda409691bbd275a29285296fdfc0eae41
-  md5: b80dbfc6eda0f4e454473f7f4d48d176
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psycopg2-2.9.10-py311h83e8966_1.conda
+  sha256: c1e0800377b24ce8a72a354e9514553c2a2247b367e912c089d9501a2950588f
+  md5: a976e9fc01115118bfc73a82b0222d66
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -17843,11 +18036,11 @@ packages:
   license_family: LGPL
   purls:
   - pkg:pypi/psycopg2?source=hash-mapping
-  size: 189333
-  timestamp: 1747320240197
-- conda: https://conda.anaconda.org/conda-forge/linux-64/psycopg2-2.9.10-py312hfaedaf9_0.conda
-  sha256: 9d72d1adb5febf492a5a66cbdbc14ecdd1c8ae9ceb4f58924e9764ba630dd346
-  md5: 10ee480865c0a90decf9ef3b3e1cfd23
+  size: 190648
+  timestamp: 1750255562181
+- conda: https://conda.anaconda.org/conda-forge/linux-64/psycopg2-2.9.10-py312hfaedaf9_1.conda
+  sha256: b80e79fe8188f0e6c744502ae4d30934f935e2e98b49951e8c1ff68231c2116b
+  md5: 1a6f87e99b279b699b30fe19bad92910
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -17858,11 +18051,11 @@ packages:
   license_family: LGPL
   purls:
   - pkg:pypi/psycopg2?source=hash-mapping
-  size: 188004
-  timestamp: 1747320230932
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psycopg2-2.9.10-py311h2c64ce4_0.conda
-  sha256: 54a84f4f9aa2c1f6b8795af62be6baec60867037aaf07e7460c4992f60fbc933
-  md5: 2d2e9647e16c437a3398470bb7ca8c7e
+  size: 189145
+  timestamp: 1750255552672
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psycopg2-2.9.10-py311h2c64ce4_1.conda
+  sha256: e5ce1eadac8afd0fb98280e3263c8c1062ce0c9278575757fd6ec25264f421d4
+  md5: defad0e341e8ad443b373d315214734a
   depends:
   - __osx >=11.0
   - libpq >=17.5,<18.0a0
@@ -17874,11 +18067,11 @@ packages:
   license_family: LGPL
   purls:
   - pkg:pypi/psycopg2?source=hash-mapping
-  size: 168025
-  timestamp: 1747320711369
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psycopg2-2.9.10-py312h96c7839_0.conda
-  sha256: f5f98cd84cf88b5945bd123c212d06e08be03368ac1b98566aee74bdd8022a8e
-  md5: 8876ed89a9bb6749284d1ea5cbdfacec
+  size: 167754
+  timestamp: 1750255795880
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/psycopg2-2.9.10-py312h96c7839_1.conda
+  sha256: 6c40e66292bf753ce6198c41a77ea7f2eea3ba0afac81067e1b42c86c03c94c7
+  md5: ef053668d5f5a06a359ec321edefdf94
   depends:
   - __osx >=11.0
   - libpq >=17.5,<18.0a0
@@ -17890,11 +18083,11 @@ packages:
   license_family: LGPL
   purls:
   - pkg:pypi/psycopg2?source=hash-mapping
-  size: 167396
-  timestamp: 1747320438391
-- conda: https://conda.anaconda.org/conda-forge/win-64/psycopg2-2.9.10-py311hd732c25_0.conda
-  sha256: b65866360507b64c072f89f456683d50c1066d9f6ac7ee5da242f4b8b814b60a
-  md5: c2fb64dd0b93f69b9a0dffea1c552776
+  size: 165772
+  timestamp: 1750255793141
+- conda: https://conda.anaconda.org/conda-forge/win-64/psycopg2-2.9.10-py311hd732c25_1.conda
+  sha256: 687ec2065942f2264cbb97bcbb3d9458f1ca9923277075c7c9bd04720e918da0
+  md5: c24cb0a848dc482c2aba29ca41a71413
   depends:
   - libpq >=17.5,<18.0a0
   - openssl >=3.5.0,<4.0a0
@@ -17907,11 +18100,11 @@ packages:
   license_family: LGPL
   purls:
   - pkg:pypi/psycopg2?source=hash-mapping
-  size: 173205
-  timestamp: 1747320907160
-- conda: https://conda.anaconda.org/conda-forge/win-64/psycopg2-2.9.10-py312h16142e3_0.conda
-  sha256: 1e8b7fd3e1a71e333fb334d99f16941018867ab274f80b926f001b2547ebcaa1
-  md5: 3eef7047247d97bd7d64fd462f1516ef
+  size: 172286
+  timestamp: 1750255799014
+- conda: https://conda.anaconda.org/conda-forge/win-64/psycopg2-2.9.10-py312h16142e3_1.conda
+  sha256: ae1c00caa250165389535af1f6ecb86906ee878804a13228647e5abc298d300c
+  md5: 261db260db2dd148d9015dbfa200b4b4
   depends:
   - libpq >=17.5,<18.0a0
   - openssl >=3.5.0,<4.0a0
@@ -17924,8 +18117,8 @@ packages:
   license_family: LGPL
   purls:
   - pkg:pypi/psycopg2?source=hash-mapping
-  size: 171354
-  timestamp: 1747320525317
+  size: 171369
+  timestamp: 1750255854927
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
   sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
   md5: b3c17d95b5a10c6e64a21fa17573e70e
@@ -18325,9 +18518,9 @@ packages:
   - pkg:pypi/pycryptodome?source=hash-mapping
   size: 1715610
   timestamp: 1747561659278
-- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.4-pyh3cfb1c2_0.conda
-  sha256: a522473505ac6a9c10bb304d7338459a406ba22a6d3bb1a355c1b5283553a372
-  md5: 8ad3ad8db5ce2ba470c9facc37af00a9
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.7-pyh3cfb1c2_0.conda
+  sha256: ee7823e8bc227f804307169870905ce062531d36c1dcf3d431acd65c6e0bd674
+  md5: 1b337e3d378cde62889bb735c024b7a2
   depends:
   - annotated-types >=0.6.0
   - pydantic-core 2.33.2
@@ -18339,8 +18532,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pydantic?source=compressed-mapping
-  size: 306304
-  timestamp: 1746632069456
+  size: 307333
+  timestamp: 1749927245525
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.33.2-py311hdae7d1d_0.conda
   sha256: b48e5abb6debae4f559b08cdbaf0736c7806adc00c106ced2c98a622b7081d8f
   md5: 484d0d62d4b069d5372680309fc5f00c
@@ -18447,9 +18640,9 @@ packages:
   - pkg:pypi/pydantic-core?source=hash-mapping
   size: 1900306
   timestamp: 1746625389678
-- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.9.1-pyh3cfb1c2_0.conda
-  sha256: ea2f1027218e83e484fd581933e0ce60b9194486c56c98053b4277b0fb291364
-  md5: 29dd5c4ece2497b75b4050ec3c8d4044
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.10.1-pyh3cfb1c2_0.conda
+  sha256: e56b9a0320e3cab58b88f62ccdcd4bf7cd89ec348c878e1843d4d22315bfced1
+  md5: a5f9c3e867917c62d796c20dba792cbd
   depends:
   - pydantic >=2.7.0
   - python >=3.9
@@ -18459,25 +18652,25 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pydantic-settings?source=hash-mapping
-  size: 38135
-  timestamp: 1745015303766
-- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.1-pyhd8ed1ab_0.conda
-  sha256: 28a3e3161390a9d23bc02b4419448f8d27679d9e2c250e29849e37749c8de86b
-  md5: 232fb4577b6687b2d503ef8e254270c9
+  size: 38816
+  timestamp: 1750801673349
+- conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+  sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
+  md5: 6b6ece66ebcae2d5f326c77ef2c5a066
   depends:
   - python >=3.9
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pygments?source=hash-mapping
-  size: 888600
-  timestamp: 1736243563082
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.0-py311hab620ed_0.conda
-  sha256: 7eb9c40a460ea769f024aaf45dae9fde7ca41137ca82154c50c8aead8a32ff88
-  md5: cc865b09e7a02328840b163fb8856731
+  - pkg:pypi/pygments?source=compressed-mapping
+  size: 889287
+  timestamp: 1750615908735
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.1-py311hf0763de_0.conda
+  sha256: ae4d7acab635209c88586849e1023892fc3242b0540567178efc17546eb33586
+  md5: bff41faa73404184a27ec3903bc1baf2
   depends:
   - __osx >=11.0
-  - libffi >=3.4,<4.0a0
+  - libffi >=3.4.6,<3.5.0a0
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
@@ -18486,14 +18679,14 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyobjc-core?source=hash-mapping
-  size: 480994
-  timestamp: 1736891387770
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.0-py312hb9d441b_0.conda
-  sha256: 7805d910dd6ac686e2f780c879a986f35d7a4c73f4236c956c03bdcb26bec421
-  md5: 0726db04477a28c51d1a260afb356b67
+  size: 476864
+  timestamp: 1750208146293
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-11.1-py312h4c66426_0.conda
+  sha256: d4b1ae7f925720c1a6643c03199c6a47ba6a536bfd630f522baa5fe6ebf4a786
+  md5: 02247b8a9ba52a15a53edd6d4cf9dac4
   depends:
   - __osx >=11.0
-  - libffi >=3.4,<4.0a0
+  - libffi >=3.4.6,<3.5.0a0
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
@@ -18502,15 +18695,15 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyobjc-core?source=hash-mapping
-  size: 478921
-  timestamp: 1736891272846
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.0-py311hab620ed_0.conda
-  sha256: 33635759c626103696963a4d439f01cc534fe94c318ce5a14c7b9ddbe8dfb78c
-  md5: 39da4013010bd559600f775ebf6a5915
+  size: 474838
+  timestamp: 1750207878592
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.1-py311hab620ed_0.conda
+  sha256: 78d7e37661a41f18190a9b51c74712e69f7fdc2505fb2d5866d1d1843acb98e3
+  md5: 1cdf530164d41cf7424e28f39562fe83
   depends:
   - __osx >=11.0
-  - libffi >=3.4,<4.0a0
-  - pyobjc-core 11.0.*
+  - libffi >=3.4.6,<3.5.0a0
+  - pyobjc-core 11.1.*
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
@@ -18518,15 +18711,15 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
-  size: 389214
-  timestamp: 1736927161972
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.0-py312hb9d441b_0.conda
-  sha256: 53d099865f8f758029708f4365ee7c9184d9ffcc8fc8210971b723a3936f9c00
-  md5: dc263e6e18b32318a43252dbb0596ad4
+  size: 390526
+  timestamp: 1750225447749
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-11.1-py312hb9d441b_0.conda
+  sha256: a6f262fe5706c73dce7ca7fbec9a055fc225422ad8d7fc45dd66ad9dddb0afe3
+  md5: 5b7a58b273bca2c67dd8ddaea92e404e
   depends:
   - __osx >=11.0
-  - libffi >=3.4,<4.0a0
-  - pyobjc-core 11.0.*
+  - libffi >=3.4.6,<3.5.0a0
+  - pyobjc-core 11.1.*
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
@@ -18534,15 +18727,15 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
-  size: 383608
-  timestamp: 1736927118445
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.11.0-py311hf6089d3_0.conda
-  sha256: 294f3ddc6307639b9966ee9ad064d611c1caeb239fca91cde357c59909a7fba7
-  md5: aa38d38d9516dbca2b7c60173b0ff8f1
+  size: 386128
+  timestamp: 1750225477437
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.11.0-py311h75bf2cc_1.conda
+  sha256: 340d35a66f9092c5dec3f871f2b273119bdb81ed9e16381830495a251058fc6c
+  md5: 5f63bcd0ae1819b568c2481bb26d6c99
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libgdal-core >=3.10.3,<3.11.0a0
+  - libgdal-core >=3.11.0,<3.12.0a0
   - libstdcxx >=13
   - numpy
   - packaging
@@ -18552,15 +18745,15 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 676035
-  timestamp: 1746734704838
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.11.0-py312h02b19dd_0.conda
-  sha256: 28ad34f1e1ddad99bbbd7d2609fe46855e920f6985644f52852adf9ecfddc868
-  md5: b4e4e057ab327b7a1270612587a75523
+  size: 642875
+  timestamp: 1747922066118
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.11.0-py312h5426b81_1.conda
+  sha256: 5fcca77a711cdbce16e10203e801a22f77c1f6b461e670b524f5d7a950e89b19
+  md5: f1b260973fb300127155bc9f7cc40baa
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libgdal-core >=3.10.3,<3.11.0a0
+  - libgdal-core >=3.11.0,<3.12.0a0
   - libstdcxx >=13
   - numpy
   - packaging
@@ -18570,8 +18763,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 665062
-  timestamp: 1746734790035
+  size: 633239
+  timestamp: 1747922018865
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.10.0-py311h595b8b0_1.conda
   sha256: 8b06f5aeeaadd1e91a0c40a45f282671e2cad9cf8c241fcbcc8d19d05626d6ac
   md5: 785211386ef0d4f2d486192515d7397c
@@ -18608,11 +18801,11 @@ packages:
   - pkg:pypi/pyogrio?source=hash-mapping
   size: 564110
   timestamp: 1732013713458
-- conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.11.0-py311haedb144_0.conda
-  sha256: 84068162d92ce9c0d0afc08247aab241101da5d274fc8c7e1e5f301b102a3992
-  md5: 2f0ad0fa24e32365c02407a943a93b03
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.11.0-py311h2467ed7_1.conda
+  sha256: 8c7462bbfc7fd5e9584e2607a1e93ce0902078d7d4c7a6e73c21e1c4625b0d28
+  md5: 599c8b4bd96253623f6e7789e513da00
   depends:
-  - libgdal-core >=3.10.3,<3.11.0a0
+  - libgdal-core >=3.11.0,<3.12.0a0
   - numpy
   - packaging
   - python >=3.11,<3.12.0a0
@@ -18624,13 +18817,13 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 848541
-  timestamp: 1746735043001
-- conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.11.0-py312h6e88f47_0.conda
-  sha256: 05bdd65b1eb49161841a6dc22031ac1026874665d4f4b3a87cdf5e34751f86a0
-  md5: d2d9db06ba554156ba333c450607043c
+  size: 820388
+  timestamp: 1747922238003
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.11.0-py312h8f0c04e_1.conda
+  sha256: b38ce9767b6eaf75d94efa5dea8886792ca13210d60f17dd88cfbcc6cf236d94
+  md5: ede38cce4a09243f3c395b5d6f399992
   depends:
-  - libgdal-core >=3.10.3,<3.11.0a0
+  - libgdal-core >=3.11.0,<3.12.0a0
   - numpy
   - packaging
   - python >=3.12,<3.13.0a0
@@ -18642,8 +18835,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 832234
-  timestamp: 1746735147143
+  size: 806037
+  timestamp: 1747922517982
 - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.3-pyhd8ed1ab_1.conda
   sha256: b92afb79b52fcf395fd220b29e0dd3297610f2059afac45298d44e00fcbf23b6
   md5: 513d3c262ee49b54a8fec85c5bc99764
@@ -18652,7 +18845,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyparsing?source=compressed-mapping
+  - pkg:pypi/pyparsing?source=hash-mapping
   size: 95988
   timestamp: 1743089832359
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyproj-3.7.1-py311h0960b38_1.conda
@@ -18753,40 +18946,72 @@ packages:
   - pkg:pypi/pyproj?source=hash-mapping
   size: 747774
   timestamp: 1742323873263
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.9-py311hf0fb5b6_5.conda
-  sha256: 74fcdb8772c7eaf654b32922f77d9a8a1350b3446111c69a32ba4d15be74905a
-  md5: ec7e45bc76d9d0b69a74a2075932b8e8
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.11-py311he22028a_1.conda
+  sha256: c2b568492db18dfaf9d920498bc338c657a2a5db65ed82287f73846ecea0fe66
+  md5: bfd19c4ed7170fe34df119f5b225a5bf
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - pyqt5-sip 12.12.2 py311hb755f60_5
+  - __glibc >=2.17,<3.0.a0
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libstdcxx >=13
+  - pyqt5-sip 12.17.0 py311hfdbb021_1
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  - qt-main >=5.15.8,<5.16.0a0
-  - sip >=6.7.11,<6.8.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - sip >=6.10.0,<6.11.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
   license: GPL-3.0-only
   license_family: GPL
   purls:
   - pkg:pypi/pyqt5?source=hash-mapping
-  size: 5315719
-  timestamp: 1695420475603
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.9-py312h949fe66_5.conda
-  sha256: 22ccc59c03872fc680be597a1783d2c77e6b2d16953e2ec67df91f073820bebe
-  md5: f6548a564e2d01b2a42020259503945b
+  size: 5242946
+  timestamp: 1749226326779
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.11-py312hcec5e1c_0.conda
+  sha256: ec0eace8987e9c800065c640b27f4acfdf12e9ee5a6173fd539a8b5233eced58
+  md5: 5ea2e4f02749e69864e4f2be8ceb09d4
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - pyqt5-sip 12.12.2 py312h30efb56_5
-  - python >=3.12.0rc3,<3.13.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libstdcxx >=13
+  - pyqt5-sip 12.17.0 py312h2ec8cdc_0
+  - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  - qt-main >=5.15.8,<5.16.0a0
-  - sip >=6.7.11,<6.8.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - sip >=6.10.0,<6.11.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
   license: GPL-3.0-only
   license_family: GPL
   purls:
   - pkg:pypi/pyqt5?source=hash-mapping
-  size: 5263946
-  timestamp: 1695421350577
+  size: 5246359
+  timestamp: 1746851726240
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqt-5.15.11-py311h2146069_1.conda
   sha256: 92f61d8aac18de3671bfc5f4d4e9e8b2b85715077f9b31e5f3d3235bc5deeafb
   md5: 8909cf082fc6ef72c70658011d5e7232
@@ -18821,15 +19046,15 @@ packages:
   - pkg:pypi/pyqt5?source=compressed-mapping
   size: 3971844
   timestamp: 1749226864098
-- conda: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.9-py311h125bc19_5.conda
-  sha256: 4608b9caafc4fa16d887f5af08e1bafe95f4cb07596ca8f5af184bf5de8f2c4c
-  md5: 29d36acae7ccbcb1f0ec4a39841b3197
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.11-py311h2d05f59_1.conda
+  sha256: 2233b8b78dde2d364811095ca6f9c14e553e2f92076ea28632fa59e993de90c7
+  md5: ea51bea0016f502880c2d067c458bd56
   depends:
-  - pyqt5-sip 12.12.2 py311h12c1d0e_5
+  - pyqt5-sip 12.17.0 py311hda3d55a_1
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  - qt-main >=5.15.8,<5.16.0a0
-  - sip >=6.7.11,<6.8.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - sip >=6.10.0,<6.11.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -18837,17 +19062,17 @@ packages:
   license_family: GPL
   purls:
   - pkg:pypi/pyqt5?source=hash-mapping
-  size: 3906427
-  timestamp: 1695422270104
-- conda: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.9-py312he09f080_5.conda
-  sha256: c524cafaf98661f3bd5819494b41563fe5a851f6e44a7d08631c99f1dfb961c7
-  md5: fb0861092c40e5d054e984abd88e5ea8
+  size: 3908452
+  timestamp: 1749226835914
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.11-py312he11f4ca_1.conda
+  sha256: de4d0cfa7e57c2cf6a436b0a641ac8ab2fd545b2f1149256a034752c497ceaaf
+  md5: a28a2b75068454e20b1d2480370d4351
   depends:
-  - pyqt5-sip 12.12.2 py312h53d5487_5
-  - python >=3.12.0rc3,<3.13.0a0
+  - pyqt5-sip 12.17.0 py312h275cf98_1
+  - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  - qt-main >=5.15.8,<5.16.0a0
-  - sip >=6.7.11,<6.8.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - sip >=6.10.0,<6.11.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -18855,8 +19080,8 @@ packages:
   license_family: GPL
   purls:
   - pkg:pypi/pyqt5?source=hash-mapping
-  size: 3894083
-  timestamp: 1695421066159
+  size: 3853728
+  timestamp: 1749227511762
 - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-stubs-5.15.6.0-pyhb6d5dde_1.conda
   sha256: b66c53cd1bc940987d63598759c7bb86af05554bdf9a6eb5af911f1d7826e5c0
   md5: 8daf174cf7e54fcebfa3da31fd37edb2
@@ -18869,12 +19094,13 @@ packages:
   - pkg:pypi/pyqt5-stubs?source=hash-mapping
   size: 304801
   timestamp: 1735898434166
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.12.2-py311hb755f60_5.conda
-  sha256: cf6936273d92e5213b085bfd9ce1a37defb46b317b6ee991f2712bf4a25b8456
-  md5: e4d262cc3600e70b505a6761d29f6207
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.17.0-py311hfdbb021_1.conda
+  sha256: f2fbe31a7bd423c2d473516de5a2f648f6cc598350d233d2459390a6da8b15bc
+  md5: e5dfc88ced7eae4918db0dd17c28633f
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
   - packaging
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
@@ -18884,16 +19110,17 @@ packages:
   license_family: GPL
   purls:
   - pkg:pypi/pyqt5-sip?source=hash-mapping
-  size: 85162
-  timestamp: 1695418076285
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.12.2-py312h30efb56_5.conda
-  sha256: c7154e1933360881b99687d580c4b941fb0cc6ad9574762d409a28196ef5e240
-  md5: 8a2a122dc4fe14d8cff38f1cf426381f
+  size: 84215
+  timestamp: 1749224312844
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.17.0-py312h2ec8cdc_0.conda
+  sha256: ff3bdea51ee709fdd471c8fba2680779c85b5de01ec0cc47b621764995386a06
+  md5: f3c52fc8602a631848ffd394c4c5b31e
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
   - packaging
-  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - sip
   - toml
@@ -18901,8 +19128,8 @@ packages:
   license_family: GPL
   purls:
   - pkg:pypi/pyqt5-sip?source=hash-mapping
-  size: 85809
-  timestamp: 1695418132533
+  size: 84845
+  timestamp: 1746849713950
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqt5-sip-12.17.0-py311h155a34a_1.conda
   sha256: 2e7a375faa60668d63eb5f5ccfe5ee79eea2698478b00cf0baacc07a4a47b8f5
   md5: 2e17721a68314daf89c676a1ddcd79c1
@@ -18939,9 +19166,9 @@ packages:
   - pkg:pypi/pyqt5-sip?source=hash-mapping
   size: 75541
   timestamp: 1749224419014
-- conda: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.12.2-py311h12c1d0e_5.conda
-  sha256: 7130493794e4c65f4e78258619a6ef9d022ba9f9b0f61e70d2973d9bc5f10e11
-  md5: 1b53a20f311bd99a1e55b31b7219106f
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.17.0-py311hda3d55a_1.conda
+  sha256: 2c42a900bc43fc87f9c860391f2b6c306659faf213ed5e32e9f50db44e717610
+  md5: 71c0c9b9343cdb746a8b8403329a193f
   depends:
   - packaging
   - python >=3.11,<3.12.0a0
@@ -18955,14 +19182,14 @@ packages:
   license_family: GPL
   purls:
   - pkg:pypi/pyqt5-sip?source=hash-mapping
-  size: 79724
-  timestamp: 1695418442619
-- conda: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.12.2-py312h53d5487_5.conda
-  sha256: 56242d5203e7231ee5bdd25df417dfc60a4f38e335f922f7e00f8c518ba87bd1
-  md5: dbaa69d84f7da6ac3ec20de2a9529a4b
+  size: 75820
+  timestamp: 1749224745973
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.17.0-py312h275cf98_1.conda
+  sha256: 7e69849e88be311711dc79ed7dbb2fd2597801bac57ea4cc1275b5e7d9227af2
+  md5: 2f4f68f0ca558a843d2e9de4792f8dd1
   depends:
   - packaging
-  - python >=3.12.0rc3,<3.13.0a0
+  - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - sip
   - toml
@@ -18973,44 +19200,74 @@ packages:
   license_family: GPL
   purls:
   - pkg:pypi/pyqt5-sip?source=hash-mapping
-  size: 79366
-  timestamp: 1695418564486
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyqtwebkit-5.15.9-py311h4c6dc46_2.conda
-  sha256: 4f92cb54dd303eb4e940647b42eefc5ab00e0cb9d1873814b95fef78f1edd97d
-  md5: c991f90dff9816159fefac95be32741e
+  size: 75189
+  timestamp: 1749224660677
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyqtwebkit-5.15.11-py311he22028a_0.conda
+  sha256: 45bd9991bebede1dc6da948c550d460b2d3ea3965a9dc94a530d0cccedeab488
+  md5: c4499d187fd8fa6ca77f8229f0d6807c
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - pyqt >=5.15.9,<5.16.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libstdcxx >=13
+  - pyqt >=5.15.11,<5.16.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  - qt-main >=5.15.8,<5.16.0a0
+  - qt-main >=5.15.15,<5.16.0a0
   - qtwebkit
-  - sip >=6.7.11,<6.8.0a0
+  - sip >=6.10.0,<6.11.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
   license: LicenseRef-Commercial or GPL-3.0-only
   license_family: GPL
   purls: []
-  size: 155701
-  timestamp: 1695649097615
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyqtwebkit-5.15.9-py312hc23280e_2.conda
-  sha256: 4070a7685df9355b2bee3cf56af679d744bc01a1bf7e2f3c7923d0d90cae83de
-  md5: 811adee477670ad385b4c9c8e9f71440
+  size: 155836
+  timestamp: 1748841700164
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyqtwebkit-5.15.11-py312hcec5e1c_0.conda
+  sha256: 54ab22642d5a24bda2d9b2e1d11960243e5c7a4405b8bbf1459239f1685d3647
+  md5: 7471ef67a385cfdf5e44288ce2573e08
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - pyqt >=5.15.9,<5.16.0a0
-  - python >=3.12.0rc3,<3.13.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libstdcxx >=13
+  - pyqt >=5.15.11,<5.16.0a0
+  - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  - qt-main >=5.15.8,<5.16.0a0
+  - qt-main >=5.15.15,<5.16.0a0
   - qtwebkit
-  - sip >=6.7.11,<6.8.0a0
+  - sip >=6.10.0,<6.11.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
   license: LicenseRef-Commercial or GPL-3.0-only
   license_family: GPL
   purls: []
-  size: 155959
-  timestamp: 1695649151624
+  size: 155724
+  timestamp: 1748841878718
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqtwebkit-5.15.11-py311h2146069_0.conda
   sha256: f2292ca755f953c1464c8ec0784ad8fcc202c3ec2cc889f040aaa5d14b6a29c5
   md5: 01421a7cd11255757ccdd0ed4b3689f1
@@ -19045,42 +19302,42 @@ packages:
   purls: []
   size: 128372
   timestamp: 1748842084589
-- conda: https://conda.anaconda.org/conda-forge/win-64/pyqtwebkit-5.15.9-py311h5a77453_2.conda
-  sha256: 7e98e8cb281131da97af0c1f8081fa877bfbdc5917c54897928ed9bd4a651c68
-  md5: 2d3591431ba7d9d1790b10093ff5dcf1
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyqtwebkit-5.15.11-py311h2d05f59_0.conda
+  sha256: c18d83f59b7de539c1894ecbc81f3ffd64c4979873edd4075e75799fb30aaff7
+  md5: 81d7c785bbc24c966aafc921c76f52d5
   depends:
-  - pyqt >=5.15.9,<5.16.0a0
+  - pyqt >=5.15.11,<5.16.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  - qt-main >=5.15.8,<5.16.0a0
+  - qt-main >=5.15.15,<5.16.0a0
   - qtwebkit
-  - sip >=6.7.11,<6.8.0a0
+  - sip >=6.10.0,<6.11.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: LicenseRef-Commercial or GPL-3.0-only
   license_family: GPL
   purls: []
-  size: 124670
-  timestamp: 1695652112782
-- conda: https://conda.anaconda.org/conda-forge/win-64/pyqtwebkit-5.15.9-py312hca0710b_2.conda
-  sha256: 0234202c25300bc3526c95a0dff625214a4705cd3f8c43cdb2dd73631918b312
-  md5: 478e037ac192b5a065dc42f0422482d2
+  size: 124590
+  timestamp: 1748844132330
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyqtwebkit-5.15.11-py312he11f4ca_0.conda
+  sha256: feb6dd234edd90a5793b46fa1a861ef62d57b40ee77479961968d40c6db62f81
+  md5: 64804ed49d0c9cee6ed7f6ef4d539d29
   depends:
-  - pyqt >=5.15.9,<5.16.0a0
-  - python >=3.12.0rc3,<3.13.0a0
+  - pyqt >=5.15.11,<5.16.0a0
+  - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  - qt-main >=5.15.8,<5.16.0a0
+  - qt-main >=5.15.15,<5.16.0a0
   - qtwebkit
-  - sip >=6.7.11,<6.8.0a0
+  - sip >=6.10.0,<6.11.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: LicenseRef-Commercial or GPL-3.0-only
   license_family: GPL
   purls: []
-  size: 124366
-  timestamp: 1695651311454
+  size: 124564
+  timestamp: 1748843258672
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.9.1-py311h846acb3_0.conda
   sha256: e12c65ff50636191f2145117d1bb1b9f9d95e066fe89e1ad214958a92d7532cb
   md5: ad35b71ce948f1a2b5b1452a9cc46823
@@ -19196,9 +19453,9 @@ packages:
   - pkg:pypi/pysocks?source=hash-mapping
   size: 21085
   timestamp: 1733217331982
-- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.0-pyhd8ed1ab_0.conda
-  sha256: f8c5a65ff4216f7c0a9be1708be1ee1446ad678da5a01eeb2437551156e32a06
-  md5: 516d31f063ce7e49ced17f105b63a1f1
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.1-pyhd8ed1ab_0.conda
+  sha256: 93e267e4ec35353e81df707938a6527d5eb55c97bf54c3b87229b69523afb59d
+  md5: a49c2283f24696a7b30367b7346a0144
   depends:
   - colorama >=0.4
   - exceptiongroup >=1
@@ -19213,12 +19470,12 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pytest?source=compressed-mapping
-  size: 275014
-  timestamp: 1748907618871
-- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.1.1-pyhd8ed1ab_0.conda
-  sha256: 9961a1524f63d10bc29efdc52013ec06b0e95fb2619a250e250ff3618261d5cd
-  md5: 1e35d8f975bc0e984a19819aa91c440a
+  - pkg:pypi/pytest?source=hash-mapping
+  size: 276562
+  timestamp: 1750239526127
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-6.2.1-pyhd8ed1ab_0.conda
+  sha256: 3a9fc07be76bc67aef355b78816b5117bfe686e7d8c6f28b45a1f89afe104761
+  md5: ce978e1b9ed8b8d49164e90a5cdc94cd
   depends:
   - coverage >=7.5
   - pytest >=4.6
@@ -19227,12 +19484,12 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pytest-cov?source=hash-mapping
-  size: 27565
-  timestamp: 1743886993683
-- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.7.0-pyhd8ed1ab_0.conda
-  sha256: 3cd4dabfaf17f207011f5c3fdb6068568aa71fea86ecd234a2bd0a6fd6fbc6b9
-  md5: 15353a2a0ea6dfefaa52fc5ab5b98f41
+  - pkg:pypi/pytest-cov?source=compressed-mapping
+  size: 28216
+  timestamp: 1749778064293
+- conda: https://conda.anaconda.org/conda-forge/noarch/pytest-xdist-3.8.0-pyhd8ed1ab_0.conda
+  sha256: b7b58a5be090883198411337b99afb6404127809c3d1c9f96e99b59f36177a96
+  md5: 8375cfbda7c57fbceeda18229be10417
   depends:
   - execnet >=2.1
   - pytest >=7.0.0
@@ -19243,8 +19500,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pytest-xdist?source=hash-mapping
-  size: 39210
-  timestamp: 1748342202415
+  size: 39300
+  timestamp: 1751452761594
 - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.13-h9e4cc4f_0_cpython.conda
   sha256: 9979a7d4621049388892489267139f1aa629b10c26601ba5dce96afc2b1551d4
   md5: 8c399445b6dc73eab839659e6c7b5ad1
@@ -19387,21 +19644,22 @@ packages:
   purls: []
   size: 15829289
   timestamp: 1749047682640
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_1.conda
-  sha256: a50052536f1ef8516ed11a844f9413661829aa083304dc624c5925298d078d79
-  md5: 5ba79d7c71f03c678c8ead841f347d6e
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
+  sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
+  md5: 5b8d21249ff20967101ffa321cab24e8
   depends:
   - python >=3.9
   - six >=1.5
+  - python
   license: Apache-2.0
   license_family: APACHE
   purls:
   - pkg:pypi/python-dateutil?source=hash-mapping
-  size: 222505
-  timestamp: 1733215763718
-- conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.0-pyh29332c3_1.conda
-  sha256: 7d927317003544049c97e7108e8ca5f2be5ff0ea954f5c84c8bbeb243b663fc8
-  md5: 27d816c6981a8d50090537b761de80f4
+  size: 233310
+  timestamp: 1751104122689
+- conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.1.1-pyhe01879c_0.conda
+  sha256: 9a90570085bedf4c6514bcd575456652c47918ff3d7b383349e26192a4805cc8
+  md5: a245b3c04afa11e2e52a0db91550da7c
   depends:
   - python >=3.9
   - python
@@ -19409,8 +19667,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/python-dotenv?source=hash-mapping
-  size: 25557
-  timestamp: 1742948348635
+  size: 26031
+  timestamp: 1750789290754
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.21.1-pyhd8ed1ab_0.conda
   sha256: 1b09a28093071c1874862422696429d0d35bd0b8420698003ac004746c5e82a2
   md5: 38e34d2d1d9dca4fb2b9a0a04f604e2c
@@ -19684,9 +19942,9 @@ packages:
   - pkg:pypi/pyyaml?source=hash-mapping
   size: 181734
   timestamp: 1737455207230
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.4.0-py311h7deb3e3_0.conda
-  sha256: e78fc8c500b96070359311082b4ebc5d66e52ddb2891861c728a247cf52892ba
-  md5: eb719a63f26215bba3ee5b0227c6452b
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.0.0-py311h7deb3e3_0.conda
+  sha256: 1bf06369b9c22caf69351aecef3aed2282ba5224338aa6a8316dc5754f3f9a85
+  md5: 43618006ed69ec49e144206b34ab93e6
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -19699,11 +19957,11 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/pyzmq?source=hash-mapping
-  size: 390342
-  timestamp: 1743831429166
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.4.0-py312hbf22597_0.conda
-  sha256: 65a264837f189b0c69c5431ea8ef44e405c472fedba145b05055f284f08bc663
-  md5: fa0ab7d5bee9efbc370e71bcb5da9856
+  size: 391376
+  timestamp: 1749898590440
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-27.0.0-py312hbf22597_0.conda
+  sha256: 8564a7beb906476813a59a81a814d00e8f9697c155488dbc59a5c6e950d5f276
+  md5: 4b9a9cda3292668831cf47257ade22a6
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -19716,11 +19974,11 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/pyzmq?source=hash-mapping
-  size: 379554
-  timestamp: 1743831426292
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.4.0-py311h01f2145_0.conda
-  sha256: 5f50272cbe00701a79d3b5f3aa14808b6f8b80a3ea636f99f4746f109f02030d
-  md5: 461e2af0a7a77162309bda6f92a1a66c
+  size: 378610
+  timestamp: 1749898590652
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.0.0-py311h01f2145_0.conda
+  sha256: 44e2bd871b2a0e122ffbda49cd8545ba1b08eaa90927d245ab59d45fea3c25f8
+  md5: 2f9bf162aa29335b0c16a4a9fa9dad4f
   depends:
   - __osx >=11.0
   - libcxx >=18
@@ -19733,11 +19991,11 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/pyzmq?source=hash-mapping
-  size: 367977
-  timestamp: 1743831535027
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.4.0-py312hf4875e0_0.conda
-  sha256: b8b41da0aac8aab5e48e62ff341374f12cd0ace7a59b80f56bc75371aa4796d5
-  md5: 1e2a85e9493ad7c892ecbca89a11837c
+  size: 365985
+  timestamp: 1749898718919
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-27.0.0-py312hf4875e0_0.conda
+  sha256: 709c673d5b45774ce003648427103732c834a300447452a3c8369469e2aa6bfd
+  md5: 0ff6afa66b15299c051f57e5ec257e88
   depends:
   - __osx >=11.0
   - libcxx >=18
@@ -19750,11 +20008,11 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/pyzmq?source=hash-mapping
-  size: 364333
-  timestamp: 1743831518152
-- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.4.0-py311h484c95c_0.conda
-  sha256: d917b120cb10b32d90d40fc2b6a612cf75a9298d159e11da3a8672a3474b4f93
-  md5: 0497becb33761fca9b8cfcb9f7278361
+  size: 359326
+  timestamp: 1749898793266
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-27.0.0-py311h484c95c_0.conda
+  sha256: cc47fc0264c839c9062423406d8c2e4b25360041bb47d33277daeaeab3f88101
+  md5: 5ff8a3328db08043afb64b77cdc4b6ea
   depends:
   - libsodium >=1.0.20,<1.0.21.0a0
   - python >=3.11,<3.12.0a0
@@ -19767,11 +20025,11 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/pyzmq?source=hash-mapping
-  size: 372040
-  timestamp: 1743831788464
-- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.4.0-py312hd7027bb_0.conda
-  sha256: 07fbf17632c6300e53550f829f2e10d2c6f68923aa139d0618eaeadf2d0043ae
-  md5: ccfe948627071c03e36aa46d9e94bf12
+  size: 374069
+  timestamp: 1749899010761
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-27.0.0-py312hd7027bb_0.conda
+  sha256: e66267a7a61bfba5cdb50089c04a6f140edb9133c5ce34331ee2f95370460b8c
+  md5: 37d6508caaa4c3a91e3434192d192685
   depends:
   - libsodium >=1.0.20,<1.0.21.0a0
   - python >=3.12,<3.13.0a0
@@ -19784,8 +20042,8 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/pyzmq?source=hash-mapping
-  size: 363177
-  timestamp: 1743831815399
+  size: 364291
+  timestamp: 1749899188003
 - conda: https://conda.anaconda.org/conda-forge/linux-64/qca-2.3.10-h71e8f01_0.conda
   sha256: 78ed8b4adfafca24318905b063ce522ce8d9d462baa87bc4127be16792b48b48
   md5: 02bb684679d42acbad901bb4106a38a1
@@ -19824,9 +20082,9 @@ packages:
   purls: []
   size: 746111
   timestamp: 1741779591791
-- conda: https://conda.anaconda.org/conda-forge/linux-64/qgis-3.42.2-py311hfd6a7af_0.conda
-  sha256: aaa55be180f8881b1581c197c39be1fa8323f261913dcda6f5b07d9906d63e74
-  md5: 73424a29c9363999869309a787627f6d
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qgis-3.44.0-py311hf085377_0.conda
+  sha256: 15dce0d7a00d4157597fd08bb35340afdac28b1d0e92f17f01b05fac36f7ad34
+  md5: 84f26530ea2ad6cfca712c193b24ceea
   depends:
   - __glibc >=2.17,<3.0.a0
   - exiv2 >=0.28.5,<0.29.0a0
@@ -19838,27 +20096,30 @@ packages:
   - icu >=75.1,<76.0a0
   - jinja2
   - laz-perf
+  - libegl >=1.7.0,<2.0a0
   - libexpat >=2.7.0,<3.0a0
   - libgcc >=13
-  - libgdal >=3.10.3,<3.11.0a0
-  - libgdal-core >=3.10.3,<3.11.0a0
+  - libgdal >=3.11.0,<3.12.0a0
+  - libgdal-core >=3.11.0,<3.12.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
   - libpdal
-  - libpdal-arrow >=2.8.4,<2.9.0a0
-  - libpdal-core >=2.8.4,<2.9.0a0
-  - libpdal-cpd >=2.8.4,<2.9.0a0
-  - libpdal-draco >=2.8.4,<2.9.0a0
-  - libpdal-e57 >=2.8.4,<2.9.0a0
-  - libpdal-hdf >=2.8.4,<2.9.0a0
-  - libpdal-icebridge >=2.8.4,<2.9.0a0
-  - libpdal-nitf >=2.8.4,<2.9.0a0
-  - libpdal-pgpointcloud >=2.8.4,<2.9.0a0
-  - libpdal-tiledb >=2.8.4,<2.9.0a0
-  - libpdal-trajectory >=2.8.4,<2.9.0a0
-  - libpq >=17.4,<18.0a0
+  - libpdal-arrow >=2.9.0,<2.10.0a0
+  - libpdal-core >=2.9.0,<2.10.0a0
+  - libpdal-cpd >=2.9.0,<2.10.0a0
+  - libpdal-draco >=2.9.0,<2.10.0a0
+  - libpdal-e57 >=2.9.0,<2.10.0a0
+  - libpdal-hdf >=2.9.0,<2.10.0a0
+  - libpdal-icebridge >=2.9.0,<2.10.0a0
+  - libpdal-nitf >=2.9.0,<2.10.0a0
+  - libpdal-pgpointcloud >=2.9.0,<2.10.0a0
+  - libpdal-tiledb >=2.9.0,<2.10.0a0
+  - libpdal-trajectory >=2.9.0,<2.10.0a0
+  - libpq >=17.5,<18.0a0
   - libprotobuf >=5.29.3,<5.29.4.0a0
   - libspatialindex >=2.1.0,<2.1.1.0a0
   - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.49.1,<4.0a0
+  - libsqlite >=3.50.1,<4.0a0
   - libstdcxx >=13
   - libzip >=1.11.2,<2.0a0
   - markupsafe
@@ -19868,11 +20129,11 @@ packages:
   - owslib
   - plotly
   - postgresql
-  - proj >=9.6.0,<9.7.0a0
+  - proj >=9.6.2,<9.7.0a0
   - psycopg2
   - pygments
   - pyproj
-  - pyqt >=5.15.9,<5.16.0a0
+  - pyqt >=5.15.11,<5.16.0a0
   - pyqt5-sip
   - pyqtwebkit
   - python >=3.11,<3.12.0a0
@@ -19888,18 +20149,30 @@ packages:
   - qtwebkit
   - qwt >=6.3.0,<6.4.0a0
   - requests
-  - sip >=6.7.12,<6.8.0a0
+  - sip >=6.10.0,<6.11.0a0
   - six
   - sqlite
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
   - yaml
   license: GPL-2.0-only
   license_family: GPL
   purls: []
-  size: 97721033
-  timestamp: 1745230967796
-- conda: https://conda.anaconda.org/conda-forge/linux-64/qgis-3.42.2-py312h9cdd117_0.conda
-  sha256: 4922b858b3189a4ef5aa02242d7ef5c1e3f72c4ec017a0082bb6e2ff782c2d60
-  md5: 1d7c962d8b8bb844d282c2d386774e95
+  size: 99893375
+  timestamp: 1750813962058
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qgis-3.44.0-py312h47e9dea_0.conda
+  sha256: c8227073103b60319bccaa9d4b2860b0f91aacd658a57a92493084888e9d8756
+  md5: a3ea4babed55bc215f9856fe1a71beec
   depends:
   - __glibc >=2.17,<3.0.a0
   - exiv2 >=0.28.5,<0.29.0a0
@@ -19911,27 +20184,30 @@ packages:
   - icu >=75.1,<76.0a0
   - jinja2
   - laz-perf
+  - libegl >=1.7.0,<2.0a0
   - libexpat >=2.7.0,<3.0a0
   - libgcc >=13
-  - libgdal >=3.10.3,<3.11.0a0
-  - libgdal-core >=3.10.3,<3.11.0a0
+  - libgdal >=3.11.0,<3.12.0a0
+  - libgdal-core >=3.11.0,<3.12.0a0
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
   - libpdal
-  - libpdal-arrow >=2.8.4,<2.9.0a0
-  - libpdal-core >=2.8.4,<2.9.0a0
-  - libpdal-cpd >=2.8.4,<2.9.0a0
-  - libpdal-draco >=2.8.4,<2.9.0a0
-  - libpdal-e57 >=2.8.4,<2.9.0a0
-  - libpdal-hdf >=2.8.4,<2.9.0a0
-  - libpdal-icebridge >=2.8.4,<2.9.0a0
-  - libpdal-nitf >=2.8.4,<2.9.0a0
-  - libpdal-pgpointcloud >=2.8.4,<2.9.0a0
-  - libpdal-tiledb >=2.8.4,<2.9.0a0
-  - libpdal-trajectory >=2.8.4,<2.9.0a0
-  - libpq >=17.4,<18.0a0
+  - libpdal-arrow >=2.9.0,<2.10.0a0
+  - libpdal-core >=2.9.0,<2.10.0a0
+  - libpdal-cpd >=2.9.0,<2.10.0a0
+  - libpdal-draco >=2.9.0,<2.10.0a0
+  - libpdal-e57 >=2.9.0,<2.10.0a0
+  - libpdal-hdf >=2.9.0,<2.10.0a0
+  - libpdal-icebridge >=2.9.0,<2.10.0a0
+  - libpdal-nitf >=2.9.0,<2.10.0a0
+  - libpdal-pgpointcloud >=2.9.0,<2.10.0a0
+  - libpdal-tiledb >=2.9.0,<2.10.0a0
+  - libpdal-trajectory >=2.9.0,<2.10.0a0
+  - libpq >=17.5,<18.0a0
   - libprotobuf >=5.29.3,<5.29.4.0a0
   - libspatialindex >=2.1.0,<2.1.1.0a0
   - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.49.1,<4.0a0
+  - libsqlite >=3.50.1,<4.0a0
   - libstdcxx >=13
   - libzip >=1.11.2,<2.0a0
   - markupsafe
@@ -19941,11 +20217,11 @@ packages:
   - owslib
   - plotly
   - postgresql
-  - proj >=9.6.0,<9.7.0a0
+  - proj >=9.6.2,<9.7.0a0
   - psycopg2
   - pygments
   - pyproj
-  - pyqt >=5.15.9,<5.16.0a0
+  - pyqt >=5.15.11,<5.16.0a0
   - pyqt5-sip
   - pyqtwebkit
   - python >=3.12,<3.13.0a0
@@ -19961,15 +20237,27 @@ packages:
   - qtwebkit
   - qwt >=6.3.0,<6.4.0a0
   - requests
-  - sip >=6.7.12,<6.8.0a0
+  - sip >=6.10.0,<6.11.0a0
   - six
   - sqlite
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
   - yaml
   license: GPL-2.0-only
   license_family: GPL
   purls: []
-  size: 96967082
-  timestamp: 1745230805700
+  size: 99696302
+  timestamp: 1750814045966
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qgis-3.40.3-py311ha25bd51_2.conda
   sha256: b32a300044a88c5d262c3c426977c5dd7f6021167afb2e192d73dce632998be7
   md5: b607f487cf8139823e2790b54f6d5e7a
@@ -20118,9 +20406,9 @@ packages:
   purls: []
   size: 74725713
   timestamp: 1739585987678
-- conda: https://conda.anaconda.org/conda-forge/win-64/qgis-3.42.2-py311h1440119_0.conda
-  sha256: 7b117a8d39c7dbbc517545e24eb9463b9db72a0eddfb196ac42eec5ec7bf10d9
-  md5: 5957ef8c39da121285017366a9e65360
+- conda: https://conda.anaconda.org/conda-forge/win-64/qgis-3.42.3-py311he4d1a5a_0.conda
+  sha256: 8b125363ec7cb6a67eef268b0de3944e95ec33055e4e0c56494d3b1db53a97cb
+  md5: 4a4cce6082d370fb33317a855d8d4ff8
   depends:
   - exiv2 >=0.28.5,<0.29.0a0
   - future
@@ -20133,8 +20421,8 @@ packages:
   - khronos-opencl-icd-loader >=2024.10.24
   - laz-perf
   - libexpat >=2.7.0,<3.0a0
-  - libgdal >=3.10.3,<3.11.0a0
-  - libgdal-core >=3.10.3,<3.11.0a0
+  - libgdal >=3.11.0,<3.12.0a0
+  - libgdal-core >=3.11.0,<3.12.0a0
   - libpdal
   - libpdal-arrow >=2.8.4,<2.9.0a0
   - libpdal-core >=2.8.4,<2.9.0a0
@@ -20146,11 +20434,11 @@ packages:
   - libpdal-pgpointcloud >=2.8.4,<2.9.0a0
   - libpdal-tiledb >=2.8.4,<2.9.0a0
   - libpdal-trajectory >=2.8.4,<2.9.0a0
-  - libpq >=17.4,<18.0a0
+  - libpq >=17.5,<18.0a0
   - libprotobuf >=5.29.3,<5.29.4.0a0
   - libspatialindex >=2.1.0,<2.1.1.0a0
   - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.49.1,<4.0a0
+  - libsqlite >=3.50.1,<4.0a0
   - libzip >=1.11.2,<2.0a0
   - markupsafe
   - mock
@@ -20158,11 +20446,11 @@ packages:
   - owslib
   - plotly
   - postgresql
-  - proj >=9.6.0,<9.7.0a0
+  - proj >=9.6.2,<9.7.0a0
   - psycopg2
   - pygments
   - pyproj
-  - pyqt >=5.15.9,<5.16.0a0
+  - pyqt >=5.15.11,<5.16.0a0
   - pyqt5-sip
   - pyqtwebkit
   - python >=3.11,<3.12.0a0
@@ -20178,21 +20466,21 @@ packages:
   - qtwebkit
   - qwt >=6.3.0,<6.4.0a0
   - requests
-  - sip >=6.7.12,<6.8.0a0
+  - sip >=6.10.0,<6.11.0a0
   - six
   - sqlite
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - yaml
   license: GPL-2.0-only
   license_family: GPL
   purls: []
-  size: 75142910
-  timestamp: 1745237260226
-- conda: https://conda.anaconda.org/conda-forge/win-64/qgis-3.42.2-py312h20a3e66_0.conda
-  sha256: 30e597d889f591e8144c6697795d6aefb5762a00b2ca5d9cc1adce8096739186
-  md5: 72430c6eefaf0bd6b4e8ecb22fa8c873
+  size: 75577932
+  timestamp: 1750420548642
+- conda: https://conda.anaconda.org/conda-forge/win-64/qgis-3.42.3-py312h8977587_0.conda
+  sha256: eeb68424f6228da51eff8dd24d29a39152284d638e104abc8276edd49aa4bf42
+  md5: 5276b353e690b957189ad2a1246b063b
   depends:
   - exiv2 >=0.28.5,<0.29.0a0
   - future
@@ -20205,8 +20493,8 @@ packages:
   - khronos-opencl-icd-loader >=2024.10.24
   - laz-perf
   - libexpat >=2.7.0,<3.0a0
-  - libgdal >=3.10.3,<3.11.0a0
-  - libgdal-core >=3.10.3,<3.11.0a0
+  - libgdal >=3.11.0,<3.12.0a0
+  - libgdal-core >=3.11.0,<3.12.0a0
   - libpdal
   - libpdal-arrow >=2.8.4,<2.9.0a0
   - libpdal-core >=2.8.4,<2.9.0a0
@@ -20218,11 +20506,11 @@ packages:
   - libpdal-pgpointcloud >=2.8.4,<2.9.0a0
   - libpdal-tiledb >=2.8.4,<2.9.0a0
   - libpdal-trajectory >=2.8.4,<2.9.0a0
-  - libpq >=17.4,<18.0a0
+  - libpq >=17.5,<18.0a0
   - libprotobuf >=5.29.3,<5.29.4.0a0
   - libspatialindex >=2.1.0,<2.1.1.0a0
   - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.49.1,<4.0a0
+  - libsqlite >=3.50.1,<4.0a0
   - libzip >=1.11.2,<2.0a0
   - markupsafe
   - mock
@@ -20230,11 +20518,11 @@ packages:
   - owslib
   - plotly
   - postgresql
-  - proj >=9.6.0,<9.7.0a0
+  - proj >=9.6.2,<9.7.0a0
   - psycopg2
   - pygments
   - pyproj
-  - pyqt >=5.15.9,<5.16.0a0
+  - pyqt >=5.15.11,<5.16.0a0
   - pyqt5-sip
   - pyqtwebkit
   - python >=3.12,<3.13.0a0
@@ -20250,18 +20538,18 @@ packages:
   - qtwebkit
   - qwt >=6.3.0,<6.4.0a0
   - requests
-  - sip >=6.7.12,<6.8.0a0
+  - sip >=6.10.0,<6.11.0a0
   - six
   - sqlite
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - yaml
   license: GPL-2.0-only
   license_family: GPL
   purls: []
-  size: 74110835
-  timestamp: 1745235563657
+  size: 74842550
+  timestamp: 1750416114569
 - conda: https://conda.anaconda.org/conda-forge/noarch/qgis-plugin-manager-1.6.1-pyhd8ed1ab_0.conda
   sha256: 9df61faa73fb66315430af866fe90076fb363893ae6fe31d4105e36072b74a0a
   md5: 3039cc77e9dd82d527de5d77933a5d76
@@ -20338,83 +20626,115 @@ packages:
   purls: []
   size: 54905
   timestamp: 1676253253926
-- conda: https://conda.anaconda.org/conda-forge/linux-64/qscintilla2-2.14.1-py311h4c6dc46_0.conda
-  sha256: 0ed3a91fcd25a49a59c7b9dd9edcaf75a293028355e48cb9a8a796973d3b3117
-  md5: b79f1ea8ba7db0f42714110e91856d70
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qscintilla2-2.14.1-py311he22028a_1.conda
+  sha256: 28ac54b414111d816192f4058ed3757d08238b8af6ae7644e48e515063c16de7
+  md5: accbfee8a970db36194feccc66fcfe2a
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - pyqt >=5.15.9,<5.16.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libstdcxx >=13
+  - pyqt >=5.15.11,<5.16.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  - qt-main >=5.15.8,<5.16.0a0
-  - sip >=6.7.11,<6.8.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - sip >=6.10.0,<6.11.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
   license: GPL-3.0-or-later
   license_family: GPL
   purls:
   - pkg:pypi/qscintilla?source=hash-mapping
-  size: 1710660
-  timestamp: 1695486377934
-- conda: https://conda.anaconda.org/conda-forge/linux-64/qscintilla2-2.14.1-py312hc23280e_0.conda
-  sha256: fabd11ed7904a0356a1a7794be2160d639c119863b7555ba2c6e37cfd9e5243f
-  md5: 6bad10e9a62c22dce10fcc0837178738
+  size: 1701135
+  timestamp: 1750210738296
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qscintilla2-2.14.1-py312hcec5e1c_1.conda
+  sha256: 5345f32203604f5aff6e0eb612d05821f201bf212367c2768020db76eae03f09
+  md5: 1d93231d26c332d1c44c86945a626f8c
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - pyqt >=5.15.9,<5.16.0a0
-  - python >=3.12.0rc3,<3.13.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=13
+  - libgl >=1.7.0,<2.0a0
+  - libopengl >=1.7.0,<2.0a0
+  - libstdcxx >=13
+  - pyqt >=5.15.11,<5.16.0a0
+  - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  - qt-main >=5.15.8,<5.16.0a0
-  - sip >=6.7.11,<6.8.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - sip >=6.10.0,<6.11.0a0
+  - xcb-util >=0.4.1,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.1,<0.5.0a0
+  - xcb-util-renderutil >=0.3.10,<0.4.0a0
+  - xcb-util-wm >=0.4.2,<0.5.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxcomposite >=0.4.6,<1.0a0
+  - xorg-libxdamage >=1.1.6,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxxf86vm >=1.1.6,<2.0a0
   license: GPL-3.0-or-later
   license_family: GPL
   purls:
   - pkg:pypi/qscintilla?source=hash-mapping
-  size: 1710828
-  timestamp: 1695486254081
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/qscintilla2-2.14.1-py311h14ede98_0.conda
-  sha256: 0d76b2d46fc08d04e999a8281325b17c172022fafdb5dac39fc8aa715233a89b
-  md5: a04602fc5f7bd3646199db03245b2e5c
+  size: 1706812
+  timestamp: 1750210723061
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/qscintilla2-2.14.1-py311h2146069_1.conda
+  sha256: ed8879c6096a0012daf644342dbafee30ff325e4869d73d2963b8a6f80b8bde3
+  md5: 80dbf3a3a6db4bd22ed12a289fff3c48
   depends:
-  - libcxx >=15.0.7
-  - pyqt >=5.15.9,<5.16.0a0
+  - __osx >=11.0
+  - libcxx >=18
+  - pyqt >=5.15.11,<5.16.0a0
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
-  - qt-main >=5.15.8,<5.16.0a0
-  - sip >=6.7.11,<6.8.0a0
+  - qt-main >=5.15.15,<5.16.0a0
   license: GPL-3.0-or-later
   license_family: GPL
-  purls: []
-  size: 1257709
-  timestamp: 1695486575127
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/qscintilla2-2.14.1-py312h14105d7_0.conda
-  sha256: aa3bd33df4c776ab96432c1f4bf12715742dc59d1ae2e013069d1f814e0da366
-  md5: 31d17bbc23db4377185684ed18e2bc19
+  purls:
+  - pkg:pypi/qscintilla?source=hash-mapping
+  size: 1219383
+  timestamp: 1750210793408
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/qscintilla2-2.14.1-py312he8164c3_1.conda
+  sha256: 9b2904d3535b34bddd6b3d13e6132671a1a7303fc7a3c5c96332557290309d63
+  md5: 47f4257087ab56bc343f243c74514bdc
   depends:
-  - libcxx >=15.0.7
-  - pyqt >=5.15.9,<5.16.0a0
-  - python >=3.12.0rc3,<3.13.0a0
-  - python >=3.12.0rc3,<3.13.0a0 *_cpython
+  - __osx >=11.0
+  - libcxx >=18
+  - pyqt >=5.15.11,<5.16.0a0
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
-  - qt-main >=5.15.8,<5.16.0a0
-  - sip >=6.7.11,<6.8.0a0
+  - qt-main >=5.15.15,<5.16.0a0
   license: GPL-3.0-or-later
   license_family: GPL
-  purls: []
-  size: 1258259
-  timestamp: 1695486794043
-- conda: https://conda.anaconda.org/conda-forge/win-64/qscintilla2-2.14.1-py311h5a77453_0.conda
-  sha256: 8b823806bfe0cd1e60f19ccda0aa9d8f37fdd1faa23e7c12a89986a97518c464
-  md5: e7ce3f0a344f3a4177e52f52e884d77b
+  purls:
+  - pkg:pypi/qscintilla?source=hash-mapping
+  size: 1219049
+  timestamp: 1750211215350
+- conda: https://conda.anaconda.org/conda-forge/win-64/qscintilla2-2.14.1-py311h2d05f59_1.conda
+  sha256: 3e6f470ebf32b5b2e6788b4c0c9bef334f4e97e7572b63ade5ab032327694174
+  md5: 06938d251b2fab16b2337705f10ef06c
   depends:
-  - pyqt >=5.15.9,<5.16.0a0
+  - pyqt >=5.15.11,<5.16.0a0
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
-  - qt-main >=5.15.8,<5.16.0a0
-  - sip >=6.7.11,<6.8.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - sip >=6.10.0,<6.11.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -20422,17 +20742,17 @@ packages:
   license_family: GPL
   purls:
   - pkg:pypi/qscintilla?source=hash-mapping
-  size: 1282124
-  timestamp: 1695486843852
-- conda: https://conda.anaconda.org/conda-forge/win-64/qscintilla2-2.14.1-py312hca0710b_0.conda
-  sha256: 0dcf01cfa6c0d9e38f8f289d9cd890f66d93d74e09b5ad3e31f5feecfd479734
-  md5: eb8f50e856c4e37de39bafdea637ae2e
+  size: 1270741
+  timestamp: 1750211276026
+- conda: https://conda.anaconda.org/conda-forge/win-64/qscintilla2-2.14.1-py312he11f4ca_1.conda
+  sha256: 6e0745a5a29044666085aec6c84cd1f7a3168bacd9220abd2779cef59042db17
+  md5: 9a733fc7675fc1d39e090ce54edcccd2
   depends:
-  - pyqt >=5.15.9,<5.16.0a0
-  - python >=3.12.0rc3,<3.13.0a0
+  - pyqt >=5.15.11,<5.16.0a0
+  - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
-  - qt-main >=5.15.8,<5.16.0a0
-  - sip >=6.7.11,<6.8.0a0
+  - qt-main >=5.15.15,<5.16.0a0
+  - sip >=6.10.0,<6.11.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -20440,8 +20760,8 @@ packages:
   license_family: GPL
   purls:
   - pkg:pypi/qscintilla?source=hash-mapping
-  size: 1276533
-  timestamp: 1695486800155
+  size: 1272510
+  timestamp: 1750210982779
 - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.15-hea1682b_4.conda
   sha256: 723a2afd0a1d15baf20117ba6fa5c03ecb161557c607ef542eb017ff422198f7
   md5: c054d7f22cc719e12c72d454b2328d6c
@@ -20557,9 +20877,9 @@ packages:
   purls: []
   size: 59723234
   timestamp: 1747037191195
-- conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.9.1-h0384650_0.conda
-  sha256: e0b9e32fa88b23e71ba1aaae49fd8f600010a1e7d19003177a50367d801a45b0
-  md5: e1f80d7fca560024b107368dd77d96be
+- conda: https://conda.anaconda.org/conda-forge/linux-64/qt6-main-6.9.1-h0384650_1.conda
+  sha256: 820338eadfdac82e0ec208e41a7f02cc3a7adb8fc0dcf107a57b2a1cdec9f89e
+  md5: 3610aa92d2de36047886f30e99342f21
   depends:
   - __glibc >=2.17,<3.0.a0
   - alsa-lib >=1.2.14,<1.3.0a0
@@ -20570,10 +20890,10 @@ packages:
   - harfbuzz >=11.0.1
   - icu >=75.1,<76.0a0
   - krb5 >=1.21.3,<1.22.0a0
-  - libclang-cpp20.1 >=20.1.6,<20.2.0a0
-  - libclang13 >=20.1.6
+  - libclang-cpp20.1 >=20.1.7,<20.2.0a0
+  - libclang13 >=20.1.7
   - libcups >=2.3.3,<2.4.0a0
-  - libdrm >=2.4.124,<2.5.0a0
+  - libdrm >=2.4.125,<2.5.0a0
   - libegl >=1.7.0,<2.0a0
   - libfreetype >=2.13.3
   - libfreetype6 >=2.13.3
@@ -20581,10 +20901,10 @@ packages:
   - libgl >=1.7.0,<2.0a0
   - libglib >=2.84.2,<3.0a0
   - libjpeg-turbo >=3.1.0,<4.0a0
-  - libllvm20 >=20.1.6,<20.2.0a0
-  - libpng >=1.6.47,<1.7.0a0
+  - libllvm20 >=20.1.7,<20.2.0a0
+  - libpng >=1.6.49,<1.7.0a0
   - libpq >=17.5,<18.0a0
-  - libsqlite >=3.50.0,<4.0a0
+  - libsqlite >=3.50.1,<4.0a0
   - libstdcxx >=13
   - libtiff >=4.7.0,<4.8.0a0
   - libwebp-base >=1.5.0,<2.0a0
@@ -20617,21 +20937,21 @@ packages:
   license: LGPL-3.0-only
   license_family: LGPL
   purls: []
-  size: 51972981
-  timestamp: 1748902080649
-- conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.9.1-h02ddd7d_0.conda
-  sha256: f84aca0278b8cc497311e23b959b51fda7f6a0a2dceb98267ff70f7ba9827797
-  md5: feaaaae25a51188fb0544aca8b26ef4d
+  size: 52006560
+  timestamp: 1750920502800
+- conda: https://conda.anaconda.org/conda-forge/win-64/qt6-main-6.9.1-h02ddd7d_1.conda
+  sha256: cd7a9a3972c0f1114294c9f84463838d645c6f596cbcfefef03b4ee229d88d43
+  md5: fc796cf6c16db38d44c2efefbe6afcea
   depends:
   - double-conversion >=3.3.1,<3.4.0a0
   - harfbuzz >=11.0.1
   - icu >=75.1,<76.0a0
   - krb5 >=1.21.3,<1.22.0a0
-  - libclang13 >=20.1.6
+  - libclang13 >=20.1.7
   - libglib >=2.84.2,<3.0a0
   - libjpeg-turbo >=3.1.0,<4.0a0
-  - libpng >=1.6.47,<1.7.0a0
-  - libsqlite >=3.50.0,<4.0a0
+  - libpng >=1.6.49,<1.7.0a0
+  - libsqlite >=3.50.1,<4.0a0
   - libtiff >=4.7.0,<4.8.0a0
   - libwebp-base >=1.5.0,<2.0a0
   - libzlib >=1.3.1,<2.0a0
@@ -20639,15 +20959,15 @@ packages:
   - pcre2 >=10.45,<10.46.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
-  - vc14_runtime >=14.42.34438
+  - vc14_runtime >=14.44.35208
   - zstd >=1.5.7,<1.6.0a0
   constrains:
   - qt 6.9.1
   license: LGPL-3.0-only
   license_family: LGPL
   purls: []
-  size: 94304228
-  timestamp: 1748906173006
+  size: 91608911
+  timestamp: 1750922811982
 - conda: https://conda.anaconda.org/conda-forge/linux-64/qtkeychain-0.15.0-h518214a_0.conda
   sha256: dd8bfee50f38a983c86a063cb6a29cee060219190001cfd5d3b4f8b9c9d73b56
   md5: ffc2e8f55690a620cf9db6549a130013
@@ -20749,9 +21069,9 @@ packages:
   purls: []
   size: 10909121
   timestamp: 1733295012534
-- conda: https://conda.anaconda.org/conda-forge/linux-64/quarto-1.7.31-ha770c72_0.conda
-  sha256: faa43a44b8b84b402e4553779092d5591ac8beab4dba2459d045ac177eb2adba
-  md5: d31768d16b86c6b6c30929e9d5428c56
+- conda: https://conda.anaconda.org/conda-forge/linux-64/quarto-1.7.32-ha770c72_0.conda
+  sha256: d7cfff8828665559e884d1e69c241b73f9f5bb698381242bff82083fdbcddfab
+  md5: 73e003bb81d9f065d35f89047f4d8bc4
   depends:
   - dart-sass
   - deno >=1.46.3,<1.46.4.0a0
@@ -20762,11 +21082,11 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 16025799
-  timestamp: 1747102656284
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/quarto-1.7.31-hce30654_0.conda
-  sha256: db9ec68c8ff6e54859653546dffaf7de2bb2df0f5ee80651d5447c58ebb23b11
-  md5: 9d45f3a91e5f7728988eca330e007908
+  size: 16446911
+  timestamp: 1750116245256
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/quarto-1.7.32-hce30654_0.conda
+  sha256: 1bb74c9077b57cf653dc12ba2a0f05ba426864d95a2d5ba008dd1083fb952592
+  md5: 81fbf6241ae6d5fb140d4d77441a17bd
   depends:
   - dart-sass
   - deno >=1.46.3,<1.46.4.0a0
@@ -20777,11 +21097,11 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 16471882
-  timestamp: 1747103031570
-- conda: https://conda.anaconda.org/conda-forge/win-64/quarto-1.7.31-h57928b3_0.conda
-  sha256: 3cd2a9b4314f8a0df288a599b591dc37de850fc4190043ee6b4da9aef1d0d523
-  md5: cb062630531226fcd9b583dd50d78fa9
+  size: 15676474
+  timestamp: 1750116455400
+- conda: https://conda.anaconda.org/conda-forge/win-64/quarto-1.7.32-h57928b3_0.conda
+  sha256: b053cba6f4e0c275951246d8629f6a319ca5f4bba78dedd06656a4bb3de42da7
+  md5: 2bd53524cdf3cc88ae93fbbd2cc0eb60
   depends:
   - dart-sass
   - deno >=1.46.3,<1.46.4.0a0
@@ -20792,11 +21112,11 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 16480141
-  timestamp: 1747102730542
-- conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.11.0-pyhd8ed1ab_0.conda
-  sha256: 8191407bb9f9d88667e0ebdf6a86f0ed17bfcfd7dd624f199e4bc9a4d6895aa5
-  md5: 561056693da21db68fcb38aa9a76e71a
+  size: 16403530
+  timestamp: 1750116299399
+- conda: https://conda.anaconda.org/conda-forge/noarch/quartodoc-0.11.1-pyhd8ed1ab_0.conda
+  sha256: 351371773b1ee713d1987bf105f567016273c6e9d368b3bebe74f7dc00c6df6c
+  md5: 08026bd0a9b1686920c91fb47368feb8
   depends:
   - black
   - click
@@ -20817,8 +21137,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/quartodoc?source=hash-mapping
-  size: 72606
-  timestamp: 1749507903864
+  size: 72577
+  timestamp: 1749664077086
 - conda: https://conda.anaconda.org/conda-forge/linux-64/qwt-6.3.0-h7c222af_0.conda
   sha256: 984fa11d5e6fb70a8780c5b6145b663251af9c954e83f3d6ea6f4d58b939fd0e
   md5: 0b860b7c4d9d39043d168a279724ce1a
@@ -20893,16 +21213,16 @@ packages:
   purls: []
   size: 1238038
   timestamp: 1745325325058
-- conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2024.07.02-h9925aae_3.conda
-  sha256: 66d34e3b4881f856486d11914392c585713100ca547ccfc0947f3a4765c2c486
-  md5: 6f445fb139c356f903746b2b91bbe786
+- conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2025.06.26-h9925aae_0.conda
+  sha256: 7a0b82cb162229e905f500f18e32118ef581e1fd182036f3298510b8e8663134
+  md5: 2b4249747a9091608dbff2bd22afde44
   depends:
-  - libre2-11 2024.07.02 hba17884_3
+  - libre2-11 2025.06.26 hba17884_0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 26811
-  timestamp: 1741121137599
+  size: 27330
+  timestamp: 1751053087063
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2024.07.02-h6589ca4_2.conda
   sha256: 4d3799c05f8f662922a0acd129d119774760a3281b883603678e128d1cb307fb
   md5: 7a8b4ad8c58a3408ca89d78788c78178
@@ -20913,16 +21233,16 @@ packages:
   purls: []
   size: 26861
   timestamp: 1735541088455
-- conda: https://conda.anaconda.org/conda-forge/win-64/re2-2024.07.02-haf4117d_3.conda
-  sha256: d67e5d4b934f6ab9d50504584f672062bc5363f15a587b52d7c827611d0dbf44
-  md5: f94cfa965a6498540057555957903dba
+- conda: https://conda.anaconda.org/conda-forge/win-64/re2-2025.06.26-h3dd2b4f_0.conda
+  sha256: e7b9a7c39987589f7b597882d60193b9599cc4cb2fe950ae406c010fed53aaaa
+  md5: 83fe4d44b2c2089ad3778a49c5ca5340
   depends:
-  - libre2-11 2024.07.02 hd248061_3
+  - libre2-11 2025.06.26 habfad5f_0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 220297
-  timestamp: 1741121702233
+  size: 219218
+  timestamp: 1751053300752
 - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
   sha256: 2d6d0c026902561ed77cd646b5021aef2d4db22e57a5b0178dfc669231e06d2c
   md5: 283b96675859b20a825f8fa30f311446
@@ -21111,13 +21431,13 @@ packages:
   - pkg:pypi/rich?source=hash-mapping
   size: 200323
   timestamp: 1743371105291
-- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.25.1-py311hdae7d1d_0.conda
-  sha256: 9654a1c11dda67b2782cad03f2a3793e18dbf5d9dbf5d2fdf86bdac3f2ad8a1d
-  md5: a82b805c84bca54329510d03656cf57b
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.26.0-py311hdae7d1d_0.conda
+  sha256: 552e826f953f974f20573c8fb061136a24ca0456c73ecf99e0da24c2aed281e8
+  md5: 875fcd394b4ea7df4f73827db7674a82
   depends:
   - python
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
   - python_abi 3.11.* *_cp311
   constrains:
   - __glibc >=2.17
@@ -21125,11 +21445,11 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/rpds-py?source=hash-mapping
-  size: 389113
-  timestamp: 1747837968273
-- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.25.1-py312h680f630_0.conda
-  sha256: a5b168b991c23ab6d74679a6f5ad1ed87b98ba6c383b5fe41f5f6b335b10d545
-  md5: ea8f79edf890d1f9b2f1bd6fbb11be1e
+  size: 386382
+  timestamp: 1751468291209
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.26.0-py312h680f630_0.conda
+  sha256: bb051358e7550fd8ef9129def61907ad03853604f5e641108b1dbe2ce93247cc
+  md5: 5b251d4dd547d8b5970152bae2cc1600
   depends:
   - python
   - __glibc >=2.17,<3.0.a0
@@ -21140,16 +21460,16 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=hash-mapping
-  size: 391950
-  timestamp: 1747837859184
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.25.1-py311hf245fc6_0.conda
-  sha256: 8928c4cacc668db0c62dd9a11415319f6fa7f06d01360e5398264941c0ab404d
-  md5: 3c969fae89e5832566890421a074eb92
+  - pkg:pypi/rpds-py?source=compressed-mapping
+  size: 389020
+  timestamp: 1751467350968
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.26.0-py311hf245fc6_0.conda
+  sha256: 5a948f9cfa509e109886221ed12a1d52e8449c511282f904727a1e21a4ee727a
+  md5: dbe0cd513bb08a56153cbd554055e14f
   depends:
   - python
+  - __osx >=11.0
   - python 3.11.* *_cpython
-  - __osx >=11.0
   - python_abi 3.11.* *_cp311
   constrains:
   - __osx >=11.0
@@ -21157,15 +21477,15 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/rpds-py?source=hash-mapping
-  size: 367093
-  timestamp: 1747837773204
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.25.1-py312hd3c0895_0.conda
-  sha256: 9a2f4a7340a73bc618550738bdf22835325d4ce88a98e26a55e2b5f6e873f306
-  md5: 3b50fde83777a12d5bf4511d9baecc98
+  size: 364202
+  timestamp: 1751467159808
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.26.0-py312hd3c0895_0.conda
+  sha256: b22152ead8e06a489cc6ed03828b884bfccfa085d972a0420179757809d721fd
+  md5: 19681f34a4071b4380a986fc524fe1c4
   depends:
   - python
+  - __osx >=11.0
   - python 3.12.* *_cpython
-  - __osx >=11.0
   - python_abi 3.12.* *_cp312
   constrains:
   - __osx >=11.0
@@ -21173,47 +21493,47 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/rpds-py?source=hash-mapping
-  size: 360032
-  timestamp: 1747837743255
-- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.25.1-py311hc4022dc_0.conda
-  sha256: 3a76edb8f446351f36eb43a215e0df0b444f73b0f22453c0966611653b05c06f
-  md5: 9cbe2af742a0fa8387caef089682a92f
+  size: 357102
+  timestamp: 1751467161700
+- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.26.0-py311hf51aa87_0.conda
+  sha256: 100b94d884fe06a7d97ad6ddcefa4a125fa86a8d65f0144fe19526e372fef789
+  md5: fde2d272a1f0659b7c0cc8b6465976b9
   depends:
   - python
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/rpds-py?source=hash-mapping
-  size: 249938
-  timestamp: 1747837737577
-- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.25.1-py312h8422cdd_0.conda
-  sha256: dfea71a35d7d5eb348893e24136ce6fb1004fc9402eaafae441fa61887638764
-  md5: 30d51df2ebcc324cce80fa6a317df920
+  size: 249152
+  timestamp: 1751467083817
+- conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.26.0-py312hdabe01f_0.conda
+  sha256: 665d771c3d4a028dc49c45e47634ef3adac80500ed6206ba6837885f02b0947f
+  md5: 353d4c6bd46906805189af9a7394b0d1
   depends:
   - python
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/rpds-py?source=hash-mapping
-  size: 252939
-  timestamp: 1747837730306
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.11.13-py311h82b16fd_0.conda
-  sha256: 68f10b1adda97574c442a38be99e736789378913cbfa18559fe54ca00da12f9c
-  md5: ba0cd1446e31a0cf5f7643a6d7c03b4c
+  size: 250960
+  timestamp: 1751467083088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.12.1-py311h4b9d5fb_1.conda
+  sha256: dbac37b3693cc285962fca8cd694d6a1d1bff3c5720739252ec8314f5c069475
+  md5: 4b8b52ca6fbd587feb55e3369059fe1b
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -21225,12 +21545,12 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/ruff?source=compressed-mapping
-  size: 8256120
-  timestamp: 1749216271370
-- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.11.13-py312h1d08497_0.conda
-  sha256: 25e99382bbe8431e25f086960ba34de8d975c903a4810fbf2009e95285e4d719
-  md5: 8e7c909d4f48865c8c5241d83649fc66
+  - pkg:pypi/ruff?source=hash-mapping
+  size: 8258627
+  timestamp: 1751128688343
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.12.1-py312h1d2019f_1.conda
+  sha256: 6b8fde7d3ce1657661e8220626ca1c1076a87c158ebd69b089fcc613489fc12d
+  md5: 57e1657c1c0b90bddfd2f90a8afbe7df
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
@@ -21243,143 +21563,109 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/ruff?source=hash-mapping
-  size: 8254968
-  timestamp: 1749215957598
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.11.13-py311hb8aca82_0.conda
-  sha256: 852f92cfb0f456ec9bca3e4131b1ed1f3e525a5e5f0d96b2e8d3c585cfadbb3f
-  md5: 3f92be4c76838109caf35d8fa49828fb
+  size: 8253854
+  timestamp: 1751128668888
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.12.1-h412e174_1.conda
+  noarch: python
+  sha256: 1d945867d12878ce13b8f7ae11a62ee9008413858927f8d21f4f6832897bbe30
+  md5: 92e4991059ccbe838b5522af264992f1
   depends:
+  - python
   - __osx >=11.0
-  - libcxx >=18
-  - python >=3.11,<3.12.0a0
-  - python >=3.11,<3.12.0a0 *_cpython
-  - python_abi 3.11.* *_cp311
-  constrains:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/ruff?source=compressed-mapping
-  size: 7446229
-  timestamp: 1749216509364
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.11.13-py312h846f395_0.conda
-  sha256: e61d21b1cce7dd07436937bce9e98f832ca08e1fc10c9e676eb7352d703b865c
-  md5: 183fd50b1c0b9c37490d044e151013f3
-  depends:
-  - __osx >=11.0
-  - libcxx >=18
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
   constrains:
   - __osx >=11.0
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/ruff?source=hash-mapping
-  size: 7451777
-  timestamp: 1749216226429
-- conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.11.13-py311hfc2f1ad_0.conda
-  sha256: 49972a79402ed86bf6c8b5b2c1e4a0f47a098aa3536927f9f9bb797b3fceaeba
-  md5: e83840c56dbaaf1fdcc570fc93315946
+  size: 8616500
+  timestamp: 1751465829518
+- conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.12.1-hd40eec1_1.conda
+  noarch: python
+  sha256: 037c7e07778e619cda114cbc262ce1dcc8a7c20feedaa40df60f70e361f1ff75
+  md5: ef52c0533535cecabd9cc44bfd79121f
   depends:
-  - python >=3.11,<3.12.0a0
-  - python_abi 3.11.* *_cp311
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/ruff?source=compressed-mapping
-  size: 8265564
-  timestamp: 1749217029383
-- conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.11.13-py312h24a9d25_0.conda
-  sha256: 65cf46367541fd75ebf0dbc7f3ad710ede1c7ed8b4a3164321cd044d7637adf6
-  md5: aa982291138f839fef1cb92312267fc3
-  depends:
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/ruff?source=hash-mapping
-  size: 8270984
-  timestamp: 1749216836205
-- conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.87.0-h1a8d7c4_0.conda
-  sha256: b1b3309f0855dd06f40ff4a16722a6be0a1747526da4da1d80af422fe2c20fee
-  md5: c158d0c5b3e731e564477ebdcdc1dcd4
+  size: 9616026
+  timestamp: 1751465777672
+- conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.88.0-h1a8d7c4_0.conda
+  sha256: dd68c0e4788660826421548adeb855f8c9c3b559303ad356c56892bb4fa2f455
+  md5: c77dfd18f5f3f7648bc1c8aa600e3ff7
   depends:
   - __glibc >=2.17,<3.0.a0
   - gcc_impl_linux-64
   - libgcc >=13
   - libzlib >=1.3.1,<2.0a0
-  - rust-std-x86_64-unknown-linux-gnu 1.87.0 h2c6d0dc_0
+  - rust-std-x86_64-unknown-linux-gnu 1.88.0 h2c6d0dc_0
   - sysroot_linux-64 >=2.17
   license: MIT
   license_family: MIT
   purls: []
-  size: 223997953
-  timestamp: 1747383350751
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.87.0-h4ff7c5d_0.conda
-  sha256: db7cdc20393b1a502b11fb6c1e544de4c19a1680ed7192e5795546ec669960ef
-  md5: 1a81ee84cd698e1bae4529f335361c70
+  size: 221696092
+  timestamp: 1751057661538
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.88.0-h4ff7c5d_0.conda
+  sha256: 3eddfe3559b541b16fbdf75573c846c7ff0c7e01eb9f6df0a1fd9a1feaa3a9a0
+  md5: 20efa2b160429d07d9dea21e902ebfff
   depends:
-  - rust-std-aarch64-apple-darwin 1.87.0 hf6ec828_0
+  - rust-std-aarch64-apple-darwin 1.88.0 hf6ec828_0
   license: MIT
   license_family: MIT
   purls: []
-  size: 231190136
-  timestamp: 1747382484253
-- conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.87.0-hf8d6059_0.conda
-  sha256: 50bcd7d2f95547da7cea3fa0dd1e19103127915209b4994e4ed2495d62f51f90
-  md5: 7aaabd5800247687e34fab3694bd90f4
+  size: 231619939
+  timestamp: 1751057438846
+- conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.88.0-hf8d6059_0.conda
+  sha256: 4207e2e17294f445de3bcf4b3f245dfbf20bd66e83fa5f8f44d6760a9d642027
+  md5: 6f46023abb727f149616747fc88a9f7a
   depends:
-  - rust-std-x86_64-pc-windows-msvc 1.87.0 h17fc481_0
+  - rust-std-x86_64-pc-windows-msvc 1.88.0 h17fc481_0
   license: MIT
   license_family: MIT
   purls: []
-  size: 248189351
-  timestamp: 1747385951560
-- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.87.0-hf6ec828_0.conda
-  sha256: da8519d811eea491154bb28034d8a7405d640595ce08300b92a7851a157bb8f2
-  md5: 6370965a42381e5173d98c5a25861da5
+  size: 250835268
+  timestamp: 1751059235898
+- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.88.0-hf6ec828_0.conda
+  sha256: b14253e50bcafef9a61a289371b018d2664da23ae925b8fe2d52432fef187212
+  md5: 90ec3b7a075f493fd5a4782eb00b45c1
   depends:
   - __unix
   constrains:
-  - rust >=1.87.0,<1.87.1.0a0
+  - rust >=1.88.0,<1.88.1.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 33567727
-  timestamp: 1747382333320
-- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.87.0-h17fc481_0.conda
-  sha256: eabe598e244d9a083c261f6be20c89fbb4d052bc09641267db4a6c4867ffce5f
-  md5: be68986ec79a1d50ada2e5af3795d4ae
+  size: 33374075
+  timestamp: 1751057161230
+- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.88.0-h17fc481_0.conda
+  sha256: 93526e9ecd738500907c53c2360505c6f00aafe44b65090853346c0f604b5781
+  md5: bf0ce8fdd5b7dd1ee308b9fda630f877
   depends:
   - __win
   constrains:
-  - rust >=1.87.0,<1.87.1.0a0
+  - rust >=1.88.0,<1.88.1.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 27954158
-  timestamp: 1747385592636
-- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.87.0-h2c6d0dc_0.conda
-  sha256: 7dfa89025dc6dc19da5455d9d9a57eb8b584aa2d208b964de093b1fe74effe7d
-  md5: 64c88c10adc2a260ff356e42747311a4
+  size: 28047137
+  timestamp: 1751059035565
+- conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.88.0-h2c6d0dc_0.conda
+  sha256: a89f522fb261ab744ea1e4e8a8929a66d7c28e58b4b7e02462dcb644887c9dce
+  md5: d62b829141d3fa542a312e2760b8abd4
   depends:
   - __unix
   constrains:
-  - rust >=1.87.0,<1.87.1.0a0
+  - rust >=1.88.0,<1.88.1.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 37879016
-  timestamp: 1747383157657
+  size: 37041309
+  timestamp: 1751057508252
 - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.21-h7ab7c64_0.conda
   sha256: c8b252398b502a5cc6ea506fd2fafe7e102e7c9e2ef48b7813566e8a72ce2205
   md5: 28b5a7895024a754249b2ad7de372faa
@@ -21408,12 +21694,12 @@ packages:
   - python-magic
   - python-magic-bin ; sys_platform == 'win32'
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/5d/ab/ca69eca5d16b550d227df7616ab24f32d528903a3f1305953ad038adecaa/sbom4python-0.12.3-py2.py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/18/13/cbf8f3937c6bb9f59b19281998589097769057d38e5af894db78ae95386f/sbom4python-0.12.4-py2.py3-none-any.whl
   name: sbom4python
-  version: 0.12.3
-  sha256: 46ac0698c268db0565791ebd53eef04d71190b2e29697a5b36253e7766033880
+  version: 0.12.4
+  sha256: 4fdd5b27e097dedc2efdb9b444efd11403690c105ef0c00d48e64b287254f408
   requires_dist:
-  - lib4package>=0.3.1
+  - lib4package>=0.3.3
   - lib4sbom>=0.8.0
   - sbom2dot>=0.3.0
   - sbom4files>=0.4.4
@@ -21544,9 +21830,9 @@ packages:
   - pkg:pypi/scikit-learn?source=hash-mapping
   size: 9368625
   timestamp: 1749488399645
-- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.15.2-py311h8f841c2_0.conda
-  sha256: 6d0902775e3ff96dd1d36ac627e03fe6c0b3d2159bb71e115dd16a1f31693b25
-  md5: 5ec0a1732a05376241e1e4c6d50e0e91
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.0-py311h2d3ef60_0.conda
+  sha256: 52352d0f9388cf215c79690732e560bc6a33fb463a9176f6d2af6df84da8f4f7
+  md5: 87f6abadb59e4b17fc3a7b666faa721f
   depends:
   - __glibc >=2.17,<3.0.a0
   - libblas >=3.9.0,<4.0a0
@@ -21556,20 +21842,20 @@ packages:
   - libgfortran5 >=13.3.0
   - liblapack >=3.9.0,<4.0a0
   - libstdcxx >=13
-  - numpy <2.5
-  - numpy >=1.19,<3
-  - numpy >=1.23.5
+  - numpy <2.6
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/scipy?source=hash-mapping
-  size: 17193126
-  timestamp: 1739791897768
-- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.15.2-py312ha707e6e_0.conda
-  sha256: b9faaa024b77a3678a988c5a490f02c4029c0d5903998b585100e05bc7d4ff36
-  md5: 00b999c5f9d01fb633db819d79186bd4
+  size: 16924578
+  timestamp: 1751148580997
+- conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.16.0-py312hf734454_0.conda
+  sha256: 8406e26bf853e699b1ea97792f63987808783ff4ab6ddeff9cf1ec0b9d1aa342
+  md5: 7513ac56209d27a85ffa1582033f10a8
   depends:
   - __glibc >=2.17,<3.0.a0
   - libblas >=3.9.0,<4.0a0
@@ -21579,31 +21865,32 @@ packages:
   - libgfortran5 >=13.3.0
   - liblapack >=3.9.0,<4.0a0
   - libstdcxx >=13
-  - numpy <2.5
-  - numpy >=1.19,<3
-  - numpy >=1.23.5
+  - numpy <2.6
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/scipy?source=hash-mapping
-  size: 17064784
-  timestamp: 1739791925628
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.15.2-py311h0675101_0.conda
-  sha256: bc3e873e85c55deaaad446c410d9001d12a133c1b48fa2cb0050b4f46f926aa3
-  md5: df904770f3fdb6c0265a09cdc22acf54
+  size: 16847456
+  timestamp: 1751148548291
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.16.0-py311h53b02f6_0.conda
+  sha256: 1cc259f00b3854302c64c1d53dfa2f82de77399587fc30111434f949978bccc5
+  md5: e9968a1c5dfa62d8cf446e82f8bb79cb
   depends:
   - __osx >=11.0
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - libcxx >=18
-  - libgfortran >=5
-  - libgfortran5 >=13.2.0
+  - libgfortran 5.*
+  - libgfortran5 >=13.3.0
+  - libgfortran5 >=14.2.0
   - liblapack >=3.9.0,<4.0a0
-  - numpy <2.5
-  - numpy >=1.19,<3
-  - numpy >=1.23.5
+  - numpy <2.6
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
   - python >=3.11,<3.12.0a0
   - python >=3.11,<3.12.0a0 *_cpython
   - python_abi 3.11.* *_cp311
@@ -21611,22 +21898,23 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/scipy?source=hash-mapping
-  size: 14569129
-  timestamp: 1739792318601
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.15.2-py312h99a188d_0.conda
-  sha256: af61f6e29a0d3d4c66699a35b19ce6849d6e0fa15017d7a9ef6268cc1c4e1264
-  md5: b1d324bf5018b451152bbdc4ffd3d378
+  size: 13899648
+  timestamp: 1751148714405
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.16.0-py312hcedbd36_0.conda
+  sha256: d0033c0414910c2bb6005e005e0df266a6c21e1928efec2df3251736245c1258
+  md5: b3ab5755feaabeaf889063663790eb25
   depends:
   - __osx >=11.0
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - libcxx >=18
-  - libgfortran >=5
-  - libgfortran5 >=13.2.0
+  - libgfortran 5.*
+  - libgfortran5 >=13.3.0
+  - libgfortran5 >=14.2.0
   - liblapack >=3.9.0,<4.0a0
-  - numpy <2.5
-  - numpy >=1.19,<3
-  - numpy >=1.23.5
+  - numpy <2.6
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
   - python_abi 3.12.* *_cp312
@@ -21634,50 +21922,50 @@ packages:
   license_family: BSD
   purls:
   - pkg:pypi/scipy?source=hash-mapping
-  size: 14394729
-  timestamp: 1739792424558
-- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.15.2-py311h99d06ae_0.conda
-  sha256: 62ae1a1e02c919513213351474d1c72480fb70388a345fa81f1c95fa822d98bf
-  md5: c7ec15b5ea6a27bb71af2ea5f7c97cbb
+  size: 13846609
+  timestamp: 1751148522848
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.16.0-py311h0e21e1b_0.conda
+  sha256: f8f841f30c37562a9ad91d2e732d43612e13281685079a53f70b96f81ff71a0b
+  md5: ebd2a2cf9bcbd786d45fedafb97026e1
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
-  - numpy <2.5
-  - numpy >=1.19,<3
-  - numpy >=1.23.5
+  - numpy <2.6
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/scipy?source=hash-mapping
-  size: 15487645
-  timestamp: 1739793313482
-- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.15.2-py312h451d5c4_0.conda
-  sha256: a154a6b6f4efefc65366437f611fa89c8178059e2ee7350515fe4a4c3da55c1d
-  md5: 50632c72cc92ae3ebb615cb496bbf946
+  size: 15232499
+  timestamp: 1751161780133
+- conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.16.0-py312h1416ca1_0.conda
+  sha256: 81dfa8ab6ab7c7570175bd1d3007c7197e98f95b2c5751797ccab116f53cd1aa
+  md5: ddb9926010a879852022bb9152ab3298
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
-  - numpy <2.5
-  - numpy >=1.19,<3
-  - numpy >=1.23.5
+  - numpy <2.6
+  - numpy >=1.23,<3
+  - numpy >=1.25.2
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: BSD-3-Clause
   license_family: BSD
   purls:
   - pkg:pypi/scipy?source=hash-mapping
-  size: 15350553
-  timestamp: 1739793319263
+  size: 14932332
+  timestamp: 1751161759720
 - conda: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.3.3-py311h38be061_3.conda
   sha256: e7d68675349e80416aa0d4fb8262c2f4a223ef9e6e430704be3f809ea0c34d57
   md5: b7d5a90193f112c78e25befb013dd606
@@ -21884,40 +22172,44 @@ packages:
   - pkg:pypi/shellingham?source=compressed-mapping
   size: 14462
   timestamp: 1733301007770
-- conda: https://conda.anaconda.org/conda-forge/linux-64/sip-6.7.12-py311hb755f60_0.conda
-  sha256: 71a0ee22522b232bf50d4d03d012e53cd5d1251d09dffc1c72d7c33a1086fe6f
-  md5: 02336abab4cb5dd794010ef53c54bd09
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sip-6.10.0-py311hfdbb021_0.conda
+  sha256: 1eae0d5f0152714cdabb5cd3d480080e164b3fb5f7bd8208df7925d8e173d36b
+  md5: 78e5e37d25d5ab01fb5e91b8653b8f6d
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
   - packaging
   - ply
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
+  - setuptools
   - tomli
-  license: GPL-3.0-only
-  license_family: GPL
+  license: BSD-2-Clause
+  license_family: BSD
   purls:
   - pkg:pypi/sip?source=hash-mapping
-  size: 585197
-  timestamp: 1697300605264
-- conda: https://conda.anaconda.org/conda-forge/linux-64/sip-6.7.12-py312h30efb56_0.conda
-  sha256: baf6e63e213bb11e369a51e511b44217546a11f8470242bbaa8fac45cb4a39c3
-  md5: 32633871002ee9902f747d2236e0d122
+  size: 686578
+  timestamp: 1745411313879
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sip-6.10.0-py312h2ec8cdc_0.conda
+  sha256: b5c9f4fa4acc78d1d74d4d6670d2abccc3e028c94d92d25e579ff26eb59d7c0f
+  md5: 85ec3ebe43bcbad66496b95be0f2f895
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
   - packaging
   - ply
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
+  - setuptools
   - tomli
-  license: GPL-3.0-only
-  license_family: GPL
+  license: BSD-2-Clause
+  license_family: BSD
   purls:
   - pkg:pypi/sip?source=hash-mapping
-  size: 576283
-  timestamp: 1697300599736
+  size: 685395
+  timestamp: 1745411325345
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sip-6.7.12-py311hbaf5611_0.conda
   sha256: de207b35783f439e8796bc5cd3421007b79e1a0f8395d5e864bcb1479a2b422f
   md5: a7c9cb9dbbb0f5d2052ccf5f52d793b7
@@ -21954,42 +22246,44 @@ packages:
   - pkg:pypi/sip?source=hash-mapping
   size: 565794
   timestamp: 1697300818082
-- conda: https://conda.anaconda.org/conda-forge/win-64/sip-6.7.12-py311h12c1d0e_0.conda
-  sha256: 1129ac093d0c04ca07603fab9dfd2ee1e9a760eb94b31450e2cef1ffffa6a31a
-  md5: c29f20b2860d1824535135d76d022394
+- conda: https://conda.anaconda.org/conda-forge/win-64/sip-6.10.0-py311hda3d55a_0.conda
+  sha256: ea79542e045a319c12c70f01df9ebf89e6fbb4703fc8af352c2a4d198e1e10e8
+  md5: 15929ab309361207eddea4d0db1e3cef
   depends:
   - packaging
   - ply
   - python >=3.11,<3.12.0a0
   - python_abi 3.11.* *_cp311
+  - setuptools
   - tomli
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  license: GPL-3.0-only
-  license_family: GPL
+  license: BSD-2-Clause
+  license_family: BSD
   purls:
   - pkg:pypi/sip?source=hash-mapping
-  size: 595071
-  timestamp: 1697300986959
-- conda: https://conda.anaconda.org/conda-forge/win-64/sip-6.7.12-py312h53d5487_0.conda
-  sha256: 2347c2e7d5e7282b991d5d4f7448d9e6fe8c26e5d6df0d09f0e60b11b7d19586
-  md5: a5d3d1363d6d0b4827d6b940414a5b76
+  size: 713674
+  timestamp: 1745412192536
+- conda: https://conda.anaconda.org/conda-forge/win-64/sip-6.10.0-py312h275cf98_0.conda
+  sha256: 8677caa2140818e9ff6ad55d595e2913a1e24f9ca4a4ab32ac2bd70ed4d9c642
+  md5: 271191e6a289fe4ec98186edf485c956
   depends:
   - packaging
   - ply
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
+  - setuptools
   - tomli
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  license: GPL-3.0-only
-  license_family: GPL
+  license: BSD-2-Clause
+  license_family: BSD
   purls:
   - pkg:pypi/sip?source=hash-mapping
-  size: 589657
-  timestamp: 1697301028797
+  size: 713429
+  timestamp: 1745411754981
 - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.17.0-pyhd8ed1ab_0.conda
   sha256: 41db0180680cc67c3fa76544ffd48d6a5679d96f4b71d7498a759e94edc9a2db
   md5: a451d576819089b0d672f18768be0f65
@@ -22069,19 +22363,19 @@ packages:
   - pkg:pypi/soupsieve?source=hash-mapping
   size: 37773
   timestamp: 1746563720271
-- conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.15.3-h10b92b3_0.conda
-  sha256: bbda0b4676358480798b9f82fc0923e433bcd5efdfc06061f16e8b5cdfdea2ea
-  md5: 227ea525af0489d8fcb030c7467e2957
+- conda: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.15.3-h6dc744f_1.conda
+  sha256: e5ddcc73dac4c138b763aab4feace6101bdccf39ea4cf599705c9625c70beba0
+  md5: ffeb70e2cedafa9243bf89a20ada4cfe
   depends:
   - __glibc >=2.17,<3.0.a0
-  - fmt >=11.1.4,<11.2.0a0
+  - fmt >=11.2.0,<11.3.0a0
   - libgcc >=13
   - libstdcxx >=13
   license: MIT
   license_family: MIT
   purls: []
-  size: 195513
-  timestamp: 1746813211417
+  size: 195618
+  timestamp: 1751348678073
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.15.1-hed1c2b2_0.conda
   sha256: 076353705f6d9b530b24a795dd5cf3687bdd07e3bd63fff337dc3073e9bd7364
   md5: 95277d613352000a8cd51533076bf1db
@@ -22094,19 +22388,19 @@ packages:
   purls: []
   size: 162526
   timestamp: 1738441508167
-- conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.15.3-ha881ca7_0.conda
-  sha256: fe49004db84a236cced9f170a30e5e90ffb470bd30cde5869be3820d44841378
-  md5: ed102cefa9bba2d4e739d4234c9f7995
+- conda: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.15.3-h430ee68_1.conda
+  sha256: dab3103c03a2d26e40a5c4e83e192d99cf6de806280fe4c1298943970503e56c
+  md5: d195ba9419c5704fc42cfacb88f4c3f0
   depends:
-  - fmt >=11.1.4,<11.2.0a0
+  - fmt >=11.2.0,<11.3.0a0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: MIT
   license_family: MIT
   purls: []
-  size: 168575
-  timestamp: 1746813486793
+  size: 173572
+  timestamp: 1751348807537
 - conda: https://conda.anaconda.org/conda-forge/noarch/sphobjinv-2.3.1.3-pyhd8ed1ab_0.conda
   sha256: 8b217c9e6f6272dea3007b3de0874dfa75bcee89cb7d800d03c5deb7e5a7a385
   md5: 2d88e974ac66cced424dcf0deb323a1f
@@ -22121,45 +22415,45 @@ packages:
   - pkg:pypi/sphobjinv?source=hash-mapping
   size: 70010
   timestamp: 1748888562621
-- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.50.1-h9eae976_0.conda
-  sha256: 937862e5bb72ef471a1043feab0a847f4b7f3f10bb8df53ecdc9f95767bd0e04
-  md5: e12789602c09a875957c1c78ff47cdf6
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.50.2-hb7a22d2_0.conda
+  sha256: 47f8c0350a9c6060d63494edc9abbf115125b0b98f5f6cfdac4e5f471d7d74ba
+  md5: efe16ab2f63053af723e070f3f9bac4c
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
-  - libsqlite 3.50.1 hee588c1_0
+  - libsqlite 3.50.2 h6cd9bfd_0
   - libzlib >=1.3.1,<2.0a0
   - ncurses >=6.5,<7.0a0
   - readline >=8.2,<9.0a0
   license: Unlicense
   purls: []
-  size: 899216
-  timestamp: 1749232809030
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.50.1-hd7222ec_0.conda
-  sha256: 48fb30bc3aa07bb6de38b815a02a94449fa0fdda5607c4ad71a56f3be6aea3e9
-  md5: ace9b3f5e4ff7ecf573751fdb51291de
+  size: 165182
+  timestamp: 1751135632342
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.50.2-hc23dd5f_0.conda
+  sha256: ca6bbb63a2d709888969f99da3bd0abdb32a9f0e464c8cb3e628bb6d66cb5062
+  md5: 622f20510abdf9d98700a71d91a85d46
   depends:
   - __osx >=11.0
-  - libsqlite 3.50.1 h3f77e49_0
+  - libsqlite 3.50.2 h6fb428d_0
   - libzlib >=1.3.1,<2.0a0
   - ncurses >=6.5,<7.0a0
   - readline >=8.2,<9.0a0
   license: Unlicense
   purls: []
-  size: 886162
-  timestamp: 1749232816866
-- conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.50.1-h2466b09_0.conda
-  sha256: 83776804da2db2c14303d5c2cfffa981c1fd29416fcebe0456a863588a22879b
-  md5: b4b06802480ac6215349f8ea4a599977
+  size: 148841
+  timestamp: 1751135784791
+- conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.50.2-hdb435a2_0.conda
+  sha256: 68fba09e65ac154c6eab9fe192d52ca82aaaeee2136e1fe2675ccd1c78b28329
+  md5: d4530a25918a43ab52487f6e5bffb0cf
   depends:
-  - libsqlite 3.50.1 h67fdade_0
+  - libsqlite 3.50.2 hf5d6505_0
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   license: Unlicense
   purls: []
-  size: 1105321
-  timestamp: 1749233243122
+  size: 400821
+  timestamp: 1751135714659
 - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.3-pyhd8ed1ab_1.conda
   sha256: 570da295d421661af487f1595045760526964f41471021056e993e73089e9c41
   md5: b1b505328da7a6b246787df4b5a49fbc
@@ -22364,23 +22658,23 @@ packages:
   - pkg:pypi/threadpoolctl?source=hash-mapping
   size: 23869
   timestamp: 1741878358548
-- conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.28.0-h6f9ba5a_2.conda
-  sha256: 6afef6d5596fc0ab972b21bfbf5f25a731b001844d29b452c39038bd4adaa268
-  md5: 8c93422fa91befce05c2d81967bfe17e
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.28.0-hccce5bd_6.conda
+  sha256: 4b98d10145ef0ea07604289d9842337a6b2b61ebfc6fe043f021b382d3a5a5b8
+  md5: 4462700cb2986398ec30f25a378ab3ef
   depends:
   - __glibc >=2.17,<3.0.a0
-  - aws-crt-cpp >=0.32.8,<0.32.9.0a0
+  - aws-crt-cpp >=0.32.10,<0.32.11.0a0
   - aws-sdk-cpp >=1.11.510,<1.11.511.0a0
   - azure-core-cpp >=1.14.0,<1.14.1.0a0
   - azure-identity-cpp >=1.10.0,<1.10.1.0a0
   - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
   - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
   - bzip2 >=1.0.8,<2.0a0
-  - capnproto >=1.0.2,<1.0.3.0a0
-  - fmt >=11.1.4,<11.2.0a0
+  - capnproto >=1.2.0,<1.2.1.0a0
+  - fmt >=11.2.0,<11.3.0a0
   - libabseil * cxx17*
   - libabseil >=20250127.1,<20250128.0a0
-  - libcurl >=8.14.0,<9.0a0
+  - libcurl >=8.14.1,<9.0a0
   - libgcc >=13
   - libgoogle-cloud >=2.36.0,<2.37.0a0
   - libgoogle-cloud-storage >=2.36.0,<2.37.0a0
@@ -22394,8 +22688,8 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 4697802
-  timestamp: 1748951173953
+  size: 4696600
+  timestamp: 1751368105645
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tiledb-2.27.2-h7c48965_2.conda
   sha256: 84814547a7337b04917b0b38b0e715d159fea50976e7ee5382ae1c44d6e3c522
   md5: 6c1a63997c0031d7aa62a029750af9b6
@@ -22427,23 +22721,23 @@ packages:
   purls: []
   size: 3489322
   timestamp: 1741923935481
-- conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.28.0-h0cf81a9_2.conda
-  sha256: 271117a0997e87c68fada5c90392ebac68d876d7af43cd63f1674b48f3721696
-  md5: a65211db9b9135647e8ad8873ec8cd9b
+- conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.28.0-h7c9f11d_6.conda
+  sha256: a1ca04927a0b6f19a392f92a48cf17d58de08acfece31d2c24ce3293e6923901
+  md5: fcf35aa7b155045d16f0bde64e7227e0
   depends:
-  - aws-crt-cpp >=0.32.8,<0.32.9.0a0
+  - aws-crt-cpp >=0.32.10,<0.32.11.0a0
   - aws-sdk-cpp >=1.11.510,<1.11.511.0a0
   - azure-core-cpp >=1.14.0,<1.14.1.0a0
   - azure-identity-cpp >=1.10.0,<1.10.1.0a0
   - azure-storage-blobs-cpp >=12.13.0,<12.13.1.0a0
   - azure-storage-common-cpp >=12.8.0,<12.8.1.0a0
   - bzip2 >=1.0.8,<2.0a0
-  - capnproto >=1.0.2,<1.0.3.0a0
-  - fmt >=11.1.4,<11.2.0a0
+  - capnproto >=1.2.0,<1.2.1.0a0
+  - fmt >=11.2.0,<11.3.0a0
   - libabseil * cxx17*
   - libabseil >=20250127.1,<20250128.0a0
   - libcrc32c >=1.1.2,<1.2.0a0
-  - libcurl >=8.14.0,<9.0a0
+  - libcurl >=8.14.1,<9.0a0
   - libgoogle-cloud >=2.36.0,<2.37.0a0
   - libgoogle-cloud-storage >=2.36.0,<2.37.0a0
   - libwebp-base >=1.5.0,<2.0a0
@@ -22453,13 +22747,13 @@ packages:
   - spdlog >=1.15.3,<1.16.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
-  - vc14_runtime >=14.42.34438
+  - vc14_runtime >=14.44.35208
   - zstd >=1.5.7,<1.6.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 3332384
-  timestamp: 1748952230928
+  size: 3335411
+  timestamp: 1751368658565
 - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.4.0-pyhd8ed1ab_0.conda
   sha256: cad582d6f978276522f84bd209a5ddac824742fe2d452af6acf900f8650a73a2
   md5: f1acf5fdefa8300de697982bcb1761c9
@@ -22692,9 +22986,9 @@ packages:
   - pkg:pypi/twine?source=hash-mapping
   size: 40401
   timestamp: 1737553658703
-- conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.3-pyhd8ed1ab_0.conda
-  sha256: 82ba3fcac0dd777c568bf639d75db6d47ed44eb57b621cf241ab13eea5aa0227
-  md5: dda757df98b7ae2e6cb46e9650dc2240
+- conda: https://conda.anaconda.org/conda-forge/noarch/typeguard-4.4.4-pyhd8ed1ab_0.conda
+  sha256: 591e03a61b4966a61b15a99f91d462840b6e77bf707ecb48690b24649fee921a
+  md5: 8b2613dbfd4e2bc9080b2779b53fc210
   depends:
   - importlib-metadata >=3.6
   - python >=3.9
@@ -22706,8 +23000,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/typeguard?source=hash-mapping
-  size: 35054
-  timestamp: 1749086876861
+  size: 35158
+  timestamp: 1750249264892
 - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.9.0.20250516-pyhd8ed1ab_0.conda
   sha256: 0fb78e97cad71ebf911958bf97777ec958a64a4621615a4dcc3ffb52cda7c6d0
   md5: e3465397ca4b5b60ba9fbc92ef0672f9
@@ -23125,9 +23419,9 @@ packages:
   purls: []
   size: 49181
   timestamp: 1715010467661
-- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.4.0-pyhd8ed1ab_0.conda
-  sha256: a25403b76f7f03ca1a906e1ef0f88521edded991b9897e7fed56a3e334b3db8c
-  md5: c1e349028e0052c4eea844e94f773065
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
+  sha256: 4fb9789154bd666ca74e428d973df81087a697dbb987775bc3198d2215f240f8
+  md5: 436c165519e140cb08d246a4472a9d6a
   depends:
   - brotli-python >=1.0.9
   - h2 >=4,<5
@@ -23138,8 +23432,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/urllib3?source=hash-mapping
-  size: 100791
-  timestamp: 1744323705540
+  size: 101735
+  timestamp: 1750271478254
 - conda: https://conda.anaconda.org/conda-forge/noarch/userpath-1.9.2-pyhd8ed1ab_0.conda
   sha256: 26e53b42f7fa1127e6115a35b91c20e15f75984648b88f115136f27715d4a440
   md5: 946e3571aaa55e0870fec0dea13de3bf
@@ -23152,9 +23446,9 @@ packages:
   - pkg:pypi/userpath?source=hash-mapping
   size: 14292
   timestamp: 1735925027874
-- conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.7.12-h2f11bb8_0.conda
-  sha256: 55852231156a8f437ef2ec196d2233330ed4316e3143a1fba6f11f83118c246a
-  md5: faae2c17f567260fe5cc97aff00c37e4
+- conda: https://conda.anaconda.org/conda-forge/linux-64/uv-0.7.19-h29fcd0c_0.conda
+  sha256: d56f821cbf97063746e8de442edcafa9c1ca1029c43db702bc462031dfba311d
+  md5: b4389034184beb6cbb171393d266cd8a
   depends:
   - libstdcxx >=13
   - libgcc >=13
@@ -23164,11 +23458,11 @@ packages:
   - __glibc >=2.17
   license: Apache-2.0 OR MIT
   purls: []
-  size: 14440515
-  timestamp: 1749261525518
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.7.12-hb4c02be_0.conda
-  sha256: b7e9aff3c790a153361348c4233f7fee26de241ae59c060801ee14b37d4b43dc
-  md5: 9942fb6ca64f01450046f1c35ac5c1f7
+  size: 14354356
+  timestamp: 1751500251620
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.7.19-hcff7401_0.conda
+  sha256: 8eb3f90fc53307bde69ddb81d999ddb0c65e0afe80213bccffa4d9a9114dc47a
+  md5: ab0092745700ad870a72594fc2d818ab
   depends:
   - __osx >=11.0
   - libcxx >=18
@@ -23176,46 +23470,46 @@ packages:
   - __osx >=11.0
   license: Apache-2.0 OR MIT
   purls: []
-  size: 12848272
-  timestamp: 1749261400133
-- conda: https://conda.anaconda.org/conda-forge/win-64/uv-0.7.12-he6717ee_0.conda
-  sha256: e87d554627eaf8462327b6d6cc4d3e66823c92e5bb74b06744a55376a00f613e
-  md5: 2fa886543e2a21b7e75bd9c3a0a36d91
+  size: 12946482
+  timestamp: 1751500012777
+- conda: https://conda.anaconda.org/conda-forge/win-64/uv-0.7.19-h579f82e_0.conda
+  sha256: 35c6cd4088ab8385f64833732cdb19908d47ecf306206803e6756ab326476a52
+  md5: 1513d5d36fde09245db495bab87f1f3a
   depends:
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
   license: Apache-2.0 OR MIT
   purls: []
-  size: 15660113
-  timestamp: 1749261482430
-- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h2b53caa_26.conda
-  sha256: 7a685b5c37e9713fa314a0d26b8b1d7a2e6de5ab758698199b5d5b6dba2e3ce1
-  md5: d3f0381e38093bde620a8d85f266ae55
+  size: 15466423
+  timestamp: 1751500052106
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_26.conda
+  sha256: b388d88e04aa0257df4c1d28f8d85d985ad07c1e5645aa62335673c98704c4c6
+  md5: 18b6bf6f878501547786f7bf8052a34d
   depends:
-  - vc14_runtime >=14.42.34433
+  - vc14_runtime >=14.44.35208
   track_features:
   - vc14
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 17893
-  timestamp: 1743195261486
-- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.42.34438-hfd919c2_26.conda
-  sha256: 30dcb71bb166e351aadbdc18f1718757c32cdaa0e1e5d9368469ee44f6bf4709
-  md5: 91651a36d31aa20c7ba36299fb7068f4
+  size: 17914
+  timestamp: 1750371462857
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_26.conda
+  sha256: 7bad6e25a7c836d99011aee59dcf600b7f849a6fa5caa05a406255527e80a703
+  md5: 14d65350d3f5c8ff163dc4f76d6e2830
   depends:
   - ucrt >=10.0.20348.0
   constrains:
-  - vs2015_runtime 14.42.34438.* *_26
+  - vs2015_runtime 14.44.35208.* *_26
   license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
   license_family: Proprietary
   purls: []
-  size: 750733
-  timestamp: 1743195092905
+  size: 756109
+  timestamp: 1750371459116
 - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.31.2-pyhd8ed1ab_0.conda
   sha256: 763dc774200b2eebdf5437b112834c5455a1dd1c9b605340696950277ff36729
   md5: c0600c1b374efa7a1ff444befee108ca
@@ -23230,16 +23524,16 @@ packages:
   - pkg:pypi/virtualenv?source=hash-mapping
   size: 4133755
   timestamp: 1746781585998
-- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.42.34438-h7142326_26.conda
-  sha256: 432f2937206f1ad4a77e39f84fabc1ce7d2472b669836fb72bd2bfd19a2defc9
-  md5: 3357e4383dbce31eed332008ede242ab
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_26.conda
+  sha256: d18d77c8edfbad37fa0e0bb0f543ad80feb85e8fe5ced0f686b8be463742ec0b
+  md5: 312f3a0a6b3c5908e79ce24002411e32
   depends:
-  - vc14_runtime >=14.42.34438
+  - vc14_runtime >=14.44.35208
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 17873
-  timestamp: 1743195097269
+  size: 17888
+  timestamp: 1750371463202
 - conda: https://conda.anaconda.org/conda-forge/linux-64/watchdog-6.0.0-py311h38be061_0.conda
   sha256: 3b22d78a338b6b237566175dbd5f37a79cbeb13ed271a36ddc6ec8c812afb3bd
   md5: 7904988363c292e8ca9d3161f5fcd16a
@@ -23419,52 +23713,53 @@ packages:
   purls: []
   size: 1832744
   timestamp: 1646609481185
-- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.4.0-pyhd8ed1ab_0.conda
-  sha256: 7cebedb911d4b88e2afbd1fd6de090f7b04cd91c26086dfd67ebb47e06e3b4b2
-  md5: 1046d031d1fb4403c69abc374ebec644
+- conda: https://conda.anaconda.org/conda-forge/noarch/xarray-2025.6.1-pyhd8ed1ab_1.conda
+  sha256: e27b45ca791cfbcad37d64b8615d0672d94aafa00b014826fcbca2ce18bd1cc0
+  md5: 145c6f2ac90174d9ad1a2a51b9d7c1dd
   depends:
   - numpy >=1.24
   - packaging >=23.2
   - pandas >=2.1
   - python >=3.10
   constrains:
+  - scipy >=1.11
+  - dask-core >=2023.11
+  - bottleneck >=1.3
   - zarr >=2.16
-  - cartopy >=0.22
-  - matplotlib-base >=3.8
   - flox >=0.7
   - h5py >=3.8
   - iris >=3.7
-  - seaborn-base >=0.13
+  - cartopy >=0.22
+  - numba >=0.57
+  - sparse >=0.14
+  - pint >=0.22
   - distributed >=2023.11
   - hdf5 >=1.12
-  - netcdf4 >=1.6.0
+  - seaborn-base >=0.13
   - nc-time-axis >=1.4
-  - cftime >=1.6
-  - numba >=0.57
-  - bottleneck >=1.3
+  - matplotlib-base >=3.8
   - toolz >=0.12
-  - dask-core >=2023.11
-  - scipy >=1.11
-  - sparse >=0.14
+  - netcdf4 >=1.6.0
+  - cftime >=1.6
   - h5netcdf >=1.3
-  - pint >=0.22
   license: Apache-2.0
   license_family: APACHE
   purls:
   - pkg:pypi/xarray?source=hash-mapping
-  size: 859967
-  timestamp: 1745980911520
-- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-hb711507_2.conda
-  sha256: 416aa55d946ce4ab173ab338796564893a2f820e80e04e098ff00c25fb981263
-  md5: 8637c3e5821654d0edf97e2b0404b443
+  size: 879913
+  timestamp: 1749743321359
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.1-h4f16b4b_2.conda
+  sha256: ad8cab7e07e2af268449c2ce855cbb51f43f4664936eff679b1f3862e6e4b01d
+  md5: fdc27cb255a7a2cc73b7919a968b48f0
   depends:
-  - libgcc-ng >=12
-  - libxcb >=1.16,<2.0.0a0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libxcb >=1.17.0,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 19965
-  timestamp: 1718843348208
+  size: 20772
+  timestamp: 1750436796633
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-cursor-0.1.5-hb9d3cd8_0.conda
   sha256: c7b35db96f6e32a9e5346f97adc968ef2f33948e3d7084295baebc0e33abdd5b
   md5: eb44b3b6deb1cab08d72cb61686fe64c
@@ -23587,6 +23882,25 @@ packages:
   - pkg:pypi/xmipy?source=hash-mapping
   size: 18579
   timestamp: 1735923318779
+- pypi: https://files.pythonhosted.org/packages/c5/2c/3ba8f8aeb3cb566e88a61ab0b0b767d5398d1e7293a0f7a76df9051e2b08/xmlschema-4.1.0-py3-none-any.whl
+  name: xmlschema
+  version: 4.1.0
+  sha256: eabf610f398a58700bc4ac94380ad9ce558297a3f9ca8b7722ed3f7888eb4498
+  requires_dist:
+  - elementpath>=5.0.1,<6.0.0
+  - jinja2 ; extra == 'codegen'
+  - coverage ; extra == 'dev'
+  - flake8 ; extra == 'dev'
+  - lxml ; extra == 'dev'
+  - lxml-stubs ; extra == 'dev'
+  - mypy ; extra == 'dev'
+  - psutil ; extra == 'dev'
+  - tox ; extra == 'dev'
+  - xmlschema[docs] ; extra == 'dev'
+  - jinja2 ; extra == 'docs'
+  - sphinx ; extra == 'docs'
+  - sphinx-rtd-theme ; extra == 'docs'
+  requires_python: '>=3.9'
 - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
   sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
   md5: fb901ff28063514abb6046c9ec2c4a45


### PR DESCRIPTION
# Dependencies

<details>
<summary>Explicit dependencies</summary>

|Dependency[^1]|Before|After|Change|Environments|
|-|-|-|-|-|
|[**pandas**](https://prefix.dev/channels/conda-forge/packages/pandas)|2.2.3|2.3.0|Minor Upgrade|*all*|
|[**plotly**](https://prefix.dev/channels/conda-forge/packages/plotly)|6.1.2|6.2.0|Minor Upgrade|*all*|
|[**pydantic-settings**](https://prefix.dev/channels/conda-forge/packages/pydantic-settings)|2.9.1|2.10.1|Minor Upgrade|*all*|
|[**pytest-cov**](https://prefix.dev/channels/conda-forge/packages/pytest-cov)|6.1.1|6.2.1|Minor Upgrade|*all*|
|[**pytest-xdist**](https://prefix.dev/channels/conda-forge/packages/pytest-xdist)|3.7.0|3.8.0|Minor Upgrade|*all*|
|[**qgis**](https://prefix.dev/channels/conda-forge/packages/qgis)|3.42.2|3.44.0|Minor Upgrade|*all envs* on linux-64|
|[**ruff**](https://prefix.dev/channels/conda-forge/packages/ruff)|0.11.13|0.12.1|Minor Upgrade|*all*|
|[**rust**](https://prefix.dev/channels/conda-forge/packages/rust)|1.87.0|1.88.0|Minor Upgrade|*all*|
|[**xarray**](https://prefix.dev/channels/conda-forge/packages/xarray)|2025.4.0|2025.6.1|Minor Upgrade|*all*|
|[**datacompy**](https://prefix.dev/channels/conda-forge/packages/datacompy)|0.16.7|0.16.8|Patch Upgrade|*all*|
|[**gh**](https://prefix.dev/channels/conda-forge/packages/gh)|2.74.1|2.74.2|Patch Upgrade|*all*|
|[**mypy**](https://prefix.dev/channels/conda-forge/packages/mypy)|1.16.0|1.16.1|Patch Upgrade|*all*|
|[**pydantic**](https://prefix.dev/channels/conda-forge/packages/pydantic)|2.11.4|2.11.7|Patch Upgrade|*all*|
|[**pytest**](https://prefix.dev/channels/conda-forge/packages/pytest)|8.4.0|8.4.1|Patch Upgrade|*all*|
|[**qgis**](https://prefix.dev/channels/conda-forge/packages/qgis)|3.42.2|3.42.3|Patch Upgrade|*all envs* on win-64|
|[**quarto**](https://prefix.dev/channels/conda-forge/packages/quarto)|1.7.31|1.7.32|Patch Upgrade|*all*|
|[**quartodoc**](https://prefix.dev/channels/conda-forge/packages/quartodoc)|0.11.0|0.11.1|Patch Upgrade|*all*|
|[**sbom4python**](https://pypi.org/project/sbom4python)|0.12.3|0.12.4|Patch Upgrade|*all*|
|[**pyogrio**](https://prefix.dev/channels/conda-forge/packages/pyogrio)|py312h6e88f47_0|py312h8f0c04e_1|Only build string|default on win-64|
|[**pyogrio**](https://prefix.dev/channels/conda-forge/packages/pyogrio)|py312h02b19dd_0|py312h5426b81_1|Only build string|default on linux-64|
|[**pyogrio**](https://prefix.dev/channels/conda-forge/packages/pyogrio)|py311hf6089d3_0|py311h75bf2cc_1|Only build string|py311 on linux-64|
|[**pyogrio**](https://prefix.dev/channels/conda-forge/packages/pyogrio)|py311haedb144_0|py311h2467ed7_1|Only build string|py311 on win-64|

</details>

<details>
<summary>Implicit dependencies</summary>

|Dependency[^1]|Before|After|Change|Environments|
|-|-|-|-|-|
|[elementpath](https://pypi.org/project/elementpath)||5.0.3|Added|*all*|
|[libadbc-driver-manager](https://prefix.dev/channels/conda-forge/packages/libadbc-driver-manager)||1.6.0|Added|*all envs* on linux-64|
|[libgdal-adbc](https://prefix.dev/channels/conda-forge/packages/libgdal-adbc)||3.11.1|Added|*all envs* on linux-64|
|[libhwy](https://prefix.dev/channels/conda-forge/packages/libhwy)||1.2.0|Added|*all envs* on {linux-64, win-64}|
|[libjxl](https://prefix.dev/channels/conda-forge/packages/libjxl)||0.11.1|Added|*all envs* on {linux-64, win-64}|
|[muparser](https://prefix.dev/channels/conda-forge/packages/muparser)||2.3.5|Added|*all envs* on {linux-64, win-64}|
|[polars-default](https://prefix.dev/channels/conda-forge/packages/polars-default)||1.31.0|Added|*all*|
|[xmlschema](https://pypi.org/project/xmlschema)||4.1.0|Added|*all*|
|[libre2-11](https://prefix.dev/channels/conda-forge/packages/libre2-11)|2024.07.02|2025.06.26|Major Upgrade|*all envs* on {linux-64, win-64}|
|[lxml](https://prefix.dev/channels/conda-forge/packages/lxml)|5.4.0|6.0.0|Major Upgrade|*all*|
|[opencl-headers](https://prefix.dev/channels/conda-forge/packages/opencl-headers)|2024.10.24|2025.06.13|Major Upgrade|*all*|
|[pyzmq](https://prefix.dev/channels/conda-forge/packages/pyzmq)|26.4.0|27.0.0|Major Upgrade|*all*|
|[re2](https://prefix.dev/channels/conda-forge/packages/re2)|2024.07.02|2025.06.26|Major Upgrade|*all envs* on {linux-64, win-64}|
|[libgfortran](https://prefix.dev/channels/conda-forge/packages/libgfortran)[^2]|14.2.0|5.0.0|Major Downgrade|*all envs* on osx-arm64|
|[aws-c-io](https://prefix.dev/channels/conda-forge/packages/aws-c-io)|0.19.1|0.20.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[ca-certificates](https://prefix.dev/channels/conda-forge/packages/ca-certificates)|2025.4.26|2025.6.15|Minor Upgrade|*all*|
|[capnproto](https://prefix.dev/channels/conda-forge/packages/capnproto)|1.0.2|1.2.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[certifi](https://prefix.dev/channels/conda-forge/packages/certifi)|2025.4.26|2025.6.15|Minor Upgrade|*all*|
|[coverage](https://prefix.dev/channels/conda-forge/packages/coverage)|7.8.2|7.9.1|Minor Upgrade|*all*|
|[fmt](https://prefix.dev/channels/conda-forge/packages/fmt)|11.1.4|11.2.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[folium](https://prefix.dev/channels/conda-forge/packages/folium)|0.19.7|0.20.0|Minor Upgrade|*all*|
|[gdal](https://prefix.dev/channels/conda-forge/packages/gdal)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[ipython](https://prefix.dev/channels/conda-forge/packages/ipython)|9.3.0|9.4.0|Minor Upgrade|*all*|
|[libfabric](https://prefix.dev/channels/conda-forge/packages/libfabric)|2.1.0|2.2.0|Minor Upgrade|*all envs* on {linux-64, osx-arm64}|
|[libfabric1](https://prefix.dev/channels/conda-forge/packages/libfabric1)|2.1.0|2.2.0|Minor Upgrade|*all envs* on {linux-64, osx-arm64}|
|[libgdal](https://prefix.dev/channels/conda-forge/packages/libgdal)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libgdal-arrow-parquet](https://prefix.dev/channels/conda-forge/packages/libgdal-arrow-parquet)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libgdal-core](https://prefix.dev/channels/conda-forge/packages/libgdal-core)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libgdal-fits](https://prefix.dev/channels/conda-forge/packages/libgdal-fits)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libgdal-grib](https://prefix.dev/channels/conda-forge/packages/libgdal-grib)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libgdal-hdf4](https://prefix.dev/channels/conda-forge/packages/libgdal-hdf4)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libgdal-hdf5](https://prefix.dev/channels/conda-forge/packages/libgdal-hdf5)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libgdal-jp2openjpeg](https://prefix.dev/channels/conda-forge/packages/libgdal-jp2openjpeg)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libgdal-kea](https://prefix.dev/channels/conda-forge/packages/libgdal-kea)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libgdal-netcdf](https://prefix.dev/channels/conda-forge/packages/libgdal-netcdf)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libgdal-pdf](https://prefix.dev/channels/conda-forge/packages/libgdal-pdf)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libgdal-pg](https://prefix.dev/channels/conda-forge/packages/libgdal-pg)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libgdal-postgisraster](https://prefix.dev/channels/conda-forge/packages/libgdal-postgisraster)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libgdal-tiledb](https://prefix.dev/channels/conda-forge/packages/libgdal-tiledb)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libgdal-xls](https://prefix.dev/channels/conda-forge/packages/libgdal-xls)|3.10.3|3.11.1|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libpdal](https://prefix.dev/channels/conda-forge/packages/libpdal)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
|[libpdal-arrow](https://prefix.dev/channels/conda-forge/packages/libpdal-arrow)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
|[libpdal-core](https://prefix.dev/channels/conda-forge/packages/libpdal-core)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
|[libpdal-cpd](https://prefix.dev/channels/conda-forge/packages/libpdal-cpd)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
|[libpdal-draco](https://prefix.dev/channels/conda-forge/packages/libpdal-draco)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
|[libpdal-e57](https://prefix.dev/channels/conda-forge/packages/libpdal-e57)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
|[libpdal-hdf](https://prefix.dev/channels/conda-forge/packages/libpdal-hdf)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
|[libpdal-icebridge](https://prefix.dev/channels/conda-forge/packages/libpdal-icebridge)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
|[libpdal-nitf](https://prefix.dev/channels/conda-forge/packages/libpdal-nitf)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
|[libpdal-pgpointcloud](https://prefix.dev/channels/conda-forge/packages/libpdal-pgpointcloud)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
|[libpdal-tiledb](https://prefix.dev/channels/conda-forge/packages/libpdal-tiledb)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
|[libpdal-trajectory](https://prefix.dev/channels/conda-forge/packages/libpdal-trajectory)|2.8.4|2.9.0|Minor Upgrade|*all envs* on linux-64|
|[libsystemd0](https://prefix.dev/channels/conda-forge/packages/libsystemd0)|257.6|257.7|Minor Upgrade|*all envs* on linux-64|
|[libudev1](https://prefix.dev/channels/conda-forge/packages/libudev1)|257.6|257.7|Minor Upgrade|*all envs* on linux-64|
|[narwhals](https://prefix.dev/channels/conda-forge/packages/narwhals)|1.42.0|1.45.0|Minor Upgrade|*all*|
|[nss](https://prefix.dev/channels/conda-forge/packages/nss)|3.112|3.113|Minor Upgrade|*all envs* on {linux-64, osx-arm64}|
|[pillow](https://prefix.dev/channels/conda-forge/packages/pillow)|11.2.1|11.3.0|Minor Upgrade|*all*|
|[polars](https://prefix.dev/channels/conda-forge/packages/polars)|1.27.1|1.31.0|Minor Upgrade|*all*|
|[pyobjc-core](https://prefix.dev/channels/conda-forge/packages/pyobjc-core)|11.0|11.1|Minor Upgrade|*all envs* on osx-arm64|
|[pyobjc-framework-cocoa](https://prefix.dev/channels/conda-forge/packages/pyobjc-framework-cocoa)|11.0|11.1|Minor Upgrade|*all envs* on osx-arm64|
|[pyqt5-sip](https://prefix.dev/channels/conda-forge/packages/pyqt5-sip)|12.12.2|12.17.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[rpds-py](https://prefix.dev/channels/conda-forge/packages/rpds-py)|0.25.1|0.26.0|Minor Upgrade|*all*|
|[rust-std-aarch64-apple-darwin](https://prefix.dev/channels/conda-forge/packages/rust-std-aarch64-apple-darwin)|1.87.0|1.88.0|Minor Upgrade|*all envs* on osx-arm64|
|[rust-std-x86_64-pc-windows-msvc](https://prefix.dev/channels/conda-forge/packages/rust-std-x86_64-pc-windows-msvc)|1.87.0|1.88.0|Minor Upgrade|*all envs* on win-64|
|[rust-std-x86_64-unknown-linux-gnu](https://prefix.dev/channels/conda-forge/packages/rust-std-x86_64-unknown-linux-gnu)|1.87.0|1.88.0|Minor Upgrade|*all envs* on linux-64|
|[scipy](https://prefix.dev/channels/conda-forge/packages/scipy)|1.15.2|1.16.0|Minor Upgrade|*all*|
|[sip](https://prefix.dev/channels/conda-forge/packages/sip)|6.7.12|6.10.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[urllib3](https://prefix.dev/channels/conda-forge/packages/urllib3)|2.4.0|2.5.0|Minor Upgrade|*all*|
|[vc14_runtime](https://prefix.dev/channels/conda-forge/packages/vc14_runtime)|14.42.34438|14.44.35208|Minor Upgrade|*all envs* on win-64|
|[vs2015_runtime](https://prefix.dev/channels/conda-forge/packages/vs2015_runtime)|14.42.34438|14.44.35208|Minor Upgrade|*all envs* on win-64|
|[aws-c-s3](https://prefix.dev/channels/conda-forge/packages/aws-c-s3)|0.8.1|0.8.3|Patch Upgrade|*all envs* on {linux-64, win-64}|
|[aws-crt-cpp](https://prefix.dev/channels/conda-forge/packages/aws-crt-cpp)|0.32.8|0.32.10|Patch Upgrade|*all envs* on {linux-64, win-64}|
|[cryptography](https://prefix.dev/channels/conda-forge/packages/cryptography)|45.0.4|45.0.5|Patch Upgrade|*all envs* on linux-64|
|[cyrus-sasl](https://prefix.dev/channels/conda-forge/packages/cyrus-sasl)|2.1.27|2.1.28|Patch Upgrade|*all envs* on {linux-64, osx-arm64}|
|[fonttools](https://prefix.dev/channels/conda-forge/packages/fonttools)|4.58.2|4.58.4|Patch Upgrade|*all*|
|[graphite2](https://prefix.dev/channels/conda-forge/packages/graphite2)|1.3.13|1.3.14|Patch Upgrade|*all envs* on {linux-64, win-64}|
|[jupyterlab](https://prefix.dev/channels/conda-forge/packages/jupyterlab)|4.4.3|4.4.4|Patch Upgrade|*all*|
|[kiwisolver](https://prefix.dev/channels/conda-forge/packages/kiwisolver)|1.4.7|1.4.8|Patch Upgrade|py311 on *all platforms*|
|[lib4package](https://pypi.org/project/lib4package)|0.3.2|0.3.3|Patch Upgrade|*all*|
|[lib4sbom](https://pypi.org/project/lib4sbom)|0.8.4|0.8.6|Patch Upgrade|*all*|
|[libaec](https://prefix.dev/channels/conda-forge/packages/libaec)|1.1.3|1.1.4|Patch Upgrade|*all*|
|[libasprintf](https://prefix.dev/channels/conda-forge/packages/libasprintf)|0.24.1|0.24.2|Patch Upgrade|*all envs* on osx-arm64|
|[libclang-cpp20.1](https://prefix.dev/channels/conda-forge/packages/libclang-cpp20.1)|20.1.6|20.1.7|Patch Upgrade|*all envs* on linux-64|
|[libclang13](https://prefix.dev/channels/conda-forge/packages/libclang13)|20.1.6|20.1.7|Patch Upgrade|*all*|
|[libcxx](https://prefix.dev/channels/conda-forge/packages/libcxx)|20.1.6|20.1.7|Patch Upgrade|*all envs* on osx-arm64|
|[libdrm](https://prefix.dev/channels/conda-forge/packages/libdrm)|2.4.124|2.4.125|Patch Upgrade|*all envs* on linux-64|
|[libgettextpo](https://prefix.dev/channels/conda-forge/packages/libgettextpo)|0.24.1|0.24.2|Patch Upgrade|*all envs* on osx-arm64|
|[libintl](https://prefix.dev/channels/conda-forge/packages/libintl)|0.24.1|0.24.2|Patch Upgrade|*all envs* on osx-arm64|
|[libintl-devel](https://prefix.dev/channels/conda-forge/packages/libintl-devel)|0.24.1|0.24.2|Patch Upgrade|*all envs* on osx-arm64|
|[libllvm20](https://prefix.dev/channels/conda-forge/packages/libllvm20)|20.1.6|20.1.7|Patch Upgrade|*all envs* on {linux-64, osx-arm64}|
|[libopenblas](https://prefix.dev/channels/conda-forge/packages/libopenblas)|0.3.29|0.3.30|Patch Upgrade|*all envs* on {linux-64, osx-arm64}|
|[libpng](https://prefix.dev/channels/conda-forge/packages/libpng)|1.6.47|1.6.49|Patch Upgrade|*all*|
|[libsqlite](https://prefix.dev/channels/conda-forge/packages/libsqlite)|3.50.1|3.50.2|Patch Upgrade|*all*|
|[llvm-openmp](https://prefix.dev/channels/conda-forge/packages/llvm-openmp)|20.1.6|20.1.7|Patch Upgrade|*all envs* on osx-arm64|
|[msgpack-python](https://prefix.dev/channels/conda-forge/packages/msgpack-python)|1.1.0|1.1.1|Patch Upgrade|*all*|
|[notebook](https://prefix.dev/channels/conda-forge/packages/notebook)|7.4.3|7.4.4|Patch Upgrade|*all*|
|[openmpi](https://prefix.dev/channels/conda-forge/packages/openmpi)|5.0.7|5.0.8|Patch Upgrade|*all envs* on osx-arm64|
|[openssl](https://prefix.dev/channels/conda-forge/packages/openssl)|3.5.0|3.5.1|Patch Upgrade|*all*|
|[owslib](https://prefix.dev/channels/conda-forge/packages/owslib)|0.34.0|0.34.1|Patch Upgrade|*all*|
|[pygments](https://prefix.dev/channels/conda-forge/packages/pygments)|2.19.1|2.19.2|Patch Upgrade|*all*|
|[pyqt](https://prefix.dev/channels/conda-forge/packages/pyqt)|5.15.9|5.15.11|Patch Upgrade|*all envs* on {linux-64, win-64}|
|[pyqtwebkit](https://prefix.dev/channels/conda-forge/packages/pyqtwebkit)|5.15.9|5.15.11|Patch Upgrade|*all envs* on {linux-64, win-64}|
|[python-dotenv](https://prefix.dev/channels/conda-forge/packages/python-dotenv)|1.1.0|1.1.1|Patch Upgrade|*all*|
|[sqlite](https://prefix.dev/channels/conda-forge/packages/sqlite)|3.50.1|3.50.2|Patch Upgrade|*all*|
|[typeguard](https://prefix.dev/channels/conda-forge/packages/typeguard)|4.4.3|4.4.4|Patch Upgrade|*all*|
|[uv](https://prefix.dev/channels/conda-forge/packages/uv)|0.7.12|0.7.19|Patch Upgrade|*all*|
|[aws-c-auth](https://prefix.dev/channels/conda-forge/packages/aws-c-auth)|h3537544_13|hd490b63_15|Only build string|*all envs* on win-64|
|[aws-c-auth](https://prefix.dev/channels/conda-forge/packages/aws-c-auth)|hf280997_13|hbfa7f16_15|Only build string|*all envs* on linux-64|
|[aws-c-event-stream](https://prefix.dev/channels/conda-forge/packages/aws-c-event-stream)|hf27a43c_10|ha416645_12|Only build string|*all envs* on win-64|
|[aws-c-event-stream](https://prefix.dev/channels/conda-forge/packages/aws-c-event-stream)|haaa725d_10|h76f0014_12|Only build string|*all envs* on linux-64|
|[aws-c-http](https://prefix.dev/channels/conda-forge/packages/aws-c-http)|h633db33_0|h81282ae_2|Only build string|*all envs* on win-64|
|[aws-c-http](https://prefix.dev/channels/conda-forge/packages/aws-c-http)|hcfde5e4_0|h015de20_2|Only build string|*all envs* on linux-64|
|[aws-c-mqtt](https://prefix.dev/channels/conda-forge/packages/aws-c-mqtt)|h6306086_1|h5c1ae27_3|Only build string|*all envs* on win-64|
|[aws-c-mqtt](https://prefix.dev/channels/conda-forge/packages/aws-c-mqtt)|h08b274c_1|h1e5e6c0_3|Only build string|*all envs* on linux-64|
|[aws-sdk-cpp](https://prefix.dev/channels/conda-forge/packages/aws-sdk-cpp)|h7deb975_10|hd13e2d4_12|Only build string|*all envs* on win-64|
|[aws-sdk-cpp](https://prefix.dev/channels/conda-forge/packages/aws-sdk-cpp)|h4607db7_10|h937e755_12|Only build string|*all envs* on linux-64|
|[binutils_impl_linux-64](https://prefix.dev/channels/conda-forge/packages/binutils_impl_linux-64)|h4bf12b8_4|h4bf12b8_5|Only build string|*all envs* on linux-64|
|[gcc_impl_linux-64](https://prefix.dev/channels/conda-forge/packages/gcc_impl_linux-64)|h4393ad2_2|h4393ad2_3|Only build string|*all envs* on linux-64|
|[kiwisolver](https://prefix.dev/channels/conda-forge/packages/kiwisolver)|py312hc790b64_0|py312hf90b1b7_1|Only build string|default on win-64|
|[kiwisolver](https://prefix.dev/channels/conda-forge/packages/kiwisolver)|py312h2c4a281_0|py312hb23fbb9_1|Only build string|default on osx-arm64|
|[kiwisolver](https://prefix.dev/channels/conda-forge/packages/kiwisolver)|py312h84d6215_0|py312h68727a3_1|Only build string|default on linux-64|
|[ld_impl_linux-64](https://prefix.dev/channels/conda-forge/packages/ld_impl_linux-64)|h712a8e2_4|h712a8e2_5|Only build string|*all envs* on linux-64|
|[libarrow](https://prefix.dev/channels/conda-forge/packages/libarrow)|hc090743_6_cpu|h3e40a90_8_cpu|Only build string|*all envs* on win-64|
|[libarrow](https://prefix.dev/channels/conda-forge/packages/libarrow)|h314c690_6_cpu|h1b9301b_8_cpu|Only build string|*all envs* on linux-64|
|[libarrow-acero](https://prefix.dev/channels/conda-forge/packages/libarrow-acero)|hcb10f89_6_cpu|hcb10f89_8_cpu|Only build string|*all envs* on linux-64|
|[libarrow-acero](https://prefix.dev/channels/conda-forge/packages/libarrow-acero)|h7d8d6a5_6_cpu|h7d8d6a5_8_cpu|Only build string|*all envs* on win-64|
|[libarrow-dataset](https://prefix.dev/channels/conda-forge/packages/libarrow-dataset)|hcb10f89_6_cpu|hcb10f89_8_cpu|Only build string|*all envs* on linux-64|
|[libarrow-dataset](https://prefix.dev/channels/conda-forge/packages/libarrow-dataset)|h7d8d6a5_6_cpu|h7d8d6a5_8_cpu|Only build string|*all envs* on win-64|
|[libarrow-substrait](https://prefix.dev/channels/conda-forge/packages/libarrow-substrait)|hb76e781_6_cpu|hb76e781_8_cpu|Only build string|*all envs* on win-64|
|[libarrow-substrait](https://prefix.dev/channels/conda-forge/packages/libarrow-substrait)|h1bed206_6_cpu|h1bed206_8_cpu|Only build string|*all envs* on linux-64|
|[libblas](https://prefix.dev/channels/conda-forge/packages/libblas)|31_h641d27c_mkl|32_h641d27c_mkl|Only build string|*all envs* on win-64|
|[libblas](https://prefix.dev/channels/conda-forge/packages/libblas)|31_h59b9bed_openblas|32_h59b9bed_openblas|Only build string|*all envs* on linux-64|
|[libblas](https://prefix.dev/channels/conda-forge/packages/libblas)|31_h10e41b3_openblas|32_h10e41b3_openblas|Only build string|*all envs* on osx-arm64|
|[libcblas](https://prefix.dev/channels/conda-forge/packages/libcblas)|31_he106b2a_openblas|32_he106b2a_openblas|Only build string|*all envs* on linux-64|
|[libcblas](https://prefix.dev/channels/conda-forge/packages/libcblas)|31_hb3479ef_openblas|32_hb3479ef_openblas|Only build string|*all envs* on osx-arm64|
|[libcblas](https://prefix.dev/channels/conda-forge/packages/libcblas)|31_h5e41251_mkl|32_h5e41251_mkl|Only build string|*all envs* on win-64|
|[libcups](https://prefix.dev/channels/conda-forge/packages/libcups)|h4637d8d_4|hb8b1518_5|Only build string|*all envs* on linux-64|
|[libgcc](https://prefix.dev/channels/conda-forge/packages/libgcc)|h767d61c_2|h767d61c_3|Only build string|*all envs* on linux-64|
|[libgcc](https://prefix.dev/channels/conda-forge/packages/libgcc)|h1383e82_2|h1383e82_3|Only build string|*all envs* on win-64|
|[libgcc-devel_linux-64](https://prefix.dev/channels/conda-forge/packages/libgcc-devel_linux-64)|h4c094af_102|h4c094af_103|Only build string|*all envs* on linux-64|
|[libgcc-ng](https://prefix.dev/channels/conda-forge/packages/libgcc-ng)|h69a702a_2|h69a702a_3|Only build string|*all envs* on linux-64|
|[libgfortran](https://prefix.dev/channels/conda-forge/packages/libgfortran)|h69a702a_2|h69a702a_3|Only build string|*all envs* on linux-64|
|[libgfortran-ng](https://prefix.dev/channels/conda-forge/packages/libgfortran-ng)|h69a702a_2|h69a702a_3|Only build string|*all envs* on linux-64|
|[libgfortran5](https://prefix.dev/channels/conda-forge/packages/libgfortran5)|hcea5267_2|hcea5267_3|Only build string|*all envs* on linux-64|
|[libgfortran5](https://prefix.dev/channels/conda-forge/packages/libgfortran5)|h2c44a93_105|h6c33f7e_103|Only build string|*all envs* on osx-arm64|
|[libgomp](https://prefix.dev/channels/conda-forge/packages/libgomp)|h767d61c_2|h767d61c_3|Only build string|*all envs* on linux-64|
|[libgomp](https://prefix.dev/channels/conda-forge/packages/libgomp)|h1383e82_2|h1383e82_3|Only build string|*all envs* on win-64|
|[liblapack](https://prefix.dev/channels/conda-forge/packages/liblapack)|31_hc9a63f6_openblas|32_hc9a63f6_openblas|Only build string|*all envs* on osx-arm64|
|[liblapack](https://prefix.dev/channels/conda-forge/packages/liblapack)|31_h7ac8fdf_openblas|32_h7ac8fdf_openblas|Only build string|*all envs* on linux-64|
|[liblapack](https://prefix.dev/channels/conda-forge/packages/liblapack)|31_h1aa476e_mkl|32_h1aa476e_mkl|Only build string|*all envs* on win-64|
|[libnsl](https://prefix.dev/channels/conda-forge/packages/libnsl)|hd590300_0|hb9d3cd8_1|Only build string|*all envs* on linux-64|
|[libparquet](https://prefix.dev/channels/conda-forge/packages/libparquet)|ha850022_6_cpu|ha850022_8_cpu|Only build string|*all envs* on win-64|
|[libparquet](https://prefix.dev/channels/conda-forge/packages/libparquet)|h081d1f1_6_cpu|h081d1f1_8_cpu|Only build string|*all envs* on linux-64|
|[libpciaccess](https://prefix.dev/channels/conda-forge/packages/libpciaccess)|hd590300_0|hb9d3cd8_0|Only build string|*all envs* on linux-64|
|[libpdal](https://prefix.dev/channels/conda-forge/packages/libpdal)|hb3590ec_6|hb3590ec_7|Only build string|*all envs* on win-64|
|[libpdal-arrow](https://prefix.dev/channels/conda-forge/packages/libpdal-arrow)|h6c57e06_6|h6c57e06_7|Only build string|*all envs* on win-64|
|[libpdal-core](https://prefix.dev/channels/conda-forge/packages/libpdal-core)|h6f06235_6|heefb544_7|Only build string|*all envs* on win-64|
|[libpdal-draco](https://prefix.dev/channels/conda-forge/packages/libpdal-draco)|ha763671_6|ha763671_7|Only build string|*all envs* on win-64|
|[libpdal-e57](https://prefix.dev/channels/conda-forge/packages/libpdal-e57)|h482c529_6|h482c529_7|Only build string|*all envs* on win-64|
|[libpdal-hdf](https://prefix.dev/channels/conda-forge/packages/libpdal-hdf)|h2520430_6|h2520430_7|Only build string|*all envs* on win-64|
|[libpdal-icebridge](https://prefix.dev/channels/conda-forge/packages/libpdal-icebridge)|h2520430_6|h2520430_7|Only build string|*all envs* on win-64|
|[libpdal-nitf](https://prefix.dev/channels/conda-forge/packages/libpdal-nitf)|h1b836ec_6|h1b836ec_7|Only build string|*all envs* on win-64|
|[libpdal-pgpointcloud](https://prefix.dev/channels/conda-forge/packages/libpdal-pgpointcloud)|hb7c6058_6|hb7c6058_7|Only build string|*all envs* on win-64|
|[libpdal-tiledb](https://prefix.dev/channels/conda-forge/packages/libpdal-tiledb)|hc4b2a02_6|hc4b2a02_7|Only build string|*all envs* on win-64|
|[libpdal-trajectory](https://prefix.dev/channels/conda-forge/packages/libpdal-trajectory)|h82545d7_6|hf542bf2_7|Only build string|*all envs* on win-64|
|[libsanitizer](https://prefix.dev/channels/conda-forge/packages/libsanitizer)|h97b714f_2|h97b714f_3|Only build string|*all envs* on linux-64|
|[libstdcxx](https://prefix.dev/channels/conda-forge/packages/libstdcxx)|h8f9b012_2|h8f9b012_3|Only build string|*all envs* on linux-64|
|[libstdcxx-ng](https://prefix.dev/channels/conda-forge/packages/libstdcxx-ng)|h4852527_2|h4852527_3|Only build string|*all envs* on linux-64|
|[munkres](https://prefix.dev/channels/conda-forge/packages/munkres)|pyh9f0ad1d_0|pyhd8ed1ab_1|Only build string|*all*|
|[nh3](https://prefix.dev/channels/conda-forge/packages/nh3)|py39he870945_1|py39h81ceba4_2|Only build string|*all envs* on win-64|
|[nh3](https://prefix.dev/channels/conda-forge/packages/nh3)|py39h77e2912_1|py39h7c48542_2|Only build string|*all envs* on linux-64|
|[nh3](https://prefix.dev/channels/conda-forge/packages/nh3)|py39h52c9f89_1|py39h39b1003_2|Only build string|*all envs* on osx-arm64|
|[psycopg2](https://prefix.dev/channels/conda-forge/packages/psycopg2)|py312hfaedaf9_0|py312hfaedaf9_1|Only build string|default on linux-64|
|[psycopg2](https://prefix.dev/channels/conda-forge/packages/psycopg2)|py312h96c7839_0|py312h96c7839_1|Only build string|default on osx-arm64|
|[psycopg2](https://prefix.dev/channels/conda-forge/packages/psycopg2)|py312h16142e3_0|py312h16142e3_1|Only build string|default on win-64|
|[psycopg2](https://prefix.dev/channels/conda-forge/packages/psycopg2)|py311hd732c25_0|py311hd732c25_1|Only build string|py311 on win-64|
|[psycopg2](https://prefix.dev/channels/conda-forge/packages/psycopg2)|py311h83e8966_0|py311h83e8966_1|Only build string|py311 on linux-64|
|[psycopg2](https://prefix.dev/channels/conda-forge/packages/psycopg2)|py311h2c64ce4_0|py311h2c64ce4_1|Only build string|py311 on osx-arm64|
|[python-dateutil](https://prefix.dev/channels/conda-forge/packages/python-dateutil)|pyhff2d567_1|pyhe01879c_2|Only build string|*all*|
|[qscintilla2](https://prefix.dev/channels/conda-forge/packages/qscintilla2)|py312h14105d7_0|py312he8164c3_1|Only build string|default on osx-arm64|
|[qscintilla2](https://prefix.dev/channels/conda-forge/packages/qscintilla2)|py312hca0710b_0|py312he11f4ca_1|Only build string|default on win-64|
|[qscintilla2](https://prefix.dev/channels/conda-forge/packages/qscintilla2)|py312hc23280e_0|py312hcec5e1c_1|Only build string|default on linux-64|
|[qscintilla2](https://prefix.dev/channels/conda-forge/packages/qscintilla2)|py311h4c6dc46_0|py311he22028a_1|Only build string|py311 on linux-64|
|[qscintilla2](https://prefix.dev/channels/conda-forge/packages/qscintilla2)|py311h5a77453_0|py311h2d05f59_1|Only build string|py311 on win-64|
|[qscintilla2](https://prefix.dev/channels/conda-forge/packages/qscintilla2)|py311h14ede98_0|py311h2146069_1|Only build string|py311 on osx-arm64|
|[qt6-main](https://prefix.dev/channels/conda-forge/packages/qt6-main)|h0384650_0|h0384650_1|Only build string|*all envs* on linux-64|
|[qt6-main](https://prefix.dev/channels/conda-forge/packages/qt6-main)|h02ddd7d_0|h02ddd7d_1|Only build string|*all envs* on win-64|
|[spdlog](https://prefix.dev/channels/conda-forge/packages/spdlog)|h10b92b3_0|h6dc744f_1|Only build string|*all envs* on linux-64|
|[spdlog](https://prefix.dev/channels/conda-forge/packages/spdlog)|ha881ca7_0|h430ee68_1|Only build string|*all envs* on win-64|
|[tiledb](https://prefix.dev/channels/conda-forge/packages/tiledb)|h6f9ba5a_2|hccce5bd_6|Only build string|*all envs* on linux-64|
|[tiledb](https://prefix.dev/channels/conda-forge/packages/tiledb)|h0cf81a9_2|h7c9f11d_6|Only build string|*all envs* on win-64|
|[vc](https://prefix.dev/channels/conda-forge/packages/vc)|h2b53caa_26|h41ae7f8_26|Only build string|*all envs* on win-64|
|[xcb-util](https://prefix.dev/channels/conda-forge/packages/xcb-util)|hb711507_2|h4f16b4b_2|Only build string|*all envs* on linux-64|

</details>

[^1]: **Bold** means explicit dependency.
[^2]: Dependency got downgraded.

