### PR TITLE
[python] Forbid any extra values in (base)model

### DIFF
--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -266,6 +266,10 @@ class TableModel(FileModel, Generic[TableT]):
     df: DataFrame[TableT] | None = Field(default=None, exclude=True, repr=False)
     _sort_keys: list[str] = PrivateAttr(default=[])
 
+    model_config = ConfigDict(
+        extra="allow",
+    )
+
     def __eq__(self, other: object) -> bool:
         if isinstance(other, TableModel):
             if self.df is None and other.df is None:

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -116,7 +116,6 @@ class Model(FileModel):
     terminal: Terminal = Field(default_factory=Terminal)
     user_demand: UserDemand = Field(default_factory=UserDemand)
 
-    edge: Any = Field(default=None, exclude=True)  # Backwards compatible alias for link
     link: LinkTable = Field(default_factory=LinkTable)
     use_validation: bool = Field(default=True, exclude=True)
 
@@ -192,7 +191,6 @@ class Model(FileModel):
         # Since migration runs on reading, the ribasim_version should be reset.
         self.ribasim_version = ribasim.__version__
         self.model_fields_set.update({"input_dir", "results_dir"})
-        self.edge = self.link  # Backwards compatible alias for link
 
     def __repr__(self) -> str:
         """Generate a succinct overview of the Model content.

--- a/python/ribasim_testmodels/ribasim_testmodels/basic.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/basic.py
@@ -462,9 +462,9 @@ def cyclic_time_model() -> Model:
         ],
     )
 
-    model.edge.add(bsn, lr)
-    model.edge.add(lr, lb)
-    model.edge.add(fb, bsn)
+    model.link.add(bsn, lr)
+    model.link.add(lr, lb)
+    model.link.add(fb, bsn)
 
     return model
 

--- a/python/ribasim_testmodels/ribasim_testmodels/discrete_control.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/discrete_control.py
@@ -801,9 +801,9 @@ def transient_condition_model() -> Model:
         ],
     )
 
-    model.edge.add(lb, pmp)
-    model.edge.add(pmp, bsn)
-    model.edge.add(dc, pmp)
+    model.link.add(lb, pmp)
+    model.link.add(pmp, bsn)
+    model.link.add(dc, pmp)
 
     return model
 


### PR DESCRIPTION
Fixes #2577.

This might break some Ribasim-NL usage.

I had to hardcode the edge field, as some (test)models still use it directly.