### PR TITLE
Update Julia manifest

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -5,9 +5,9 @@ manifest_format = "2.0"
 project_hash = "5e2757a611de48926fb2b526538347416ac107c8"
 
 [[deps.ADTypes]]
-git-tree-sha1 = "be7ae030256b8ef14a441726c4c37766b90b93a3"
+git-tree-sha1 = "7927b9af540ee964cc5d1b73293f1eb0b761a3a1"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
-version = "1.15.0"
+version = "1.16.0"
 weakdeps = ["ChainRulesCore", "ConstructionBase", "EnzymeCore"]
 
     [deps.ADTypes.extensions]
@@ -225,9 +225,9 @@ version = "0.1.13"
 
 [[deps.CodeTracking]]
 deps = ["InteractiveUtils", "UUIDs"]
-git-tree-sha1 = "062c5e1a5bf6ada13db96a4ae4749a4c2234f521"
+git-tree-sha1 = "5ac098a7c8660e217ffac31dc2af0964a8c3182a"
 uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
-version = "1.3.9"
+version = "2.0.0"
 
 [[deps.CodecBzip2]]
 deps = ["Bzip2_jll", "TranscodingStreams"]
@@ -303,9 +303,9 @@ version = "1.0.0"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
-git-tree-sha1 = "3a3dfb30697e96a440e4149c8c51bf32f818c0f3"
+git-tree-sha1 = "0037835448781bb46feb39866934e243886d756a"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.17.0"
+version = "4.18.0"
 weakdeps = ["Dates", "LinearAlgebra"]
 
     [deps.Compat.extensions]
@@ -452,9 +452,9 @@ version = "1.9.1"
 
 [[deps.DiffEqBase]]
 deps = ["ArrayInterface", "ConcreteStructs", "DataStructures", "DocStringExtensions", "EnumX", "EnzymeCore", "FastBroadcast", "FastClosures", "FastPower", "FunctionWrappers", "FunctionWrappersWrappers", "LinearAlgebra", "Logging", "Markdown", "MuladdMacro", "Parameters", "PrecompileTools", "Printf", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLOperators", "SciMLStructures", "Setfield", "Static", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface", "TruncatedStacktraces"]
-git-tree-sha1 = "52af5ee5af4eb6ca03b3782bf65c1e5fc3024c86"
+git-tree-sha1 = "6f8f25122389ba34e491bdfe143ae16fda37cad3"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
-version = "6.178.0"
+version = "6.180.0"
 
     [deps.DiffEqBase.extensions]
     DiffEqBaseCUDAExt = "CUDA"
@@ -632,15 +632,15 @@ version = "0.10.14"
 
 [[deps.FFMPEG]]
 deps = ["FFMPEG_jll"]
-git-tree-sha1 = "53ebe7511fa11d33bec688a9178fac4e49eeee00"
+git-tree-sha1 = "83dc665d0312b41367b7263e8a4d172eac1897f4"
 uuid = "c87230d0-a227-11e9-1b43-d7ebe4e7570a"
-version = "0.4.2"
+version = "0.4.4"
 
 [[deps.FFMPEG_jll]]
 deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "PCRE2_jll", "Zlib_jll", "libaom_jll", "libass_jll", "libfdk_aac_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
-git-tree-sha1 = "466d45dc38e15794ec7d5d63ec03d776a9aff36e"
+git-tree-sha1 = "3a948313e7a41eb1db7a1e733e6335f17b4ab3c4"
 uuid = "b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
-version = "4.4.4+1"
+version = "7.1.1+0"
 
 [[deps.FastBroadcast]]
 deps = ["ArrayInterface", "LinearAlgebra", "Polyester", "Static", "StaticArrayInterface", "StrideArraysCore"]
@@ -877,10 +877,10 @@ uuid = "076d061b-32b6-4027-95e0-9a2c6f6d7e74"
 version = "0.2.0"
 
 [[deps.HiGHS]]
-deps = ["HiGHS_jll", "MathOptInterface", "PrecompileTools", "SparseArrays"]
-git-tree-sha1 = "2aab56d4e161be93c44fc16dfc95940996f84a12"
+deps = ["HiGHS_jll", "MathOptIIS", "MathOptInterface", "PrecompileTools", "SparseArrays"]
+git-tree-sha1 = "3fae2ee8d6ea22009532d5919ff592fcbcab0ad9"
 uuid = "87dc4568-4c63-4d18-b0c0-bb2238e4078b"
