### PR TITLE
Use quarto-publish task

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,8 +39,6 @@ jobs:
         run: pixi run quarto-render
       - name: Publish Quarto Project
         if: github.ref == 'refs/heads/main'
-        uses: quarto-dev/quarto-actions/publish@v2
-        with:
-          target: gh-pages
+        run: pixi run quarto-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Render Quarto Project
         run: pixi run quarto-render
       - name: Publish Quarto Project
+        if: github.ref == 'refs/heads/main'
         run: pixi run quarto-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,6 @@ jobs:
       - name: Render Quarto Project
         run: pixi run quarto-render
       - name: Publish Quarto Project
-        if: github.ref == 'refs/heads/main'
         run: pixi run quarto-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,10 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Configure Git for quarto-publish
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
       - uses: actions/checkout@v5
       - uses: julia-actions/cache@v2
         with:

--- a/pixi.toml
+++ b/pixi.toml
@@ -58,6 +58,7 @@ quarto-render = { cmd = "PYTHON_JULIAPKG_PROJECT=$PIXI_PROJECT_ROOT quarto rende
     "generate-testmodels",
     "initialize-julia",
 ], env = { "PYTHON_JULIACALL_CHECK_BOUNDS" = "yes", "PYTHON_JULIACALL_HANDLE_SIGNALS" = "yes", "PYTHON_JULIAPKG_OFFLINE" = "yes" } }
+quarto-publish = { cmd = "quarto publish gh-pages --no-render --no-prompt --no-browser", cwd = "docs", env = { "PRE_COMMIT_ALLOW_NO_CONFIG" = "1" } }
 docs = { depends-on = ["quarto-preview"] }
 # Lint
 mypy-ribasim-python = "mypy python/ribasim/ribasim"

--- a/pixi.toml
+++ b/pixi.toml
@@ -58,6 +58,7 @@ quarto-render = { cmd = "PYTHON_JULIAPKG_PROJECT=$PIXI_PROJECT_ROOT quarto rende
     "generate-testmodels",
     "initialize-julia",
 ], env = { "PYTHON_JULIACALL_CHECK_BOUNDS" = "yes", "PYTHON_JULIACALL_HANDLE_SIGNALS" = "yes", "PYTHON_JULIAPKG_OFFLINE" = "yes" } }
+# Publish pre-rendered docs to ribasim.org; should normally only run on CI on main
 quarto-publish = { cmd = "quarto publish gh-pages --no-render --no-prompt --no-browser", cwd = "docs", env = { "PRE_COMMIT_ALLOW_NO_CONFIG" = "1" } }
 docs = { depends-on = ["quarto-preview"] }
 # Lint


### PR DESCRIPTION
The action in https://github.com/Deltares/Ribasim/pull/2593 cannot find quarto, and this does not seem configurable. So it is failing on main.

Since we run render the step before, I call `--no-render`.
This uses git worktrees and when trying out this task locally pre-commit failed on gh-pages which doesn't have a pre commit yaml, hence PRE_COMMIT_ALLOW_NO_CONFIG.

The `_publish.yml` is created by quarto, and the docs seem to indicate this needs an ID, but I haven't been able to generate that yet.