### PR TITLE
Update Julia manifest

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -5,9 +5,9 @@ manifest_format = "2.0"
 project_hash = "de9ad13affa2b00ebf4eec9768befd6e72190223"
 
 [[deps.ADTypes]]
-git-tree-sha1 = "60665b326b75db6517939d0e1875850bc4a54368"
+git-tree-sha1 = "27cecae79e5cc9935255f90c53bb831cc3c870d7"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
-version = "1.17.0"
+version = "1.18.0"
 weakdeps = ["ChainRulesCore", "ConstructionBase", "EnzymeCore"]
 
     [deps.ADTypes.extensions]
@@ -46,9 +46,9 @@ version = "0.1.42"
 
 [[deps.Adapt]]
 deps = ["LinearAlgebra", "Requires"]
-git-tree-sha1 = "f7817e2e585aa6d924fd714df1e2a84be7896c60"
+git-tree-sha1 = "7e35fca2bdfba44d797c53dfe63a51fabf39bfc0"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "4.3.0"
+version = "4.4.0"
 weakdeps = ["SparseArrays", "StaticArrays"]
 
     [deps.Adapt.extensions]
@@ -182,9 +182,9 @@ version = "1.21.7+0"
 
 [[deps.BracketingNonlinearSolve]]
 deps = ["CommonSolve", "ConcreteStructs", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase"]
-git-tree-sha1 = "a9014924595b7a2c1dd14aac516e38fa10ada656"
+git-tree-sha1 = "90740f16aef91d898424bc11c1cabada475435e0"
 uuid = "70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
-version = "1.3.0"
+version = "1.4.0"
 weakdeps = ["ChainRulesCore", "ForwardDiff"]
 
     [deps.BracketingNonlinearSolve.extensions]
@@ -199,9 +199,9 @@ version = "1.0.9+0"
 
 [[deps.CFTime]]
 deps = ["Dates", "Printf"]
-git-tree-sha1 = "e85b90dfcf01b9de2f4bbda8d989e1344728c0a6"
+git-tree-sha1 = "2ed76cf4ac70526e3df565435d65e7c7b5c7a77a"
 uuid = "179af706-886a-5703-950a-314cd64e0468"
-version = "0.2.2"
+version = "0.2.4"
 
 [[deps.CPUSummary]]
 deps = ["CpuId", "IfElse", "PrecompileTools", "Preferences", "Static"]
@@ -232,21 +232,21 @@ weakdeps = ["SparseArrays"]
     ChainRulesCoreSparseArraysExt = "SparseArrays"
 
 [[deps.ChunkCodecCore]]
-git-tree-sha1 = "e4a8d39a846ef288256a2cb94a60eb95c78e300a"
+git-tree-sha1 = "51f4c10ee01bda57371e977931de39ee0f0cdb3e"
 uuid = "0b6fb165-00bc-4d37-ab8b-79f91016dbe1"
-version = "0.5.3"
+version = "1.0.0"
 
 [[deps.ChunkCodecLibZlib]]
 deps = ["ChunkCodecCore", "Zlib_jll"]
-git-tree-sha1 = "5866bf08bebfb3743e40c17ce805fbf03f85dbf4"
+git-tree-sha1 = "cee8104904c53d39eb94fd06cbe60cb5acde7177"
 uuid = "4c0bbee4-addc-4d73-81a0-b6caacae83c8"
-version = "0.2.1"
+version = "1.0.0"
 
 [[deps.ChunkCodecLibZstd]]
 deps = ["ChunkCodecCore", "Zstd_jll"]
-git-tree-sha1 = "6225e84baab33a74d6b16186c4465c46cb6b035a"
+git-tree-sha1 = "34d9873079e4cb3d0c62926a225136824677073f"
 uuid = "55437552-ac27-4d47-9aa3-63184e8fd398"
-version = "0.2.1"
+version = "1.0.0"
 
 [[deps.CloseOpenIntervals]]
 deps = ["Static", "StaticArrayInterface"]
@@ -256,9 +256,9 @@ version = "0.1.13"
 
 [[deps.CodeTracking]]
 deps = ["InteractiveUtils", "UUIDs"]
-git-tree-sha1 = "5ac098a7c8660e217ffac31dc2af0964a8c3182a"
+git-tree-sha1 = "980f01d6d3283b3dbdfd7ed89405f96b7256ad57"
 uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
-version = "2.0.0"
+version = "2.0.1"
 
 [[deps.CodecBzip2]]
 deps = ["Bzip2_jll", "TranscodingStreams"]
@@ -286,9 +286,9 @@ version = "0.8.6"
 
 [[deps.ColorSchemes]]
 deps = ["ColorTypes", "ColorVectorSpace", "Colors", "FixedPointNumbers", "PrecompileTools", "Random"]
-git-tree-sha1 = "a656525c8b46aa6a1c76891552ed5381bb32ae7b"
+git-tree-sha1 = "b0fd3f56fa442f81e0a47815c92245acfaaa4e34"
 uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
-version = "3.30.0"
+version = "3.31.0"
 
 [[deps.ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
@@ -345,9 +345,9 @@ version = "1.0.0"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
-git-tree-sha1 = "0037835448781bb46feb39866934e243886d756a"
+git-tree-sha1 = "9d8a54ce4b17aa5bdce0ea5c34bc5e7c340d16ad"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.18.0"
+version = "4.18.1"
 weakdeps = ["Dates", "LinearAlgebra"]
 
     [deps.Compat.extensions]
@@ -385,9 +385,9 @@ version = "2.5.0"
 
 [[deps.CondaPkg]]
 deps = ["JSON3", "Markdown", "MicroMamba", "Pidfile", "Pkg", "Preferences", "Scratch", "TOML", "pixi_jll"]
-git-tree-sha1 = "04dcfa548a95032ca3756aa25664ad9a11aece75"
+git-tree-sha1 = "bd491d55b97a036caae1d78729bdb70bf7dababc"
 uuid = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
-version = "0.2.31"
+version = "0.2.33"
 
 [[deps.Configurations]]
 deps = ["ExproniconLite", "OrderedCollections", "TOML"]
@@ -438,15 +438,15 @@ version = "1.16.0"
 
 [[deps.DataFrames]]
 deps = ["Compat", "DataAPI", "DataStructures", "Future", "InlineStrings", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "Markdown", "Missings", "PooledArrays", "PrecompileTools", "PrettyTables", "Printf", "Random", "Reexport", "SentinelArrays", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
-git-tree-sha1 = "a37ac0840a1196cd00317b57e39d6586bf0fd6f6"
+git-tree-sha1 = "c967271c27a95160e30432e011b58f42cd7501b5"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "1.7.1"
+version = "1.8.0"
 
 [[deps.DataInterpolations]]
 deps = ["EnumX", "FindFirstFunctions", "ForwardDiff", "LinearAlgebra", "PrettyTables", "RecipesBase", "Reexport"]
-git-tree-sha1 = "d8a84dc566622fce3c9bca8c5341006ff1cec491"
+git-tree-sha1 = "58ae0a38dd3002963a3c8d4af097e660cf409c38"
 uuid = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
-version = "8.5.0"
+version = "8.6.1"
 
     [deps.DataInterpolations.extensions]
     DataInterpolationsChainRulesCoreExt = "ChainRulesCore"
@@ -496,9 +496,9 @@ version = "1.9.1"
 
 [[deps.DiffEqBase]]
 deps = ["ArrayInterface", "ConcreteStructs", "DocStringExtensions", "EnzymeCore", "FastBroadcast", "FastClosures", "FastPower", "FunctionWrappers", "FunctionWrappersWrappers", "LinearAlgebra", "Logging", "Markdown", "MuladdMacro", "PrecompileTools", "Printf", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLOperators", "SciMLStructures", "Setfield", "Static", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface", "TruncatedStacktraces"]
-git-tree-sha1 = "20c11d6686206f4ccaea93915901ab6ee352128c"
+git-tree-sha1 = "087632db966c90079a5534e4147afea9136ca39a"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
-version = "6.186.0"
+version = "6.190.2"
 
     [deps.DiffEqBase.extensions]
     DiffEqBaseCUDAExt = "CUDA"
@@ -553,9 +553,9 @@ version = "1.15.1"
 
 [[deps.DifferentiationInterface]]
 deps = ["ADTypes", "LinearAlgebra"]
-git-tree-sha1 = "16946a4d305607c3a4af54ff35d56f0e9444ed0e"
+git-tree-sha1 = "cee1700673af54db57bd1c7fb834ad4ff31309a0"
 uuid = "a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63"
-version = "0.7.7"
+version = "0.7.8"
 
     [deps.DifferentiationInterface.extensions]
     DifferentiationInterfaceChainRulesCoreExt = "ChainRulesCore"
@@ -603,9 +603,9 @@ version = "0.7.7"
 
 [[deps.DiskArrays]]
 deps = ["ConstructionBase", "LRUCache", "Mmap", "OffsetArrays"]
-git-tree-sha1 = "bfde0790720fcac006a3d62149309a685fc3aa13"
+git-tree-sha1 = "297ac5efb7c9c7849114eba76111af2814cac8ec"
 uuid = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
-version = "0.4.15"
+version = "0.4.16"
 
 [[deps.DisplayAs]]
 git-tree-sha1 = "43c017d5dd3a48d56486055973f443f8a39bb6d9"
@@ -643,9 +643,9 @@ uuid = "4e289a0a-7415-4d19-859d-a7e5c4648b56"
 version = "1.0.5"
 
 [[deps.EnzymeCore]]
-git-tree-sha1 = "8272a687bca7b5c601c0c24fc0c71bff10aafdfd"
+git-tree-sha1 = "e059db5d02720ae826445f5ce2fdfb3d53236b87"
 uuid = "f151be2c-9106-41f4-ab19-57ee4f262869"
-version = "0.8.12"
+version = "0.8.14"
 weakdeps = ["Adapt"]
 
     [deps.EnzymeCore.extensions]
@@ -752,9 +752,9 @@ version = "1.11.0"
 
 [[deps.FillArrays]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "6a70198746448456524cb442b8af316927ff3e1a"
+git-tree-sha1 = "173e4d8f14230a7523ae11b9a3fa9edb3e0efd78"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.13.0"
+version = "1.14.0"
 
     [deps.FillArrays.extensions]
     FillArraysPDMatsExt = "PDMats"
@@ -767,9 +767,9 @@ version = "1.13.0"
     Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[deps.FindFirstFunctions]]
-git-tree-sha1 = "670e1d9ceaa4a3161d32fe2d2fb2177f8d78b330"
+git-tree-sha1 = "544bdc2902fa966900d354510be775f8668a57bd"
 uuid = "64ca27bc-2ba2-4a57-88aa-44e436879224"
-version = "1.4.1"
+version = "1.4.2"
 
 [[deps.FiniteDiff]]
 deps = ["ArrayInterface", "LinearAlgebra", "Setfield"]
@@ -808,9 +808,9 @@ version = "1.3.7"
 
 [[deps.ForwardDiff]]
 deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions"]
-git-tree-sha1 = "ce15956960057e9ff7f1f535400ffa14c92429a4"
+git-tree-sha1 = "dc41303865a16274ecb8450c220021ce1e0cf05f"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "1.1.0"
+version = "1.2.1"
 weakdeps = ["StaticArrays"]
 
     [deps.ForwardDiff.extensions]
@@ -880,11 +880,17 @@ git-tree-sha1 = "45288942190db7c5f760f59c04495064eedf9340"
 uuid = "b0724c58-0f36-5564-988d-3bb0596ebc4a"
 version = "0.22.4+0"
 
+[[deps.Ghostscript_jll]]
+deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Zlib_jll"]
+git-tree-sha1 = "38044a04637976140074d0b0621c1edf0eb531fd"
+uuid = "61579ee1-b43e-5ca0-a5da-69d92c66a64b"
+version = "9.55.1+0"
+
 [[deps.Glib_jll]]
 deps = ["Artifacts", "GettextRuntime_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE2_jll", "Zlib_jll"]
-git-tree-sha1 = "35fbd0cefb04a516104b8e183ce0df11b70a3f1a"
+git-tree-sha1 = "50c11ffab2a3d50192a228c313f05b5b5dc5acb2"
 uuid = "7746bdde-850d-59dc-9ae8-88ece973131d"
-version = "2.84.3+0"
+version = "2.86.0+0"
 
 [[deps.Glob]]
 git-tree-sha1 = "97285bbd5230dd766e9ef6749b80fc617126d496"
@@ -1024,9 +1030,9 @@ version = "1.0.0"
 
 [[deps.JLD2]]
 deps = ["ChunkCodecLibZlib", "ChunkCodecLibZstd", "FileIO", "MacroTools", "Mmap", "OrderedCollections", "PrecompileTools", "ScopedValues"]
-git-tree-sha1 = "da485e1e36e9c6d4403aa7b6d1db6806a66aa05a"
+git-tree-sha1 = "da2e9b4d1abbebdcca0aa68afa0aa272102baad7"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.6.0"
+version = "0.6.2"
 weakdeps = ["UnPack"]
 
     [deps.JLD2.extensions]
@@ -1068,15 +1074,15 @@ version = "0.2.1"
 
 [[deps.JpegTurbo_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "e95866623950267c1e4878846f848d94810de475"
+git-tree-sha1 = "4255f0032eafd6451d707a51d5f0248b8a165e4d"
 uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
-version = "3.1.2+0"
+version = "3.1.3+0"
 
 [[deps.JuMP]]
 deps = ["LinearAlgebra", "MacroTools", "MathOptInterface", "MutableArithmetics", "OrderedCollections", "PrecompileTools", "Printf", "SparseArrays"]
-git-tree-sha1 = "d9c29fadef257492791c83b34ceede0d92a51470"
+git-tree-sha1 = "b201ac010ecdcc3617649175fa59c3dbd9bf96a0"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
-version = "1.29.0"
+version = "1.29.1"
 
     [deps.JuMP.extensions]
     JuMPDimensionalDataExt = "DimensionalData"
@@ -1092,9 +1098,9 @@ version = "0.10.5"
 
 [[deps.Krylov]]
 deps = ["LinearAlgebra", "Printf", "SparseArrays"]
-git-tree-sha1 = "b94257a1a8737099ca40bc7271a8b374033473ed"
+git-tree-sha1 = "d1fc961038207e43982851e57ee257adc37be5e8"
 uuid = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
-version = "0.10.1"
+version = "0.10.2"
 
 [[deps.LAME_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -1135,10 +1141,10 @@ uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 version = "1.4.0"
 
 [[deps.Latexify]]
-deps = ["Format", "InteractiveUtils", "LaTeXStrings", "MacroTools", "Markdown", "OrderedCollections", "Requires"]
-git-tree-sha1 = "52e1296ebbde0db845b356abbbe67fb82a0a116c"
+deps = ["Format", "Ghostscript_jll", "InteractiveUtils", "LaTeXStrings", "MacroTools", "Markdown", "OrderedCollections", "Requires"]
+git-tree-sha1 = "44f93c47f9cd6c7e431f2f2091fcba8f01cd7e8f"
 uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
-version = "0.16.9"
+version = "0.16.10"
 
     [deps.Latexify.extensions]
     DataFramesExt = "DataFrames"
@@ -1165,9 +1171,9 @@ version = "1.3.0"
 
 [[deps.LazyArrays]]
 deps = ["ArrayLayouts", "FillArrays", "LinearAlgebra", "MacroTools", "SparseArrays"]
-git-tree-sha1 = "76627adb8c542c6b73f68d4bfd0aa71c9893a079"
+git-tree-sha1 = "21057b6f4f5db1475e653735fda7d1de1c267b46"
 uuid = "5078a376-72f3-5289-bfd5-ec5146d43c02"
-version = "2.6.2"
+version = "2.6.3"
 
     [deps.LazyArrays.extensions]
     LazyArraysBandedMatricesExt = "BandedMatrices"
@@ -1241,21 +1247,21 @@ version = "1.18.0+0"
 
 [[deps.Libmount_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "706dfd3c0dd56ca090e86884db6eda70fa7dd4af"
+git-tree-sha1 = "3acf07f130a76f87c041cfb2ff7d7284ca67b072"
 uuid = "4b2f31a3-9ecc-558c-b454-b3730dcb73e9"
-version = "2.41.1+0"
+version = "2.41.2+0"
 
 [[deps.Libtiff_jll]]
 deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "LERC_jll", "Libdl", "XZ_jll", "Zlib_jll", "Zstd_jll"]
-git-tree-sha1 = "4ab7581296671007fc33f07a721631b8855f4b1d"
+git-tree-sha1 = "f04133fe05eff1667d2054c53d59f9122383fe05"
 uuid = "89763e89-9b03-5906-acba-b20f662cd828"
-version = "4.7.1+0"
+version = "4.7.2+0"
 
 [[deps.Libuuid_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "d3c8af829abaeba27181db4acb485b18d15d89c6"
+git-tree-sha1 = "2a7a12fc0a4e7fb773450d17975322aa77142106"
 uuid = "38a345b3-de98-5d2b-a5d3-14cd9215e700"
-version = "2.41.1+0"
+version = "2.41.2+0"
 
 [[deps.LicenseCheck]]
 deps = ["licensecheck_jll"]
@@ -1282,9 +1288,9 @@ version = "1.11.0"
 
 [[deps.LinearSolve]]
 deps = ["ArrayInterface", "ChainRulesCore", "ConcreteStructs", "DocStringExtensions", "EnumX", "GPUArraysCore", "InteractiveUtils", "Krylov", "LazyArrays", "Libdl", "LinearAlgebra", "MKL_jll", "Markdown", "OpenBLAS_jll", "PrecompileTools", "Preferences", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLOperators", "Setfield", "StaticArraysCore", "UnPack"]
-git-tree-sha1 = "9874796f130d8642fbed2a9f240e517b46639288"
+git-tree-sha1 = "6c22b14a5ea7fbcc140ea1f52f3cfe20d3da32e0"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "3.38.0"
+version = "3.40.2"
 
     [deps.LinearSolve.extensions]
     LinearSolveAMDGPUExt = "AMDGPU"
@@ -1361,9 +1367,9 @@ version = "1.1.0"
 
 [[deps.LoweredCodeUtils]]
 deps = ["CodeTracking", "Compiler", "JuliaInterpreter"]
-git-tree-sha1 = "73b98709ad811a6f81d84e105f4f695c229385ba"
+git-tree-sha1 = "e24491cb83551e44a69b9106c50666dea9d953ab"
 uuid = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
-version = "3.4.3"
+version = "3.4.4"
 
 [[deps.Lz4_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -1434,9 +1440,9 @@ version = "0.1.1"
 
 [[deps.MathOptInterface]]
 deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "DataStructures", "ForwardDiff", "JSON3", "LinearAlgebra", "MutableArithmetics", "NaNMath", "OrderedCollections", "PrecompileTools", "Printf", "SparseArrays", "SpecialFunctions", "Test"]
-git-tree-sha1 = "583abfbd38f15198adde0658e1b1222ece232ae2"
+git-tree-sha1 = "700acfa97a2b23569c0a6dcfcd85f183d7258e31"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.43.0"
+version = "1.45.0"
 
 [[deps.MaybeInplace]]
 deps = ["ArrayInterface", "LinearAlgebra", "MacroTools"]
@@ -1515,9 +1521,9 @@ version = "0.2.4"
 
 [[deps.MultiObjectiveAlgorithms]]
 deps = ["Combinatorics", "MathOptInterface"]
-git-tree-sha1 = "9279f54e52bc71082e3b40d2e4c67a837805ca3d"
+git-tree-sha1 = "f724f97d25fc93852604507f505ac02b3ab42933"
 uuid = "0327d340-17cd-11ea-3e99-2fd5d98cecda"
-version = "1.6.0"
+version = "1.7.0"
 
     [deps.MultiObjectiveAlgorithms.extensions]
     MultiObjectiveAlgorithmsPolyhedraExt = "Polyhedra"
@@ -1527,9 +1533,9 @@ version = "1.6.0"
 
 [[deps.MutableArithmetics]]
 deps = ["LinearAlgebra", "SparseArrays", "Test"]
-git-tree-sha1 = "491bdcdc943fcbc4c005900d7463c9f216aabf4c"
+git-tree-sha1 = "5801388fbfb801822721b5dee720a55a6d03d41d"
 uuid = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
-version = "1.6.4"
+version = "1.6.6"
 
 [[deps.NCDatasets]]
 deps = ["CFTime", "CommonDataModel", "DataStructures", "Dates", "DiskArrays", "NetCDF_jll", "NetworkOptions", "Printf"]
@@ -1554,10 +1560,10 @@ uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 version = "1.2.0"
 
 [[deps.NonlinearSolve]]
-deps = ["ADTypes", "ArrayInterface", "BracketingNonlinearSolve", "CommonSolve", "ConcreteStructs", "DiffEqBase", "DifferentiationInterface", "FastClosures", "FiniteDiff", "ForwardDiff", "LineSearch", "LinearAlgebra", "LinearSolve", "NonlinearSolveBase", "NonlinearSolveFirstOrder", "NonlinearSolveQuasiNewton", "NonlinearSolveSpectralMethods", "PrecompileTools", "Preferences", "Reexport", "SciMLBase", "SimpleNonlinearSolve", "SparseArrays", "SparseMatrixColorings", "StaticArraysCore", "SymbolicIndexingInterface"]
-git-tree-sha1 = "d2ec18c1e4eccbb70b64be2435fc3b06fbcdc0a1"
+deps = ["ADTypes", "ArrayInterface", "BracketingNonlinearSolve", "CommonSolve", "ConcreteStructs", "DifferentiationInterface", "FastClosures", "FiniteDiff", "ForwardDiff", "LineSearch", "LinearAlgebra", "LinearSolve", "NonlinearSolveBase", "NonlinearSolveFirstOrder", "NonlinearSolveQuasiNewton", "NonlinearSolveSpectralMethods", "PrecompileTools", "Preferences", "Reexport", "SciMLBase", "SimpleNonlinearSolve", "StaticArraysCore", "SymbolicIndexingInterface"]
+git-tree-sha1 = "627967f6e36aac9f5afb2fb285e33b676a6892f9"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "4.10.0"
+version = "4.11.0"
 
     [deps.NonlinearSolve.extensions]
     NonlinearSolveFastLevenbergMarquardtExt = "FastLevenbergMarquardt"
@@ -1566,7 +1572,7 @@ version = "4.10.0"
     NonlinearSolveMINPACKExt = "MINPACK"
     NonlinearSolveNLSolversExt = "NLSolvers"
     NonlinearSolveNLsolveExt = ["NLsolve", "LineSearches"]
-    NonlinearSolvePETScExt = ["PETSc", "MPI"]
+    NonlinearSolvePETScExt = ["PETSc", "MPI", "SparseArrays"]
     NonlinearSolveSIAMFANLEquationsExt = "SIAMFANLEquations"
     NonlinearSolveSpeedMappingExt = "SpeedMapping"
     NonlinearSolveSundialsExt = "Sundials"
@@ -1582,54 +1588,63 @@ version = "4.10.0"
     NLsolve = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
     PETSc = "ace2c81b-2b5f-4b1e-a30d-d662738edfe0"
     SIAMFANLEquations = "084e46ad-d928-497d-ad5e-07fa361a48c4"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
     SpeedMapping = "f1835b91-879b-4a3f-a438-e4baacf14412"
     Sundials = "c3572dad-4567-51f8-b174-8c6c989267f4"
 
 [[deps.NonlinearSolveBase]]
-deps = ["ADTypes", "Adapt", "ArrayInterface", "CommonSolve", "Compat", "ConcreteStructs", "DifferentiationInterface", "EnzymeCore", "FastClosures", "LinearAlgebra", "Markdown", "MaybeInplace", "Preferences", "Printf", "RecursiveArrayTools", "SciMLBase", "SciMLJacobianOperators", "SciMLOperators", "StaticArraysCore", "SymbolicIndexingInterface", "TimerOutputs"]
-git-tree-sha1 = "1d42a315ba627ca0027d49d0efb44e3d88db24aa"
+deps = ["ADTypes", "Adapt", "ArrayInterface", "CommonSolve", "Compat", "ConcreteStructs", "DifferentiationInterface", "EnzymeCore", "FastClosures", "LinearAlgebra", "Markdown", "MaybeInplace", "Preferences", "Printf", "RecursiveArrayTools", "SciMLBase", "SciMLJacobianOperators", "SciMLOperators", "SciMLStructures", "Setfield", "StaticArraysCore", "SymbolicIndexingInterface", "TimerOutputs"]
+git-tree-sha1 = "f05e5f3d0f280598ecdc26b06ec9acd71dcaef31"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "1.14.0"
+version = "1.16.1"
 
     [deps.NonlinearSolveBase.extensions]
     NonlinearSolveBaseBandedMatricesExt = "BandedMatrices"
-    NonlinearSolveBaseDiffEqBaseExt = "DiffEqBase"
+    NonlinearSolveBaseChainRulesCoreExt = "ChainRulesCore"
+    NonlinearSolveBaseEnzymeExt = ["ChainRulesCore", "Enzyme"]
     NonlinearSolveBaseForwardDiffExt = "ForwardDiff"
     NonlinearSolveBaseLineSearchExt = "LineSearch"
     NonlinearSolveBaseLinearSolveExt = "LinearSolve"
+    NonlinearSolveBaseMooncakeExt = "Mooncake"
+    NonlinearSolveBaseReverseDiffExt = "ReverseDiff"
     NonlinearSolveBaseSparseArraysExt = "SparseArrays"
     NonlinearSolveBaseSparseMatrixColoringsExt = "SparseMatrixColorings"
+    NonlinearSolveBaseTrackerExt = "Tracker"
 
     [deps.NonlinearSolveBase.weakdeps]
     BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
-    DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
     ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
     LineSearch = "87fe0de2-c867-4266-b59a-2f0a94fc965b"
     LinearSolve = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
+    Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
+    ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
     SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
     SparseMatrixColorings = "0a514795-09f3-496d-8182-132a7b665d35"
+    Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
 [[deps.NonlinearSolveFirstOrder]]
-deps = ["ADTypes", "ArrayInterface", "CommonSolve", "ConcreteStructs", "DiffEqBase", "FiniteDiff", "ForwardDiff", "LineSearch", "LinearAlgebra", "LinearSolve", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "SciMLJacobianOperators", "Setfield", "StaticArraysCore"]
-git-tree-sha1 = "3f1198ae5cbf21e84b8251a9e62fa1f888f3e4cb"
+deps = ["ADTypes", "ArrayInterface", "CommonSolve", "ConcreteStructs", "FiniteDiff", "ForwardDiff", "LineSearch", "LinearAlgebra", "LinearSolve", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "SciMLJacobianOperators", "Setfield", "StaticArraysCore"]
+git-tree-sha1 = "b9702235120d1161f8041b326eccebd334340de2"
 uuid = "5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
-version = "1.7.0"
+version = "1.8.0"
 
 [[deps.NonlinearSolveQuasiNewton]]
-deps = ["ArrayInterface", "CommonSolve", "ConcreteStructs", "DiffEqBase", "LinearAlgebra", "LinearSolve", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "SciMLOperators", "StaticArraysCore"]
-git-tree-sha1 = "40dfaf1bf74f1f700f81d0002d4dd90999598eb2"
+deps = ["ArrayInterface", "CommonSolve", "ConcreteStructs", "LinearAlgebra", "LinearSolve", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "SciMLOperators", "StaticArraysCore"]
+git-tree-sha1 = "4e0e34601c6c9890aa9443003180967f75c6929d"
 uuid = "9a2c21bd-3a47-402d-9113-8faf9a0ee114"
-version = "1.8.0"
+version = "1.9.0"
 weakdeps = ["ForwardDiff"]
 
     [deps.NonlinearSolveQuasiNewton.extensions]
     NonlinearSolveQuasiNewtonForwardDiffExt = "ForwardDiff"
 
 [[deps.NonlinearSolveSpectralMethods]]
-deps = ["CommonSolve", "ConcreteStructs", "DiffEqBase", "LineSearch", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase"]
-git-tree-sha1 = "84de5a469e119eb2c22ae07c543dc4e7f7001ee7"
+deps = ["CommonSolve", "ConcreteStructs", "LineSearch", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase"]
+git-tree-sha1 = "6c613302febe2bb408a888105d07073cf6824911"
 uuid = "26075421-4e9a-44e1-8bd1-420ed7ad02b2"
-version = "1.3.0"
+version = "1.4.0"
 weakdeps = ["ForwardDiff"]
 
     [deps.NonlinearSolveSpectralMethods.extensions]
@@ -1674,9 +1689,9 @@ version = "1.5.0"
 
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "2ae7d4ddec2e13ad3bddf5c0796f7547cf682391"
+git-tree-sha1 = "f19301ae653233bc88b1810ae908194f07f8db9d"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.5.2+0"
+version = "3.5.4+0"
 
 [[deps.OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
@@ -1703,9 +1718,9 @@ version = "1.10.1"
 
 [[deps.OrdinaryDiffEqCore]]
 deps = ["ADTypes", "Accessors", "Adapt", "ArrayInterface", "DataStructures", "DiffEqBase", "DocStringExtensions", "EnumX", "FastBroadcast", "FastClosures", "FastPower", "FillArrays", "FunctionWrappersWrappers", "InteractiveUtils", "LinearAlgebra", "Logging", "MacroTools", "MuladdMacro", "Polyester", "PrecompileTools", "Preferences", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLOperators", "SciMLStructures", "SimpleUnPack", "Static", "StaticArrayInterface", "StaticArraysCore", "SymbolicIndexingInterface", "TruncatedStacktraces"]
-git-tree-sha1 = "e579c9a4f9102e82da3d97c349a74d6bc11cf8dc"
+git-tree-sha1 = "688c717e8eee84dcfef02ddf71c8028215b329ca"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
-version = "1.30.0"
+version = "1.34.0"
 
     [deps.OrdinaryDiffEqCore.extensions]
     OrdinaryDiffEqCoreEnzymeCoreExt = "EnzymeCore"
@@ -1716,10 +1731,14 @@ version = "1.30.0"
     Mooncake = "da2b9cff-9c12-43a0-ae48-6db2b0edb7d6"
 
 [[deps.OrdinaryDiffEqDifferentiation]]
-deps = ["ADTypes", "ArrayInterface", "ConcreteStructs", "ConstructionBase", "DiffEqBase", "DifferentiationInterface", "FastBroadcast", "FiniteDiff", "ForwardDiff", "FunctionWrappersWrappers", "LinearAlgebra", "LinearSolve", "OrdinaryDiffEqCore", "SciMLBase", "SciMLOperators", "SparseArrays", "SparseMatrixColorings", "StaticArrayInterface", "StaticArrays"]
-git-tree-sha1 = "4c270747152db513dd80bfd5f2f9df48befff28a"
+deps = ["ADTypes", "ArrayInterface", "ConcreteStructs", "ConstructionBase", "DiffEqBase", "DifferentiationInterface", "FastBroadcast", "FiniteDiff", "ForwardDiff", "FunctionWrappersWrappers", "LinearAlgebra", "LinearSolve", "OrdinaryDiffEqCore", "SciMLBase", "SciMLOperators", "SparseMatrixColorings", "StaticArrayInterface", "StaticArrays"]
+git-tree-sha1 = "320b5f3e4e61ca0ad863c63c803f69973ba6efce"
 uuid = "4302a76b-040a-498a-8c04-15b101fed76b"
-version = "1.14.0"
+version = "1.16.1"
+weakdeps = ["SparseArrays"]
+
+    [deps.OrdinaryDiffEqDifferentiation.extensions]
+    OrdinaryDiffEqDifferentiationSparseArraysExt = "SparseArrays"
 
 [[deps.OrdinaryDiffEqLowOrderRK]]
 deps = ["DiffEqBase", "FastBroadcast", "LinearAlgebra", "MuladdMacro", "OrdinaryDiffEqCore", "RecursiveArrayTools", "Reexport", "SciMLBase", "Static"]
@@ -1735,9 +1754,9 @@ version = "1.14.1"
 
 [[deps.OrdinaryDiffEqRosenbrock]]
 deps = ["ADTypes", "DiffEqBase", "DifferentiationInterface", "FastBroadcast", "FiniteDiff", "ForwardDiff", "LinearAlgebra", "LinearSolve", "MacroTools", "MuladdMacro", "OrdinaryDiffEqCore", "OrdinaryDiffEqDifferentiation", "Polyester", "PrecompileTools", "Preferences", "RecursiveArrayTools", "Reexport", "SciMLBase", "Static"]
-git-tree-sha1 = "d0b4e34792fb64c3815fc79ad3adc300b1e35588"
+git-tree-sha1 = "f34bc2f58656843596d09a4c4de8c20724ebc2f1"
 uuid = "43230ef6-c299-4910-a778-202eb28ce4ce"
-version = "1.17.0"
+version = "1.18.1"
 
 [[deps.OrdinaryDiffEqSDIRK]]
 deps = ["ADTypes", "DiffEqBase", "FastBroadcast", "LinearAlgebra", "MacroTools", "MuladdMacro", "OrdinaryDiffEqCore", "OrdinaryDiffEqDifferentiation", "OrdinaryDiffEqNonlinearSolve", "RecursiveArrayTools", "Reexport", "SciMLBase", "TruncatedStacktraces"]
@@ -1772,9 +1791,9 @@ version = "2.2.1"
 
 [[deps.Pango_jll]]
 deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "FriBidi_jll", "Glib_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "275a9a6d85dc86c24d03d1837a0010226a96f540"
+git-tree-sha1 = "1f7f9bbd5f7a2e5a9f7d96e51c9754454ea7f60b"
 uuid = "36c8627f-9965-5494-a995-c6b170f724f3"
-version = "1.56.3+0"
+version = "1.56.4+0"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
@@ -1822,10 +1841,10 @@ uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
 version = "1.4.3"
 
 [[deps.Plots]]
-deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "JLFzf", "JSON", "LaTeXStrings", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "PrecompileTools", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "RelocatableFolders", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "TOML", "UUIDs", "UnicodeFun", "UnitfulLatexify", "Unzip"]
-git-tree-sha1 = "0c5a5b7e440c008fe31416a3ac9e0d2057c81106"
+deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "JLFzf", "JSON", "LaTeXStrings", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "PrecompileTools", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "RelocatableFolders", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "TOML", "UUIDs", "UnicodeFun", "Unzip"]
+git-tree-sha1 = "12ce661880f8e309569074a61d3767e5756a199f"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.40.19"
+version = "1.41.1"
 
     [deps.Plots.extensions]
     FileIOExt = "FileIO"
@@ -1861,9 +1880,9 @@ version = "1.4.3"
 
 [[deps.PreallocationTools]]
 deps = ["Adapt", "ArrayInterface", "PrecompileTools"]
-git-tree-sha1 = "9b4ee15d1fc68654031964a7af0c914c898e35a7"
+git-tree-sha1 = "c05b4c6325262152483a1ecb6c69846d2e01727b"
 uuid = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
-version = "0.4.33"
+version = "0.4.34"
 
     [deps.PreallocationTools.extensions]
     PreallocationToolsForwardDiffExt = "ForwardDiff"
@@ -1888,10 +1907,10 @@ uuid = "21216c6a-2e73-6563-6e65-726566657250"
 version = "1.5.0"
 
 [[deps.PrettyTables]]
-deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "Reexport", "StringManipulation", "Tables"]
-git-tree-sha1 = "1101cd475833706e4d0e7b122218257178f48f34"
+deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "REPL", "Reexport", "StringManipulation", "Tables"]
+git-tree-sha1 = "5e9fe23c86d3ca630baa1efcad78575a27f158b2"
 uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
-version = "2.4.0"
+version = "3.0.11"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -1914,10 +1933,18 @@ uuid = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
 version = "1.3.0"
 
 [[deps.PythonCall]]
-deps = ["CondaPkg", "Dates", "Libdl", "MacroTools", "Markdown", "Pkg", "Requires", "Serialization", "Tables", "UnsafePointers"]
-git-tree-sha1 = "be299d79459a85ea0d5c00dbecf076f3e5f5119e"
+deps = ["CondaPkg", "Dates", "Libdl", "MacroTools", "Markdown", "Pkg", "Serialization", "Tables", "UnsafePointers"]
+git-tree-sha1 = "34510e11cabd7964291f32f14d28b367e9960e6e"
 uuid = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
-version = "0.9.27"
+version = "0.9.28"
+
+    [deps.PythonCall.extensions]
+    CategoricalArraysExt = "CategoricalArrays"
+    PyCallExt = "PyCall"
+
+    [deps.PythonCall.weakdeps]
+    CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
+    PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 
 [[deps.Qt6Base_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Fontconfig_jll", "Glib_jll", "JLLWrappers", "Libdl", "Libglvnd_jll", "OpenSSL_jll", "Vulkan_Loader_jll", "Xorg_libSM_jll", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Xorg_libxcb_jll", "Xorg_xcb_util_cursor_jll", "Xorg_xcb_util_image_jll", "Xorg_xcb_util_keysyms_jll", "Xorg_xcb_util_renderutil_jll", "Xorg_xcb_util_wm_jll", "Zlib_jll", "libinput_jll", "xkbcommon_jll"]
@@ -2071,16 +2098,18 @@ version = "3.48.0+0"
 
 [[deps.SciMLBase]]
 deps = ["ADTypes", "Accessors", "Adapt", "ArrayInterface", "CommonSolve", "ConstructionBase", "Distributed", "DocStringExtensions", "EnumX", "FunctionWrappersWrappers", "IteratorInterfaceExtensions", "LinearAlgebra", "Logging", "Markdown", "Moshi", "PreallocationTools", "PrecompileTools", "Preferences", "Printf", "RecipesBase", "RecursiveArrayTools", "Reexport", "RuntimeGeneratedFunctions", "SciMLOperators", "SciMLStructures", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface"]
-git-tree-sha1 = "8fb66de06c21a4dfb5d08bb59f37dc597e4b0f9e"
+git-tree-sha1 = "16fa030fb4bd4df373a677eca0460c3eee791ab2"
 uuid = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
-version = "2.115.0"
+version = "2.120.0"
 
     [deps.SciMLBase.extensions]
     SciMLBaseChainRulesCoreExt = "ChainRulesCore"
     SciMLBaseDistributionsExt = "Distributions"
+    SciMLBaseEnzymeExt = "Enzyme"
     SciMLBaseForwardDiffExt = "ForwardDiff"
     SciMLBaseMLStyleExt = "MLStyle"
     SciMLBaseMakieExt = "Makie"
+    SciMLBaseMeasurementsExt = "Measurements"
     SciMLBaseMonteCarloMeasurementsExt = "MonteCarloMeasurements"
     SciMLBaseMooncakeExt = "Mooncake"
     SciMLBasePartialFunctionsExt = "PartialFunctions"
@@ -2095,6 +2124,7 @@ version = "2.115.0"
     ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
     ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
     Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
     ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
     MLStyle = "d8e11817-5142-5d16-987a-aa16d5891078"
     Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
@@ -2111,20 +2141,25 @@ version = "2.115.0"
 
 [[deps.SciMLJacobianOperators]]
 deps = ["ADTypes", "ArrayInterface", "ConcreteStructs", "ConstructionBase", "DifferentiationInterface", "FastClosures", "LinearAlgebra", "SciMLBase", "SciMLOperators"]
-git-tree-sha1 = "3414071e3458f3065de7fa5aed55283b236b4907"
+git-tree-sha1 = "a273b291c90909ba6fe08402dd68e09aae423008"
 uuid = "19f34311-ddf3-4b8b-af20-060888a46c0e"
-version = "0.1.8"
+version = "0.1.11"
 
 [[deps.SciMLOperators]]
 deps = ["Accessors", "ArrayInterface", "DocStringExtensions", "LinearAlgebra", "MacroTools"]
-git-tree-sha1 = "1d5b9c3677ea17503045024900dde8ba8585fac5"
+git-tree-sha1 = "024d829102878141aaee5cf8f8288bcabd2f57a0"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
-version = "1.7.0"
+version = "1.7.2"
 weakdeps = ["SparseArrays", "StaticArraysCore"]
 
     [deps.SciMLOperators.extensions]
     SciMLOperatorsSparseArraysExt = "SparseArrays"
     SciMLOperatorsStaticArraysCoreExt = "StaticArraysCore"
+
+[[deps.SciMLPublic]]
+git-tree-sha1 = "ed647f161e8b3f2973f24979ec074e8d084f1bee"
+uuid = "431bcebd-1456-4ced-9d72-93c2757fff0b"
+version = "1.0.0"
 
 [[deps.SciMLStructures]]
 deps = ["ArrayInterface"]
@@ -2178,19 +2213,17 @@ version = "1.2.0"
 
 [[deps.SimpleNonlinearSolve]]
 deps = ["ADTypes", "ArrayInterface", "BracketingNonlinearSolve", "CommonSolve", "ConcreteStructs", "DifferentiationInterface", "FastClosures", "FiniteDiff", "ForwardDiff", "LineSearch", "LinearAlgebra", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "Setfield", "StaticArraysCore"]
-git-tree-sha1 = "09d986e27a606f172c5b6cffbd8b8b2f10bf1c75"
+git-tree-sha1 = "782c67176b473abf62a6786399c4b7ddcc1a2d77"
 uuid = "727e6d20-b764-4bd8-a329-72de5adea6c7"
-version = "2.7.0"
+version = "2.8.0"
 
     [deps.SimpleNonlinearSolve.extensions]
     SimpleNonlinearSolveChainRulesCoreExt = "ChainRulesCore"
-    SimpleNonlinearSolveDiffEqBaseExt = "DiffEqBase"
     SimpleNonlinearSolveReverseDiffExt = "ReverseDiff"
     SimpleNonlinearSolveTrackerExt = "Tracker"
 
     [deps.SimpleNonlinearSolve.weakdeps]
     ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-    DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
     ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
     Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 
@@ -2222,17 +2255,19 @@ version = "1.11.0"
 
 [[deps.SparseConnectivityTracer]]
 deps = ["ADTypes", "DocStringExtensions", "FillArrays", "LinearAlgebra", "Random", "SparseArrays"]
-git-tree-sha1 = "339efef69fda0cccf14c06a483561527e9169b8f"
+git-tree-sha1 = "3c3a42a29f696f16273741ffe589b4003f539088"
 uuid = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
-version = "1.0.1"
+version = "1.1.0"
 
     [deps.SparseConnectivityTracer.extensions]
+    SparseConnectivityTracerChainRulesCoreExt = "ChainRulesCore"
     SparseConnectivityTracerLogExpFunctionsExt = "LogExpFunctions"
     SparseConnectivityTracerNNlibExt = "NNlib"
     SparseConnectivityTracerNaNMathExt = "NaNMath"
     SparseConnectivityTracerSpecialFunctionsExt = "SpecialFunctions"
 
     [deps.SparseConnectivityTracer.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
     LogExpFunctions = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
     NNlib = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
     NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
@@ -2271,10 +2306,10 @@ uuid = "860ef19b-820b-49d6-a774-d7a799459cd3"
 version = "1.0.3"
 
 [[deps.Static]]
-deps = ["CommonWorldInvalidations", "IfElse", "PrecompileTools"]
-git-tree-sha1 = "f737d444cb0ad07e61b3c1bef8eb91203c321eff"
+deps = ["CommonWorldInvalidations", "IfElse", "PrecompileTools", "SciMLPublic"]
+git-tree-sha1 = "1e44e7b1dbb5249876d84c32466f8988a6b41bbb"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-version = "1.2.0"
+version = "1.3.0"
 
 [[deps.StaticArrayInterface]]
 deps = ["ArrayInterface", "Compat", "IfElse", "LinearAlgebra", "PrecompileTools", "Static"]
@@ -2380,9 +2415,9 @@ version = "7.7.0+0"
 
 [[deps.SymbolicIndexingInterface]]
 deps = ["Accessors", "ArrayInterface", "RuntimeGeneratedFunctions", "StaticArraysCore"]
-git-tree-sha1 = "93104ca226670c0cb92ba8bc6998852ad55a2d4c"
+git-tree-sha1 = "617400a198bd433f921ca2a4e89999f835dd3fde"
 uuid = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
-version = "0.3.43"
+version = "0.3.45"
 weakdeps = ["PrettyTables"]
 
     [deps.SymbolicIndexingInterface.extensions]
@@ -2516,25 +2551,6 @@ git-tree-sha1 = "53915e50200959667e78a92a418594b428dffddf"
 uuid = "1cfade01-22cf-5700-b092-accc4b62d6e1"
 version = "0.4.1"
 
-[[deps.Unitful]]
-deps = ["Dates", "LinearAlgebra", "Random"]
-git-tree-sha1 = "6258d453843c466d84c17a58732dda5deeb8d3af"
-uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
-version = "1.24.0"
-weakdeps = ["ConstructionBase", "ForwardDiff", "InverseFunctions", "Printf"]
-
-    [deps.Unitful.extensions]
-    ConstructionBaseUnitfulExt = "ConstructionBase"
-    ForwardDiffExt = "ForwardDiff"
-    InverseFunctionsUnitfulExt = "InverseFunctions"
-    PrintfExt = "Printf"
-
-[[deps.UnitfulLatexify]]
-deps = ["LaTeXStrings", "Latexify", "Unitful"]
-git-tree-sha1 = "af305cc62419f9bd61b6644d19170a4d258c7967"
-uuid = "45397f5d-5981-4c77-b2b3-fc36d6e9b728"
-version = "1.7.0"
-
 [[deps.UnsafePointers]]
 git-tree-sha1 = "c81331b3b2e60a982be57c046ec91f599ede674a"
 uuid = "e17b2a0c-0bdf-430a-bd0c-3a23cae4ff39"
@@ -2570,9 +2586,9 @@ version = "1.6.1"
 
 [[deps.XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Zlib_jll"]
-git-tree-sha1 = "b8b243e47228b4a3877f1dd6aee0c5d56db7fcf4"
+git-tree-sha1 = "80d3930c6347cfce7ccf96bd3bafdf079d9c0390"
 uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.13.6+1"
+version = "2.13.9+0"
 
 [[deps.XZ_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -2624,9 +2640,9 @@ version = "1.3.7+0"
 
 [[deps.Xorg_libXfixes_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
-git-tree-sha1 = "9caba99d38404b285db8801d5c45ef4f4f425a6d"
+git-tree-sha1 = "75e00946e43621e09d431d9b95818ee751e6b2ef"
 uuid = "d091e8ba-531a-589c-9de9-94069b037ed8"
-version = "6.0.1+0"
+version = "6.0.2+0"
 
 [[deps.Xorg_libXi_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXext_jll", "Xorg_libXfixes_jll"]
@@ -2672,9 +2688,9 @@ version = "1.1.3+0"
 
 [[deps.Xorg_xcb_util_cursor_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_xcb_util_image_jll", "Xorg_xcb_util_jll", "Xorg_xcb_util_renderutil_jll"]
-git-tree-sha1 = "c5bf2dad6a03dfef57ea0a170a1fe493601603f2"
+git-tree-sha1 = "9750dc53819eba4e9a20be42349a6d3b86c7cdf8"
 uuid = "e920d4aa-a673-5f3a-b3d7-f755a4d47c43"
-version = "0.1.5+0"
+version = "0.1.6+0"
 
 [[deps.Xorg_xcb_util_image_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_xcb_util_jll"]

--- a/Ribasim.spdx.json
+++ b/Ribasim.spdx.json
@@ -3,12 +3,12 @@
     "dataLicense": "CC0-1.0",
     "SPDXID": "SPDXRef-DOCUMENT",
     "name": "Ribasim.jl",
-    "documentNamespace": "https://github.com/Deltares/Ribasim/Ribasim.spdx.json-7ffe5810-b7c6-4391-96c9-1ac7ca4f16a9",
+    "documentNamespace": "https://github.com/Deltares/Ribasim/Ribasim.spdx.json-02e55f87-c0f8-46c4-b0b0-44a8d973297f",
     "creationInfo": {
         "creators": [
             "Organization:  Deltares  (software@deltares.nl)"
         ],
-        "created": "2025-09-02T03:19:33Z",
+        "created": "2025-10-02T03:13:59Z",
         "comment": "Target Platform: Platform(\"x86_64\", \"linux\"; libgfortran_version = \"5.0.0\", julia_version = \"1.11.6\", libc = \"glibc\", libstdcxx_version = \"3.4.30\", cxxstring_abi = \"cxx11\")"
     },
     "comment": "Registries used for populating Package data:\nGeneral registry: https://github.com/JuliaRegistries/General.git\nOfficial general Julia package registry where people can\nregister any package they want without too much debate about\nnaming and without enforced standards on documentation or\ntesting. We nevertheless encourage documentation, testing and\nsome amount of consideration when choosing package names.\n",
@@ -435,13 +435,13 @@
         {
             "name": "ForwardDiff",
             "SPDXID": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210",
-            "versionInfo": "1.1.0",
+            "versionInfo": "1.2.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaDiff/ForwardDiff.jl.git@ce15956960057e9ff7f1f535400ffa14c92429a4",
+            "downloadLocation": "git+https://github.com/JuliaDiff/ForwardDiff.jl.git@dc41303865a16274ecb8450c220021ce1e0cf05f",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "ba782141ad2f20400962c24edf7d96d0e376127a"
+                "packageVerificationCodeValue": "472b2685908130e65506d0b22916bfe8310baefb"
             },
             "homepage": "https://github.com/JuliaDiff/ForwardDiff.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -657,13 +657,13 @@
         {
             "name": "Compat",
             "SPDXID": "SPDXRef-Compat-34da2185-b29b-5c13-b0c7-acf172513d20",
-            "versionInfo": "4.18.0",
+            "versionInfo": "4.18.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaLang/Compat.jl.git@0037835448781bb46feb39866934e243886d756a",
+            "downloadLocation": "git+https://github.com/JuliaLang/Compat.jl.git@9d8a54ce4b17aa5bdce0ea5c34bc5e7c340d16ad",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "6c7553f043185d42029730c650ae1aa3b20bd981"
+                "packageVerificationCodeValue": "76de5eebbf85c7543c1a18534be2a8e66abd3da2"
             },
             "homepage": "https://github.com/JuliaLang/Compat.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -883,13 +883,13 @@
         {
             "name": "MutableArithmetics",
             "SPDXID": "SPDXRef-MutableArithmetics-d8a4904e-b15c-11e9-3269-09a3773c0cb0",
-            "versionInfo": "1.6.4",
+            "versionInfo": "1.6.6",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/jump-dev/MutableArithmetics.jl.git@491bdcdc943fcbc4c005900d7463c9f216aabf4c",
+            "downloadLocation": "git+https://github.com/jump-dev/MutableArithmetics.jl.git@5801388fbfb801822721b5dee720a55a6d03d41d",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "c70ec86942f3b284b43e792d65b1d8cfc1fca205"
+                "packageVerificationCodeValue": "f147c8038d7abed7152c2d0c8e407b85a1990f23"
             },
             "homepage": "https://github.com/jump-dev/MutableArithmetics.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -905,13 +905,13 @@
         {
             "name": "MathOptInterface",
             "SPDXID": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee",
-            "versionInfo": "1.43.0",
+            "versionInfo": "1.45.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/jump-dev/MathOptInterface.jl.git@583abfbd38f15198adde0658e1b1222ece232ae2",
+            "downloadLocation": "git+https://github.com/jump-dev/MathOptInterface.jl.git@700acfa97a2b23569c0a6dcfcd85f183d7258e31",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "c35ea8eb50d91524169b014edb7119e335917a3c"
+                "packageVerificationCodeValue": "3f499125f7f5ad2f49e465b8e25f67fb959dbf75"
             },
             "homepage": "https://github.com/jump-dev/MathOptInterface.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -1604,13 +1604,13 @@
         {
             "name": "Krylov",
             "SPDXID": "SPDXRef-Krylov-ba0b0d4f-ebba-5204-a429-3ac8c609bfb7",
-            "versionInfo": "0.10.1",
+            "versionInfo": "0.10.2",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaSmoothOptimizers/Krylov.jl.git@b94257a1a8737099ca40bc7271a8b374033473ed",
+            "downloadLocation": "git+https://github.com/JuliaSmoothOptimizers/Krylov.jl.git@d1fc961038207e43982851e57ee257adc37be5e8",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "d6334675947d30ad076afea8b05612b5cd7da714"
+                "packageVerificationCodeValue": "4e048d3e263c53f50c8d9b9c8f9697fe34c30922"
             },
             "homepage": "https://github.com/JuliaSmoothOptimizers/Krylov.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -1648,13 +1648,13 @@
         {
             "name": "Adapt",
             "SPDXID": "SPDXRef-Adapt-79e6a3ab-5dfb-504d-930d-738a2a938a0e",
-            "versionInfo": "4.3.0",
+            "versionInfo": "4.4.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaGPU/Adapt.jl.git@f7817e2e585aa6d924fd714df1e2a84be7896c60",
+            "downloadLocation": "git+https://github.com/JuliaGPU/Adapt.jl.git@7e35fca2bdfba44d797c53dfe63a51fabf39bfc0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "feb2efc5fca2736a55890380026753f821ba4874"
+                "packageVerificationCodeValue": "16cf2019fbe587243843cbd42b67166fcbb753ff"
             },
             "homepage": "https://github.com/JuliaGPU/Adapt.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -1714,13 +1714,13 @@
         {
             "name": "SciMLOperators",
             "SPDXID": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961",
-            "versionInfo": "1.7.0",
+            "versionInfo": "1.7.2",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/SciMLOperators.jl.git@1d5b9c3677ea17503045024900dde8ba8585fac5",
+            "downloadLocation": "git+https://github.com/SciML/SciMLOperators.jl.git@024d829102878141aaee5cf8f8288bcabd2f57a0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "b82ec34fbb7c4908fb873b966734675a71b12e82"
+                "packageVerificationCodeValue": "057d35c91433effc94cda3e913ae356d83f0a4fc"
             },
             "homepage": "https://github.com/SciML/SciMLOperators.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -1890,13 +1890,13 @@
         {
             "name": "SymbolicIndexingInterface",
             "SPDXID": "SPDXRef-SymbolicIndexingInterface-2efcf032-c050-4f8e-a9bb-153293bab1f5",
-            "versionInfo": "0.3.43",
+            "versionInfo": "0.3.45",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/SymbolicIndexingInterface.jl.git@93104ca226670c0cb92ba8bc6998852ad55a2d4c",
+            "downloadLocation": "git+https://github.com/SciML/SymbolicIndexingInterface.jl.git@617400a198bd433f921ca2a4e89999f835dd3fde",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "e3db6c711613d8d5d8e89c40351f242c0ae08173"
+                "packageVerificationCodeValue": "61c5c7838553a6140496327ed472dc985f6a2586"
             },
             "homepage": "https://github.com/SciML/SymbolicIndexingInterface.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -1934,13 +1934,13 @@
         {
             "name": "ADTypes",
             "SPDXID": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
-            "versionInfo": "1.17.0",
+            "versionInfo": "1.18.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/ADTypes.jl.git@60665b326b75db6517939d0e1875850bc4a54368",
+            "downloadLocation": "git+https://github.com/SciML/ADTypes.jl.git@27cecae79e5cc9935255f90c53bb831cc3c870d7",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "5296e66ad16775fad75e0afcc0a11e5936eae028"
+                "packageVerificationCodeValue": "23ab18d34139eb0849818cf50c4dd19aeb77e2c0"
             },
             "homepage": "https://github.com/SciML/ADTypes.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -1978,13 +1978,13 @@
         {
             "name": "PreallocationTools",
             "SPDXID": "SPDXRef-PreallocationTools-d236fae5-4411-538c-8e31-a6e3d9e00b46",
-            "versionInfo": "0.4.33",
+            "versionInfo": "0.4.34",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/PreallocationTools.jl.git@9b4ee15d1fc68654031964a7af0c914c898e35a7",
+            "downloadLocation": "git+https://github.com/SciML/PreallocationTools.jl.git@c05b4c6325262152483a1ecb6c69846d2e01727b",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "b0715a4d210607b215fe64b19d8816ea36d494bc"
+                "packageVerificationCodeValue": "1834dee4a9ffa8f303399cc5fe98546ac17df3fb"
             },
             "homepage": "https://github.com/SciML/PreallocationTools.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2044,13 +2044,13 @@
         {
             "name": "SciMLBase",
             "SPDXID": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
-            "versionInfo": "2.115.0",
+            "versionInfo": "2.120.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/SciMLBase.jl.git@8fb66de06c21a4dfb5d08bb59f37dc597e4b0f9e",
+            "downloadLocation": "git+https://github.com/SciML/SciMLBase.jl.git@16fa030fb4bd4df373a677eca0460c3eee791ab2",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "9fde5f0cb182d44916c2bdb33562535ff9dcdcb3"
+                "packageVerificationCodeValue": "7041a81dd2c4280018f8fbb5f9bb0de01ec4ae4b"
             },
             "homepage": "https://github.com/SciML/SciMLBase.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2066,13 +2066,13 @@
         {
             "name": "FillArrays",
             "SPDXID": "SPDXRef-FillArrays-1a297f60-69ca-5386-bcde-b61e274b549b",
-            "versionInfo": "1.13.0",
+            "versionInfo": "1.14.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaArrays/FillArrays.jl.git@6a70198746448456524cb442b8af316927ff3e1a",
+            "downloadLocation": "git+https://github.com/JuliaArrays/FillArrays.jl.git@173e4d8f14230a7523ae11b9a3fa9edb3e0efd78",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "ccc3face6f25846016b5a99bec699e0fd095909e"
+                "packageVerificationCodeValue": "a610c999e68c6a3ebedbb5d776423656fc92f10e"
             },
             "homepage": "https://github.com/JuliaArrays/FillArrays.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2133,13 +2133,13 @@
         {
             "name": "LazyArrays",
             "SPDXID": "SPDXRef-LazyArrays-5078a376-72f3-5289-bfd5-ec5146d43c02",
-            "versionInfo": "2.6.2",
+            "versionInfo": "2.6.3",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaArrays/LazyArrays.jl.git@76627adb8c542c6b73f68d4bfd0aa71c9893a079",
+            "downloadLocation": "git+https://github.com/JuliaArrays/LazyArrays.jl.git@21057b6f4f5db1475e653735fda7d1de1c267b46",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "17b86b45c51a64cfaab3962e52cb76fb92e6f05f"
+                "packageVerificationCodeValue": "81e10776cee60e8f7e7b8308df5f586d02c18dc3"
             },
             "homepage": "https://github.com/JuliaArrays/LazyArrays.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2428,13 +2428,13 @@
         {
             "name": "LinearSolve",
             "SPDXID": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae",
-            "versionInfo": "3.38.0",
+            "versionInfo": "3.40.2",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/LinearSolve.jl.git@9874796f130d8642fbed2a9f240e517b46639288",
+            "downloadLocation": "git+https://github.com/SciML/LinearSolve.jl.git@6c22b14a5ea7fbcc140ea1f52f3cfe20d3da32e0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "549f14a31e8d24d7d299f4d6290619ad2a4aa3bf"
+                "packageVerificationCodeValue": "07afa267aa3da9b82bff9f72cc7e11c4535b7e9f"
             },
             "homepage": "https://github.com/SciML/LinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2603,6 +2603,28 @@
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
+            "name": "SciMLPublic",
+            "SPDXID": "SPDXRef-SciMLPublic-431bcebd-1456-4ced-9d72-93c2757fff0b",
+            "versionInfo": "1.0.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/SciMLPublic.jl.git@ed647f161e8b3f2973f24979ec074e8d084f1bee",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "fe72cb1f40548a19edca0e3c1c287ff2a1112083"
+            },
+            "homepage": "https://github.com/SciML/SciMLPublic.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
             "name": "CommonWorldInvalidations",
             "SPDXID": "SPDXRef-CommonWorldInvalidations-f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8",
             "versionInfo": "1.0.0",
@@ -2627,13 +2649,13 @@
         {
             "name": "Static",
             "SPDXID": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3",
-            "versionInfo": "1.2.0",
+            "versionInfo": "1.3.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/Static.jl.git@f737d444cb0ad07e61b3c1bef8eb91203c321eff",
+            "downloadLocation": "git+https://github.com/SciML/Static.jl.git@1e44e7b1dbb5249876d84c32466f8988a6b41bbb",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "e03e7ea4cac7cd4bf4ed1f40911d06dac5580bb2"
+                "packageVerificationCodeValue": "743b5a70ec935b65b34aa91b1491426d38931dfb"
             },
             "homepage": "https://github.com/SciML/Static.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2891,13 +2913,13 @@
         {
             "name": "EnzymeCore",
             "SPDXID": "SPDXRef-EnzymeCore-f151be2c-9106-41f4-ab19-57ee4f262869",
-            "versionInfo": "0.8.12",
+            "versionInfo": "0.8.14",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/EnzymeAD/Enzyme.jl.git@8272a687bca7b5c601c0c24fc0c71bff10aafdfd#lib/EnzymeCore",
+            "downloadLocation": "git+https://github.com/EnzymeAD/Enzyme.jl.git@e059db5d02720ae826445f5ce2fdfb3d53236b87#lib/EnzymeCore",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "bb6f65bb3577ba76c6f7c5dac64c7d947156e3f7"
+                "packageVerificationCodeValue": "722b88a154e532be99a91945329855f7e9dd0eba"
             },
             "homepage": "https://github.com/EnzymeAD/Enzyme.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3004,13 +3026,13 @@
         {
             "name": "DiffEqBase",
             "SPDXID": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
-            "versionInfo": "6.186.0",
+            "versionInfo": "6.190.2",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/DiffEqBase.jl.git@20c11d6686206f4ccaea93915901ab6ee352128c",
+            "downloadLocation": "git+https://github.com/SciML/DiffEqBase.jl.git@087632db966c90079a5534e4147afea9136ca39a",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "332fc86f19f34122357e167956f63dfab882d86a"
+                "packageVerificationCodeValue": "59b30e6946779a3c9b5e9dbb8a49c16647047803"
             },
             "homepage": "https://github.com/SciML/DiffEqBase.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3048,13 +3070,13 @@
         {
             "name": "OrdinaryDiffEqCore",
             "SPDXID": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8",
-            "versionInfo": "1.30.0",
+            "versionInfo": "1.34.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@e579c9a4f9102e82da3d97c349a74d6bc11cf8dc#lib/OrdinaryDiffEqCore",
+            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@688c717e8eee84dcfef02ddf71c8028215b329ca#lib/OrdinaryDiffEqCore",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "66f1988544ed15457d33bbc22a23d6739d0ea7f0"
+                "packageVerificationCodeValue": "ce35a548be36068ef2929a6c479039673420795b"
             },
             "homepage": "https://github.com/SciML/OrdinaryDiffEq.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3445,13 +3467,13 @@
         {
             "name": "DifferentiationInterface",
             "SPDXID": "SPDXRef-DifferentiationInterface-a0c0ee7d-e4b9-4e03-894e-1c5f64a51d63",
-            "versionInfo": "0.7.7",
+            "versionInfo": "0.7.8",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaDiff/DifferentiationInterface.jl.git@16946a4d305607c3a4af54ff35d56f0e9444ed0e#DifferentiationInterface",
+            "downloadLocation": "git+https://github.com/JuliaDiff/DifferentiationInterface.jl.git@cee1700673af54db57bd1c7fb834ad4ff31309a0#DifferentiationInterface",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "29cbf26133c62b813d6f99317b8c71b153b65892"
+                "packageVerificationCodeValue": "4cfb7e4e8e99fa7e36b4ddf129b10158e3bd0c07"
             },
             "homepage": "https://github.com/JuliaDiff/DifferentiationInterface.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3467,13 +3489,13 @@
         {
             "name": "OrdinaryDiffEqDifferentiation",
             "SPDXID": "SPDXRef-OrdinaryDiffEqDifferentiation-4302a76b-040a-498a-8c04-15b101fed76b",
-            "versionInfo": "1.14.0",
+            "versionInfo": "1.16.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@4c270747152db513dd80bfd5f2f9df48befff28a#lib/OrdinaryDiffEqDifferentiation",
+            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@320b5f3e4e61ca0ad863c63c803f69973ba6efce#lib/OrdinaryDiffEqDifferentiation",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "2b381ebb8d30209e2123b30e53a0a41032b3447c"
+                "packageVerificationCodeValue": "f3d428f4691622bbe80864333d3e16ae1a55940b"
             },
             "homepage": "https://github.com/SciML/OrdinaryDiffEq.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3489,13 +3511,13 @@
         {
             "name": "OrdinaryDiffEqRosenbrock",
             "SPDXID": "SPDXRef-OrdinaryDiffEqRosenbrock-43230ef6-c299-4910-a778-202eb28ce4ce",
-            "versionInfo": "1.17.0",
+            "versionInfo": "1.18.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@d0b4e34792fb64c3815fc79ad3adc300b1e35588#lib/OrdinaryDiffEqRosenbrock",
+            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@f34bc2f58656843596d09a4c4de8c20724ebc2f1#lib/OrdinaryDiffEqRosenbrock",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "5d71ca5d569c5bc17a0acf5cfc66c154d7e980b8"
+                "packageVerificationCodeValue": "bf3333b5d9543e44bbac0af3e0b90835c24ef0a1"
             },
             "homepage": "https://github.com/SciML/OrdinaryDiffEq.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3533,13 +3555,13 @@
         {
             "name": "SparseConnectivityTracer",
             "SPDXID": "SPDXRef-SparseConnectivityTracer-9f842d2f-2579-4b1d-911e-f412cf18a3f5",
-            "versionInfo": "1.0.1",
+            "versionInfo": "1.1.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/adrhill/SparseConnectivityTracer.jl.git@339efef69fda0cccf14c06a483561527e9169b8f",
+            "downloadLocation": "git+https://github.com/adrhill/SparseConnectivityTracer.jl.git@3c3a42a29f696f16273741ffe589b4003f539088",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "3d581a7dce91936a9745475a3ae14c1f47f7ed5d"
+                "packageVerificationCodeValue": "becc7508bffd506576f7e00519eb0245044a83ad"
             },
             "homepage": "https://github.com/adrhill/SparseConnectivityTracer.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3599,13 +3621,13 @@
         {
             "name": "SciMLJacobianOperators",
             "SPDXID": "SPDXRef-SciMLJacobianOperators-19f34311-ddf3-4b8b-af20-060888a46c0e",
-            "versionInfo": "0.1.8",
+            "versionInfo": "0.1.11",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@3414071e3458f3065de7fa5aed55283b236b4907#lib/SciMLJacobianOperators",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@a273b291c90909ba6fe08402dd68e09aae423008#lib/SciMLJacobianOperators",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "7082ee61de490304875c6108975117c17fdb3e95"
+                "packageVerificationCodeValue": "d98ead6b213189ed8372296b20bc5534e5fa54a8"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3643,13 +3665,13 @@
         {
             "name": "NonlinearSolveBase",
             "SPDXID": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0",
-            "versionInfo": "1.14.0",
+            "versionInfo": "1.16.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@1d42a315ba627ca0027d49d0efb44e3d88db24aa#lib/NonlinearSolveBase",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@f05e5f3d0f280598ecdc26b06ec9acd71dcaef31#lib/NonlinearSolveBase",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "1d50f42fce04da237afdaba5e3c175a0824a5515"
+                "packageVerificationCodeValue": "f59bd3ab584cab3c0f2a862177710273e720d082"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3665,13 +3687,13 @@
         {
             "name": "NonlinearSolveQuasiNewton",
             "SPDXID": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114",
-            "versionInfo": "1.8.0",
+            "versionInfo": "1.9.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@40dfaf1bf74f1f700f81d0002d4dd90999598eb2#lib/NonlinearSolveQuasiNewton",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@4e0e34601c6c9890aa9443003180967f75c6929d#lib/NonlinearSolveQuasiNewton",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "1bc34cc39965970bdb600bf4b44835a1bcfbd2b0"
+                "packageVerificationCodeValue": "02dbbda64eeea74c37d6dddec7638b75e64e7bf7"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3687,13 +3709,13 @@
         {
             "name": "BracketingNonlinearSolve",
             "SPDXID": "SPDXRef-BracketingNonlinearSolve-70df07ce-3d50-431d-a3e7-ca6ddb60ac1e",
-            "versionInfo": "1.3.0",
+            "versionInfo": "1.4.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@a9014924595b7a2c1dd14aac516e38fa10ada656#lib/BracketingNonlinearSolve",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@90740f16aef91d898424bc11c1cabada475435e0#lib/BracketingNonlinearSolve",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "faeebdf94f3bd6bc77e3f29b76fd767907ec6b36"
+                "packageVerificationCodeValue": "c33b3363ff9987b9337bccb035ec4a21cb44e874"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3731,13 +3753,13 @@
         {
             "name": "SimpleNonlinearSolve",
             "SPDXID": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7",
-            "versionInfo": "2.7.0",
+            "versionInfo": "2.8.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@09d986e27a606f172c5b6cffbd8b8b2f10bf1c75#lib/SimpleNonlinearSolve",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@782c67176b473abf62a6786399c4b7ddcc1a2d77#lib/SimpleNonlinearSolve",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "a4ac9c52ede5b085defa3ae56d69d4d089940ab5"
+                "packageVerificationCodeValue": "32c204c4adb54e350ebe530a0191d3b722141b91"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3753,13 +3775,13 @@
         {
             "name": "NonlinearSolveSpectralMethods",
             "SPDXID": "SPDXRef-NonlinearSolveSpectralMethods-26075421-4e9a-44e1-8bd1-420ed7ad02b2",
-            "versionInfo": "1.3.0",
+            "versionInfo": "1.4.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@84de5a469e119eb2c22ae07c543dc4e7f7001ee7#lib/NonlinearSolveSpectralMethods",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@6c613302febe2bb408a888105d07073cf6824911#lib/NonlinearSolveSpectralMethods",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "95bbcbe38431333f7c90488bada1c42733409a66"
+                "packageVerificationCodeValue": "59c46cd1751f4150ab20317c270348eedc658531"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3775,13 +3797,13 @@
         {
             "name": "NonlinearSolveFirstOrder",
             "SPDXID": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d",
-            "versionInfo": "1.7.0",
+            "versionInfo": "1.8.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@3f1198ae5cbf21e84b8251a9e62fa1f888f3e4cb#lib/NonlinearSolveFirstOrder",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@b9702235120d1161f8041b326eccebd334340de2#lib/NonlinearSolveFirstOrder",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "cc6880b979cd3f39fbfe1cbe837248e9c40941ab"
+                "packageVerificationCodeValue": "b069bc4bd44b6609adadc6bf58b93acb7d26e06b"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3797,13 +3819,13 @@
         {
             "name": "NonlinearSolve",
             "SPDXID": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec",
-            "versionInfo": "4.10.0",
+            "versionInfo": "4.11.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@d2ec18c1e4eccbb70b64be2435fc3b06fbcdc0a1",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@627967f6e36aac9f5afb2fb285e33b676a6892f9",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "d8ac9875066ea1bfcbd05135934d1c5029579745"
+                "packageVerificationCodeValue": "f3b121fa1cbd210ad02fe44ff181aab7c78dfb2b"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3951,13 +3973,13 @@
         {
             "name": "MultiObjectiveAlgorithms",
             "SPDXID": "SPDXRef-MultiObjectiveAlgorithms-0327d340-17cd-11ea-3e99-2fd5d98cecda",
-            "versionInfo": "1.6.0",
+            "versionInfo": "1.7.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/jump-dev/MultiObjectiveAlgorithms.jl.git@9279f54e52bc71082e3b40d2e4c67a837805ca3d",
+            "downloadLocation": "git+https://github.com/jump-dev/MultiObjectiveAlgorithms.jl.git@f724f97d25fc93852604507f505ac02b3ab42933",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "5f3e0b417185dd037499748df5fcc65480635125"
+                "packageVerificationCodeValue": "b078a5fad7921d8179c3c7c3c788f5bb1543641e"
             },
             "homepage": "https://github.com/jump-dev/MultiObjectiveAlgorithms.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3995,13 +4017,13 @@
         {
             "name": "JuMP",
             "SPDXID": "SPDXRef-JuMP-4076af6c-e467-56ae-b986-b466b2749572",
-            "versionInfo": "1.29.0",
+            "versionInfo": "1.29.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/jump-dev/JuMP.jl.git@d9c29fadef257492791c83b34ceede0d92a51470",
+            "downloadLocation": "git+https://github.com/jump-dev/JuMP.jl.git@b201ac010ecdcc3617649175fa59c3dbd9bf96a0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "784c2dbd4b6e260d37abdec9ee6cc7ac47a6286a"
+                "packageVerificationCodeValue": "9a0c330f0bd6592079b3a2b745c477359fc15268"
             },
             "homepage": "https://github.com/jump-dev/JuMP.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4084,13 +4106,13 @@
         {
             "name": "ChunkCodecCore",
             "SPDXID": "SPDXRef-ChunkCodecCore-0b6fb165-00bc-4d37-ab8b-79f91016dbe1",
-            "versionInfo": "0.5.3",
+            "versionInfo": "1.0.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaIO/ChunkCodecs.jl.git@e4a8d39a846ef288256a2cb94a60eb95c78e300a#ChunkCodecCore",
+            "downloadLocation": "git+https://github.com/JuliaIO/ChunkCodecs.jl.git@51f4c10ee01bda57371e977931de39ee0f0cdb3e#ChunkCodecCore",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "e0b8bf5b037f29a64ba257f40ae9b428eac84510"
+                "packageVerificationCodeValue": "6ec65e69ba5f95934a3646d7fd266d75f65f95c6"
             },
             "homepage": "https://github.com/JuliaIO/ChunkCodecs.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4106,13 +4128,13 @@
         {
             "name": "ChunkCodecLibZlib",
             "SPDXID": "SPDXRef-ChunkCodecLibZlib-4c0bbee4-addc-4d73-81a0-b6caacae83c8",
-            "versionInfo": "0.2.1",
+            "versionInfo": "1.0.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaIO/ChunkCodecs.jl.git@5866bf08bebfb3743e40c17ce805fbf03f85dbf4#LibZlib",
+            "downloadLocation": "git+https://github.com/JuliaIO/ChunkCodecs.jl.git@cee8104904c53d39eb94fd06cbe60cb5acde7177#LibZlib",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "275fcc17e1932d4505996f1d518930c6e846af3b"
+                "packageVerificationCodeValue": "3e0bdbd46f6d74f6985369d2c8c129c9193ef051"
             },
             "homepage": "https://github.com/JuliaIO/ChunkCodecs.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4129,13 +4151,13 @@
         {
             "name": "ChunkCodecLibZstd",
             "SPDXID": "SPDXRef-ChunkCodecLibZstd-55437552-ac27-4d47-9aa3-63184e8fd398",
-            "versionInfo": "0.2.1",
+            "versionInfo": "1.0.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaIO/ChunkCodecs.jl.git@6225e84baab33a74d6b16186c4465c46cb6b035a#LibZstd",
+            "downloadLocation": "git+https://github.com/JuliaIO/ChunkCodecs.jl.git@34d9873079e4cb3d0c62926a225136824677073f#LibZstd",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "26771021026b6fbb38d65e47e3f999a49947d92e"
+                "packageVerificationCodeValue": "f95c81d47b0f7125455b0b5ec46a5a5d776f809c"
             },
             "homepage": "https://github.com/JuliaIO/ChunkCodecs.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4177,12 +4199,12 @@
             "versionInfo": "1.5.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/vchuravy/ScopedValues.jl.git@c3b2323466378a2ba15bea4b2f73b081e022f473",
+            "downloadLocation": "git+https://github.com/JuliaLang/ScopedValues.jl.git@c3b2323466378a2ba15bea4b2f73b081e022f473",
             "filesAnalyzed": true,
             "packageVerificationCode": {
                 "packageVerificationCodeValue": "913977f64e28ee17a5c3cecb74f92a4cdbb0d570"
             },
-            "homepage": "https://github.com/vchuravy/ScopedValues.jl.git",
+            "homepage": "https://github.com/JuliaLang/ScopedValues.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
             "licenseConcluded": "NOASSERTION",
             "licenseInfoFromFiles": [
@@ -4196,13 +4218,13 @@
         {
             "name": "JLD2",
             "SPDXID": "SPDXRef-JLD2-033835bb-8acc-5ee8-8aae-3f567f8a3819",
-            "versionInfo": "0.6.0",
+            "versionInfo": "0.6.2",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaIO/JLD2.jl.git@da485e1e36e9c6d4403aa7b6d1db6806a66aa05a",
+            "downloadLocation": "git+https://github.com/JuliaIO/JLD2.jl.git@da2e9b4d1abbebdcca0aa68afa0aa272102baad7",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "31a69eac7c3c532da658cd3c778944c65c16f8d6"
+                "packageVerificationCodeValue": "35634c96e2399b0bd46c57bc154f94b952943446"
             },
             "homepage": "https://github.com/JuliaIO/JLD2.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4240,13 +4262,13 @@
         {
             "name": "FindFirstFunctions",
             "SPDXID": "SPDXRef-FindFirstFunctions-64ca27bc-2ba2-4a57-88aa-44e436879224",
-            "versionInfo": "1.4.1",
+            "versionInfo": "1.4.2",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/FindFirstFunctions.jl.git@670e1d9ceaa4a3161d32fe2d2fb2177f8d78b330",
+            "downloadLocation": "git+https://github.com/SciML/FindFirstFunctions.jl.git@544bdc2902fa966900d354510be775f8668a57bd",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "d77e35630ffd0c875daf71f2f22a5173fe0e4cea"
+                "packageVerificationCodeValue": "455f3e36f0127175bcd0af34e3a8cb2641fdb42b"
             },
             "homepage": "https://github.com/SciML/FindFirstFunctions.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4328,13 +4350,13 @@
         {
             "name": "PrettyTables",
             "SPDXID": "SPDXRef-PrettyTables-08abe8d2-0d0c-5749-adfa-8a2ac140af0d",
-            "versionInfo": "2.4.0",
+            "versionInfo": "3.0.11",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/ronisbr/PrettyTables.jl.git@1101cd475833706e4d0e7b122218257178f48f34",
+            "downloadLocation": "git+https://github.com/ronisbr/PrettyTables.jl.git@5e9fe23c86d3ca630baa1efcad78575a27f158b2",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "df34e78bc274f050ddb3006e03577248922af06f"
+                "packageVerificationCodeValue": "4d4faf161e484eec65a4feeeaed54cbfe70078ed"
             },
             "homepage": "https://github.com/ronisbr/PrettyTables.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4350,13 +4372,13 @@
         {
             "name": "DataInterpolations",
             "SPDXID": "SPDXRef-DataInterpolations-82cc6244-b520-54b8-b5a6-8a565e85f1d0",
-            "versionInfo": "8.5.0",
+            "versionInfo": "8.6.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/DataInterpolations.jl.git@d8a84dc566622fce3c9bca8c5341006ff1cec491",
+            "downloadLocation": "git+https://github.com/SciML/DataInterpolations.jl.git@58ae0a38dd3002963a3c8d4af097e660cf409c38",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "8d9f5eaef1c9cf255102ed25c2e19ef3fd130b13"
+                "packageVerificationCodeValue": "c07b4d62b8f0ac47752439b1d1b4bcd66b06a659"
             },
             "homepage": "https://github.com/SciML/DataInterpolations.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4372,13 +4394,13 @@
         {
             "name": "CFTime",
             "SPDXID": "SPDXRef-CFTime-179af706-886a-5703-950a-314cd64e0468",
-            "versionInfo": "0.2.2",
+            "versionInfo": "0.2.4",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaGeo/CFTime.jl.git@e85b90dfcf01b9de2f4bbda8d989e1344728c0a6",
+            "downloadLocation": "git+https://github.com/JuliaGeo/CFTime.jl.git@2ed76cf4ac70526e3df565435d65e7c7b5c7a77a",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "0ea1e0fa406357a825669943268ddf4654e1325c"
+                "packageVerificationCodeValue": "7eea648b6e89ebf77db9e82c954e65e6716830b7"
             },
             "homepage": "https://github.com/JuliaGeo/CFTime.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4437,27 +4459,27 @@
         },
         {
             "name": "OpenSSL_source",
-            "SPDXID": "SPDXRef-e8d8c8c4d3d8891e07096b339f89d177dbbb37f7",
+            "SPDXID": "SPDXRef-6f7f93891ce6030e4713a070c1691e880019ccd2",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaPackaging/Yggdrasil.git@e8d8c8c4d3d8891e07096b339f89d177dbbb37f7#/O/OpenSSL/OpenSSL@3.5/",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/Yggdrasil.git@6f7f93891ce6030e4713a070c1691e880019ccd2#/O/OpenSSL/OpenSSL@3.5/",
             "filesAnalyzed": false,
-            "sourceInfo": "The location of this repository was extracted from the README.md file of SPDXRef-48d69f95e00f33788b0bddee11ce58dd15ba21e5",
+            "sourceInfo": "The location of this repository was extracted from the README.md file of SPDXRef-7f39a18d94f87b5135df6731a327b61b8c463af6",
             "licenseConcluded": "NOASSERTION",
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
-            "summary": "The binary artifact SPDXRef-48d69f95e00f33788b0bddee11ce58dd15ba21e5 is built using the scripts and source files in this package.\nThe build system is called Yggdrasil, the Julia community build tree.",
+            "summary": "The binary artifact SPDXRef-7f39a18d94f87b5135df6731a327b61b8c463af6 is built using the scripts and source files in this package.\nThe build system is called Yggdrasil, the Julia community build tree.",
             "comment": "The SPDX ID field is derived from the Git hash in the DownloadLocation"
         },
         {
             "name": "OpenSSL",
-            "SPDXID": "SPDXRef-48d69f95e00f33788b0bddee11ce58dd15ba21e5",
+            "SPDXID": "SPDXRef-7f39a18d94f87b5135df6731a327b61b8c463af6",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "https://github.com/JuliaBinaryWrappers/OpenSSL_jll.jl/releases/download/OpenSSL-v3.5.2+0/OpenSSL.v3.5.2.x86_64-linux-gnu.tar.gz",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/OpenSSL_jll.jl/releases/download/OpenSSL-v3.5.4+0/OpenSSL.v3.5.4.x86_64-linux-gnu.tar.gz",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "768d1d6116ea6a62a53e4e402eb1b24bd197ef9a",
+                "packageVerificationCodeValue": "e83ed8b394091e162fabdd0e0bf7daad0f7a7c7e",
                 "packageVerificationCodeExcludedFiles": [
                     "lib/libcrypto.so",
                     "lib/libssl.so"
@@ -4466,7 +4488,7 @@
             "checksums": [
                 {
                     "algorithm": "SHA256",
-                    "checksumValue": "67ab1445967361f8c855def1ac9941f290261fa0153398b502d03b3ce9088f0d"
+                    "checksumValue": "0a8f95b5797e4a4c226b71146adb8afd90947b933c4820707d1fbf592063cf83"
                 }
             ],
             "homepage": "NOASSERTION",
@@ -4484,13 +4506,13 @@
         {
             "name": "OpenSSL_jll",
             "SPDXID": "SPDXRef-OpenSSL_jll-458c3c95-2e84-50aa-8efc-19380b2a3a95",
-            "versionInfo": "3.5.2+0",
+            "versionInfo": "3.5.4+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/OpenSSL_jll.jl.git@2ae7d4ddec2e13ad3bddf5c0796f7547cf682391",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/OpenSSL_jll.jl.git@f19301ae653233bc88b1810ae908194f07f8db9d",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "f9f68af40516257fe5117d5c6d1de7a73f895d46"
+                "packageVerificationCodeValue": "53da81d4d37dc42b19bfe46c6548ff3c2de9b76a"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/OpenSSL_jll.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4993,27 +5015,27 @@
         },
         {
             "name": "XML2_source",
-            "SPDXID": "SPDXRef-5b74b245d91d6d54db702be3f0fc5b7c9d9376d6",
+            "SPDXID": "SPDXRef-20fc3e3235b3776492ab2d3f60bce93acb966bc3",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaPackaging/Yggdrasil.git@5b74b245d91d6d54db702be3f0fc5b7c9d9376d6#/X/XML2/",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/Yggdrasil.git@20fc3e3235b3776492ab2d3f60bce93acb966bc3#/X/XML2/",
             "filesAnalyzed": false,
-            "sourceInfo": "The location of this repository was extracted from the README.md file of SPDXRef-7f882b869c126a717e15be05453b83bd9135eab0",
+            "sourceInfo": "The location of this repository was extracted from the README.md file of SPDXRef-4a89e14d2f652ad45bcc093d040c97fbcc1a3669",
             "licenseConcluded": "NOASSERTION",
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
-            "summary": "The binary artifact SPDXRef-7f882b869c126a717e15be05453b83bd9135eab0 is built using the scripts and source files in this package.\nThe build system is called Yggdrasil, the Julia community build tree.",
+            "summary": "The binary artifact SPDXRef-4a89e14d2f652ad45bcc093d040c97fbcc1a3669 is built using the scripts and source files in this package.\nThe build system is called Yggdrasil, the Julia community build tree.",
             "comment": "The SPDX ID field is derived from the Git hash in the DownloadLocation"
         },
         {
             "name": "XML2",
-            "SPDXID": "SPDXRef-7f882b869c126a717e15be05453b83bd9135eab0",
+            "SPDXID": "SPDXRef-4a89e14d2f652ad45bcc093d040c97fbcc1a3669",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "https://github.com/JuliaBinaryWrappers/XML2_jll.jl/releases/download/XML2-v2.13.6+1/XML2.v2.13.6.x86_64-linux-gnu.tar.gz",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/XML2_jll.jl/releases/download/XML2-v2.13.9+0/XML2.v2.13.9.x86_64-linux-gnu.tar.gz",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "27a360f7e274e54af99fe7c005d6382de5d75c93",
+                "packageVerificationCodeValue": "cc2b70317efaaa0cf0e68be3163e0b081d293d36",
                 "packageVerificationCodeExcludedFiles": [
                     "lib/libxml2.so",
                     "lib/libxml2.so.2"
@@ -5022,7 +5044,7 @@
             "checksums": [
                 {
                     "algorithm": "SHA256",
-                    "checksumValue": "64fedf508fe5262e4329002d244a7fe4827e1b12c51339b6d3041e5d2bf8ea70"
+                    "checksumValue": "55df6e9273fda4e16bdc4056f2afded28875af4e5232f0bf4c233ec08bd9198a"
                 }
             ],
             "homepage": "NOASSERTION",
@@ -5039,13 +5061,13 @@
         {
             "name": "XML2_jll",
             "SPDXID": "SPDXRef-XML2_jll-02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a",
-            "versionInfo": "2.13.6+1",
+            "versionInfo": "2.13.9+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/XML2_jll.jl.git@b8b243e47228b4a3877f1dd6aee0c5d56db7fcf4",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/XML2_jll.jl.git@80d3930c6347cfce7ccf96bd3bafdf079d9c0390",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "ae019f179133002cc15fa139ce295e47ae803803"
+                "packageVerificationCodeValue": "f2f1f4e9dabd4534c9d0240b84a5d327bdc88fd6"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/XML2_jll.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -5573,13 +5595,13 @@
         {
             "name": "DiskArrays",
             "SPDXID": "SPDXRef-DiskArrays-3c3547ce-8d99-4f5e-a174-61eb10b00ae3",
-            "versionInfo": "0.4.15",
+            "versionInfo": "0.4.16",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaIO/DiskArrays.jl.git@bfde0790720fcac006a3d62149309a685fc3aa13",
+            "downloadLocation": "git+https://github.com/JuliaIO/DiskArrays.jl.git@297ac5efb7c9c7849114eba76111af2814cac8ec",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "d752fca9b4d180b2be4d17de1490614fd49de6d4"
+                "packageVerificationCodeValue": "f45e76e01e260d3ff81f9ba2d94e6cfb516961f4"
             },
             "homepage": "https://github.com/JuliaIO/DiskArrays.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -6642,6 +6664,11 @@
             "relatedSpdxElement": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3"
         },
         {
+            "spdxElementId": "SPDXRef-SciMLPublic-431bcebd-1456-4ced-9d72-93c2757fff0b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3"
+        },
+        {
             "spdxElementId": "SPDXRef-CommonWorldInvalidations-f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3"
@@ -7562,6 +7589,11 @@
             "relatedSpdxElement": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114"
         },
         {
+            "spdxElementId": "SPDXRef-SciMLStructures-53ae85a6-f571-4167-b2af-e1d143709226",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
             "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
@@ -7692,6 +7724,11 @@
             "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
         },
         {
+            "spdxElementId": "SPDXRef-Setfield-efcf1570-3423-57d1-acb7-fd33fddbac46",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
+        },
+        {
             "spdxElementId": "SPDXRef-CommonSolve-38540f10-b2f7-11e9-35d8-d573e4eb0ff2",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0"
@@ -7743,11 +7780,6 @@
         },
         {
             "spdxElementId": "SPDXRef-CommonSolve-38540f10-b2f7-11e9-35d8-d573e4eb0ff2",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114"
-        },
-        {
-            "spdxElementId": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114"
         },
@@ -8002,7 +8034,7 @@
             "relatedSpdxElement": "SPDXRef-NonlinearSolveSpectralMethods-26075421-4e9a-44e1-8bd1-420ed7ad02b2"
         },
         {
-            "spdxElementId": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
+            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-NonlinearSolveSpectralMethods-26075421-4e9a-44e1-8bd1-420ed7ad02b2"
         },
@@ -8013,11 +8045,6 @@
         },
         {
             "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-NonlinearSolveSpectralMethods-26075421-4e9a-44e1-8bd1-420ed7ad02b2"
-        },
-        {
-            "spdxElementId": "SPDXRef-SciMLBase-0bca4576-84f4-4d90-8ffe-ffa030f20462",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-NonlinearSolveSpectralMethods-26075421-4e9a-44e1-8bd1-420ed7ad02b2"
         },
@@ -8117,11 +8144,6 @@
             "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
         },
         {
-            "spdxElementId": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
-        },
-        {
             "spdxElementId": "SPDXRef-Reexport-189a3867-3050-52da-a836-e630ba90ab69",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
@@ -8142,22 +8164,12 @@
             "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
         },
         {
-            "spdxElementId": "SPDXRef-SparseMatrixColorings-0a514795-09f3-496d-8182-132a7b665d35",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-        },
-        {
             "spdxElementId": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
         },
         {
             "spdxElementId": "SPDXRef-CommonSolve-38540f10-b2f7-11e9-35d8-d573e4eb0ff2",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-        },
-        {
-            "spdxElementId": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec"
         },
@@ -8677,12 +8689,12 @@
             "relatedSpdxElement": "SPDXRef-OpenSSL_jll-458c3c95-2e84-50aa-8efc-19380b2a3a95"
         },
         {
-            "spdxElementId": "SPDXRef-48d69f95e00f33788b0bddee11ce58dd15ba21e5",
+            "spdxElementId": "SPDXRef-7f39a18d94f87b5135df6731a327b61b8c463af6",
             "relationshipType": "GENERATED_FROM",
-            "relatedSpdxElement": "SPDXRef-e8d8c8c4d3d8891e07096b339f89d177dbbb37f7"
+            "relatedSpdxElement": "SPDXRef-6f7f93891ce6030e4713a070c1691e880019ccd2"
         },
         {
-            "spdxElementId": "SPDXRef-48d69f95e00f33788b0bddee11ce58dd15ba21e5",
+            "spdxElementId": "SPDXRef-7f39a18d94f87b5135df6731a327b61b8c463af6",
             "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-OpenSSL_jll-458c3c95-2e84-50aa-8efc-19380b2a3a95"
         },
@@ -8842,12 +8854,12 @@
             "relatedSpdxElement": "SPDXRef-XML2_jll-02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
         },
         {
-            "spdxElementId": "SPDXRef-7f882b869c126a717e15be05453b83bd9135eab0",
+            "spdxElementId": "SPDXRef-4a89e14d2f652ad45bcc093d040c97fbcc1a3669",
             "relationshipType": "GENERATED_FROM",
-            "relatedSpdxElement": "SPDXRef-5b74b245d91d6d54db702be3f0fc5b7c9d9376d6"
+            "relatedSpdxElement": "SPDXRef-20fc3e3235b3776492ab2d3f60bce93acb966bc3"
         },
         {
-            "spdxElementId": "SPDXRef-7f882b869c126a717e15be05453b83bd9135eab0",
+            "spdxElementId": "SPDXRef-4a89e14d2f652ad45bcc093d040c97fbcc1a3669",
             "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-XML2_jll-02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
         },


### PR DESCRIPTION
Update the Julia Manifest.toml to get the latest dependencies.

__Changed packages__
```
  Installing known registries into `~/.julia`
       Added `General` registry to ~/.julia/registries
    Updating registry at `~/.julia/registries/General.toml`
     Cloning git-repo `https://github.com/visr/PackageCompiler.jl`
    Updating git-repo `https://github.com/visr/PackageCompiler.jl`
     Cloning git-repo `https://github.com/julia-vscode/TestItemRunner.jl.git`
    Updating git-repo `https://github.com/julia-vscode/TestItemRunner.jl.git`
    Updating `~/work/Ribasim/Ribasim/Project.toml`
  [47edcb42] ↑ ADTypes v1.17.0 ⇒ v1.18.0
  [a93c6f00] ↑ DataFrames v1.7.1 ⇒ v1.8.0
  [82cc6244] ↑ DataInterpolations v8.5.0 ⇒ v8.6.1
  [a0c0ee7d] ↑ DifferentiationInterface v0.7.7 ⇒ v0.7.8
  [64ca27bc] ↑ FindFirstFunctions v1.4.1 ⇒ v1.4.2
  [f6369f11] ↑ ForwardDiff v1.1.0 ⇒ v1.2.1
  [4076af6c] ↑ JuMP v1.29.0 ⇒ v1.29.1
  [7ed4a6bd] ↑ LinearSolve v3.38.0 ⇒ v3.40.2
  [0327d340] ↑ MultiObjectiveAlgorithms v1.6.0 ⇒ v1.7.0
  [bbf590c4] ↑ OrdinaryDiffEqCore v1.30.0 ⇒ v1.34.0
  [43230ef6] ↑ OrdinaryDiffEqRosenbrock v1.17.0 ⇒ v1.18.1
  [91a5bcdd] ↑ Plots v1.40.19 ⇒ v1.41.1
  [6099a3de] ↑ PythonCall v0.9.27 ⇒ v0.9.28
  [0bca4576] ↑ SciMLBase v2.115.0 ⇒ v2.120.0
  [9f842d2f] ↑ SparseConnectivityTracer v1.0.1 ⇒ v1.1.0
  [458c3c95] ↑ OpenSSL_jll v3.5.2+0 ⇒ v3.5.4+0
    Updating `~/work/Ribasim/Ribasim/Manifest.toml`
  [47edcb42] ↑ ADTypes v1.17.0 ⇒ v1.18.0
  [79e6a3ab] ↑ Adapt v4.3.0 ⇒ v4.4.0
  [70df07ce] ↑ BracketingNonlinearSolve v1.3.0 ⇒ v1.4.0
  [179af706] ↑ CFTime v0.2.2 ⇒ v0.2.4
  [0b6fb165] ↑ ChunkCodecCore v0.5.3 ⇒ v1.0.0
  [4c0bbee4] ↑ ChunkCodecLibZlib v0.2.1 ⇒ v1.0.0
  [55437552] ↑ ChunkCodecLibZstd v0.2.1 ⇒ v1.0.0
  [da1fd8a2] ↑ CodeTracking v2.0.0 ⇒ v2.0.1
  [35d6a980] ↑ ColorSchemes v3.30.0 ⇒ v3.31.0
  [34da2185] ↑ Compat v4.18.0 ⇒ v4.18.1
  [992eb4ea] ↑ CondaPkg v0.2.31 ⇒ v0.2.33
  [a93c6f00] ↑ DataFrames v1.7.1 ⇒ v1.8.0
  [82cc6244] ↑ DataInterpolations v8.5.0 ⇒ v8.6.1
  [2b5f629d] ↑ DiffEqBase v6.186.0 ⇒ v6.190.2
  [a0c0ee7d] ↑ DifferentiationInterface v0.7.7 ⇒ v0.7.8
  [3c3547ce] ↑ DiskArrays v0.4.15 ⇒ v0.4.16
  [f151be2c] ↑ EnzymeCore v0.8.12 ⇒ v0.8.14
  [1a297f60] ↑ FillArrays v1.13.0 ⇒ v1.14.0
  [64ca27bc] ↑ FindFirstFunctions v1.4.1 ⇒ v1.4.2
  [f6369f11] ↑ ForwardDiff v1.1.0 ⇒ v1.2.1
  [033835bb] ↑ JLD2 v0.6.0 ⇒ v0.6.2
  [4076af6c] ↑ JuMP v1.29.0 ⇒ v1.29.1
  [ba0b0d4f] ↑ Krylov v0.10.1 ⇒ v0.10.2
  [23fbe1c1] ↑ Latexify v0.16.9 ⇒ v0.16.10
  [5078a376] ↑ LazyArrays v2.6.2 ⇒ v2.6.3
  [7ed4a6bd] ↑ LinearSolve v3.38.0 ⇒ v3.40.2
  [6f1432cf] ↑ LoweredCodeUtils v3.4.3 ⇒ v3.4.4
  [b8f27783] ↑ MathOptInterface v1.43.0 ⇒ v1.45.0
  [0327d340] ↑ MultiObjectiveAlgorithms v1.6.0 ⇒ v1.7.0
  [d8a4904e] ↑ MutableArithmetics v1.6.4 ⇒ v1.6.6
  [8913a72c] ↑ NonlinearSolve v4.10.0 ⇒ v4.11.0
  [be0214bd] ↑ NonlinearSolveBase v1.14.0 ⇒ v1.16.1
  [5959db7a] ↑ NonlinearSolveFirstOrder v1.7.0 ⇒ v1.8.0
  [9a2c21bd] ↑ NonlinearSolveQuasiNewton v1.8.0 ⇒ v1.9.0
  [26075421] ↑ NonlinearSolveSpectralMethods v1.3.0 ⇒ v1.4.0
  [bbf590c4] ↑ OrdinaryDiffEqCore v1.30.0 ⇒ v1.34.0
  [4302a76b] ↑ OrdinaryDiffEqDifferentiation v1.14.0 ⇒ v1.16.1
  [43230ef6] ↑ OrdinaryDiffEqRosenbrock v1.17.0 ⇒ v1.18.1
  [91a5bcdd] ↑ Plots v1.40.19 ⇒ v1.41.1
  [d236fae5] ↑ PreallocationTools v0.4.33 ⇒ v0.4.34
  [08abe8d2] ↑ PrettyTables v2.4.0 ⇒ v3.0.11
  [6099a3de] ↑ PythonCall v0.9.27 ⇒ v0.9.28
  [0bca4576] ↑ SciMLBase v2.115.0 ⇒ v2.120.0
  [19f34311] ↑ SciMLJacobianOperators v0.1.8 ⇒ v0.1.11
  [c0aeaf25] ↑ SciMLOperators v1.7.0 ⇒ v1.7.2
  [431bcebd] + SciMLPublic v1.0.0
  [727e6d20] ↑ SimpleNonlinearSolve v2.7.0 ⇒ v2.8.0
  [9f842d2f] ↑ SparseConnectivityTracer v1.0.1 ⇒ v1.1.0
  [aedffcd0] ↑ Static v1.2.0 ⇒ v1.3.0
  [2efcf032] ↑ SymbolicIndexingInterface v0.3.43 ⇒ v0.3.45
  [1986cc42] - Unitful v1.24.0
  [45397f5d] - UnitfulLatexify v1.7.0
  [61579ee1] + Ghostscript_jll v9.55.1+0
  [7746bdde] ↑ Glib_jll v2.84.3+0 ⇒ v2.86.0+0
  [aacddb02] ↑ JpegTurbo_jll v3.1.2+0 ⇒ v3.1.3+0
  [4b2f31a3] ↑ Libmount_jll v2.41.1+0 ⇒ v2.41.2+0
  [89763e89] ↑ Libtiff_jll v4.7.1+0 ⇒ v4.7.2+0
  [38a345b3] ↑ Libuuid_jll v2.41.1+0 ⇒ v2.41.2+0
  [458c3c95] ↑ OpenSSL_jll v3.5.2+0 ⇒ v3.5.4+0
  [36c8627f] ↑ Pango_jll v1.56.3+0 ⇒ v1.56.4+0
⌅ [02c8fc9c] ↑ XML2_jll v2.13.6+1 ⇒ v2.13.9+0
  [d091e8ba] ↑ Xorg_libXfixes_jll v6.0.1+0 ⇒ v6.0.2+0
  [e920d4aa] ↑ Xorg_xcb_util_cursor_jll v0.1.5+0 ⇒ v0.1.6+0
        Info Packages marked with ⌅ have new versions available but compatibility constraints restrict them from upgrading. To see why use `status --outdated -m`
        Info We haven't cleaned this depot up for a bit, running Pkg.gc()...
      Active manifest files: 1 found
      Active artifact files: 101 found
      Active scratchspaces: 0 found
     Deleted no artifacts, repos, packages or scratchspaces
```

__Packages still outdated after update__
```
Status `~/work/Ribasim/Ribasim/Project.toml`
⌅ [864edb3b] DataStructures v0.18.22 (<v0.19.1): NCDatasets, SPDX
  [9b87118b] PackageCompiler v2.2.1 `https://github.com/visr/PackageCompiler.jl#bundle_less_artifacts` (<v2.2.2)
⌅ [aea7be01] PrecompileTools v1.2.1 (<v1.3.3): julia
```
<details>
<summary>
All package versions
</summary>

```

ADTypes ────────────────────────── v1.18.0
AbstractTrees ──────────────────── v0.4.5
Accessors ──────────────────────── v0.1.42
Adapt ──────────────────────────── v4.4.0
AliasTables ────────────────────── v1.1.3
Aqua ───────────────────────────── v0.8.14
ArgCheck ───────────────────────── v2.5.0
ArnoldiMethod ──────────────────── v0.4.0
ArrayInterface ─────────────────── v7.20.0
ArrayLayouts ───────────────────── v1.11.2
Arrow ──────────────────────────── v2.8.0
ArrowTypes ─────────────────────── v2.3.0
BasicModelInterface ────────────── v0.1.1
BenchmarkTools ─────────────────── v1.6.0
BitFlags ───────────────────────── v0.1.9
BitIntegers ────────────────────── v0.3.5
BitTwiddlingConvenienceFunctions ─ v0.1.6
Blosc_jll ──────────────────────── v1.21.7+0
BracketingNonlinearSolve ───────── v1.4.0
Bzip2_jll ──────────────────────── v1.0.9+0
CFTime ─────────────────────────── v0.2.4
CPUSummary ─────────────────────── v0.2.7
CSV ────────────────────────────── v0.10.15
Cairo_jll ──────────────────────── v1.18.5+0
ChainRulesCore ─────────────────── v1.26.0
ChunkCodecCore ─────────────────── v1.0.0
ChunkCodecLibZlib ──────────────── v1.0.0
ChunkCodecLibZstd ──────────────── v1.0.0
CloseOpenIntervals ─────────────── v0.1.13
CodeTracking ───────────────────── v2.0.1
CodecBzip2 ─────────────────────── v0.8.5
CodecLz4 ───────────────────────── v0.4.6
CodecZlib ──────────────────────── v0.7.8
CodecZstd ──────────────────────── v0.8.6
ColorSchemes ───────────────────── v3.31.0
ColorTypes ─────────────────────── v0.12.1
ColorVectorSpace ───────────────── v0.11.0
Colors ─────────────────────────── v0.13.1
Combinatorics ──────────────────── v1.0.3
CommonDataModel ────────────────── v0.3.10
CommonSolve ────────────────────── v0.2.4
CommonSubexpressions ───────────── v0.3.1
CommonWorldInvalidations ───────── v1.0.0
Compat ─────────────────────────── v4.18.1
Compiler ───────────────────────── v0.1.1
CompositionsBase ───────────────── v0.1.2
ConcreteStructs ────────────────── v0.2.3
ConcurrentUtilities ────────────── v2.5.0
CondaPkg ───────────────────────── v0.2.33
Configurations ─────────────────── v0.17.6
ConstructionBase ───────────────── v1.6.0
Contour ────────────────────────── v0.6.3
CpuId ──────────────────────────── v0.3.1
Crayons ────────────────────────── v4.1.1
DBInterface ────────────────────── v2.6.1
DataAPI ────────────────────────── v1.16.0
DataFrames ─────────────────────── v1.8.0
DataInterpolations ─────────────── v8.6.1
DataStructures ─────────────────── v0.18.22
DataValueInterfaces ────────────── v1.0.0
Dbus_jll ───────────────────────── v1.16.2+0
DelimitedFiles ─────────────────── v1.9.1
DiffEqBase ─────────────────────── v6.190.2
DiffEqCallbacks ────────────────── v4.9.0
DiffResults ────────────────────── v1.1.0
DiffRules ──────────────────────── v1.15.1
DifferentiationInterface ───────── v0.7.8
DiskArrays ─────────────────────── v0.4.16
DisplayAs ──────────────────────── v0.1.6
DocStringExtensions ────────────── v0.9.5
Dualization ────────────────────── v0.6.1
EnumX ──────────────────────────── v1.0.5
EnzymeCore ─────────────────────── v0.8.14
EpollShim_jll ──────────────────── v0.0.20230411+1
ExceptionUnwrapping ────────────── v0.1.11
Expat_jll ──────────────────────── v2.7.1+0
ExprTools ──────────────────────── v0.1.10
ExproniconLite ─────────────────── v0.10.14
FFMPEG ─────────────────────────── v0.4.4
FFMPEG_jll ─────────────────────── v7.1.1+0
FastBroadcast ──────────────────── v0.3.5
FastClosures ───────────────────── v0.3.2
FastPower ──────────────────────── v1.1.3
FileIO ─────────────────────────── v1.17.0
FilePathsBase ──────────────────── v0.9.24
FillArrays ─────────────────────── v1.14.0
FindFirstFunctions ─────────────── v1.4.2
FiniteDiff ─────────────────────── v2.28.1
FixedPointNumbers ──────────────── v0.8.5
Fontconfig_jll ─────────────────── v2.17.1+0
Format ─────────────────────────── v1.3.7
ForwardDiff ────────────────────── v1.2.1
FreeType2_jll ──────────────────── v2.13.4+0
FriBidi_jll ────────────────────── v1.0.17+0
FunctionWrappers ───────────────── v1.1.3
FunctionWrappersWrappers ───────── v0.1.3
Functors ───────────────────────── v0.5.2
GLFW_jll ───────────────────────── v3.4.0+2
GPUArraysCore ──────────────────── v0.2.0
GR ─────────────────────────────── v0.73.17
GR_jll ─────────────────────────── v0.73.17+0
GettextRuntime_jll ─────────────── v0.22.4+0
Ghostscript_jll ────────────────── v9.55.1+0
Glib_jll ───────────────────────── v2.86.0+0
Glob ───────────────────────────── v1.3.1
Graphite2_jll ──────────────────── v1.3.15+0
Graphs ─────────────────────────── v1.13.1
Grisu ──────────────────────────── v1.0.2
HDF5_jll ───────────────────────── v1.14.6+0
HTTP ───────────────────────────── v1.10.17
HarfBuzz_jll ───────────────────── v8.5.1+0
HashArrayMappedTries ───────────── v0.2.0
HiGHS ──────────────────────────── v1.19.0
HiGHS_jll ──────────────────────── v1.11.0+1
Hwloc_jll ──────────────────────── v2.12.2+0
IOCapture ──────────────────────── v0.2.5
IfElse ─────────────────────────── v0.1.1
Infiltrator ────────────────────── v1.9.3
Inflate ────────────────────────── v0.1.5
InlineStrings ──────────────────── v1.4.5
IntelOpenMP_jll ────────────────── v2025.2.0+0
InverseFunctions ───────────────── v0.1.17
InvertedIndices ────────────────── v1.3.1
IrrationalConstants ────────────── v0.2.4
IterTools ──────────────────────── v1.10.0
IteratorInterfaceExtensions ────── v1.0.0
JLD2 ───────────────────────────── v0.6.2
JLFzf ──────────────────────────── v0.1.11
JLLWrappers ────────────────────── v1.7.1
JSON ───────────────────────────── v0.21.4
JSON3 ──────────────────────────── v1.14.3
Jieko ──────────────────────────── v0.2.1
JpegTurbo_jll ──────────────────── v3.1.3+0
JuMP ───────────────────────────── v1.29.1
JuliaInterpreter ───────────────── v0.10.5
Krylov ─────────────────────────── v0.10.2
LAME_jll ───────────────────────── v3.100.3+0
LERC_jll ───────────────────────── v4.0.1+0
LLVMOpenMP_jll ─────────────────── v18.1.8+0
LRUCache ───────────────────────── v1.6.2
LZO_jll ────────────────────────── v2.10.3+0
LaTeXStrings ───────────────────── v1.4.0
Latexify ───────────────────────── v0.16.10
LayoutPointers ─────────────────── v0.1.17
LazilyInitializedFields ────────── v1.3.0
LazyArrays ─────────────────────── v2.6.3
LeftChildRightSiblingTrees ─────── v0.2.1
Libffi_jll ─────────────────────── v3.4.7+0
Libglvnd_jll ───────────────────── v1.7.1+1
Libiconv_jll ───────────────────── v1.18.0+0
Libmount_jll ───────────────────── v2.41.2+0
Libtiff_jll ────────────────────── v4.7.2+0
Libuuid_jll ────────────────────── v2.41.2+0
LicenseCheck ───────────────────── v0.2.2
LineSearch ─────────────────────── v0.1.4
LinearSolve ────────────────────── v3.40.2
LogExpFunctions ────────────────── v0.3.29
LoggingExtras ──────────────────── v1.1.0
LoweredCodeUtils ───────────────── v3.4.4
Lz4_jll ────────────────────────── v1.10.1+0
MKL_jll ────────────────────────── v2025.2.0+0
MPICH_jll ──────────────────────── v4.3.1+0
MPIPreferences ─────────────────── v0.1.11
MPItrampoline_jll ──────────────── v5.5.4+0
MacroTools ─────────────────────── v0.5.16
ManualMemory ───────────────────── v0.1.8
MarkdownTables ─────────────────── v1.1.0
MathOptAnalyzer ────────────────── v0.1.0
MathOptIIS ─────────────────────── v0.1.1
MathOptInterface ───────────────── v1.45.0
MaybeInplace ───────────────────── v0.1.4
MbedTLS ────────────────────────── v1.1.9
Measures ───────────────────────── v0.3.2
MetaGraphsNext ─────────────────── v0.7.4
MicroMamba ─────────────────────── v0.1.14
MicrosoftMPI_jll ───────────────── v10.1.4+3
Missings ───────────────────────── v1.2.0
Mocking ────────────────────────── v0.8.1
Moshi ──────────────────────────── v0.3.7
MuladdMacro ────────────────────── v0.2.4
MultiObjectiveAlgorithms ───────── v1.7.0
MutableArithmetics ─────────────── v1.6.6
NCDatasets ─────────────────────── v0.14.8
NaNMath ────────────────────────── v1.1.3
NetCDF_jll ─────────────────────── v401.900.300+0
NonlinearSolve ─────────────────── v4.11.0
NonlinearSolveBase ─────────────── v1.16.1
NonlinearSolveFirstOrder ───────── v1.8.0
NonlinearSolveQuasiNewton ──────── v1.9.0
NonlinearSolveSpectralMethods ──── v1.4.0
OffsetArrays ───────────────────── v1.17.0
Ogg_jll ────────────────────────── v1.3.6+0
OpenMPI_jll ────────────────────── v5.0.8+0
OpenSSL ────────────────────────── v1.5.0
OpenSSL_jll ────────────────────── v3.5.4+0
OpenSpecFun_jll ────────────────── v0.5.6+0
Opus_jll ───────────────────────── v1.5.2+0
OrderedCollections ─────────────── v1.8.1
OrdinaryDiffEqBDF ──────────────── v1.10.1
OrdinaryDiffEqCore ─────────────── v1.34.0
OrdinaryDiffEqDifferentiation ──── v1.16.1
OrdinaryDiffEqLowOrderRK ───────── v1.6.0
OrdinaryDiffEqNonlinearSolve ───── v1.14.1
OrdinaryDiffEqRosenbrock ───────── v1.18.1
OrdinaryDiffEqSDIRK ────────────── v1.7.0
OrdinaryDiffEqTsit5 ────────────── v1.5.0
OteraEngine ────────────────────── v1.1.3
Pango_jll ──────────────────────── v1.56.4+0
Parsers ────────────────────────── v2.8.3
Pidfile ────────────────────────── v1.3.0
Pixman_jll ─────────────────────── v0.44.2+0
PkgToSoftwareBOM ───────────────── v0.1.13
PlotThemes ─────────────────────── v3.3.0
PlotUtils ──────────────────────── v1.4.3
Plots ──────────────────────────── v1.41.1
Polyester ──────────────────────── v0.7.18
PolyesterWeave ─────────────────── v0.2.2
PooledArrays ───────────────────── v1.4.3
PreallocationTools ─────────────── v0.4.34
PrecompileTools ────────────────── v1.2.1
Preferences ────────────────────── v1.5.0
PrettyTables ───────────────────── v3.0.11
ProgressLogging ────────────────── v0.1.5
PtrArrays ──────────────────────── v1.3.0
PythonCall ─────────────────────── v0.9.28
Qt6Base_jll ────────────────────── v6.8.2+1
Qt6Declarative_jll ─────────────── v6.8.2+1
Qt6ShaderTools_jll ─────────────── v6.8.2+1
Qt6Wayland_jll ─────────────────── v6.8.2+1
RecipesBase ────────────────────── v1.3.4
RecipesPipeline ────────────────── v0.6.12
RecursiveArrayTools ────────────── v3.37.1
Reexport ───────────────────────── v1.2.2
RegistryInstances ──────────────── v0.1.0
RelocatableFolders ─────────────── v1.0.1
Requires ───────────────────────── v1.3.1
Revise ─────────────────────────── v3.9.0
RuntimeGeneratedFunctions ──────── v0.5.15
SIMDTypes ──────────────────────── v0.1.0
SPDX ───────────────────────────── v0.4.1
SQLite ─────────────────────────── v1.6.1
SQLite_jll ─────────────────────── v3.48.0+0
SciMLBase ──────────────────────── v2.120.0
SciMLJacobianOperators ─────────── v0.1.11
SciMLOperators ─────────────────── v1.7.2
SciMLPublic ────────────────────── v1.0.0
SciMLStructures ────────────────── v1.7.0
ScopedValues ───────────────────── v1.5.0
Scratch ────────────────────────── v1.3.0
SentinelArrays ─────────────────── v1.4.8
Setfield ───────────────────────── v1.1.2
Showoff ────────────────────────── v1.0.3
SimpleBufferStream ─────────────── v1.2.0
SimpleNonlinearSolve ───────────── v2.8.0
SimpleTraits ───────────────────── v0.9.5
SimpleUnPack ───────────────────── v1.1.0
SortingAlgorithms ──────────────── v1.2.2
SparseConnectivityTracer ───────── v1.1.0
SparseMatrixColorings ──────────── v0.4.21
SpecialFunctions ───────────────── v2.5.1
StableRNGs ─────────────────────── v1.0.3
Static ─────────────────────────── v1.3.0
StaticArrayInterface ───────────── v1.8.0
StaticArrays ───────────────────── v1.9.15
StaticArraysCore ───────────────── v1.4.3
Statistics ─────────────────────── v1.11.1
StatsAPI ───────────────────────── v1.7.1
StatsBase ──────────────────────── v0.34.6
StrideArraysCore ───────────────── v0.5.8
StringManipulation ─────────────── v0.4.1
StringViews ────────────────────── v1.3.5
StructArrays ───────────────────── v0.7.1
StructTypes ────────────────────── v1.11.0
SymbolicIndexingInterface ──────── v0.3.45
TZJData ────────────────────────── v1.5.0+2025b
TableTraits ────────────────────── v1.0.1
Tables ─────────────────────────── v1.12.1
TensorCore ─────────────────────── v0.1.1
TerminalLoggers ────────────────── v0.1.7
TestEnv ────────────────────────── v1.102.2
TestItems ──────────────────────── v1.0.0
ThreadingUtilities ─────────────── v0.5.5
TimeZones ──────────────────────── v1.22.0
TimerOutputs ───────────────────── v0.5.29
TranscodingStreams ─────────────── v0.11.3
TruncatedStacktraces ───────────── v1.4.0
URIs ───────────────────────────── v1.6.1
UnPack ─────────────────────────── v1.0.2
UnicodeFun ─────────────────────── v0.4.1
UnsafePointers ─────────────────── v1.0.0
Unzip ──────────────────────────── v0.2.0
Vulkan_Loader_jll ──────────────── v1.3.243+0
Wayland_jll ────────────────────── v1.24.0+0
WeakRefStrings ─────────────────── v1.4.2
WorkerUtilities ────────────────── v1.6.1
XML2_jll ───────────────────────── v2.13.9+0
XZ_jll ─────────────────────────── v5.8.1+0
Xorg_libICE_jll ────────────────── v1.1.2+0
Xorg_libSM_jll ─────────────────── v1.2.6+0
Xorg_libX11_jll ────────────────── v1.8.12+0
Xorg_libXau_jll ────────────────── v1.0.13+0
Xorg_libXcursor_jll ────────────── v1.2.4+0
Xorg_libXdmcp_jll ──────────────── v1.1.6+0
Xorg_libXext_jll ───────────────── v1.3.7+0
Xorg_libXfixes_jll ─────────────── v6.0.2+0
Xorg_libXi_jll ─────────────────── v1.8.3+0
Xorg_libXinerama_jll ───────────── v1.1.6+0
Xorg_libXrandr_jll ─────────────── v1.5.5+0
Xorg_libXrender_jll ────────────── v0.9.12+0
Xorg_libpciaccess_jll ──────────── v0.18.1+0
Xorg_libxcb_jll ────────────────── v1.17.1+0
Xorg_libxkbfile_jll ────────────── v1.1.3+0
Xorg_xcb_util_cursor_jll ───────── v0.1.6+0
Xorg_xcb_util_image_jll ────────── v0.4.1+0
Xorg_xcb_util_jll ──────────────── v0.4.1+0
Xorg_xcb_util_keysyms_jll ──────── v0.4.1+0
Xorg_xcb_util_renderutil_jll ───── v0.3.10+0
Xorg_xcb_util_wm_jll ───────────── v0.4.2+0
Xorg_xkbcomp_jll ───────────────── v1.4.7+0
Xorg_xkeyboard_config_jll ──────── v2.44.0+0
Xorg_xtrans_jll ────────────────── v1.6.0+0
Zstd_jll ───────────────────────── v1.5.7+1
eudev_jll ──────────────────────── v3.2.14+0
fzf_jll ────────────────────────── v0.61.1+0
libaec_jll ─────────────────────── v1.1.4+0
libaom_jll ─────────────────────── v3.12.1+0
libass_jll ─────────────────────── v0.17.4+0
libdecor_jll ───────────────────── v0.2.2+0
libevdev_jll ───────────────────── v1.13.4+0
libfdk_aac_jll ─────────────────── v2.0.4+0
libinput_jll ───────────────────── v1.28.1+0
libpng_jll ─────────────────────── v1.6.50+0
libvorbis_jll ──────────────────── v1.3.8+0
libzip_jll ─────────────────────── v1.11.3+0
licensecheck_jll ───────────────── v0.3.101+0
micromamba_jll ─────────────────── v1.5.12+0
mtdev_jll ──────────────────────── v1.1.7+0
oneTBB_jll ─────────────────────── v2022.0.0+0
pixi_jll ───────────────────────── v0.41.3+0
x264_jll ───────────────────────── v10164.0.1+0
x265_jll ───────────────────────── v4.1.0+0
xkbcommon_jll ──────────────────── v1.9.2+0