-version = "1.18.2"
+version = "1.19.0"
 
 [[deps.HiGHS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
@@ -1025,9 +1025,9 @@ version = "1.27.0"
 
 [[deps.JuliaInterpreter]]
 deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
-git-tree-sha1 = "6ac9e4acc417a5b534ace12690bc6973c25b862f"
+git-tree-sha1 = "e09121f4c523d8d8d9226acbed9cb66df515fcf2"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
-version = "0.10.3"
+version = "0.10.4"
 
 [[deps.Krylov]]
 deps = ["LinearAlgebra", "Printf", "SparseArrays"]
@@ -1212,9 +1212,9 @@ version = "1.11.0"
 
 [[deps.LinearSolve]]
 deps = ["ArrayInterface", "ChainRulesCore", "ConcreteStructs", "DocStringExtensions", "EnumX", "GPUArraysCore", "InteractiveUtils", "Krylov", "LazyArrays", "Libdl", "LinearAlgebra", "MKL_jll", "Markdown", "PrecompileTools", "Preferences", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLOperators", "Setfield", "StaticArraysCore", "UnPack"]
-git-tree-sha1 = "22e90c33c5297d6162ee54e2383584849379aa53"
+git-tree-sha1 = "d768ff40cc3fe42581708696b24ee65dccc9c6ba"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "3.23.0"
+version = "3.24.0"
 
     [deps.LinearSolve.extensions]
     LinearSolveBandedMatricesExt = "BandedMatrices"
@@ -1281,10 +1281,10 @@ uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
 version = "1.1.0"
 
 [[deps.LoweredCodeUtils]]
-deps = ["Compiler", "JuliaInterpreter"]
-git-tree-sha1 = "b882a7dd7ef37643066ae8f9380beea8fdd89cae"
+deps = ["CodeTracking", "Compiler", "JuliaInterpreter"]
+git-tree-sha1 = "73b98709ad811a6f81d84e105f4f695c229385ba"
 uuid = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
-version = "3.4.2"
+version = "3.4.3"
 
 [[deps.Lz4_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -1329,11 +1329,17 @@ weakdeps = ["JuMP"]
     [deps.MathOptAnalyzer.extensions]
     MathOptAnalyzerJuMPExt = "JuMP"
 
+[[deps.MathOptIIS]]
+deps = ["MathOptInterface"]
+git-tree-sha1 = "c3793e137ae31f7efc5db9d54b261abba06801e0"
+uuid = "8c4f8055-bd93-4160-a86b-a0c04941dbff"
+version = "0.1.0"
+
 [[deps.MathOptInterface]]
 deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "DataStructures", "ForwardDiff", "JSON3", "LinearAlgebra", "MutableArithmetics", "NaNMath", "OrderedCollections", "PrecompileTools", "Printf", "SparseArrays", "SpecialFunctions", "Test"]
-git-tree-sha1 = "1251fce78b907fe415a2f680291b67cf51360d2a"
+git-tree-sha1 = "ce5a316de39941da67730ffec38e5396f7504853"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.42.0"
+version = "1.42.1"
 
 [[deps.MaybeInplace]]
 deps = ["ArrayInterface", "LinearAlgebra", "MacroTools"]
@@ -1829,9 +1835,9 @@ version = "0.6.12"
 
 [[deps.RecursiveArrayTools]]
 deps = ["Adapt", "ArrayInterface", "DocStringExtensions", "GPUArraysCore", "IteratorInterfaceExtensions", "LinearAlgebra", "RecipesBase", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface", "Tables"]
-git-tree-sha1 = "4dd1a95cc16d5abdccc4eac5faf6bc73904be1a2"
+git-tree-sha1 = "f8726bd5a8b7f5f5d3f6c0ce4793454a599b5243"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
-version = "3.35.0"
+version = "3.36.0"
 
     [deps.RecursiveArrayTools.extensions]
     RecursiveArrayToolsFastBroadcastExt = "FastBroadcast"
@@ -1882,9 +1888,9 @@ version = "1.3.1"
 
 [[deps.Revise]]
 deps = ["CodeTracking", "FileWatching", "JuliaInterpreter", "LibGit2", "LoweredCodeUtils", "OrderedCollections", "REPL", "Requires", "UUIDs", "Unicode"]
-git-tree-sha1 = "f6f7d30fb0d61c64d0cfe56cf085a7c9e7d5bc80"
+git-tree-sha1 = "20ccb7e2501e9da93fe8450d01aeabf16a5f0c82"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.8.0"
+version = "3.8.1"
 weakdeps = ["Distributed"]
 
     [deps.Revise.extensions]
@@ -1931,9 +1937,9 @@ version = "3.48.0+0"
 
 [[deps.SciMLBase]]
 deps = ["ADTypes", "Accessors", "Adapt", "ArrayInterface", "CommonSolve", "ConstructionBase", "Distributed", "DocStringExtensions", "EnumX", "FunctionWrappersWrappers", "IteratorInterfaceExtensions", "LinearAlgebra", "Logging", "Markdown", "Moshi", "PrecompileTools", "Preferences", "Printf", "RecipesBase", "RecursiveArrayTools", "Reexport", "RuntimeGeneratedFunctions", "SciMLOperators", "SciMLStructures", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface"]
-git-tree-sha1 = "c9dc4c04bcb0146a35dd6af726073c5738b80e3b"
+git-tree-sha1 = "1c7fd50df465f0684f04f3a63736eac01999c659"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "2.104.0"
+version = "2.107.0"
 
     [deps.SciMLBase.extensions]
     SciMLBaseChainRulesCoreExt = "ChainRulesCore"
@@ -2188,9 +2194,9 @@ uuid = "892a3eda-7b42-436c-8928-eab12a02cf0e"
 version = "0.4.1"
 
 [[deps.StringViews]]
-git-tree-sha1 = "ec4bf39f7d25db401bcab2f11d2929798c0578e5"
+git-tree-sha1 = "d3c7a06c80622b8404b1105886c732abcb25cc2b"
 uuid = "354b36f9-a18e-4713-926e-db85100087ba"
-version = "1.3.4"
+version = "1.3.5"
 
 [[deps.StructArrays]]
 deps = ["ConstructionBase", "DataAPI", "Tables"]
@@ -2364,9 +2370,9 @@ version = "0.4.1"
 
 [[deps.Unitful]]
 deps = ["Dates", "LinearAlgebra", "Random"]
-git-tree-sha1 = "d2282232f8a4d71f79e85dc4dd45e5b12a6297fb"
+git-tree-sha1 = "6258d453843c466d84c17a58732dda5deeb8d3af"
 uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
-version = "1.23.1"
+version = "1.24.0"
 weakdeps = ["ConstructionBase", "ForwardDiff", "InverseFunctions", "Printf"]
 
     [deps.Unitful.extensions]
@@ -2589,9 +2595,9 @@ version = "3.12.1+0"
 
 [[deps.libass_jll]]
 deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
-git-tree-sha1 = "e17c115d55c5fbb7e52ebedb427a0dca79d4484e"
+git-tree-sha1 = "125eedcb0a4a0bba65b657251ce1d27c8714e9d6"
 uuid = "0ac62f75-1d6f-5e53-bd7c-93b484bb37c0"
-version = "0.15.2+0"
+version = "0.17.4+0"
 
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -2642,9 +2648,9 @@ version = "0.3.101+0"
 
 [[deps.micromamba_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl"]
-git-tree-sha1 = "b4a5a3943078f9fd11ae0b5ab1bdbf7718617945"
+git-tree-sha1 = "2ca2ac0b23a8e6b76752453e08428b3b4de28095"
 uuid = "f8abcde7-e9b7-5caa-b8af-a437887ae8e4"
-version = "1.5.8+0"
+version = "1.5.12+0"
 
 [[deps.mtdev_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -2675,16 +2681,16 @@ uuid = "4d7b5844-a134-5dcd-ac86-c8f19cd51bed"
 version = "0.41.3+0"
 
 [[deps.x264_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "4fea590b89e6ec504593146bf8b988b2c00922b2"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "14cc7083fc6dff3cc44f2bc435ee96d06ed79aa7"
 uuid = "1270edf5-f2f9-52d2-97e9-ab00b5d0237a"
-version = "2021.5.5+0"
+version = "10164.0.1+0"
 
 [[deps.x265_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "ee567a171cce03570d77ad3a43e90218e38937a9"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "e7b67590c14d487e734dcb925924c5dc43ec85f3"
 uuid = "dfaa095f-4041-5dcd-9319-2fabd8486b76"
-version = "3.5.0+0"
+version = "4.1.0+0"
 
 [[deps.xkbcommon_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libxcb_jll", "Xorg_xkeyboard_config_jll"]

--- a/Ribasim.spdx.json
+++ b/Ribasim.spdx.json
@@ -3,12 +3,12 @@
     "dataLicense": "CC0-1.0",
     "SPDXID": "SPDXRef-DOCUMENT",
     "name": "Ribasim.jl",
-    "documentNamespace": "https://github.com/Deltares/Ribasim/Ribasim.spdx.json-5c6dd339-3f34-4dd5-965f-3ece3ae5283c",
+    "documentNamespace": "https://github.com/Deltares/Ribasim/Ribasim.spdx.json-8d4e2cf8-2ba8-4bf6-b147-9eb5a24129e6",
     "creationInfo": {
         "creators": [
             "Organization:  Deltares  (software@deltares.nl)"
         ],
-        "created": "2025-07-25T14:50:02Z",
+        "created": "2025-08-02T03:30:50Z",
         "comment": "Target Platform: Platform(\"x86_64\", \"linux\"; libgfortran_version = \"5.0.0\", julia_version = \"1.11.6\", libc = \"glibc\", libstdcxx_version = \"3.4.30\", cxxstring_abi = \"cxx11\")"
     },
     "comment": "Registries used for populating Package data:\nGeneral registry: https://github.com/JuliaRegistries/General.git\nOfficial general Julia package registry where people can\nregister any package they want without too much debate about\nnaming and without enforced standards on documentation or\ntesting. We nevertheless encourage documentation, testing and\nsome amount of consideration when choosing package names.\n",
@@ -657,13 +657,13 @@
         {
             "name": "Compat",
             "SPDXID": "SPDXRef-Compat-34da2185-b29b-5c13-b0c7-acf172513d20",
-            "versionInfo": "4.17.0",
+            "versionInfo": "4.18.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaLang/Compat.jl.git@3a3dfb30697e96a440e4149c8c51bf32f818c0f3",
+            "downloadLocation": "git+https://github.com/JuliaLang/Compat.jl.git@0037835448781bb46feb39866934e243886d756a",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "e5eebd9a160a405f4e44e248c40ff2e8c491c47e"
+                "packageVerificationCodeValue": "6c7553f043185d42029730c650ae1aa3b20bd981"
             },
             "homepage": "https://github.com/JuliaLang/Compat.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -905,13 +905,13 @@
         {
             "name": "MathOptInterface",
             "SPDXID": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee",
-            "versionInfo": "1.42.0",
+            "versionInfo": "1.42.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/jump-dev/MathOptInterface.jl.git@1251fce78b907fe415a2f680291b67cf51360d2a",
+            "downloadLocation": "git+https://github.com/jump-dev/MathOptInterface.jl.git@ce5a316de39941da67730ffec38e5396f7504853",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "04873fa7fc53ade491bd3c113789d5946a7227ed"
+                "packageVerificationCodeValue": "c4fb869985dfe4f48c806fe49b87981777f557d3"
             },
             "homepage": "https://github.com/jump-dev/MathOptInterface.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -925,15 +925,37 @@
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
-            "name": "HiGHS",
-            "SPDXID": "SPDXRef-HiGHS-87dc4568-4c63-4d18-b0c0-bb2238e4078b",
-            "versionInfo": "1.18.2",
+            "name": "MathOptIIS",
+            "SPDXID": "SPDXRef-MathOptIIS-8c4f8055-bd93-4160-a86b-a0c04941dbff",
+            "versionInfo": "0.1.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/jump-dev/HiGHS.jl.git@2aab56d4e161be93c44fc16dfc95940996f84a12",
+            "downloadLocation": "git+https://github.com/jump-dev/MathOptIIS.jl.git@c3793e137ae31f7efc5db9d54b261abba06801e0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "842958acdd6b63cd5f1f958e32b5bb91de1550f2"
+                "packageVerificationCodeValue": "4cb5c2f6c0bcaeef821f41b41ff2daa59ef23888"
+            },
+            "homepage": "https://github.com/jump-dev/MathOptIIS.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "HiGHS",
+            "SPDXID": "SPDXRef-HiGHS-87dc4568-4c63-4d18-b0c0-bb2238e4078b",
+            "versionInfo": "1.19.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/jump-dev/HiGHS.jl.git@3fae2ee8d6ea22009532d5919ff592fcbcab0ad9",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "1e15ed2b5a3225b8e89ae1ff6d143f93b95f5a9c"
             },
             "homepage": "https://github.com/jump-dev/HiGHS.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -1421,13 +1443,13 @@
         {
             "name": "StringViews",
             "SPDXID": "SPDXRef-StringViews-354b36f9-a18e-4713-926e-db85100087ba",
-            "versionInfo": "1.3.4",
+            "versionInfo": "1.3.5",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaStrings/StringViews.jl.git@ec4bf39f7d25db401bcab2f11d2929798c0578e5",
+            "downloadLocation": "git+https://github.com/JuliaStrings/StringViews.jl.git@d3c7a06c80622b8404b1105886c732abcb25cc2b",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "118089a4a506d392514fcb37b0f25a23db3d2f44"
+                "packageVerificationCodeValue": "8365cfc231828cc929f41d03517cdb84779bedce"
             },
             "homepage": "https://github.com/JuliaStrings/StringViews.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2022,13 +2044,13 @@
         {
             "name": "ADTypes",
             "SPDXID": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
-            "versionInfo": "1.15.0",
+            "versionInfo": "1.16.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/ADTypes.jl.git@be7ae030256b8ef14a441726c4c37766b90b93a3",
+            "downloadLocation": "git+https://github.com/SciML/ADTypes.jl.git@7927b9af540ee964cc5d1b73293f1eb0b761a3a1",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "ac7537ad1547ca6eadd88f2c9165cbcfe454b42f"
+                "packageVerificationCodeValue": "03af9e283f8210499f8fab2d13521fcaf55a0f55"
             },
             "homepage": "https://github.com/SciML/ADTypes.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2044,13 +2066,13 @@
         {
             "name": "RecursiveArrayTools",
             "SPDXID": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd",
-            "versionInfo": "3.35.0",
+            "versionInfo": "3.36.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/RecursiveArrayTools.jl.git@4dd1a95cc16d5abdccc4eac5faf6bc73904be1a2",
+            "downloadLocation": "git+https://github.com/SciML/RecursiveArrayTools.jl.git@f8726bd5a8b7f5f5d3f6c0ce4793454a599b5243",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "65d8e93538419b6ad8408837f22219729e863909"
+                "packageVerificationCodeValue": "704724b15b15adf8afa61b4efb8bf0beacebc964"
             },
             "homepage": "https://github.com/SciML/RecursiveArrayTools.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2088,13 +2110,13 @@
         {
             "name": "SciMLBase",
             "SPDXID": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
-            "versionInfo": "2.104.0",
+            "versionInfo": "2.107.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/SciMLBase.jl.git@c9dc4c04bcb0146a35dd6af726073c5738b80e3b",
+            "downloadLocation": "git+https://github.com/SciML/SciMLBase.jl.git@1c7fd50df465f0684f04f3a63736eac01999c659",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "a64bad23c3368f73e4147af64fd11e7e1935d3e3"
+                "packageVerificationCodeValue": "e6afe8babfbdc29a5abddc38adda1476335bf3dd"
             },
             "homepage": "https://github.com/SciML/SciMLBase.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2472,13 +2494,13 @@
         {
             "name": "LinearSolve",
             "SPDXID": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae",
-            "versionInfo": "3.23.0",
+            "versionInfo": "3.24.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/LinearSolve.jl.git@22e90c33c5297d6162ee54e2383584849379aa53",
+            "downloadLocation": "git+https://github.com/SciML/LinearSolve.jl.git@d768ff40cc3fe42581708696b24ee65dccc9c6ba",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "7e62e2cca7d16d6f19248a8c69de1d2b8975fb95"
+                "packageVerificationCodeValue": "28d5569902c3801729881b5fee125c45e226a704"
             },
             "homepage": "https://github.com/SciML/LinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3115,13 +3137,13 @@
         {
             "name": "DiffEqBase",
             "SPDXID": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
-            "versionInfo": "6.178.0",
+            "versionInfo": "6.180.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/DiffEqBase.jl.git@52af5ee5af4eb6ca03b3782bf65c1e5fc3024c86",
+            "downloadLocation": "git+https://github.com/SciML/DiffEqBase.jl.git@6f8f25122389ba34e491bdfe143ae16fda37cad3",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "b9cdc8086d3523588810b863833451107ad91d7b"
+                "packageVerificationCodeValue": "29f52589a14bd41b182d4e89bf8f84f9b4b35b90"
             },
             "homepage": "https://github.com/SciML/DiffEqBase.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4575,6 +4597,16 @@
             "spdxElementId": "SPDXRef-NaNMath-77ba4419-2d1f-58cd-9bb1-8ffee604a2e3",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+        },
+        {
+            "spdxElementId": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MathOptIIS-8c4f8055-bd93-4160-a86b-a0c04941dbff"
+        },
+        {
+            "spdxElementId": "SPDXRef-MathOptIIS-8c4f8055-bd93-4160-a86b-a0c04941dbff",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-HiGHS-87dc4568-4c63-4d18-b0c0-bb2238e4078b"
         },
         {
             "spdxElementId": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee",


### PR DESCRIPTION
Update the Julia Manifest.toml to get the latest dependencies.

__Changed packages__
```
  Installing known registries into `~/.julia`
       Added `General` registry to ~/.julia/registries
    Updating registry at `~/.julia/registries/General.toml`
     Cloning git-repo `https://github.com/visr/PackageCompiler.jl`
    Updating git-repo `https://github.com/visr/PackageCompiler.jl`
     Cloning git-repo `https://github.com/julia-vscode/TestItemRunner.jl.git`
    Updating git-repo `https://github.com/julia-vscode/TestItemRunner.jl.git`
    Updating `~/work/Ribasim/Ribasim/Project.toml`
  [47edcb42] ↑ ADTypes v1.15.0 ⇒ v1.16.0
  [87dc4568] ↑ HiGHS v1.18.2 ⇒ v1.19.0
  [aa1ae85d] ↑ JuliaInterpreter v0.10.3 ⇒ v0.10.4
  [7ed4a6bd] ↑ LinearSolve v3.23.0 ⇒ v3.24.0
  [295af30f] ↑ Revise v3.8.0 ⇒ v3.8.1
  [0bca4576] ↑ SciMLBase v2.104.0 ⇒ v2.107.0
    Updating `~/work/Ribasim/Ribasim/Manifest.toml`
  [47edcb42] ↑ ADTypes v1.15.0 ⇒ v1.16.0
  [da1fd8a2] ↑ CodeTracking v1.3.9 ⇒ v2.0.0
  [34da2185] ↑ Compat v4.17.0 ⇒ v4.18.0
  [2b5f629d] ↑ DiffEqBase v6.178.0 ⇒ v6.180.0
  [c87230d0] ↑ FFMPEG v0.4.2 ⇒ v0.4.4
  [87dc4568] ↑ HiGHS v1.18.2 ⇒ v1.19.0
  [aa1ae85d] ↑ JuliaInterpreter v0.10.3 ⇒ v0.10.4
  [7ed4a6bd] ↑ LinearSolve v3.23.0 ⇒ v3.24.0
  [6f1432cf] ↑ LoweredCodeUtils v3.4.2 ⇒ v3.4.3
  [8c4f8055] + MathOptIIS v0.1.0
  [b8f27783] ↑ MathOptInterface v1.42.0 ⇒ v1.42.1
  [731186ca] ↑ RecursiveArrayTools v3.35.0 ⇒ v3.36.0
  [295af30f] ↑ Revise v3.8.0 ⇒ v3.8.1
  [0bca4576] ↑ SciMLBase v2.104.0 ⇒ v2.107.0
  [354b36f9] ↑ StringViews v1.3.4 ⇒ v1.3.5
  [1986cc42] ↑ Unitful v1.23.1 ⇒ v1.24.0
  [b22a6f82] ↑ FFMPEG_jll v4.4.4+1 ⇒ v7.1.1+0
  [0ac62f75] ↑ libass_jll v0.15.2+0 ⇒ v0.17.4+0
⌅ [f8abcde7] ↑ micromamba_jll v1.5.8+0 ⇒ v1.5.12+0
  [1270edf5] ↑ x264_jll v2021.5.5+0 ⇒ v10164.0.1+0
  [dfaa095f] ↑ x265_jll v3.5.0+0 ⇒ v4.1.0+0
        Info Packages marked with ⌅ have new versions available but compatibility constraints restrict them from upgrading. To see why use `status --outdated -m`
        Info We haven't cleaned this depot up for a bit, running Pkg.gc()...
      Active manifest files: 1 found
      Active artifact files: 88 found
      Active scratchspaces: 0 found
     Deleted no artifacts, repos, packages or scratchspaces
```

__Packages still outdated after update__
```
Status `~/work/Ribasim/Ribasim/Project.toml`
⌅ [864edb3b] DataStructures v0.18.22 (<v0.19.0): DataFrames, DiffEqBase, DiffEqCallbacks, Graphs, MathOptInterface, OrdinaryDiffEqCore, SPDX, SortingAlgorithms, StatsBase
⌅ [aea7be01] PrecompileTools v1.2.1 (<v1.3.2): julia
```
<details>
<summary>
All package versions
</summary>

```

ADTypes ────────────────────────── v1.16.0
AbstractTrees ──────────────────── v0.4.5
Accessors ──────────────────────── v0.1.42
Adapt ──────────────────────────── v4.3.0
AliasTables ────────────────────── v1.1.3
Aqua ───────────────────────────── v0.8.13
ArgCheck ───────────────────────── v2.5.0
ArnoldiMethod ──────────────────── v0.4.0
ArrayInterface ─────────────────── v7.19.0
ArrayLayouts ───────────────────── v1.11.2
Arrow ──────────────────────────── v2.8.0
ArrowTypes ─────────────────────── v2.3.0
BasicModelInterface ────────────── v0.1.1
BenchmarkTools ─────────────────── v1.6.0
BitFlags ───────────────────────── v0.1.9
BitIntegers ────────────────────── v0.3.5
BitTwiddlingConvenienceFunctions ─ v0.1.6
BracketingNonlinearSolve ───────── v1.3.0
Bzip2_jll ──────────────────────── v1.0.9+0
CPUSummary ─────────────────────── v0.2.6
CSV ────────────────────────────── v0.10.15
Cairo_jll ──────────────────────── v1.18.5+0
ChainRulesCore ─────────────────── v1.25.2
CloseOpenIntervals ─────────────── v0.1.13
CodeTracking ───────────────────── v2.0.0
CodecBzip2 ─────────────────────── v0.8.5
CodecLz4 ───────────────────────── v0.4.6
CodecZlib ──────────────────────── v0.7.8
CodecZstd ──────────────────────── v0.8.6
ColorSchemes ───────────────────── v3.30.0
ColorTypes ─────────────────────── v0.12.1
ColorVectorSpace ───────────────── v0.11.0
Colors ─────────────────────────── v0.13.1
CommonSolve ────────────────────── v0.2.4
CommonSubexpressions ───────────── v0.3.1
CommonWorldInvalidations ───────── v1.0.0
Compat ─────────────────────────── v4.18.0
Compiler ───────────────────────── v0.1.1
CompositionsBase ───────────────── v0.1.2
ConcreteStructs ────────────────── v0.2.3
ConcurrentUtilities ────────────── v2.5.0
CondaPkg ───────────────────────── v0.2.29
Configurations ─────────────────── v0.17.6
ConstructionBase ───────────────── v1.6.0
Contour ────────────────────────── v0.6.3
CpuId ──────────────────────────── v0.3.1
Crayons ────────────────────────── v4.1.1
DBInterface ────────────────────── v2.6.1
DataAPI ────────────────────────── v1.16.0
DataFrames ─────────────────────── v1.7.0
DataInterpolations ─────────────── v8.3.1
DataStructures ─────────────────── v0.18.22
DataValueInterfaces ────────────── v1.0.0
Dbus_jll ───────────────────────── v1.16.2+0
DelimitedFiles ─────────────────── v1.9.1
DiffEqBase ─────────────────────── v6.180.0
DiffEqCallbacks ────────────────── v4.8.0
DiffResults ────────────────────── v1.1.0
DiffRules ──────────────────────── v1.15.1
DifferentiationInterface ───────── v0.7.3
DisplayAs ──────────────────────── v0.1.6
DocStringExtensions ────────────── v0.9.5
Dualization ────────────────────── v0.6.1
EnumX ──────────────────────────── v1.0.5
EnzymeCore ─────────────────────── v0.8.12
EpollShim_jll ──────────────────── v0.0.20230411+1
ExceptionUnwrapping ────────────── v0.1.11
Expat_jll ──────────────────────── v2.6.5+0
ExprTools ──────────────────────── v0.1.10
ExproniconLite ─────────────────── v0.10.14
FFMPEG ─────────────────────────── v0.4.4
FFMPEG_jll ─────────────────────── v7.1.1+0
FastBroadcast ──────────────────── v0.3.5
FastClosures ───────────────────── v0.3.2
FastPower ──────────────────────── v1.1.3
FileIO ─────────────────────────── v1.17.0
FilePathsBase ──────────────────── v0.9.24
FillArrays ─────────────────────── v1.13.0
FindFirstFunctions ─────────────── v1.4.1
FiniteDiff ─────────────────────── v2.27.0
FixedPointNumbers ──────────────── v0.8.5
Fontconfig_jll ─────────────────── v2.16.0+0
Format ─────────────────────────── v1.3.7
ForwardDiff ────────────────────── v1.0.1
FreeType2_jll ──────────────────── v2.13.4+0
FriBidi_jll ────────────────────── v1.0.17+0
FunctionWrappers ───────────────── v1.1.3
FunctionWrappersWrappers ───────── v0.1.3
Functors ───────────────────────── v0.5.2
GLFW_jll ───────────────────────── v3.4.0+2
GPUArraysCore ──────────────────── v0.2.0
GR ─────────────────────────────── v0.73.17
GR_jll ─────────────────────────── v0.73.17+0
GettextRuntime_jll ─────────────── v0.22.4+0
Glib_jll ───────────────────────── v2.84.3+0
Glob ───────────────────────────── v1.3.1
Graphite2_jll ──────────────────── v1.3.15+0
Graphs ─────────────────────────── v1.13.0
Grisu ──────────────────────────── v1.0.2
HTTP ───────────────────────────── v1.10.17
HarfBuzz_jll ───────────────────── v8.5.1+0
HashArrayMappedTries ───────────── v0.2.0
HiGHS ──────────────────────────── v1.19.0
HiGHS_jll ──────────────────────── v1.11.0+1
IOCapture ──────────────────────── v0.2.5
IfElse ─────────────────────────── v0.1.1
Infiltrator ────────────────────── v1.9.2
Inflate ────────────────────────── v0.1.5
InlineStrings ──────────────────── v1.4.4
IntelOpenMP_jll ────────────────── v2025.2.0+0
InverseFunctions ───────────────── v0.1.17
InvertedIndices ────────────────── v1.3.1
IrrationalConstants ────────────── v0.2.4
IterTools ──────────────────────── v1.10.0
IteratorInterfaceExtensions ────── v1.0.0
JLD2 ───────────────────────────── v0.5.15
JLFzf ──────────────────────────── v0.1.11
JLLWrappers ────────────────────── v1.7.1
JSON ───────────────────────────── v0.21.4
JSON3 ──────────────────────────── v1.14.3
Jieko ──────────────────────────── v0.2.1
JpegTurbo_jll ──────────────────── v3.1.1+0
JuMP ───────────────────────────── v1.27.0
JuliaInterpreter ───────────────── v0.10.4
Krylov ─────────────────────────── v0.10.1
LAME_jll ───────────────────────── v3.100.3+0
LERC_jll ───────────────────────── v4.0.1+0
LLVMOpenMP_jll ─────────────────── v18.1.8+0
LZO_jll ────────────────────────── v2.10.3+0
LaTeXStrings ───────────────────── v1.4.0
Latexify ───────────────────────── v0.16.8
LayoutPointers ─────────────────── v0.1.17
LazilyInitializedFields ────────── v1.3.0
LazyArrays ─────────────────────── v2.6.2
LeftChildRightSiblingTrees ─────── v0.2.1
Libffi_jll ─────────────────────── v3.4.7+0
Libglvnd_jll ───────────────────── v1.7.1+1
Libiconv_jll ───────────────────── v1.18.0+0
Libmount_jll ───────────────────── v2.41.0+0
Libtiff_jll ────────────────────── v4.7.1+0
Libuuid_jll ────────────────────── v2.41.0+0
LicenseCheck ───────────────────── v0.2.2
LineSearch ─────────────────────── v0.1.4
LinearSolve ────────────────────── v3.24.0
LogExpFunctions ────────────────── v0.3.29
LoggingExtras ──────────────────── v1.1.0
LoweredCodeUtils ───────────────── v3.4.3
Lz4_jll ────────────────────────── v1.10.1+0
MKL_jll ────────────────────────── v2025.2.0+0
MacroTools ─────────────────────── v0.5.16
ManualMemory ───────────────────── v0.1.8
MarkdownTables ─────────────────── v1.1.0
MathOptAnalyzer ────────────────── v0.1.0
MathOptIIS ─────────────────────── v0.1.0
MathOptInterface ───────────────── v1.42.1
MaybeInplace ───────────────────── v0.1.4
MbedTLS ────────────────────────── v1.1.9
Measures ───────────────────────── v0.3.2
MetaGraphsNext ─────────────────── v0.7.3
MicroMamba ─────────────────────── v0.1.14
Missings ───────────────────────── v1.2.0
Mocking ────────────────────────── v0.8.1
Moshi ──────────────────────────── v0.3.7
MuladdMacro ────────────────────── v0.2.4
MutableArithmetics ─────────────── v1.6.4
NaNMath ────────────────────────── v1.1.3
NonlinearSolve ─────────────────── v4.10.0
NonlinearSolveBase ─────────────── v1.13.0
NonlinearSolveFirstOrder ───────── v1.6.0
NonlinearSolveQuasiNewton ──────── v1.7.0
NonlinearSolveSpectralMethods ──── v1.2.0
Ogg_jll ────────────────────────── v1.3.6+0
OpenSSL ────────────────────────── v1.5.0
OpenSSL_jll ────────────────────── v3.5.1+0
OpenSpecFun_jll ────────────────── v0.5.6+0
Opus_jll ───────────────────────── v1.5.2+0
OrderedCollections ─────────────── v1.8.1
OrdinaryDiffEqBDF ──────────────── v1.7.0
OrdinaryDiffEqCore ─────────────── v1.26.2
OrdinaryDiffEqDifferentiation ──── v1.10.1
OrdinaryDiffEqLowOrderRK ───────── v1.3.0
OrdinaryDiffEqNonlinearSolve ───── v1.11.0
OrdinaryDiffEqRosenbrock ───────── v1.12.0
OrdinaryDiffEqSDIRK ────────────── v1.4.0
OrdinaryDiffEqTsit5 ────────────── v1.2.0
OteraEngine ────────────────────── v1.1.3
Pango_jll ──────────────────────── v1.56.3+0
Parameters ─────────────────────── v0.12.3
Parsers ────────────────────────── v2.8.3
Pidfile ────────────────────────── v1.3.0
PiecewiseLinearOpt ─────────────── v0.4.2
Pixman_jll ─────────────────────── v0.44.2+0
PkgToSoftwareBOM ───────────────── v0.1.13
PlotThemes ─────────────────────── v3.3.0
PlotUtils ──────────────────────── v1.4.3
Plots ──────────────────────────── v1.40.17
Polyester ──────────────────────── v0.7.18
PolyesterWeave ─────────────────── v0.2.2
PooledArrays ───────────────────── v1.4.3
PreallocationTools ─────────────── v0.4.29
PrecompileTools ────────────────── v1.2.1
Preferences ────────────────────── v1.4.3
PrettyTables ───────────────────── v2.4.0
ProgressLogging ────────────────── v0.1.5
PtrArrays ──────────────────────── v1.3.0
PythonCall ─────────────────────── v0.9.26
Qt6Base_jll ────────────────────── v6.8.2+1
Qt6Declarative_jll ─────────────── v6.8.2+1
Qt6ShaderTools_jll ─────────────── v6.8.2+1
Qt6Wayland_jll ─────────────────── v6.8.2+1
RecipesBase ────────────────────── v1.3.4
RecipesPipeline ────────────────── v0.6.12
RecursiveArrayTools ────────────── v3.36.0
Reexport ───────────────────────── v1.2.2
RegistryInstances ──────────────── v0.1.0
RelocatableFolders ─────────────── v1.0.1
Requires ───────────────────────── v1.3.1
Revise ─────────────────────────── v3.8.1
RuntimeGeneratedFunctions ──────── v0.5.15
SIMDTypes ──────────────────────── v0.1.0
SPDX ───────────────────────────── v0.4.1
SQLite ─────────────────────────── v1.6.1
SQLite_jll ─────────────────────── v3.48.0+0
SciMLBase ──────────────────────── v2.107.0
SciMLJacobianOperators ─────────── v0.1.8
SciMLOperators ─────────────────── v1.4.0
SciMLStructures ────────────────── v1.7.0
ScopedValues ───────────────────── v1.4.0
Scratch ────────────────────────── v1.3.0
SentinelArrays ─────────────────── v1.4.8
Setfield ───────────────────────── v1.1.2
Showoff ────────────────────────── v1.0.3
SimpleBufferStream ─────────────── v1.2.0
SimpleNonlinearSolve ───────────── v2.7.0
SimpleTraits ───────────────────── v0.9.4
SimpleUnPack ───────────────────── v1.1.0
SortingAlgorithms ──────────────── v1.2.1
SparseConnectivityTracer ───────── v1.0.0
SparseMatrixColorings ──────────── v0.4.21
SpecialFunctions ───────────────── v2.5.1
StableRNGs ─────────────────────── v1.0.3
Static ─────────────────────────── v1.2.0
StaticArrayInterface ───────────── v1.8.0
StaticArrays ───────────────────── v1.9.14
StaticArraysCore ───────────────── v1.4.3
Statistics ─────────────────────── v1.11.1
StatsAPI ───────────────────────── v1.7.1
StatsBase ──────────────────────── v0.34.5
StrideArraysCore ───────────────── v0.5.7
StringManipulation ─────────────── v0.4.1
StringViews ────────────────────── v1.3.5
StructArrays ───────────────────── v0.7.1
StructTypes ────────────────────── v1.11.0
SymbolicIndexingInterface ──────── v0.3.42
TZJData ────────────────────────── v1.5.0+2025b
TableTraits ────────────────────── v1.0.1
Tables ─────────────────────────── v1.12.1
TensorCore ─────────────────────── v0.1.1
TerminalLoggers ────────────────── v0.1.7
TestEnv ────────────────────────── v1.102.1
TestItems ──────────────────────── v1.0.0
ThreadingUtilities ─────────────── v0.5.5
TimeZones ──────────────────────── v1.22.0
TimerOutputs ───────────────────── v0.5.29
TranscodingStreams ─────────────── v0.11.3
TruncatedStacktraces ───────────── v1.4.0
URIs ───────────────────────────── v1.6.1
UnPack ─────────────────────────── v1.0.2
UnicodeFun ─────────────────────── v0.4.1
Unitful ────────────────────────── v1.24.0
UnitfulLatexify ────────────────── v1.7.0
UnsafePointers ─────────────────── v1.0.0
Unzip ──────────────────────────── v0.2.0
Vulkan_Loader_jll ──────────────── v1.3.243+0
Wayland_jll ────────────────────── v1.24.0+0
WeakRefStrings ─────────────────── v1.4.2
WorkerUtilities ────────────────── v1.6.1
XZ_jll ─────────────────────────── v5.8.1+0
Xorg_libICE_jll ────────────────── v1.1.2+0
Xorg_libSM_jll ─────────────────── v1.2.6+0
Xorg_libX11_jll ────────────────── v1.8.12+0
Xorg_libXau_jll ────────────────── v1.0.13+0
Xorg_libXcursor_jll ────────────── v1.2.4+0
Xorg_libXdmcp_jll ──────────────── v1.1.6+0
Xorg_libXext_jll ───────────────── v1.3.7+0
Xorg_libXfixes_jll ─────────────── v6.0.1+0
Xorg_libXi_jll ─────────────────── v1.8.3+0
Xorg_libXinerama_jll ───────────── v1.1.6+0
Xorg_libXrandr_jll ─────────────── v1.5.5+0
Xorg_libXrender_jll ────────────── v0.9.12+0
Xorg_libxcb_jll ────────────────── v1.17.1+0
Xorg_libxkbfile_jll ────────────── v1.1.3+0
Xorg_xcb_util_cursor_jll ───────── v0.1.5+0
Xorg_xcb_util_image_jll ────────── v0.4.1+0
Xorg_xcb_util_jll ──────────────── v0.4.1+0
Xorg_xcb_util_keysyms_jll ──────── v0.4.1+0
Xorg_xcb_util_renderutil_jll ───── v0.3.10+0
Xorg_xcb_util_wm_jll ───────────── v0.4.2+0
Xorg_xkbcomp_jll ───────────────── v1.4.7+0
Xorg_xkeyboard_config_jll ──────── v2.44.0+0
Xorg_xtrans_jll ────────────────── v1.6.0+0
Zstd_jll ───────────────────────── v1.5.7+1
eudev_jll ──────────────────────── v3.2.14+0
fzf_jll ────────────────────────── v0.61.1+0
libaom_jll ─────────────────────── v3.12.1+0
libass_jll ─────────────────────── v0.17.4+0
libdecor_jll ───────────────────── v0.2.2+0
libevdev_jll ───────────────────── v1.13.4+0
libfdk_aac_jll ─────────────────── v2.0.4+0
libinput_jll ───────────────────── v1.28.1+0
libpng_jll ─────────────────────── v1.6.50+0
libvorbis_jll ──────────────────── v1.3.8+0
licensecheck_jll ───────────────── v0.3.101+0
micromamba_jll ─────────────────── v1.5.12+0
mtdev_jll ──────────────────────── v1.1.7+0
oneTBB_jll ─────────────────────── v2022.0.0+0
pixi_jll ───────────────────────── v0.41.3+0
x264_jll ───────────────────────── v10164.0.1+0
x265_jll ───────────────────────── v4.1.0+0
xkbcommon_jll ──────────────────── v1.9.2+0
