### PR TITLE
Use FlowDemand demand as minimum Pump/Outlet flow when allocation is not active

### DIFF
--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -605,6 +605,23 @@ function formulate_pump_or_outlet_flow!(
 
         q = flow_rate * get_low_storage_factor(p, inflow_id)
 
+        lower_bound = eval_time_interp(min_flow_rate, current_min_flow_rate, id.idx, p, t)
+        upper_bound = eval_time_interp(max_flow_rate, current_max_flow_rate, id.idx, p, t)
+
+        # When allocation is not active, set the flow demand directly as a lower bound on the
+        # pump or outlet flow rate
+        if !is_active(allocation)
+            has_demand, flow_demand_id = has_external_flow_demand(graph, id, :flow_demand)
+            if has_demand
+                lower_bound = clamp(
+                    flow_demand.demand_itp[flow_demand_id.idx](t),
+                    lower_bound,
+                    upper_bound,
+                )
+            end
+        end
+        q = clamp(q, lower_bound, upper_bound)
+
         # Special case for outlet: check level difference
         if reduce_Δlevel
             Δlevel = src_level - dst_level
@@ -624,23 +641,6 @@ function formulate_pump_or_outlet_flow!(
         )
         q *= reduction_factor(max_downstream_level_ - dst_level, 0.02)
 
-        lower_bound = eval_time_interp(min_flow_rate, current_min_flow_rate, id.idx, p, t)
-        upper_bound = eval_time_interp(max_flow_rate, current_max_flow_rate, id.idx, p, t)
-
-        # When allocation is not active, set the flow demand directly as a lower bound on the
-        # pump or outlet flow rate
-        if !is_active(allocation)
-            has_demand, flow_demand_id = has_external_flow_demand(graph, id, :flow_demand)
-            if has_demand
-                lower_bound = clamp(
-                    flow_demand.demand_itp[flow_demand_id.idx](t),
-                    lower_bound,
-                    upper_bound,
-                )
-            end
-        end
-
-        q = clamp(q, lower_bound, upper_bound)
         du_component[id.idx] = q
     end
     return nothing

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -630,7 +630,7 @@ function formulate_pump_or_outlet_flow!(
         # When allocation is not active, set the flow demand directly as a lower bound on the
         # pump or outlet flow rate
         if !is_active(allocation)
-            has_demand, flow_demand_id = has_external_flow_demand(graph, id, :FlowDemand)
+            has_demand, flow_demand_id = has_external_flow_demand(graph, id, :flow_demand)
             if has_demand
                 lower_bound = clamp(
                     flow_demand.demand_itp[flow_demand_id.idx](t),

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -568,7 +568,7 @@ function formulate_pump_or_outlet_flow!(
     component_cache::NamedTuple,
     reduce_Δlevel::Bool = false,
 )::Nothing
-    (; allocation, graph, flow_demand) = p.p_mutable
+    (; allocation, graph, flow_demand) = p.p_independent
 
     (;
         current_min_flow_rate,

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -568,7 +568,7 @@ function formulate_pump_or_outlet_flow!(
     component_cache::NamedTuple,
     reduce_Δlevel::Bool = false,
 )::Nothing
-    (p_mutable) = p
+    (; allocation, graph, flow_demand) = p.p_mutable
 
     (;
         current_min_flow_rate,
@@ -624,11 +624,23 @@ function formulate_pump_or_outlet_flow!(
         )
         q *= reduction_factor(max_downstream_level_ - dst_level, 0.02)
 
-        q = clamp(
-            q,
-            eval_time_interp(min_flow_rate, current_min_flow_rate, id.idx, p, t),
-            eval_time_interp(max_flow_rate, current_max_flow_rate, id.idx, p, t),
-        )
+        lower_bound = eval_time_interp(min_flow_rate, current_min_flow_rate, id.idx, p, t)
+        upper_bound = eval_time_interp(max_flow_rate, current_max_flow_rate, id.idx, p, t)
+
+        # When allocation is not active, set the flow demand directly as a lower bound on the
+        # pump or outlet flow rate
+        if !is_active(allocation)
+            has_demand, flow_demand_id = has_external_flow_demand(graph, id, :FlowDemand)
+            if has_demand
+                lower_bound = clamp(
+                    flow_demand.demand_itp[flow_demand_id.idx](t),
+                    lower_bound,
+                    upper_bound,
+                )
+            end
+        end
+
+        q = clamp(q, lower_bound, upper_bound)
         du_component[id.idx] = q
     end
     return nothing

--- a/core/test/allocation_test.jl
+++ b/core/test/allocation_test.jl
@@ -736,3 +736,13 @@ end
     allocation_control_table = Ribasim.allocation_control_table(model)
     @test all(q -> isapprox(q, 1e-3; rtol = 1e-5), allocation_control_table.flow_rate[1:5])
 end
+
+@testitem "FlowDemand without allocation" begin
+    toml_path = normpath(
+        @__DIR__,
+        "../../generated_testmodels/allocation_off_flow_demand/ribasim.toml",
+    )
+    @test ispath(toml_path)
+
+    model = Ribasim.run(toml_path)
+end

--- a/core/test/allocation_test.jl
+++ b/core/test/allocation_test.jl
@@ -745,4 +745,5 @@ end
     @test ispath(toml_path)
 
     model = Ribasim.run(toml_path)
+    @test all(q -> isapprox(q, 1e-3; rtol = 1e-4), Ribasim.flow_table(model).flow_rate)
 end

--- a/core/test/allocation_test.jl
+++ b/core/test/allocation_test.jl
@@ -745,5 +745,9 @@ end
     @test ispath(toml_path)
 
     model = Ribasim.run(toml_path)
-    @test all(q -> isapprox(q, 1e-3; rtol = 1e-4), Ribasim.flow_table(model).flow_rate)
+    @test success(model)
+
+    flow = Ribasim.flow_table(model).flow_rate
+    @test !isempty(flow)
+    @test all(q -> isapprox(q, 1e-3; rtol = 1e-4), flow[1:100])
 end

--- a/docs/reference/node/flow-demand.qmd
+++ b/docs/reference/node/flow-demand.qmd
@@ -4,6 +4,7 @@ title: "FlowDemand"
 
 A `FlowDemand` node associates a non-consuming flow demand to a connector node (e.g. `Pump`, `TabulatedRatingCurve`) for one single demand priority.
 FlowDemand nodes can set a flow demand only for a single connector node.
+FlowDemand nodes do nothing when allocation is not activated, except when they are connected to a Pump or an Outlet. In that case the flow demand flow rate is taken as the minimum flow trough that Pump or Outlet.
 
 # Tables
 

--- a/python/ribasim_testmodels/ribasim_testmodels/__init__.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/__init__.py
@@ -8,6 +8,7 @@ import ribasim_testmodels
 from ribasim_testmodels.allocation import (
     allocation_control_model,
     allocation_example_model,
+    allocation_off_flow_demand_model,
     allocation_training_model,
     bommelerwaard_model,
     cyclic_demand_model,
@@ -88,6 +89,7 @@ __all__ = [
     "allocation_control_model",
     "allocation_training_model",
     "allocation_example_model",
+    "allocation_off_flow_demand_model",
     "backwater_model",
     "basic_arrow_model",
     "basic_model",

--- a/python/ribasim_testmodels/ribasim_testmodels/allocation.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/allocation.py
@@ -1610,3 +1610,32 @@ def drain_surplus_model() -> Model:
     model.link.add(lvl, bsn)
 
     return model
+
+
+def allocation_off_flow_demand_model() -> Model:
+    """Set up a model with a Pump with a FlowDemand but allocation turned off."""
+    model = Model(
+        starttime="2020-01-01",
+        endtime="2021-01-01",
+        crs="EPSG:28992",
+        experimental=Experimental(allocation=True),
+    )
+
+    bsn = model.basin.add(
+        Node(1, Point(0, 0)),
+        [basin.Profile(level=[0.0, 10.0], area=1000.0), basin.State(level=[5.0])],
+    )
+
+    pmp = model.pump.add(Node(2, Point(1, 0)), [pump.Static(flow_rate=[0.0])])
+
+    tml = model.terminal.add(Node(3, Point(2, 0)))
+
+    fdm = model.flow_demand.add(
+        Node(4, Point(1, 1)), [flow_demand.Static(demand_priority=[1], demand=1e-3)]
+    )
+
+    model.link.add(bsn, pmp)
+    model.link.add(pmp, tml)
+    model.link.add(fdm, pmp)
+
+    return model


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/2496.