### PR TITLE
Use patched PackageCompiler to reduce artifacts folder

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1606,7 +1606,9 @@ version = "10.42.0+1"
 
 [[deps.PackageCompiler]]
 deps = ["Artifacts", "Glob", "LazyArtifacts", "Libdl", "Pkg", "Printf", "RelocatableFolders", "TOML", "UUIDs", "p7zip_jll"]
-git-tree-sha1 = "d6fdae30c99917e01b7a3776e9bfd5b32f0665cc"
+git-tree-sha1 = "6a4297cde5a01e7150c9f02b18de00cd75e05328"
+repo-rev = "bundle_less_artifacts"
+repo-url = "https://github.com/visr/PackageCompiler.jl"
 uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
 version = "2.2.1"
 


### PR DESCRIPTION
To fix #2015.
Upstream issue: https://github.com/JuliaLang/PackageCompiler.jl/issues/1051
Temporary patch applied: https://github.com/JuliaLang/PackageCompiler.jl/compare/master...visr:PackageCompiler.jl:bundle_less_artifacts

Now we only have these artifacts:
```
PackageCompiler: bundled artifacts:
  ├── Bzip2_jll - 2.136 MiB
  ├── HiGHS_jll - 11.168 MiB
  ├── Lz4_jll - 2.461 MiB
  ├── OpenSpecFun_jll - 728.003 KiB
  ├── SQLite_jll - 14.956 MiB
  ├── TZJData
  │   └── tzjdata - 403.435 KiB
  ├── Zstd_jll - 4.070 MiB
  └── oneTBB_jll - 3.527 MiB
  Total artifact file size: 39.424 MiB
```

On main: Total artifact file size: 628.473 MiB
