### PR TITLE
Set juliacall env vars for quarto-preview as well

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -48,13 +48,13 @@ quarto-preview = { cmd = "PYTHON_JULIAPKG_PROJECT=$PIXI_PROJECT_ROOT quarto prev
     "quartodoc-build",
     "generate-testmodels",
     "initialize-julia",
-] }
+], env = { "PYTHON_JULIACALL_CHECK_BOUNDS" = "yes", "PYTHON_JULIACALL_HANDLE_SIGNALS" = "yes", "PYTHON_JULIAPKG_OFFLINE" = "yes" } }
 quarto-check = { cmd = "quarto check all", depends-on = ["quartodoc-build"] }
 quarto-render = { cmd = "PYTHON_JULIAPKG_PROJECT=$PIXI_PROJECT_ROOT quarto render docs", depends-on = [
     "quartodoc-build",
     "generate-testmodels",
     "initialize-julia",
-], env = { "PYTHON_JULIACALL_CHECK_BOUNDS" = "yes", "PYTHON_JULIACALL_HANDLE_SIGNALS" = "no", "PYTHON_JULIAPKG_OFFLINE" = "yes" } }
+], env = { "PYTHON_JULIACALL_CHECK_BOUNDS" = "yes", "PYTHON_JULIACALL_HANDLE_SIGNALS" = "yes", "PYTHON_JULIAPKG_OFFLINE" = "yes" } }
 docs = { depends-on = ["quarto-preview"] }
 # Lint
 mypy-ribasim-python = "mypy python/ribasim/ribasim"


### PR DESCRIPTION
Doing this in a fresh clone caused the root Project.toml to be overwritten; see also issue https://github.com/JuliaPy/pyjuliapkg/issues/62.

That lead to errors like:

```
JuliaError: ArgumentError: Package Ribasim not found in current path.
```

Should fix the issue that @simulutions and @Fati-Mon ran into. I tested this in a fresh clone and there it was now fixed.