### PR TITLE
Make all allocation interpolations forward fill

### DIFF
--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -39,42 +39,29 @@ const RibasimCVectorType =
     5 Drainage = 6 Precipitation = 7 SurfaceRunoff = 8
 Base.to_index(id::Substance.T) = Int(id)  # used to index into concentration matrices
 
+const node_type_map::Dict{NodeType.T, Symbol} = Dict(
+    NodeType.Basin => :basin,
+    NodeType.TabulatedRatingCurve => :tabulated_rating_curve,
+    NodeType.Pump => :pump,
+    NodeType.Outlet => :outlet,
+    NodeType.UserDemand => :user_demand,
+    NodeType.FlowDemand => :flow_demand,
+    NodeType.LevelDemand => :level_demand,
+    NodeType.FlowBoundary => :flow_boundary,
+    NodeType.LevelBoundary => :level_boundary,
+    NodeType.LinearResistance => :linear_resistance,
+    NodeType.ManningResistance => :manning_resistance,
+    NodeType.Terminal => :terminal,
+    NodeType.Junction => :junction,
+    NodeType.DiscreteControl => :discrete_control,
+    NodeType.ContinuousControl => :continuous_control,
+    NodeType.PidControl => :pid_control,
+)
+
 function config.snake_case(nt::NodeType.T)::Symbol
-    if nt == NodeType.Basin
-        return :basin
-    elseif nt == NodeType.TabulatedRatingCurve
-        return :tabulated_rating_curve
-    elseif nt == NodeType.Pump
-        return :pump
-    elseif nt == NodeType.Outlet
-        return :outlet
-    elseif nt == NodeType.UserDemand
-        return :user_demand
-    elseif nt == NodeType.FlowDemand
-        return :flow_demand
-    elseif nt == NodeType.LevelDemand
-        return :level_demand
-    elseif nt == NodeType.FlowBoundary
-        return :flow_boundary
-    elseif nt == NodeType.LevelBoundary
-        return :level_boundary
-    elseif nt == NodeType.LinearResistance
-        return :linear_resistance
-    elseif nt == NodeType.ManningResistance
-        return :manning_resistance
-    elseif nt == NodeType.Terminal
-        return :terminal
-    elseif nt == NodeType.Junction
-        return :junction
-    elseif nt == NodeType.DiscreteControl
-        return :discrete_control
-    elseif nt == NodeType.ContinuousControl
-        return :continuous_control
-    elseif nt == NodeType.PidControl
-        return :pid_control
-    else
-        error("Unknown node type: $nt")
-    end
+    out = get(node_type_map, nt, nothing)
+    isnothing(out) && error("Unknown node type: $nt")
+    return out
 end
 
 # Support creating a NodeType enum instance from a symbol or string
@@ -990,12 +977,12 @@ concentration_itp: matrix with timeseries interpolations of concentrations per L
     has_demand_priority::Matrix{Bool} =
         zeros(Bool, length(node_id), length(demand_priorities))
     demand::Matrix{Float64} = zeros(length(node_id), length(demand_priorities))
-    demand_interpolation::Vector{Vector{ScalarLinearInterpolation}} =
-        trivial_linear_itp_fill(demand_priorities, node_id)
+    demand_interpolation::Vector{Vector{ScalarConstantInterpolation}} =
+        trivial_allocation_itp_fill(demand_priorities, node_id)
     demand_from_timeseries::Vector{Bool} = Vector{Bool}(undef, length(node_id))
     allocated::Matrix{Float64} = fill(Inf, length(node_id), length(demand_priorities))
-    return_factor::Vector{ScalarLinearInterpolation} =
-        Vector{ScalarLinearInterpolation}(undef, length(node_id))
+    return_factor::Vector{ScalarConstantInterpolation} =
+        Vector{ScalarConstantInterpolation}(undef, length(node_id))
     min_level::Vector{Float64} = zeros(length(node_id))
     concentration_itp::Vector{Vector{ScalarConstantInterpolation}}
 end
@@ -1018,10 +1005,10 @@ storage_demand: The storage change each Basin needs to reach the [min, max] wind
     demand_priorities::Vector{Int32} = []
     has_demand_priority::Matrix{Bool} =
         zeros(Bool, length(node_id), length(demand_priorities))
-    min_level::Vector{Vector{ScalarLinearInterpolation}} =
-        trivial_linear_itp_fill(demand_priorities, node_id; val = NaN)
-    max_level::Vector{Vector{ScalarLinearInterpolation}} =
-        trivial_linear_itp_fill(demand_priorities, node_id; val = NaN)
+    min_level::Vector{Vector{ScalarConstantInterpolation}} =
+        trivial_allocation_itp_fill(demand_priorities, node_id; val = NaN)
+    max_level::Vector{Vector{ScalarConstantInterpolation}} =
+        trivial_allocation_itp_fill(demand_priorities, node_id; val = NaN)
     basins_with_demand::Vector{Vector{NodeID}} = []
     storage_prev::Dict{NodeID, Float64} = Dict()
     storage_demand::Dict{NodeID, Vector{Float64}} = Dict()
