### PR TITLE
Update typing in Ribasim Python

### DIFF
--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -292,6 +292,7 @@ class MultiNodeModel(NodeModel):
                 f"You can only add to a {self._node_type} MultiNodeModel when attached to a Model."
             )
 
+        assert hasattr(self._parent, "_used_node_ids")
         if node_id is None:
             node_id = self._parent._used_node_ids.new_id()
         elif node_id in self._parent._used_node_ids:
@@ -299,6 +300,7 @@ class MultiNodeModel(NodeModel):
                 f"Node IDs have to be unique, but {node_id} already exists."
             )
 
+        assert hasattr(self._parent, "crs")
         for table in tables:
             member_name = _pascal_to_snake(table.__class__.__name__)
             existing_member = getattr(self, member_name)

--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -200,7 +200,7 @@ class Node(pydantic.BaseModel):
 
     Attributes
     ----------
-    node_id : Optional[NonNegativeInt]
+    node_id : NonNegativeInt | None
         Integer ID of the node. Must be unique for the model.
     geometry : shapely.geometry.Point
         The coordinates of the node.

--- a/python/ribasim/ribasim/geometry/base.py
+++ b/python/ribasim/ribasim/geometry/base.py
@@ -1,4 +1,4 @@
-from typing import Any, get_type_hints
+from typing import get_type_hints
 
 import pandera as pa
 from geopandas import GeoSeries as _GeoSeries
@@ -10,12 +10,12 @@ from ribasim.schemas import _BaseSchema
 
 class _GeoBaseSchema(_BaseSchema):
     @pa.check("geometry")
-    def is_correct_geometry_type(cls, geoseries: GeoSeries[Any]) -> Series[bool]:
+    def is_correct_geometry_type(cls, geoseries: GeoSeries[object]) -> Series[bool]:
         T = get_type_hints(cls)["geometry"].__args__[0]
         return geoseries.map(lambda geom: isinstance(geom, T))
 
     @pa.parser("geometry")
-    def force_2d(cls, geometry: GeoSeries[Any]) -> GeoSeries[Any]:
+    def force_2d(cls, geometry: GeoSeries[object]) -> GeoSeries[object]:
         if isinstance(geometry, _GeoSeries):
             # Pandera requires GeoSeries to have a name
             return GeoSeries(geometry.force_2d(), name=geometry.name)

--- a/python/ribasim/ribasim/geometry/link.py
+++ b/python/ribasim/ribasim/geometry/link.py
@@ -1,5 +1,5 @@
+from dataclasses import dataclass
 from pathlib import Path
-from typing import NamedTuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -37,7 +37,8 @@ SPATIALCONTROLNODETYPES = {
 }
 
 
-class NodeData(NamedTuple):
+@dataclass
+class NodeData:
     node_id: int
     node_type: str
     geometry: Point

--- a/python/ribasim/ribasim/geometry/node.py
+++ b/python/ribasim/ribasim/geometry/node.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import geopandas as gpd
 import matplotlib.pyplot as plt
 import numpy as np
@@ -45,7 +43,9 @@ class NodeTable(SpatialTableModel[NodeSchema]):
             mask = self.df[self.df["node_type"] != nodetype].index
             self.df.drop(mask, inplace=True)
 
-    def plot_allocation_networks(self, ax=None, zorder=None) -> Any:
+    def plot_allocation_networks(
+        self, ax=None, zorder=None
+    ) -> tuple[list[Patch], list[str]]:
         if ax is None:
             _, ax = plt.subplots()
             ax.axis("off")
@@ -85,7 +85,7 @@ class NodeTable(SpatialTableModel[NodeSchema]):
 
         return handles, labels
 
