### PR TITLE
Improve continuous control performance

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1677,7 +1677,9 @@ version = "1.11.0"
 
 [[deps.SparseConnectivityTracer]]
 deps = ["ADTypes", "DocStringExtensions", "FillArrays", "LinearAlgebra", "Random", "SparseArrays"]
-git-tree-sha1 = "182990067a09adf950274f97f38f68c76f81d2d0"
+git-tree-sha1 = "bb394bcac0275a08e71506eaa23132dfd9d383a5"
+repo-rev = "add_smoothed_linear_interpolation_support"
+repo-url = "https://github.com/SouthEndMusic/SparseConnectivityTracer.jl"
 uuid = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
 version = "0.6.21"
 

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.5"
 manifest_format = "2.0"
-project_hash = "f6a0770e1fb1a6057f88838586f8e70915108dcb"
+project_hash = "a15a36ab8f1f06e75263ce0939505903c612166d"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "be7ae030256b8ef14a441726c4c37766b90b93a3"
@@ -359,7 +359,9 @@ version = "1.7.0"
 
 [[deps.DataInterpolations]]
 deps = ["EnumX", "FindFirstFunctions", "ForwardDiff", "LinearAlgebra", "PrettyTables", "RecipesBase", "Reexport"]
-git-tree-sha1 = "13c4d72ac01c0a441d72eced702332f8eabc8366"
+git-tree-sha1 = "01dd49bd6a0f61728a0b9b2c3d6de5c95cd2b1e9"
+repo-rev = "add_smoothed_linear_interpolation"
+repo-url = "https://github.com/SciML/DataInterpolations.jl"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
 version = "8.1.0"
 

--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -66,6 +66,8 @@ using DataInterpolations:
     LinearInterpolation,
     SmoothedConstantInterpolation,
     LinearInterpolationIntInv,
+    CubicHermiteSpline,
+    PCHIPInterpolation,
     invert_integral,
     get_transition_ts,
     derivative,

--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -64,6 +64,7 @@ using LinearAlgebra: mul!
 using DataInterpolations:
     ConstantInterpolation,
     LinearInterpolation,
+    SmoothedLinearInterpolation,
     SmoothedConstantInterpolation,
     LinearInterpolationIntInv,
     CubicHermiteSpline,

--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -67,8 +67,6 @@ using DataInterpolations:
     SmoothedLinearInterpolation,
     SmoothedConstantInterpolation,
     LinearInterpolationIntInv,
-    CubicHermiteSpline,
-    PCHIPInterpolation,
     invert_integral,
     get_transition_ts,
     derivative,

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -164,12 +164,11 @@ const ScalarLinearInterpolation = LinearInterpolation{
     Float64,
 }
 