@@ -1041,8 +1028,8 @@ demand: The current demand per FlowDemand node per demand priority (node_idx, de
     inflow_link::Vector{LinkMetadata} = Vector{LinkMetadata}(undef, length(node_id))
     has_demand_priority::Matrix{Bool} =
         zeros(Bool, length(node_id), length(demand_priorities))
-    demand_interpolation::Vector{Vector{ScalarLinearInterpolation}} =
-        trivial_linear_itp_fill(demand_priorities, node_id; val = NaN)
+    demand_interpolation::Vector{Vector{ScalarConstantInterpolation}} =
+        trivial_allocation_itp_fill(demand_priorities, node_id; val = NaN)
     demand::Matrix{Float64} = fill(NaN, length(node_id), length(demand_priorities))
 end
 

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -704,6 +704,7 @@ function ConcentrationData(
                 NodeID(:Basin, first_row.node_id, 0),
                 :concentration;
                 cyclic_time,
+                interpolation_type = LinearInterpolation,
             )
             concentration_external_id["concentration_external.$substance"] = itp
             if any(itp.u .< 0)
@@ -1165,7 +1166,7 @@ function parse_static_demand_data!(
         demand_priority_idx = findsorted(demand_priorities, row.demand_priority)
         node.has_demand_priority[id.idx, demand_priority_idx] = true
         demand_row = coalesce(row.demand, 0.0)
-        demand_interpolation = trivial_linear_itp(; val = demand_row)
+        demand_interpolation = trivial_constant_itp(; val = demand_row)
         node.demand_interpolation[id.idx][demand_priority_idx] = demand_interpolation
         node.demand[id.idx, demand_priority_idx] = demand_row
     end
@@ -1261,9 +1262,9 @@ function parse_static_demand_data!(
         demand_priority_idx = findsorted(demand_priorities, row.demand_priority)
         level_demand.has_demand_priority[id.idx, demand_priority_idx] = true
         level_demand.min_level[id.idx][demand_priority_idx] =
-            trivial_linear_itp(; val = coalesce(row.min_level, -Inf))
+            trivial_constant_itp(; val = coalesce(row.min_level, -Inf))
         level_demand.max_level[id.idx][demand_priority_idx] =
-            trivial_linear_itp(; val = coalesce(row.max_level, Inf))
+            trivial_constant_itp(; val = coalesce(row.max_level, Inf))
     end
     return nothing
 end

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -71,7 +71,7 @@ function get_scalar_interpolation(
     node_id::NodeID,
     param::Symbol;
     default_value::Float64 = 0.0,
-    interpolation_type::Type{<:AbstractInterpolation} = LinearInterpolation,
+    interpolation_type::Type{<:AbstractInterpolation} = ConstantInterpolation,
     cyclic_time::Bool = false,
 )::interpolation_type
     rows = searchsorted(time.node_id, node_id)
@@ -1154,16 +1154,16 @@ function eval_time_interp(
     end
 end
 
-function trivial_linear_itp(; val = 0.0)
-    LinearInterpolation([val, val], [0.0, 1.0]; extrapolation = ConstantExtrapolation)
+function trivial_constant_itp(; val = 0.0)
+    ConstantInterpolation([val, val], [0.0, 1.0]; extrapolation = ConstantExtrapolation)
 end
 
-function trivial_linear_itp_fill(
+function trivial_allocation_itp_fill(
     demand_priorities,
     node_id;
     val = 0.0,
-)::Vector{Vector{ScalarLinearInterpolation}}
-    return [fill(trivial_linear_itp(; val), length(demand_priorities)) for _ in node_id]
+)::Vector{Vector{ScalarConstantInterpolation}}
+    return [fill(trivial_constant_itp(; val), length(demand_priorities)) for _ in node_id]
 end
 
 function finitemaximum(u::AbstractVector; init = 0)

--- a/core/src/validation.jl
+++ b/core/src/validation.jl
@@ -347,7 +347,7 @@ end
 
 function valid_demand(
     node_id::Vector{NodeID},
-    demand_interpolation::Vector{Vector{ScalarLinearInterpolation}},
+    demand_interpolation::Vector{Vector{ScalarConstantInterpolation}},
     demand_priorities::Vector{Int32},
 )::Bool
     errors = false
@@ -722,9 +722,9 @@ function validate_consistent_basin_initialization(
 end
 
 function invalid_nested_interpolation_times(
-    interpolations_min::Vector{ScalarLinearInterpolation};
-    interpolations_max::Vector{ScalarLinearInterpolation} = fill(
-        trivial_linear_itp(; val = Inf),
+    interpolations_min::Vector{ScalarConstantInterpolation};
+    interpolations_max::Vector{ScalarConstantInterpolation} = fill(
+        trivial_constant_itp(; val = Inf),
         length(interpolations_min),
     ),
 )::Vector{Float64}

--- a/core/test/bmi_test.jl
+++ b/core/test/bmi_test.jl
@@ -99,18 +99,12 @@ end
     model = Ribasim.Model(config)
     demand = BMI.get_value_ptr(model, "user_demand.demand")
     inflow = BMI.get_value_ptr(model, "user_demand.cumulative_inflow")
-    # One year in seconds
-    year = model.integrator.p.p_independent.user_demand.demand_interpolation[2][1].t[2]
-    demand_start = 1e-3
-    slope = 1e-3 / year
     day = 86400.0
-    BMI.update_until(model, day)
-    @test inflow ≈ [demand_start * day, demand_start * day + 0.5 * slope * day^2] atol =
-        1e-3
-    demand_later = 2e-3
-    demand[1] = demand_later
     BMI.update_until(model, 2day)
-    @test inflow[1] ≈ demand_start * day + demand_later * day atol = 1e-3
+    @test inflow ≈ [2e-3 * day, 3e-3 * day] atol = 1e-3
+    demand[1] = 3e-3
+    BMI.update_until(model, 3day)
+    @test inflow[1] ≈ 5e-3 * day atol = 2e-3
 end
 
 @testitem "vertical basin flux" begin

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -392,7 +392,7 @@ end
     # dynamic UserDemand withdraws to 0.5m or 500m3 due to min level = 0.5
     BMI.update_until(model, 220day)
     formulate_storages!(u, p, t)
-    @test only(state_time_dependent_cache.current_storage) ≈ 500 atol = 1
+    @test only(state_time_dependent_cache.current_storage) ≈ 500 atol = 2
 
     # Trasient return factor
     flow = DataFrame(Ribasim.flow_data(model))

--- a/core/test/validation_test.jl
+++ b/core/test/validation_test.jl
@@ -298,7 +298,7 @@ end
 
 @testitem "negative demand" begin
     using Logging
-    using DataInterpolations: LinearInterpolation
+    using DataInterpolations: ConstantInterpolation
     using DataInterpolations.ExtrapolationType: Constant
     using Ribasim: NodeID, valid_demand
 
@@ -307,7 +307,7 @@ end
     with_logger(logger) do
         node_id = [NodeID(:UserDemand, 1, 1)]
         demand_interpolation =
-            [[LinearInterpolation([-5.0, -5.0], [-1.8, 1.8]; extrapolation = Constant)]]
+            [[ConstantInterpolation([-5.0, -5.0], [-1.8, 1.8]; extrapolation = Constant)]]
         demand_priorities = Int32[1]
         @test !valid_demand(node_id, demand_interpolation, demand_priorities)
     end
@@ -517,28 +517,28 @@ end
 
 @testitem "nested interpolations" begin
     using Ribasim: invalid_nested_interpolation_times
-    using DataInterpolations: LinearInterpolation, ExtrapolationType
+    using DataInterpolations: ConstantInterpolation, ExtrapolationType
 
     t = [1.0, 2.0, 3.0, 4.0]
     u1 = [1.0, 2.0, 3.0, 4.0]
     u2 = [6.0, 5.0, 4.0, 3.0]
 
-    interpolations_min = [LinearInterpolation(u1, t)]
-    interpolations_max = [LinearInterpolation(u2, t)]
+    interpolations_min = [ConstantInterpolation(u1, t)]
+    interpolations_max = [ConstantInterpolation(u2, t)]
 
     @test invalid_nested_interpolation_times(interpolations_min; interpolations_max) ==
           [4.0]
 
     extrapolation = ExtrapolationType.Linear
     interpolations_min = [
-        LinearInterpolation([0.88, 1.18], [0.3, 0.8]; extrapolation),
-        LinearInterpolation([1.1, 1.15], [0.1, 0.15]; extrapolation),
+        ConstantInterpolation([0.88, 1.18], [0.3, 0.8]; extrapolation),
+        ConstantInterpolation([1.1, 1.2], [0.1, 0.15]; extrapolation),
     ]
     @test isempty(invalid_nested_interpolation_times(interpolations_min))
 
     interpolations_max = [
-        LinearInterpolation([9.92, 9.901], [0.8, 0.99]; extrapolation),
-        LinearInterpolation([5.6488, 5.3976], [0.314, 0.628]; extrapolation),
+        ConstantInterpolation([9.92, 9.901], [0.8, 0.99]; extrapolation),
+        ConstantInterpolation([5.6488, 5.3976], [0.314, 0.628]; extrapolation),
     ]
     @test isempty(
         invalid_nested_interpolation_times(interpolations_min; interpolations_max),

--- a/docs/reference/node/flow-demand.qmd
+++ b/docs/reference/node/flow-demand.qmd
@@ -19,7 +19,9 @@ demand          | Float64  | $\text{m}^3/\text{s}$ | non-negative
 ## Time
 
 This table is the transient form of the `FlowDemand` table, in which a time-dependent demand can be supplied.
-Similar to the static version, only a single priority per `FlowDemand` node can be provided.
+With this the demand can be updated over time. In between the given times the
+demand is interpolated with forward fill (block interpolation), and outside the demand is constant given by the
+nearest time value. The allocation algorithm evaluates the interpolation at the start of the allocation time step.
 
 column          | type     | unit                  | restriction
 --------------- | -------- | --------------------- | -----------

--- a/docs/reference/node/level-demand.qmd
+++ b/docs/reference/node/level-demand.qmd
@@ -27,6 +27,10 @@ demand_priority | Int32   | -            | positive
 ## Time
 
 This table is the transient form of the `LevelDemand` table, in which time-dependent minimum and maximum levels can be supplied.
+With this the levels can be updated over time. In between the given times the
+levels are interpolated with forward fill (block interpolation), and outside the demand is constant given by the
+nearest time value. The allocation algorithm evaluates the interpolation at the end of the allocation time step
+(notice the difference with demand interpolation evaluation for user demand and flow demand!).
 
 column          | type     | unit         | restriction
 --------------- | -------  | ------------ | -----------

--- a/docs/reference/node/user-demand.qmd
+++ b/docs/reference/node/user-demand.qmd
@@ -35,9 +35,9 @@ demand_priority | Int32   | -                     | positive
 
 This table is the transient form of the `UserDemand` table.
 The only difference is that a time column is added and activity is assumed to be true.
-With this the demand can be updated over time. In between the given times the
-demand is interpolated linearly, and outside the demand is constant given by the
-nearest time value.
+With this the demand and return factor can be updated over time. In between the given times the
+values are interpolated with forward fill (block interpolation), and outside the demand is constant given by the
+nearest time value. The allocation algorithm evaluates the interpolation at the start of the allocation time step.
 The `demand_priority` is not allowed to change over time.
 Note that a `node_id` can be either in this table or in the static one, but not both.
 

--- a/python/ribasim_testmodels/ribasim_testmodels/allocation.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/allocation.py
@@ -73,15 +73,15 @@ def user_demand_model() -> Model:
         Node(4, Point(1, 0)),
         [
             user_demand.Time(
-                time=[
-                    "2020-08-01 00:00:00",
-                    "2020-09-01 00:00:00",
-                    "2020-10-01 00:00:00",
-                    "2020-11-01 00:00:00",
-                ],
+                time=list(pd.date_range(start="2020-08-01", end="2020-09-01"))
+                + list(pd.date_range(start="2020-10-01", end="2020-11-01")),
+                demand=np.concatenate(
+                    [np.linspace(0.0, 1e-4, num=32), np.linspace(2e-4, 0.0, num=32)]
+                ),
                 min_level=0.0,
-                demand=[0.0, 1e-4, 2e-4, 0.0],
-                return_factor=[0.0, 0.1, 0.2, 0.3],
+                return_factor=np.concatenate(
+                    [np.linspace(0.0, 0.1, num=32), np.linspace(0.2, 0.3, num=32)]
+                ),
                 demand_priority=1,
             )
         ],
@@ -352,7 +352,7 @@ def minimal_subnetwork_model() -> Model:
         Node(6, Point(1, 4), subnetwork_id=2),
         [
             user_demand.Time(
-                time=["2020-01-01", "2021-01-01"],
+                time=["2020-01-01", "2020-01-02"],
                 demand=[1e-3, 2e-3],
                 return_factor=0.9,
                 min_level=0.9,
@@ -1669,8 +1669,8 @@ def multiple_source_priorities_model() -> Model:
         [
             user_demand.Time(
                 demand_priority=2,
-                time=["2020-01-01", "2021-01-01"],
-                demand=[0.0, 3.0],
+                time=pd.date_range(start="2020-01-01", end="2021-01-01"),
+                demand=np.linspace(0.0, 3.0, num=367),
                 return_factor=0,
                 min_level=0,
             )


### PR DESCRIPTION
Fixes [#2502](https://github.com/Deltares/Ribasim/issues/2502)

- UserDemand/FlowDemand interpolations are evaluated at start of allocation time step, LevelDemand level interpolations are evaluated at the end of the allocation time step
- Documentation was updated, with indication when the interpolations are evaluated