### PR TITLE
QGIS: Always use GDAL instead of pyarrow

### DIFF
--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -523,25 +523,21 @@ class DatasetWidget(QWidget):
         """Add arrow output data to the layer and setup its update mechanism."""
         if path.exists() is False:
             return None
-        try:
-            from pyarrow.feather import read_feather
 
-            df = read_feather(path, memory_map=True)
-        except ImportError:
-            dataset = ogr.Open(path)
-            dlayer = dataset.GetLayer(0)
-            stream = dlayer.GetArrowStreamAsNumPy()
-            data = stream.GetNextRecordBatch()
-            if data is None:
-                # Empty arrow file
-                return None
-            else:
-                df = pd.DataFrame(data=data)
+        dataset = ogr.Open(path)
+        dlayer = dataset.GetLayer(0)
+        stream = dlayer.GetArrowStreamAsNumPy()
+        data = stream.GetNextRecordBatch()
+        if data is None:
+            # Empty arrow file
+            return None
+        else:
+            df = pd.DataFrame(data=data)
 
-            # The OGR path introduces strings columns as bytes
-            for column in df.columns:
-                if df.dtypes[column] == object:  # noqa: E721
-                    df[column] = df[column].str.decode("utf-8")
+        # The OGR path introduces strings columns as bytes
+        for column in df.columns:
+            if df.dtypes[column] == object:  # noqa: E721
+                df[column] = df[column].str.decode("utf-8")
 
         df = postprocess(df)
         self.results[path.stem] = df


### PR DESCRIPTION
We missed https://github.com/Deltares/Ribasim/issues/2580 before the release because all developers have pyarrow in their QGIS, but many/most users do not. So the fallback path was not well tested.

This promotes the old fallback to the only way to load data. I was worried that it would be slower, but I timed both paths to read `lhm_coupled_2025_9_0`:

> PyArrow feather read took 0.4215 seconds
> PyArrow feather read took 0.4256 seconds

> OGR arrow stream read took 0.4783 seconds
> OGR arrow stream read took 0.4756 seconds

Close enough.

The behavior of the GDAL code is slightly different. Instead of loading empty tables, this doesn't load the layers. I think that is better. So e.g. for this model without allocation the allocation results don't show up in the layers.
