### PR TITLE
Add `pixi run filter-model`

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -178,10 +178,8 @@ write-allocation-problems = { cmd = "julia --project --check-bounds=yes --thread
     "generate-testmodels",
     "initialize-julia",
 ] }
-migrate-model = { cmd = "python utils/migrate_model.py {{ input_toml }} {{ output_toml }}", args = [
-    "input_toml",
-    "output_toml",
-] }
+migrate-model = "python utils/migrate_model.py"
+filter-model = "python utils/filter_model.py"
 # Release
 github-release = "python utils/github-release.py"
 

--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -330,8 +330,8 @@ class TableModel(FileModel, Generic[TableT]):
     def tablename(cls) -> str:
         """Retrieve tablename based on attached Schema.
 
-        NodeSchema -> Schema
-        TabularRatingCurveStaticSchema -> TabularRatingCurve / Static
+        NodeSchema -> Node
+        TabularRatingCurveStaticSchema -> TabularRatingCurve / static
         """
         cls_string = str(cls.tableschema())
         names: list[str] = re.sub("([A-Z]+)", r" \1", cls_string).split()[:-1]

--- a/python/ribasim/tests/test_input_base.py
+++ b/python/ribasim/tests/test_input_base.py
@@ -15,5 +15,8 @@ def test_tablename():
     cls = nodes.basin.ConcentrationExternal
     assert cls.tablename() == "Basin / concentration_external"
 
-    cls = geometry.link.LinkTable
+    cls = geometry.NodeTable
+    assert cls.tablename() == "Node"
+
+    cls = geometry.LinkTable
     assert cls.tablename() == "Link"

--- a/utils/filter_model.py
+++ b/utils/filter_model.py
@@ -1,0 +1,97 @@
+import argparse
+from pathlib import Path
+
+import pandas as pd
+from ribasim import Model
+
+
+def filter_time_tables(model: Model) -> Model:
+    """
+    Filter all time-based tables to only include rows within the simulation period.
+
+    This function removes all rows from time tables where the time column
+    is outside the range [model.starttime, model.endtime].
+
+    If there is no timestamp on the start or endtime this can affect the results,
+    because there won't be another entry to interpolate with.
+
+    Parameters
+    ----------
+    model : Model
+        The Ribasim model to filter
+
+    Returns
+    -------
+    Model
+        The filtered model
+    """
+    starttime = pd.Timestamp(model.starttime)
+    endtime = pd.Timestamp(model.endtime)
+
+    print(f"Filtering time tables to period: {starttime} to {endtime}")
+
+    total_rows_removed = 0
+
+    # Iterate over all node types in the model
+    for sub in model._nodes():
+        # Iterate over all tables in each node type
+        for table in sub._tables():
+            table_name = table.tablename()
+
+            # Check if the table has data and a time column
+            if table.df is not None and "time" in table.df.columns:
+                original_count = len(table.df)
+
+                # Convert time column to pandas Timestamp for comparison
+                time_col = pd.to_datetime(table.df["time"])
+
+                # Filter rows within the simulation period or with missing time values
+                # Keep rows where time is within range OR time is missing (NaN)
+                mask = (
+                    (time_col >= starttime) & (time_col <= endtime)
+                ) | time_col.isna()
+                filtered_df = table.df[mask].copy()
+
+                rows_removed = original_count - len(filtered_df)
+                if rows_removed > 0:
+                    print(
+                        f"{table_name.ljust(35)} "
+                        f"removed {rows_removed} / {original_count} rows "
+                        f"({rows_removed / original_count * 100:.1f}%)"
+                    )
+                    total_rows_removed += rows_removed
+
+                    # Update the table with filtered data
+                    table.df = filtered_df
+
+    print(f"Total rows removed across all time tables: {total_rows_removed}")
+    return model
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Filter Ribasim model time tables to simulation period."
+    )
+    parser.add_argument("input_toml", help="Path to input TOML file")
+    parser.add_argument(
+        "output_toml",
+        nargs="?",
+        help="Path to output TOML file (defaults to input_toml if not provided)",
+    )
+
+    args = parser.parse_args()
+
+    input_path = Path(args.input_toml)
+    # If no output path is provided, use the input path (in-place modification)
+    output_path = Path(args.output_toml) if args.output_toml else input_path
+
+    model = Model.read(input_path)
+
+    # Filter the time tables
+    filtered_model = filter_time_tables(model)
+
+    filtered_model.write(output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/migrate_model.py
+++ b/utils/migrate_model.py
@@ -1,11 +1,20 @@
 import argparse
+from pathlib import Path
 
 from ribasim import Model
 
 parser = argparse.ArgumentParser(description="Migrate Ribasim model.")
 parser.add_argument("input_toml", help="Path to input TOML file")
-parser.add_argument("output_toml", help="Path to output TOML file")
+parser.add_argument(
+    "output_toml",
+    nargs="?",
+    help="Path to output TOML file (defaults to input_toml if not provided)",
+)
 args = parser.parse_args()
 
-model = Model.read(args.input_toml)
-model.write(args.output_toml)
+input_path = Path(args.input_toml)
+# If no output path is provided, use the input path (in-place modification)
+output_path = Path(args.output_toml) if args.output_toml else input_path
+
+model = Model.read(input_path)
+model.write(output_path)


### PR DESCRIPTION
This utility can be run to avoid some of the pain from https://github.com/Deltares/Ribasim/issues/2550.

It removes all data outside the simulation period. Note that if there is no timestamp on the starttime or endtime this can affect results or break the model. It is just meant as a convenience function for developers, nothing public.

Output looks like this:
```
Filtering time tables to period: 2023-01-20 00:00:00 to 2024-04-27 00:00:00
Basin / time                        removed 6774500 / 7760500 rows (87.3%)
FlowBoundary / time                 removed 45 / 973 rows (4.6%)
LevelBoundary / time                removed 432 / 1360 rows (31.8%)
Total rows removed across all time tables: 6774977
```

I also modified both `filter-model` and `migrate-model` to accept one argument, in which case it will modify the model in place, use with caution.