### PR TITLE
Synchronize schemas with docs and QGIS

### DIFF
--- a/docs/reference/node/basin.qmd
+++ b/docs/reference/node/basin.qmd
@@ -34,11 +34,11 @@ time table, it is empty, or all timestamps of that variable are missing.
 column                | type    | unit                  | restriction
 ---------             | ------- | --------------------- | -----------
 node_id               | Int32   | -                     |
+drainage              | Float64 | $\text{m}^3/\text{s}$ | non-negative
+potential_evaporation | Float64 | $\text{m}/\text{s}$   | non-negative
+infiltration          | Float64 | $\text{m}^3/\text{s}$ | non-negative
 precipitation         | Float64 | $\text{m}/\text{s}$   | non-negative
 surface_runoff        | Float64 | $\text{m}^3/\text{s}$ | non-negative
-potential_evaporation | Float64 | $\text{m}/\text{s}$   | non-negative
-drainage              | Float64 | $\text{m}^3/\text{s}$ | non-negative
-infiltration          | Float64 | $\text{m}^3/\text{s}$ | non-negative
 
 Note that if variables are not set in the static table, default values are used when
 possible. These are generally zero, e.g. no precipitation, no inflow. If it is not possible

--- a/docs/reference/node/discrete-control.qmd
+++ b/docs/reference/node/discrete-control.qmd
@@ -103,5 +103,5 @@ DiscreteControl is applied in the Julia core as follows:
 column         | type     | unit | restriction
 -------------- | -------- | ---- | -----------
 node_id        | Int32    | -    |
-control_state  | String   | -    | -
 truth_state    | String   | -    | Consists of the characters "T" (true), "F" (false) and "*" (any)
+control_state  | String   | -    | -

--- a/docs/reference/node/linear-resistance.qmd
+++ b/docs/reference/node/linear-resistance.qmd
@@ -11,10 +11,10 @@ Bidirectional flow proportional to the level difference between the connected ba
 column        | type    | unit                  | restriction
 ------------- | ------- | --------------------- | -----------
 node_id       | Int32   | -                     |
-control_state | String  | -                     | (optional)
 active        | Bool    | -                     | (optional, default true)
 resistance    | Float64 | $\text{s}/\text{m}^2$ | -
 max_flow_rate | Float64 | $\text{m}^3/s$        | non-negative
+control_state | String  | -                     | (optional)
 
 # Equations
 

--- a/docs/reference/node/manning-resistance.qmd
+++ b/docs/reference/node/manning-resistance.qmd
@@ -12,12 +12,12 @@ The flow rate is calculated by conservation of energy and the Manning-Gauckler f
 column        | type    | unit                               | restriction
 ------------- | ------- | ---------------------------------- | -----------
 node_id       | Int32   | -                                  |
-control_state | String  | -                                  | (optional)
 active        | Bool    | -                                  | (optional, default true)
 length        | Float64 | $\text{m}$                         | positive
 manning_n     | Float64 | $\text{s} \text{m}^{-\frac{1}{3}}$ | positive
 profile_width | Float64 | $\text{m}$                         | positive
 profile_slope | Float64 | -                                  | -
+control_state | String  | -                                  | (optional)
 
 # Equations
 

--- a/docs/reference/node/outlet.qmd
+++ b/docs/reference/node/outlet.qmd
@@ -14,13 +14,13 @@ When PID controlled, the Outlet must point towards the controlled Basin in terms
 column                | type    | unit                  | restriction
 ---------             | ------- | --------------------- | -----------
 node_id               | Int32   | -                     |
-control_state         | String  | -                     | (optional)
 active                | Bool    | -                     | (optional, default true)
 flow_rate             | Float64 | $\text{m}^3/\text{s}$ | non-negative
 min_flow_rate         | Float64 | $\text{m}^3/\text{s}$ | (optional, default 0.0)
 max_flow_rate         | Float64 | $\text{m}^3/\text{s}$ | (optional)
 min_upstream_level    | Float64 | $\text{m}$            | (optional)
 max_downstream_level  | Float64 | $\text{m}$            | (optional)
+control_state         | String  | -                     | (optional)
 
 ## Time
 

--- a/docs/reference/node/pid-control.qmd
+++ b/docs/reference/node/pid-control.qmd
@@ -16,13 +16,13 @@ In the future controlling the flow on a particular link could be supported.
 column           | type     | unit            | restriction
 ---------------- | -------- | --------------- | -----------
 node_id          | Int32    | -               |
