### PR TITLE
Make convergence finite.

### DIFF
--- a/core/src/callback.jl
+++ b/core/src/callback.jl
@@ -133,7 +133,14 @@ function update_cumulative_flows!(u, t, integrator)::Nothing
     # Update convergence measure
     if hasproperty(cache, :nlsolver)
         @. temp_convergence = abs(cache.nlsolver.cache.atmp / u)
-        convergence .+= temp_convergence / finitemaximum(temp_convergence)
+        @inbounds for I in eachindex(temp_convergence)
+            if !isfinite(temp_convergence[I])
+                temp_convergence[I] = zero(eltype(temp_convergence))
+            end
+        end
+        convergence .+=
+            temp_convergence /
+            finitemaximum(temp_convergence; init = one(eltype(temp_convergence)))
         ncalls[1] += 1
     end
 

--- a/core/test/io_test.jl
+++ b/core/test/io_test.jl
@@ -122,7 +122,7 @@ end
     tbl = Arrow.Table(bytes)
     @test :convergence in Tables.columnnames(tbl)
     @test eltype(tbl.convergence) == Union{Missing, Float64}
-    @test any(isfinite, tbl.convergence)
+    @test all(isfinite, tbl.convergence)
     @test Arrow.getmetadata(tbl) ===
           Base.ImmutableDict("ribasim_version" => ribasim_version)
 
@@ -131,7 +131,7 @@ end
     tbl = Arrow.Table(bytes)
     @test :convergence in Tables.columnnames(tbl)
     @test eltype(tbl.convergence) == Union{Missing, Float64}
-    @test any(isfinite, tbl.convergence)
+    @test all(isfinite, tbl.convergence)
     @test Arrow.getmetadata(tbl) ===
           Base.ImmutableDict("ribasim_version" => ribasim_version)
 


### PR DESCRIPTION
Fixes #2485

The Inf/NaNs were caused by zero values in `atmp` or `u`, this prevents that.