### PR TITLE
Catch residuals from OrdinaryDiffEq internals

### DIFF
--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -30,7 +30,7 @@ using DifferentiationInterface:
 using ForwardDiff: derivative as forward_diff
 
 # Algorithms for solving ODEs.
-using OrdinaryDiffEqCore: OrdinaryDiffEqCore, get_du
+using OrdinaryDiffEqCore: OrdinaryDiffEqCore, get_du, calculate_residuals!, ODE_DEFAULT_NORM
 import ForwardDiff
 
 # Interface for defining and solving the ODE problem of the physical layer.

--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -236,6 +236,7 @@ function Model(config::Config)::Model
     integrator = init(
         prob,
         alg;
+        internalnorm = NormWithCache(; cache = zero(u0)),
         progress = true,
         progress_name = "Simulating",
         progress_steps = 100,


### PR DESCRIPTION
See also https://github.com/Deltares/Ribasim/pull/2448/files.

The benefit here is that we catch each computation of the residuals, and do not depend on reaching into an internal cache which might break at some point.