-control_state    | String   | -               | (optional)
 active           | Bool     | -               | (optional, default true)
 listen_node_id   | Int32    | -               | must be a Basin
 target           | Float64  | $\text{m}$      | -
 proportional     | Float64  | $\text{s}^{-1}$ | -
 integral         | Float64  | $\text{s}^{-2}$ | -
 derivative       | Float64  | -               | -
+control_state    | String   | -               | (optional)
 
 ## Time
 
@@ -36,8 +36,8 @@ Note that a `node_id` can be either in this table or in the static one, but not 
 column           | type     | unit            | restriction
 ---------------- | -------- | --------------- | -----------
 node_id          | Int32    | -               |
-time             | DateTime | -               |
 listen_node_id   | Int32    | -               | must be a Basin
+time             | DateTime | -               |
 target           | Float64  | $\text{m}$      | -
 proportional     | Float64  | $\text{s}^{-1}$ | -
 integral         | Float64  | $\text{s}^{-2}$ | -

--- a/docs/reference/node/pump.qmd
+++ b/docs/reference/node/pump.qmd
@@ -15,13 +15,13 @@ When PID controlled, the pump must point away from the controlled basin in terms
 column                | type    | unit         | restriction
 ---------             | ------- | ------------ | -----------
 node_id               | Int32   | -            |
-control_state         | String  | -            | (optional)
 active                | Bool    | -            | (optional, default true)
 flow_rate             | Float64 | $\text{m}^3/\text{s}$ | non-negative
 min_flow_rate         | Float64 | $\text{m}^3/\text{s}$ | (optional, default 0.0)
 max_flow_rate         | Float64 | $\text{m}^3/\text{s}$ | (optional)
 min_upstream_level    | Float64 | $\text{m}$          | (optional)
 max_downstream_level  | Float64 | $\text{m}$          | (optional)
+control_state         | String  | -            | (optional)
 
 ## Time
 

--- a/docs/reference/node/tabulated-rating-curve.qmd
+++ b/docs/reference/node/tabulated-rating-curve.qmd
@@ -16,11 +16,11 @@ Use it for instance to model flow over a weir.
 column               | type    | unit                  | restriction
 -------------        | ------- | --------------------- | -----------
 node_id              | Int32   | -                     |
-control_state        | String  | -                     | (optional)
 active               | Bool    | -                     | (optional, default true)
-max_downstream_level | Float64 | $\text{m}$            | (optional)
 level                | Float64 | $\text{m}$            | unique
 flow_rate            | Float64 | $\text{m}^3/\text{s}$ | start at 0, increasing
+max_downstream_level | Float64 | $\text{m}$            | (optional)
+control_state        | String  | -                     | (optional)
 
 ### Interpolation
 

--- a/docs/reference/node/user-demand.qmd
+++ b/docs/reference/node/user-demand.qmd
@@ -44,11 +44,11 @@ Note that a `node_id` can be either in this table or in the static one, but not 
 column          | type     | unit                  | restriction
 -------------   | -------- | --------------------- | -----------
 node_id         | Int32    | -                     |
-demand_priority | Int32    | -                     | positive
 time            | DateTime | -                     |
 demand          | Float64  | $\text{m}^3/\text{s}$ | non-negative
 return_factor   | Float64  | -                     | between [0 - 1]
 min_level       | Float64  | $\text{m}$            | -
+demand_priority | Int32    | -                     | positive
 
 ::: {.callout-note}
 Although it may seem that way, this table does *not* describe demands that change `demand_priority` over time. Rather, this table defines a `demand(time)` relationship for every occurring `demand_priority` in the table for a certain `node_id`.

--- a/ribasim_qgis/core/nodes.py
+++ b/ribasim_qgis/core/nodes.py
@@ -257,6 +257,7 @@ class BasinProfile(Input):
             QgsField("node_id", QVariant.Int),
             QgsField("area", QVariant.Double),
             QgsField("level", QVariant.Double),
+            QgsField("storage", QVariant.Double),
         ]
 
 
@@ -277,7 +278,7 @@ class BasinStatic(Input):
             QgsField("potential_evaporation", QVariant.Double),
             QgsField("infiltration", QVariant.Double),
             QgsField("precipitation", QVariant.Double),
