### PR TITLE
Fix empty Arrow results

### DIFF
--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -124,11 +124,6 @@ function write_results_netcdf(model::Model)::Model
     path = results_path(config, RESULTS_FILENAME.allocation)
     write_netcdf(path, data, nothing)
 
-    # allocation control
-    data = allocation_control_data(model; table = false)
-    path = results_path(config, RESULTS_FILENAME.allocation_control)
-    write_netcdf(path, data, nothing)
-
     # exported levels
     data = subgrid_level_data(model; table = false)
     path = results_path(config, RESULTS_FILENAME.subgrid_level)

--- a/core/test/allocation_test.jl
+++ b/core/test/allocation_test.jl
@@ -476,8 +476,13 @@ end
         allocation_bytes = read(normpath(dirname(toml_path), "results/allocation.arrow"))
         allocation_flow_bytes =
             read(normpath(dirname(toml_path), "results/allocation_flow.arrow"))
+        allocation_control_bytes =
+            read(normpath(dirname(toml_path), "results/allocation_control.arrow"))
+
         allocation = Arrow.Table(allocation_bytes)
         allocation_flow = Arrow.Table(allocation_flow_bytes)
+        allocation_control = Arrow.Table(allocation_control_bytes)
+
         @test Tables.schema(allocation) == Tables.Schema(
             (
                 :time,
@@ -519,8 +524,14 @@ end
                 Bool,
             ),
         )
+        @test Tables.schema(allocation_control) == Tables.Schema(
+            (:time, :node_id, :node_type, :flow_rate),
+            (DateTime, Int32, String, Float64),
+        )
+
         @test nrow(allocation) > 0
         @test nrow(allocation_flow) > 0
+        @test nrow(allocation_control) == 0
     end
 end
 

--- a/core/test/run_models_test.jl
+++ b/core/test/run_models_test.jl
@@ -27,11 +27,21 @@
     basin_bytes = read(normpath(dirname(toml_path), "results/basin.arrow"))
     subgrid_bytes = read(normpath(dirname(toml_path), "results/subgrid_level.arrow"))
     solver_stats_bytes = read(normpath(dirname(toml_path), "results/solver_stats.arrow"))
+    control_bytes = read(normpath(dirname(toml_path), "results/control.arrow"))
+    allocation_bytes = read(normpath(dirname(toml_path), "results/allocation.arrow"))
+    allocation_flow_bytes =
+        read(normpath(dirname(toml_path), "results/allocation_flow.arrow"))
+    allocation_control_bytes =
+        read(normpath(dirname(toml_path), "results/allocation_control.arrow"))
 
     flow = Arrow.Table(flow_bytes)
     basin = Arrow.Table(basin_bytes)
     subgrid = Arrow.Table(subgrid_bytes)
     solver_stats = Arrow.Table(solver_stats_bytes)
+    control = Arrow.Table(control_bytes)
+    allocation = Arrow.Table(allocation_bytes)
+    allocation_flow = Arrow.Table(allocation_flow_bytes)
+    allocation_control = Arrow.Table(allocation_control_bytes)
 
     @testset Teamcity.TeamcityTestSet "Schema" begin
         @test Tables.schema(flow) == Tables.Schema(
@@ -96,6 +106,61 @@
                 :dt,
             ),
             (DateTime, Float64, Int, Int, Int, Int, Float64),
+        )
+
+        # empty control and allocation tables should still have the right schema
+        @test nrow(control) == 0
+        @test nrow(allocation) == 0
+        @test nrow(allocation_flow) == 0
+        @test nrow(allocation_control) == 0
+        @test Tables.schema(control) == Tables.Schema(
+            (:time, :control_node_id, :truth_state, :control_state),
+            (DateTime, Int32, String, String),
+        )
+        @test Tables.schema(allocation) == Tables.Schema(
+            (
+                :time,
+                :subnetwork_id,
+                :node_type,
+                :node_id,
+                :demand_priority,
+                :demand,
+                :allocated,
+                :realized,
+            ),
+            (DateTime, Int32, String, Int32, Int32, Float64, Float64, Float64),
+        )
+        @test Tables.schema(allocation_flow) == Tables.Schema(
+            (
+                :time,
+                :link_id,
+                :from_node_type,
+                :from_node_id,
+                :to_node_type,
+                :to_node_id,
+                :subnetwork_id,
+                :flow_rate,
+                :optimization_type,
+                :lower_bound_hit,
+                :upper_bound_hit,
+            ),
+            (
+                DateTime,
+                Int32,
+                String,
+                Int32,
+                String,
+                Int32,
+                Int32,
+                Float64,
+                String,
+                Bool,
+                Bool,
+            ),
+        )
+        @test Tables.schema(allocation_control) == Tables.Schema(
+            (:time, :node_id, :node_type, :flow_rate),
+            (DateTime, Int32, String, Float64),
         )
     end
 

--- a/docs/reference/usage.qmd
+++ b/docs/reference/usage.qmd
@@ -332,6 +332,7 @@ control_state   | String   | -
 
 The allocation table contains a record of allocation results: when it happened, for which node, in which allocation network, and what the demand, allocated flow and realized flow were.
 The realized values at the starting time of the simulation can be ignored.
+
 column           | type     | unit
 ---------------- | -------- | ---------------------
 time             | DateTime | -