-    def plot(self, ax=None, zorder=None) -> Any:
+    def plot(self, ax=None, zorder=None) -> plt.Axes:
         """
         Plot the nodes. Each node type is given a separate marker.
 
@@ -142,7 +142,7 @@ class NodeTable(SpatialTableModel[NodeSchema]):
             "": "k",
         }
         if self.df is None:
-            return
+            return ax
 
         for nodetype, df in self.df.groupby("node_type"):
             assert isinstance(nodetype, str)

--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -7,10 +7,7 @@ from contextlib import closing
 from contextvars import ContextVar
 from pathlib import Path
 from sqlite3 import connect
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
-
-if TYPE_CHECKING:
-    from ribasim.model import Model
+from typing import Any, Generic, TypeVar, cast
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
@@ -598,7 +595,7 @@ class SpatialTableModel(TableModel[TableT], Generic[TableT]):
 
 
 class ChildModel(BaseModel):
-    _parent: "Model | None" = None
+    _parent: BaseModel | None = None
     _parent_field: str | None = None
 
     @model_validator(mode="after")

--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -7,12 +7,10 @@ from contextlib import closing
 from contextvars import ContextVar
 from pathlib import Path
 from sqlite3 import connect
-from typing import (
-    Any,
-    Generic,
-    TypeVar,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
+
+if TYPE_CHECKING:
+    from ribasim.model import Model
 
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
@@ -70,10 +68,10 @@ node_names_snake_case = [
     "user_demand",
 ]
 
-context_file_loading: ContextVar[dict[str, Any]] = ContextVar(
+context_file_loading: ContextVar[dict[str, Path]] = ContextVar(
     "file_loading", default={}
 )
-context_file_writing: ContextVar[dict[str, Any]] = ContextVar(
+context_file_writing: ContextVar[dict[str, Path]] = ContextVar(
     "file_writing", default={}
 )
 
@@ -96,7 +94,7 @@ class BaseModel(PydanticBaseModel):
         """Return the names of the fields contained in the Model."""
         return list(cls.model_fields.keys())
 
-    def model_dump(self, **kwargs) -> dict[str, Any]:
+    def model_dump(self, **kwargs) -> dict[str, object]:
         return super().model_dump(serialize_as_any=True, **kwargs)
 
     def diff(
@@ -132,7 +130,7 @@ class BaseModel(PydanticBaseModel):
             raise ValueError(f"Cannot compare {self} with {other}")
         if self == other:
             return None
-        data = {}
+        data: dict[str, Any] = {}
         for key in self._fields():
             self_attr = getattr(self, key)
             other_attr = getattr(other, key)
@@ -150,7 +148,7 @@ class BaseModel(PydanticBaseModel):
     # __eq__ from Pydantic BaseModel itself, edited to remove the comparison of private attrs
     # https://github.com/pydantic/pydantic/blob/ff3789d4cc06ee024b7253b919d3e36748a72829/pydantic/main.py#L1069
     # The MIT License (MIT) | Copyright (c) 2017 to present Pydantic Services Inc. and individual contributors.
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, BaseModel):
             self_type = self.__pydantic_generic_metadata__["origin"] or self.__class__
             other_type = (
@@ -213,7 +211,7 @@ class FileModel(BaseModel, ABC):
 
     @model_validator(mode="before")
     @classmethod
-    def _check_filepath(cls, value: Any) -> Any:
+    def _check_filepath(cls, value: object) -> object:
         # Enable initialization with a Path.
         if isinstance(value, dict):
             # Pydantic Model init requires a dict
@@ -250,7 +248,7 @@ class FileModel(BaseModel, ABC):
 
     @classmethod
     @abstractmethod
-    def _load(cls, filepath: Path | None) -> dict[str, Any]:
+    def _load(cls, filepath: Path | None) -> dict[str, object]:
         """Load the data at filepath and returns it as a dictionary.
 
         If a derived FileModel does not load data from disk, this should
@@ -271,7 +269,7 @@ class TableModel(FileModel, Generic[TableT]):
     df: DataFrame[TableT] | None = Field(default=None, exclude=True, repr=False)
     _sort_keys: list[str] = PrivateAttr(default=[])
 
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, TableModel):
             if self.df is None and other.df is None:
                 return True
@@ -355,7 +353,7 @@ class TableModel(FileModel, Generic[TableT]):
 
     @model_validator(mode="before")
     @classmethod
-    def _check_dataframe(cls, value: Any) -> Any:
+    def _check_dataframe(cls, value: object) -> object:
         # Enable initialization with a Dict.
         if isinstance(value, dict) and len(value) > 0 and "df" not in value:
             value = DataFrame(dict(**value))
@@ -374,7 +372,7 @@ class TableModel(FileModel, Generic[TableT]):
         return node_ids
 
     @classmethod
-    def _load(cls, filepath: Path | None) -> dict[str, Any]:
+    def _load(cls, filepath: Path | None) -> dict[str, object]:
         db = context_file_loading.get().get("database")
         if filepath is not None and db is not None:
             suffix = filepath.suffix.lower()
@@ -600,12 +598,12 @@ class SpatialTableModel(TableModel[TableT], Generic[TableT]):
 
 
 class ChildModel(BaseModel):
-    _parent: Any | None = None
+    _parent: "Model | None" = None
     _parent_field: str | None = None
 
     @model_validator(mode="after")
     def _check_parent(self) -> "ChildModel":
-        if self._parent is not None:
+        if self._parent is not None and self._parent_field is not None:
             self._parent.model_fields_set.update({self._parent_field})
         return self
 
@@ -615,14 +613,14 @@ class NodeModel(ChildModel):
 
     @model_serializer(mode="wrap")
     def set_modeld(
-        self, serializer: Callable[["NodeModel"], dict[str, Any]]
-    ) -> dict[str, Any]:
+        self, serializer: Callable[["NodeModel"], dict[str, object]]
+    ) -> dict[str, object]:
         content = serializer(self)
         return dict(filter(lambda x: x[1], content.items()))
 
     @field_validator("*")
     @classmethod
-    def set_sort_keys(cls, v: Any, info: ValidationInfo) -> Any:
+    def set_sort_keys(cls, v: object, info: ValidationInfo) -> object:
         """Set sort keys for all TableModels if present in FieldInfo."""
         if isinstance(v, TableModel):
             field = cls.model_fields[getattr(info, "field_name")]

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -303,7 +303,7 @@ class Model(FileModel):
         )
         return node_table
 
-    def _nodes(self) -> Generator[MultiNodeModel, Any, None]:
+    def _nodes(self) -> Generator[MultiNodeModel, None, None]:
         """Return all non-empty MultiNodeModel instances."""
         for key in self.__class__.model_fields.keys():
             attr = getattr(self, key)
@@ -477,7 +477,7 @@ class Model(FileModel):
         return node_info
 
     @classmethod
-    def _load(cls, filepath: Path | None) -> dict[str, Any]:
+    def _load(cls, filepath: Path | None) -> dict[str, object]:
         context_file_loading.set({})
 
         if filepath is not None and filepath.is_file():


### PR DESCRIPTION
I asked Claude to go over the type annotations, and also update to the syntax supported by our minimum Python version 3.11.

It suggested in several places to use `object` instead of `Any`, the latter bails out of typing. Also it could refine the types of our context variables and generator.