-"PCHIPInterpolation from a Float64 to a Float64"
-const ScalarPCHIPInterpolation = CubicHermiteSpline{
+"Smoothed linear interpolation from a Float64 to a Float64"
+const ScalarSmoothedLinearInterpolation = SmoothedLinearInterpolation{
     Vector{Float64},
     Vector{Float64},
-    Vector{Float64},
-    Vector{Float64},
+    Nothing,
     Vector{Float64},
     Float64,
 }
@@ -882,7 +881,7 @@ end
     compound_variable::Vector{CompoundVariable}
     controlled_variable::Vector{String}
     target_ref::Vector{CacheRef} = Vector{CacheRef}(undef, length(node_id))
-    func::Vector{ScalarPCHIPInterpolation}
+    func::Vector{ScalarSmoothedLinearInterpolation}
 end
 
 """

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -164,6 +164,16 @@ const ScalarLinearInterpolation = LinearInterpolation{
     Float64,
 }
 
+"PCHIPInterpolation from a Float64 to a Float64"
+const ScalarPCHIPInterpolation = CubicHermiteSpline{
+    Vector{Float64},
+    Vector{Float64},
+    Vector{Float64},
+    Vector{Float64},
+    Vector{Float64},
+    Float64,
+}
+
 "SmoothedConstantInterpolation from a Float64 to a Float64"
 const ScalarBlockInterpolation = SmoothedConstantInterpolation{
     Vector{Float64},
@@ -872,7 +882,7 @@ end
     compound_variable::Vector{CompoundVariable}
     controlled_variable::Vector{String}
     target_ref::Vector{CacheRef} = Vector{CacheRef}(undef, length(node_id))
-    func::Vector{ScalarLinearInterpolation}
+    func::Vector{ScalarPCHIPInterpolation}
 end
 
 """

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -946,7 +946,7 @@ function continuous_control_functions(db, config, ids)
     errors = false
     # Parse the function table
     # Create linear interpolation objects out of the provided functions
-    functions = ScalarPCHIPInterpolation[]
+    functions = ScalarSmoothedLinearInterpolation[]
     controlled_variables = String[]
 
     # Loop over the IDs of the ContinuousControl nodes
@@ -965,7 +965,7 @@ function continuous_control_functions(db, config, ids)
         else
             push!(controlled_variables, only(unique_controlled_variable))
         end
-        function_itp = PCHIPInterpolation(
+        function_itp = SmoothedLinearInterpolation(
             function_rows.output,
             function_rows.input;
             extrapolation = Linear,

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -946,7 +946,7 @@ function continuous_control_functions(db, config, ids)
     errors = false
     # Parse the function table
     # Create linear interpolation objects out of the provided functions
-    functions = ScalarLinearInterpolation[]
+    functions = ScalarPCHIPInterpolation[]
     controlled_variables = String[]
 
     # Loop over the IDs of the ContinuousControl nodes
@@ -965,7 +965,7 @@ function continuous_control_functions(db, config, ids)
         else
             push!(controlled_variables, only(unique_controlled_variable))
         end
-        function_itp = LinearInterpolation(
+        function_itp = PCHIPInterpolation(
             function_rows.output,
             function_rows.input;
             extrapolation = Linear,

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -707,7 +707,6 @@ reduction_factor(x::GradientTracer, ::Real) = x
 low_storage_factor_resistance_node(::Parameters, q::GradientTracer, ::NodeID, ::NodeID) = q
 relaxed_root(x::GradientTracer, threshold::Real) = x
 get_level_from_storage(basin::Basin, state_idx::Int, storage::GradientTracer) = storage
-(::SmoothedLinearInterpolation)(x::GradientTracer) = x
 
 "Create a NamedTuple of the node IDs per state component in the state order"
 function state_node_ids(

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -707,6 +707,7 @@ reduction_factor(x::GradientTracer, ::Real) = x
 low_storage_factor_resistance_node(::Parameters, q::GradientTracer, ::NodeID, ::NodeID) = q
 relaxed_root(x::GradientTracer, threshold::Real) = x
 get_level_from_storage(basin::Basin, state_idx::Int, storage::GradientTracer) = storage
+(::SmoothedLinearInterpolation)(x::GradientTracer) = x
 
 "Create a NamedTuple of the node IDs per state component in the state order"
 function state_node_ids(

--- a/docs/reference/node/continuous-control.qmd
+++ b/docs/reference/node/continuous-control.qmd
@@ -48,5 +48,5 @@ output               | Float64 | -       | -
 controlled_variable  | String  | -       | must be "level" or "flow_rate"
 
 :::{.callout-note}
-The data in the function table is not interpolated exactly linearly. On an interval around each data point the linear interpolation is replaced by a spline section. This interval is given by 25% of the distance between the input values on either side of the data points.
+The data in the function table is not interpolated exactly linearly. On an interval around each data point the linear interpolation is replaced by a spline section. This interval is given by 12.5% of the distance between the input values on either side of the data points.
 :::

--- a/docs/reference/node/continuous-control.qmd
+++ b/docs/reference/node/continuous-control.qmd
@@ -34,7 +34,7 @@ look_ahead           | Float64  | $\text{s}$ | Only on transient boundary condit
 
 ## Function
 
-The function table defines a piecewise linear function $f$ interpolating between `(input, output)` datapoints for each `ContinuousControl` node. It linearly extrapolates. The total computation thus looks like
+The function table defines a smoothed piecewise linear function $f$ interpolating between `(input, output)` datapoints for each `ContinuousControl` node. It linearly extrapolates. The total computation thus looks like
 
 $$
     f(\text{weight}_1 * \text{variable}_1 + \text{weight}_2 * \text{variable}_2 + \ldots).
@@ -46,3 +46,7 @@ node_id              | Int32   | -       |
 input                | Float64 | -       |
 output               | Float64 | -       | -
 controlled_variable  | String  | -       | must be "level" or "flow_rate"
+
+:::{.callout-note}
+The data in the function table is not interpolated exactly linearly. On an interval around each data point the linear interpolation is replaced by a spline section. This interval is given by 25% of the distance between the input values on either side of the data points.
+:::


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/2445.

The model `repro-models/HollandseDelta_parameterized` makes heavy use of ContinuousControl. I had the hypothesis that the fact that the functions that define the continuous relations for ContinuousControl are piecewise linear is hard on the solver due to the lack of smoothness. To test this I changed the interpolation type to `PCHIPInterpolation` (see [here](https://docs.sciml.ai/DataInterpolations/stable/methods/#PCHIP-Interpolation)), not as a change to merge, but just to see what a smoother interpolation type does. And indeed, with this smoother interpolation I can locally run the first 4 months of the simulation in 9 min. 

There are several things we can do to improve the ContinuousControl performance structurally:
- Indeed use a smoother interpolation type than LinearInterpolation. We of course have to use an interpolation type that can be understood by modelers, so this could be a good use case for [smoothed linear interpolation](https://southendmusic.github.io/CachedInterpolations.jl/stable/examples/#Smoothed-linear-interpolation)
- Treat ContinuousControl more similar to DiscreteControl, in the sense that the continuous control logic is not part of the ODE system, but the control logic is computed at the start of the timestep and then kept fixed over the timestep. This approach probably has the best performance gain, but also results in a loss of accuracy. Alternatively we could make the continuous-but-not-part-of-the-ODE-system-control a new node type (or add a switch in the TOML between callback computed or ODE computed), but then we need to make the subtle difference very clear in the docs.

@visr @gijsber @Huite let me know whether you think this warrants a design session. Maybe in the particular case of the `HollandseDelta` model the schematization can also be made a bit more solver friendly

As a side node, I think we can expect similar issues with models that have a lot of TabulatedRatingCurve nodes with very sharp transitions in the q(h) relations