### PR TITLE
Convert path to str with `.as_posix()`

### DIFF
--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -32,6 +32,7 @@ from pydantic import (
     Field,
     PrivateAttr,
     ValidationInfo,
+    field_serializer,
     field_validator,
     model_serializer,
     model_validator,
@@ -243,6 +244,10 @@ class FileModel(BaseModel, ABC):
         self.filepath = filepath
         self.model_config["validate_assignment"] = True
 
+    @field_serializer("filepath")
+    def _serialize_path(self, path: Path) -> str:
+        return path.as_posix()
+
     @classmethod
     @abstractmethod
     def _load(cls, filepath: Path | None) -> dict[str, Any]:
@@ -325,7 +330,7 @@ class TableModel(FileModel, Generic[TableT]):
 
     @model_serializer
     def _set_model(self) -> "str | None":
-        return str(self.filepath.name) if self.filepath is not None else None
+        return self.filepath.as_posix() if self.filepath is not None else None
 
     @classmethod
     def tablename(cls) -> str:

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -181,7 +181,7 @@ class Model(FileModel):
 
     @field_serializer("input_dir", "results_dir")
     def _serialize_path(self, path: Path) -> str:
-        return str(path)
+        return path.as_posix()
 
     def model_post_init(self, __context: Any) -> None:
         # When serializing we exclude fields that are set to their default values

--- a/python/ribasim/tests/conftest.py
+++ b/python/ribasim/tests/conftest.py
@@ -62,3 +62,8 @@ def trivial() -> ribasim.Model:
 @pytest.fixture()
 def tabulated_rating_curve_control() -> ribasim.Model:
     return ribasim_testmodels.tabulated_rating_curve_control_model()
+
+
+@pytest.fixture()
+def drought() -> ribasim.Model:
+    return ribasim_testmodels.drought_model()

--- a/python/ribasim/tests/test_model.py
+++ b/python/ribasim/tests/test_model.py
@@ -415,3 +415,17 @@ def test_invalid_version_string_warning(basic, tmp_path):
         match="version in the TOML file.*invalid_version_string.*does not match the Python package version",
     ):
         Model.read(toml_path)
+
+
+def test_path_serialization_uses_forward_slashes(drought, tmp_path):
+    """Test that paths in TOML files always use forward slashes for cross-platform compatibility."""
+    model = drought
+    toml_path = tmp_path / "ribasim.toml"
+    model.write(toml_path)
+
+    with open(toml_path, "rb") as f:
+        config = tomli.load(f)
+
+    assert config["input_dir"] == "nested/input"
+    assert config["results_dir"] == "nested/results"
+    assert config["basin"]["time"] == "subdir/basin-time.nc"

--- a/python/ribasim_testmodels/ribasim_testmodels/basic.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/basic.py
@@ -471,11 +471,14 @@ def cyclic_time_model() -> Model:
 
 def drought_model() -> Model:
     """Create a small subsection of the LHM Vechtstromen model containing a basin that runs dry (#2189)."""
+    # Use backslashes and nested paths to test path normalization and nested dirs
+
     model = Model(
         starttime="2020-01-01 00:00:00",
         endtime="2021-01-01 00:00:00",
         crs="EPSG:28992",
-        input_dir=Path("input"),
+        input_dir=Path("nested\\input"),
+        results_dir=Path("nested/results"),
     )
 
     model.basin.add(
@@ -579,7 +582,7 @@ def drought_model() -> Model:
     model.link.add(model.basin[2189], model.manning_resistance[1237])
     model.link.add(model.basin[1558], model.manning_resistance[1238])
 
-    model.basin.time.set_filepath(Path("basin-time.nc"))
+    model.basin.time.set_filepath(Path("subdir\\basin-time.nc"))
 
     return model
 


### PR DESCRIPTION
Fixes #2570, for `input_dir`, `results_dir` and external arrow / netcdf tables with `set_filepath`.

In doing this I noticed and fixed another bug, that if you do e.g. 

```py
model.basin.time.set_filepath(Path("subdir\\basin-time.nc"))
```

It would write the NetCDF in the right location, but the TOML path was only `"basin-time.nc"` rather than `"subdir/basin-time.nc"`. That is now fixed by changing `path.name` to `as_posix()` as well.