--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -387,8 +387,8 @@ class DatasetWidget(QWidget):
         node_layer = self.ribasim_widget.node_layer
         assert node_layer is not None
         path = self._set_results(node_layer, "node_id", "basin.arrow")
-        if path.exists():
-            df = self._add_arrow_layer(path)
+        df = self._add_arrow_layer(path)
+        if df is not None:
             self.basin_layer = self._duplicate_layer(
                 node_layer, "Basin", "node_id", "node_type", "Basin"
             )
@@ -402,8 +402,8 @@ class DatasetWidget(QWidget):
             )
             / "concentration.arrow"
         )
-        if path.exists():
-            df = self._add_arrow_layer(path, postprocess_concentration_arrow)
+        df = self._add_arrow_layer(path, postprocess_concentration_arrow)
+        if df is not None:
             self.concentration_layer = self._duplicate_layer(
                 node_layer, "Concentration", "node_id", "node_type", "Basin"
             )
@@ -421,8 +421,8 @@ class DatasetWidget(QWidget):
             )
             / "allocation.arrow"
         )
-        if path.exists():
-            df = self._add_arrow_layer(path, postprocess_allocation_arrow)
+        df = self._add_arrow_layer(path, postprocess_allocation_arrow)
+        if df is not None:
             self.allocation_layer = self._duplicate_layer(
                 node_layer, "Allocation", "node_id", fids=list(df["node_id"].unique())
             )
@@ -433,8 +433,8 @@ class DatasetWidget(QWidget):
         link_layer = self.ribasim_widget.link_layer
         assert link_layer is not None
         path = self._set_results(link_layer, "link_id", "flow.arrow")
-        if path.exists():
-            df = self._add_arrow_layer(path, postprocess_flow_arrow)
+        df = self._add_arrow_layer(path, postprocess_flow_arrow)
+        if df is not None:
             self.flow_layer = self._duplicate_layer(
                 link_layer, "Flow", "link_id", "link_type", "flow"
             )
@@ -448,8 +448,8 @@ class DatasetWidget(QWidget):
             )
             / "allocation_flow.arrow"
         )
-        if path.exists():
-            df = self._add_arrow_layer(path, postprocess_allocation_flow_arrow)
+        df = self._add_arrow_layer(path, postprocess_allocation_flow_arrow)
+        if df is not None:
             self.allocation_flow_layer = self._duplicate_layer(
                 link_layer,
                 "AllocationFlow",
@@ -518,8 +518,10 @@ class DatasetWidget(QWidget):
         postprocess: Callable[[pd.DataFrame], pd.DataFrame] = lambda df: df.set_index(
             pd.DatetimeIndex(df["time"])
         ),
-    ) -> pd.DataFrame:
+    ) -> pd.DataFrame | None:
         """Add arrow output data to the layer and setup its update mechanism."""
+        if path.exists() is False:
+            return None
         try:
             from pyarrow.feather import read_feather
 
@@ -530,15 +532,8 @@ class DatasetWidget(QWidget):
             stream = dlayer.GetArrowStreamAsNumPy()
             data = stream.GetNextRecordBatch()
             if data is None:
-                # No rows, but we still need the columns so we can groupby
-                # Get column names from the layer definition
-                # Correct dtypes don't matter, object is fine
-                layer_defn = dlayer.GetLayerDefn()
-                columns = [
-                    layer_defn.GetFieldDefn(i).GetName()
-                    for i in range(layer_defn.GetFieldCount())
-                ]
-                df = pd.DataFrame(columns=columns)
+                # Empty arrow file
+                return None
             else:
                 df = pd.DataFrame(data=data)
 

--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -529,7 +529,18 @@ class DatasetWidget(QWidget):
             dlayer = dataset.GetLayer(0)
             stream = dlayer.GetArrowStreamAsNumPy()
             data = stream.GetNextRecordBatch()
-            df = pd.DataFrame(data=data)
+            if data is None:
+                # No rows, but we still need the columns so we can groupby
+                # Get column names from the layer definition
+                # Correct dtypes don't matter, object is fine
+                layer_defn = dlayer.GetLayerDefn()
+                columns = [
+                    layer_defn.GetFieldDefn(i).GetName()
+                    for i in range(layer_defn.GetFieldCount())
+                ]
+                df = pd.DataFrame(columns=columns)
+            else:
+                df = pd.DataFrame(data=data)
 
             # The OGR path introduces strings columns as bytes
             for column in df.columns:


### PR DESCRIPTION
Fixes #2580.

The QGIS Windows standalone installer of our minimum supported QGIS 3.34 does come with pyarrow installed. I tested with 3.14.15, and the reported issues were all with older patch releases. And I see in issues that some older patch releases did have pyarrow related issues.

But as mentioned in https://github.com/Deltares/Ribasim/issues/2580#issuecomment-3302910110, we have a fallback for missing pyarrow, that we don't test. It was broken for empty Arrow tables, since `data` was None in this case, giving us a DataFrame with not only 0 rows (fine) but also 0 columns (bad), which triggered the stacktrace in the issue. This case is now explicitly handled.

After fixing that I ran into another issue, that columns were missing from the allocation result files when allocation was not used. It turned out that recently switching to `getfield.(v, :node_id)` will give us `Any[]`. This is fixed by using StructArrays to handle these Array Of Structs, so we can just use `v.node_id` and get `Int32[]`. To make sure this doesn't regress we now also test the schemas of the empty tables.