### PR TITLE
Add `smooth_clamp` function 

### DIFF
--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -436,7 +436,7 @@ function linear_resistance_flow(
 
     Δh = h_a - h_b
     q_unlimited = Δh / resistance[node_id.idx]
-    q = clamp(q_unlimited, -max_flow_rate[node_id.idx], max_flow_rate[node_id.idx])
+    q = smooth_clamp(q_unlimited, -max_flow_rate[node_id.idx], max_flow_rate[node_id.idx])
     return q * low_storage_factor_resistance_node(p, q_unlimited, inflow_id, outflow_id)
 end
 
@@ -698,7 +698,7 @@ function formulate_pump_or_outlet_flow!(
                 end
             end
         end
-        q = clamp(q, lower_bound, upper_bound)
+        q = smooth_clamp(q, lower_bound, upper_bound)
 
         # Special case for outlet: check level difference
         if reduce_Δlevel

--- a/core/test/utils_test.jl
+++ b/core/test/utils_test.jl
@@ -336,6 +336,14 @@ end
     @test reduction_factor(-Inf, 2.0) === 0.0
 end
 
+@testitem "smooth_clamp" begin
+    using Ribasim: smooth_clamp
+    @test smooth_clamp(2.5, 2.0, 3.0) == 2.5
+    @test smooth_clamp(3.14, -Inf, Inf) == 3.14
+    @test smooth_clamp(1.0, 1.41, 1.41) == 1.41
+    @test smooth_clamp(1.95, 1.0, 2.0) ≈ 1.94375
+end
+
 @testitem "Node types" begin
     using Ribasim:
         node_types,


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/1918. 

The function I implemented is somewhat different than the one suggested in the issue. In the clamp function I replaced the sections on `[lo - d, lo + d]` and `[hi - d, hi + d]` C1 smooth with a quadratic polynomial section, where `d = a (hi - lo) / 2`, so ` 0 <= a <= 1` is the relative smoothing parameter. The only edge case this cannot handle smoothly is when `isinf(lo) xor isinf(hi)`.
I haven't noticed any significant performance improvements with this but it's quite little regret.