### PR TITLE
Support giving `model_dir` to `run_delwaq`

### DIFF
--- a/python/ribasim/ribasim/delwaq/util.py
+++ b/python/ribasim/ribasim/delwaq/util.py
@@ -11,6 +11,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
+from ribasim.delwaq.generate import output_path as model_dir
 from ribasim.utils import MissingOptionalModule
 
 try:
@@ -153,21 +154,20 @@ def ugrid(G) -> xugrid.UgridDataset:
     return uds
 
 
-def run_delwaq() -> None:
+def run_delwaq(model_dir: Path = model_dir) -> None:
     d3d_home = os.environ.get("D3D_HOME")
     if d3d_home is None:
         raise ValueError("D3D_HOME is not set.")
     else:
         pd3d_home = Path(d3d_home)
     binfolder = (pd3d_home / "bin").absolute()
-    folder = Path(__file__).parent
-    inp_path = folder / "model" / "delwaq.inp"
+    inp_path = model_dir / "delwaq.inp"
     system = platform.system()
     if system == "Windows":
         # run_delwaq.bat prepends working directory to the inp file
         subprocess.run(
             [binfolder / "run_delwaq.bat", "delwaq.inp"],
-            cwd=(folder / "model").absolute(),
+            cwd=model_dir.absolute(),
             check=True,
         )
     elif system == "Linux":


### PR DESCRIPTION
Right now `run_delwaq` doesn't take arguments and assumes that the model is in a model dir next to the ribasim.delwaq folder. To make it possible to run models in other places this adds a kwarg `model_dir`, with the same default.

Perhaps we should make the kwarg mandatory, but I don't want to break it right now.