-            QgsField("runoff", QVariant.Double),
+            QgsField("surface_runoff", QVariant.Double),
         ]
 
 
@@ -299,7 +300,7 @@ class BasinTime(Input):
             QgsField("potential_evaporation", QVariant.Double),
             QgsField("infiltration", QVariant.Double),
             QgsField("precipitation", QVariant.Double),
-            QgsField("runoff", QVariant.Double),
+            QgsField("surface_runoff", QVariant.Double),
         ]
 
 
@@ -358,7 +359,7 @@ class BasinConcentration(Input):
             QgsField("substance", QVariant.String),
             QgsField("drainage", QVariant.Double),
             QgsField("precipitation", QVariant.Double),
-            QgsField("runoff", QVariant.Double),
+            QgsField("surface_runoff", QVariant.Double),
         ]
 
 
@@ -456,6 +457,7 @@ class TabulatedRatingCurveStatic(Input):
             QgsField("active", QVariant.Bool),
             QgsField("level", QVariant.Double),
             QgsField("flow_rate", QVariant.Double),
+            QgsField("max_downstream_level", QVariant.Double),
             QgsField("control_state", QVariant.String),
         ]
 
@@ -476,6 +478,7 @@ class TabulatedRatingCurveTime(Input):
             QgsField("time", QVariant.DateTime),
             QgsField("level", QVariant.Double),
             QgsField("flow_rate", QVariant.Double),
+            QgsField("max_downstream_level", QVariant.Double),
         ]
 
 
@@ -494,6 +497,7 @@ class LinearResistanceStatic(Input):
             QgsField("node_id", QVariant.Int),
             QgsField("active", QVariant.Bool),
             QgsField("resistance", QVariant.Double),
+            QgsField("max_flow_rate", QVariant.Double),
             QgsField("control_state", QVariant.String),
         ]
 
@@ -755,7 +759,9 @@ class DiscreteControlCondition(Input):
         return [
             QgsField("node_id", QVariant.Int),
             QgsField("compound_variable_id", QVariant.Int),
+            QgsField("condition_id", QVariant.Int),
             QgsField("greater_than", QVariant.Double),
+            QgsField("time", QVariant.DateTime),
         ]
 
 
@@ -783,7 +789,7 @@ class ContinuousControlVariable(Input):
         return "ContinuousControl / variable"
 
     @classmethod
-    def geometry_type(cs) -> str:
+    def geometry_type(cls) -> str:
         return "No Geometry"
 
     @classmethod
@@ -835,6 +841,7 @@ class PidControlStatic(Input):
             QgsField("proportional", QVariant.Double),
             QgsField("integral", QVariant.Double),
             QgsField("derivative", QVariant.Double),
+            QgsField("control_state", QVariant.String),
         ]
 
 
@@ -876,6 +883,7 @@ class UserDemandStatic(Input):
             QgsField("active", QVariant.Bool),
             QgsField("demand", QVariant.Double),
             QgsField("return_factor", QVariant.Double),
+            QgsField("min_level", QVariant.Double),
             QgsField("demand_priority", QVariant.Int),
         ]
 
@@ -896,6 +904,7 @@ class UserDemandTime(Input):
             QgsField("time", QVariant.DateTime),
             QgsField("demand", QVariant.Double),
             QgsField("return_factor", QVariant.Double),
+            QgsField("min_level", QVariant.Double),
             QgsField("demand_priority", QVariant.Int),
         ]
 

--- a/ribasim_qgis/core/nodes.py
+++ b/ribasim_qgis/core/nodes.py
@@ -336,7 +336,6 @@ class BasinConcentrationState(Input):
     def attributes(cls) -> list[QgsField]:
         return [
             QgsField("node_id", QVariant.Int),
-            QgsField("time", QVariant.DateTime),
             QgsField("substance", QVariant.String),
             QgsField("concentration", QVariant.Double),
         ]
@@ -778,8 +777,8 @@ class DiscreteControlLogic(Input):
     def attributes(cls) -> list[QgsField]:
         return [
             QgsField("node_id", QVariant.Int),
-            QgsField("control_state", QVariant.String),
             QgsField("truth_state", QVariant.String),
+            QgsField("control_state", QVariant.String),
         ]
 
 


### PR DESCRIPTION
Some QGIS schemas were lagging behind.
This also ensures the column order is the same everywhere, so it is easier to compare.