### PR TITLE
Reset `ribasim_version` in `model_post_init`

### DIFF
--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -188,7 +188,9 @@ class Model(FileModel):
         # However, we always want to write `input_dir`, `results_dir`, and `ribasim_version`
         # By overriding `BaseModel.model_post_init` we can set them explicitly,
         # and enforce that they are always written.
-        self.model_fields_set.update({"input_dir", "results_dir", "ribasim_version"})
+        # Since migration runs on reading, the ribasim_version should be reset.
+        self.ribasim_version = ribasim.__version__
+        self.model_fields_set.update({"input_dir", "results_dir"})
         self.edge = self.link  # Backwards compatible alias for link
 
     def __repr__(self) -> str:

--- a/python/ribasim/tests/test_model.py
+++ b/python/ribasim/tests/test_model.py
@@ -5,6 +5,7 @@ import datacompy
 import numpy as np
 import pandas as pd
 import pytest
+import ribasim
 import tomli
 import tomli_w
 import xugrid
@@ -387,7 +388,16 @@ def test_version_mismatch_warning_newer_version(basic, tmp_path):
         UserWarning,
         match="version in the TOML file.*3030.1.0.*is newer than the Python package version",
     ):
-        Model.read(toml_path)
+        model = Model.read(toml_path)
+
+    # Check that the version is reset correctly
+    assert model.ribasim_version == ribasim.__version__
+
+    # Check that the TOML file contains the correct version
+    model._write_toml(toml_path)
+    with open(toml_path, "rb") as f:
+        config = tomli.load(f)
+    assert config["ribasim_version"] == ribasim.__version__
 
 
 def test_invalid_version_string_warning(basic, tmp_path):


### PR DESCRIPTION
I noticed that when reading in old models with Ribasim Python, with an old `ribasim_version` in the TOML, this version was preserved by Ribasim Python. This isn't correct, since when we read in the model, we run the migration code automatically, so we should reset this key.

This does that, and tests that it is set in memory and written to the TOML.
