### PR TITLE
Update Julia manifest

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -182,9 +182,9 @@ version = "1.21.7+0"
 
 [[deps.BracketingNonlinearSolve]]
 deps = ["CommonSolve", "ConcreteStructs", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase"]
-git-tree-sha1 = "90740f16aef91d898424bc11c1cabada475435e0"
+git-tree-sha1 = "57f9f59bec88ce80cd3e46efc39f126395789bb0"
 uuid = "70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
-version = "1.4.0"
+version = "1.5.0"
 weakdeps = ["ChainRulesCore", "ForwardDiff"]
 
     [deps.BracketingNonlinearSolve.extensions]
@@ -322,10 +322,10 @@ uuid = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 version = "1.0.3"
 
 [[deps.CommonDataModel]]
-deps = ["CFTime", "DataStructures", "Dates", "Preferences", "Printf", "Statistics"]
-git-tree-sha1 = "1985a3201d376bf13a866527e19c2272c252870f"
+deps = ["CFTime", "DataStructures", "Dates", "DiskArrays", "Preferences", "Printf", "Statistics"]
+git-tree-sha1 = "675149c3c06350dabb9a807ca3dd473de8173703"
 uuid = "1fbeeb36-5f17-413c-809b-666fb144f157"
-version = "0.3.10"
+version = "0.4.1"
 
 [[deps.CommonSolve]]
 git-tree-sha1 = "0eee5eb66b1cf62cd6ad1b460238e60e4b09400c"
@@ -1288,9 +1288,9 @@ version = "1.11.0"
 
 [[deps.LinearSolve]]
 deps = ["ArrayInterface", "ChainRulesCore", "ConcreteStructs", "DocStringExtensions", "EnumX", "GPUArraysCore", "InteractiveUtils", "Krylov", "LazyArrays", "Libdl", "LinearAlgebra", "MKL_jll", "Markdown", "OpenBLAS_jll", "PrecompileTools", "Preferences", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLOperators", "Setfield", "StaticArraysCore", "UnPack"]
-git-tree-sha1 = "6c22b14a5ea7fbcc140ea1f52f3cfe20d3da32e0"
+git-tree-sha1 = "c8a2c7155fc27d2d9029f68c60bceae2ccb5ae75"
 uuid = "7ed4a6bd-45f5-4d41-b270-4a48e9bafcae"
-version = "3.40.2"
+version = "3.40.3"
 
     [deps.LinearSolve.extensions]
     LinearSolveAMDGPUExt = "AMDGPU"
@@ -1539,9 +1539,9 @@ version = "1.6.6"
 
 [[deps.NCDatasets]]
 deps = ["CFTime", "CommonDataModel", "DataStructures", "Dates", "DiskArrays", "NetCDF_jll", "NetworkOptions", "Printf"]
-git-tree-sha1 = "be1095e2b767c19529409ec670bcfb01b825d717"
+git-tree-sha1 = "5d5de6613f231d17cecb13a7dcdbb74740134ba8"
 uuid = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
-version = "0.14.8"
+version = "0.14.9"
 
 [[deps.NaNMath]]
 deps = ["OpenLibm_jll"]
@@ -1561,9 +1561,9 @@ version = "1.2.0"
 
 [[deps.NonlinearSolve]]
 deps = ["ADTypes", "ArrayInterface", "BracketingNonlinearSolve", "CommonSolve", "ConcreteStructs", "DifferentiationInterface", "FastClosures", "FiniteDiff", "ForwardDiff", "LineSearch", "LinearAlgebra", "LinearSolve", "NonlinearSolveBase", "NonlinearSolveFirstOrder", "NonlinearSolveQuasiNewton", "NonlinearSolveSpectralMethods", "PrecompileTools", "Preferences", "Reexport", "SciMLBase", "SimpleNonlinearSolve", "StaticArraysCore", "SymbolicIndexingInterface"]
-git-tree-sha1 = "627967f6e36aac9f5afb2fb285e33b676a6892f9"
+git-tree-sha1 = "1d091cfece012662b06d25c792b3a43a0804c47b"
 uuid = "8913a72c-1f9b-4ce2-8d82-65094dcecaec"
-version = "4.11.0"
+version = "4.12.0"
 
     [deps.NonlinearSolve.extensions]
     NonlinearSolveFastLevenbergMarquardtExt = "FastLevenbergMarquardt"
@@ -1594,9 +1594,9 @@ version = "4.11.0"
 
 [[deps.NonlinearSolveBase]]
 deps = ["ADTypes", "Adapt", "ArrayInterface", "CommonSolve", "Compat", "ConcreteStructs", "DifferentiationInterface", "EnzymeCore", "FastClosures", "LinearAlgebra", "Markdown", "MaybeInplace", "Preferences", "Printf", "RecursiveArrayTools", "SciMLBase", "SciMLJacobianOperators", "SciMLOperators", "SciMLStructures", "Setfield", "StaticArraysCore", "SymbolicIndexingInterface", "TimerOutputs"]
-git-tree-sha1 = "f05e5f3d0f280598ecdc26b06ec9acd71dcaef31"
+git-tree-sha1 = "9dba8e7ccfaf4c10b3a3b4cc52abf639f8558efd"
 uuid = "be0214bd-f91f-a760-ac4e-3421ce2b2da0"
-version = "1.16.1"
+version = "2.0.0"
 
     [deps.NonlinearSolveBase.extensions]
     NonlinearSolveBaseBandedMatricesExt = "BandedMatrices"
@@ -1626,15 +1626,15 @@ version = "1.16.1"
 
 [[deps.NonlinearSolveFirstOrder]]
 deps = ["ADTypes", "ArrayInterface", "CommonSolve", "ConcreteStructs", "FiniteDiff", "ForwardDiff", "LineSearch", "LinearAlgebra", "LinearSolve", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "SciMLJacobianOperators", "Setfield", "StaticArraysCore"]
-git-tree-sha1 = "b9702235120d1161f8041b326eccebd334340de2"
+git-tree-sha1 = "01c48c37ba47721ec6489a1668ab3bb1f5b603c0"
 uuid = "5959db7a-ea39-4486-b5fe-2dd0bf03d60d"
-version = "1.8.0"
+version = "1.9.0"
 
 [[deps.NonlinearSolveQuasiNewton]]
 deps = ["ArrayInterface", "CommonSolve", "ConcreteStructs", "LinearAlgebra", "LinearSolve", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "SciMLOperators", "StaticArraysCore"]
-git-tree-sha1 = "4e0e34601c6c9890aa9443003180967f75c6929d"
+git-tree-sha1 = "a233b7bbb32426170b238e2e2b82b0f9f1c5caba"
 uuid = "9a2c21bd-3a47-402d-9113-8faf9a0ee114"
-version = "1.9.0"
+version = "1.10.0"
 weakdeps = ["ForwardDiff"]
 
     [deps.NonlinearSolveQuasiNewton.extensions]
@@ -1642,9 +1642,9 @@ weakdeps = ["ForwardDiff"]
 
 [[deps.NonlinearSolveSpectralMethods]]
 deps = ["CommonSolve", "ConcreteStructs", "LineSearch", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase"]
-git-tree-sha1 = "6c613302febe2bb408a888105d07073cf6824911"
+git-tree-sha1 = "139bf9211930a829703481b3ffd86b1ab309cd07"
 uuid = "26075421-4e9a-44e1-8bd1-420ed7ad02b2"
-version = "1.4.0"
+version = "1.5.0"
 weakdeps = ["ForwardDiff"]
 
     [deps.NonlinearSolveSpectralMethods.extensions]
@@ -2213,9 +2213,9 @@ version = "1.2.0"
 
 [[deps.SimpleNonlinearSolve]]
 deps = ["ADTypes", "ArrayInterface", "BracketingNonlinearSolve", "CommonSolve", "ConcreteStructs", "DifferentiationInterface", "FastClosures", "FiniteDiff", "ForwardDiff", "LineSearch", "LinearAlgebra", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "Setfield", "StaticArraysCore"]
-git-tree-sha1 = "782c67176b473abf62a6786399c4b7ddcc1a2d77"
+git-tree-sha1 = "8825064775bf4ae0f22d04ea63979d8c868fd510"
 uuid = "727e6d20-b764-4bd8-a329-72de5adea6c7"
-version = "2.8.0"
+version = "2.9.0"
 
     [deps.SimpleNonlinearSolve.extensions]
     SimpleNonlinearSolveChainRulesCoreExt = "ChainRulesCore"
@@ -2495,9 +2495,9 @@ version = "0.5.5"
 
 [[deps.TimeZones]]
 deps = ["Artifacts", "Dates", "Downloads", "InlineStrings", "Mocking", "Printf", "Scratch", "TZJData", "Unicode", "p7zip_jll"]
-git-tree-sha1 = "1f9a3f379a2ce2a213a0f606895567a08a1a2d08"
+git-tree-sha1 = "06f4f1f3e8ff09e42e59b043a747332e88e01aba"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
-version = "1.22.0"
+version = "1.22.1"
 weakdeps = ["RecipesBase"]
 
     [deps.TimeZones.extensions]

--- a/Ribasim.spdx.json
+++ b/Ribasim.spdx.json
@@ -3,13 +3,13 @@
     "dataLicense": "CC0-1.0",
     "SPDXID": "SPDXRef-DOCUMENT",
     "name": "Ribasim.jl",
-    "documentNamespace": "https://github.com/Deltares/Ribasim/Ribasim.spdx.json-02e55f87-c0f8-46c4-b0b0-44a8d973297f",
+    "documentNamespace": "https://github.com/Deltares/Ribasim/Ribasim.spdx.json-ae6953d5-781d-4056-a582-5dc6b30db4f7",
     "creationInfo": {
         "creators": [
             "Organization:  Deltares  (software@deltares.nl)"
         ],
-        "created": "2025-10-02T03:13:59Z",
-        "comment": "Target Platform: Platform(\"x86_64\", \"linux\"; libgfortran_version = \"5.0.0\", julia_version = \"1.11.6\", libc = \"glibc\", libstdcxx_version = \"3.4.30\", cxxstring_abi = \"cxx11\")"
+        "created": "2025-10-02T14:49:19Z",
+        "comment": "Target Platform: Platform(\"x86_64\", \"linux\"; libgfortran_version = \"5.0.0\", julia_version = \"1.11.7\", libc = \"glibc\", libstdcxx_version = \"3.4.30\", cxxstring_abi = \"cxx11\")"
     },
     "comment": "Registries used for populating Package data:\nGeneral registry: https://github.com/JuliaRegistries/General.git\nOfficial general Julia package registry where people can\nregister any package they want without too much debate about\nnaming and without enforced standards on documentation or\ntesting. We nevertheless encourage documentation, testing and\nsome amount of consideration when choosing package names.\n",
     "packages": [
@@ -1104,13 +1104,13 @@
         {
             "name": "TimeZones",
             "SPDXID": "SPDXRef-TimeZones-f269a46b-ccf7-5d73-abea-4c690281aa53",
-            "versionInfo": "1.22.0",
+            "versionInfo": "1.22.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaTime/TimeZones.jl.git@1f9a3f379a2ce2a213a0f606895567a08a1a2d08",
+            "downloadLocation": "git+https://github.com/JuliaTime/TimeZones.jl.git@06f4f1f3e8ff09e42e59b043a747332e88e01aba",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "3727e032491ae628d0d3a6b1999e973758b0cf13"
+                "packageVerificationCodeValue": "c46f1ebb92779534bd406c0b913a484c5f3447f6"
             },
             "homepage": "https://github.com/JuliaTime/TimeZones.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2428,13 +2428,13 @@
         {
             "name": "LinearSolve",
             "SPDXID": "SPDXRef-LinearSolve-7ed4a6bd-45f5-4d41-b270-4a48e9bafcae",
-            "versionInfo": "3.40.2",
+            "versionInfo": "3.40.3",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/LinearSolve.jl.git@6c22b14a5ea7fbcc140ea1f52f3cfe20d3da32e0",
+            "downloadLocation": "git+https://github.com/SciML/LinearSolve.jl.git@c8a2c7155fc27d2d9029f68c60bceae2ccb5ae75",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "07afa267aa3da9b82bff9f72cc7e11c4535b7e9f"
+                "packageVerificationCodeValue": "be223aa9284c9e0f7c4f2163637e092738b0613c"
             },
             "homepage": "https://github.com/SciML/LinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3665,13 +3665,13 @@
         {
             "name": "NonlinearSolveBase",
             "SPDXID": "SPDXRef-NonlinearSolveBase-be0214bd-f91f-a760-ac4e-3421ce2b2da0",
-            "versionInfo": "1.16.1",
+            "versionInfo": "2.0.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@f05e5f3d0f280598ecdc26b06ec9acd71dcaef31#lib/NonlinearSolveBase",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@9dba8e7ccfaf4c10b3a3b4cc52abf639f8558efd#lib/NonlinearSolveBase",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "f59bd3ab584cab3c0f2a862177710273e720d082"
+                "packageVerificationCodeValue": "da3981c27ae5894b1f3daeb7d0199addbc088969"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3687,13 +3687,13 @@
         {
             "name": "NonlinearSolveQuasiNewton",
             "SPDXID": "SPDXRef-NonlinearSolveQuasiNewton-9a2c21bd-3a47-402d-9113-8faf9a0ee114",
-            "versionInfo": "1.9.0",
+            "versionInfo": "1.10.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@4e0e34601c6c9890aa9443003180967f75c6929d#lib/NonlinearSolveQuasiNewton",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@a233b7bbb32426170b238e2e2b82b0f9f1c5caba#lib/NonlinearSolveQuasiNewton",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "02dbbda64eeea74c37d6dddec7638b75e64e7bf7"
+                "packageVerificationCodeValue": "30ef3ea4966c8f35cf668f34c564c7af31e6178a"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3709,13 +3709,13 @@
         {
             "name": "BracketingNonlinearSolve",
             "SPDXID": "SPDXRef-BracketingNonlinearSolve-70df07ce-3d50-431d-a3e7-ca6ddb60ac1e",
-            "versionInfo": "1.4.0",
+            "versionInfo": "1.5.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@90740f16aef91d898424bc11c1cabada475435e0#lib/BracketingNonlinearSolve",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@57f9f59bec88ce80cd3e46efc39f126395789bb0#lib/BracketingNonlinearSolve",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "c33b3363ff9987b9337bccb035ec4a21cb44e874"
+                "packageVerificationCodeValue": "16cf0f9dd419006439fd4d70a6947a7875c7abb1"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3753,13 +3753,13 @@
         {
             "name": "SimpleNonlinearSolve",
             "SPDXID": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7",
-            "versionInfo": "2.8.0",
+            "versionInfo": "2.9.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@782c67176b473abf62a6786399c4b7ddcc1a2d77#lib/SimpleNonlinearSolve",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@8825064775bf4ae0f22d04ea63979d8c868fd510#lib/SimpleNonlinearSolve",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "32c204c4adb54e350ebe530a0191d3b722141b91"
+                "packageVerificationCodeValue": "01333be815db95d26b55cc020d9c57239992fe24"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3775,13 +3775,13 @@
         {
             "name": "NonlinearSolveSpectralMethods",
             "SPDXID": "SPDXRef-NonlinearSolveSpectralMethods-26075421-4e9a-44e1-8bd1-420ed7ad02b2",
-            "versionInfo": "1.4.0",
+            "versionInfo": "1.5.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@6c613302febe2bb408a888105d07073cf6824911#lib/NonlinearSolveSpectralMethods",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@139bf9211930a829703481b3ffd86b1ab309cd07#lib/NonlinearSolveSpectralMethods",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "59c46cd1751f4150ab20317c270348eedc658531"
+                "packageVerificationCodeValue": "d3c186651350acfdca448e655ece8c5f20270e4f"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3797,13 +3797,13 @@
         {
             "name": "NonlinearSolveFirstOrder",
             "SPDXID": "SPDXRef-NonlinearSolveFirstOrder-5959db7a-ea39-4486-b5fe-2dd0bf03d60d",
-            "versionInfo": "1.8.0",
+            "versionInfo": "1.9.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@b9702235120d1161f8041b326eccebd334340de2#lib/NonlinearSolveFirstOrder",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@01c48c37ba47721ec6489a1668ab3bb1f5b603c0#lib/NonlinearSolveFirstOrder",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "b069bc4bd44b6609adadc6bf58b93acb7d26e06b"
+                "packageVerificationCodeValue": "7303ba0964fc2b7621c1bd93cc3fcee60b8d807e"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3819,13 +3819,13 @@
         {
             "name": "NonlinearSolve",
             "SPDXID": "SPDXRef-NonlinearSolve-8913a72c-1f9b-4ce2-8d82-65094dcecaec",
-            "versionInfo": "4.11.0",
+            "versionInfo": "4.12.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@627967f6e36aac9f5afb2fb285e33b676a6892f9",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@1d091cfece012662b06d25c792b3a43a0804c47b",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "f3b121fa1cbd210ad02fe44ff181aab7c78dfb2b"
+                "packageVerificationCodeValue": "4c01e7a98f3f8c7061811e780f8eb6665b134931"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4414,15 +4414,81 @@
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
-            "name": "CommonDataModel",
-            "SPDXID": "SPDXRef-CommonDataModel-1fbeeb36-5f17-413c-809b-666fb144f157",
-            "versionInfo": "0.3.10",
+            "name": "OffsetArrays",
+            "SPDXID": "SPDXRef-OffsetArrays-6fe1bfb0-de20-5000-8ca7-80f57d26f881",
+            "versionInfo": "1.17.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaGeo/CommonDataModel.jl.git@1985a3201d376bf13a866527e19c2272c252870f",
+            "downloadLocation": "git+https://github.com/JuliaArrays/OffsetArrays.jl.git@117432e406b5c023f665fa73dc26e79ec3630151",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "7ed55efb96f826bc6abbd176277b4c6bbd6302d2"
+                "packageVerificationCodeValue": "4466161c151a6592b174394c06acd67ae3286db1"
+            },
+            "homepage": "https://github.com/JuliaArrays/OffsetArrays.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "LRUCache",
+            "SPDXID": "SPDXRef-LRUCache-8ac3fa9e-de4c-5943-b1dc-09c6b5f20637",
+            "versionInfo": "1.6.2",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaCollections/LRUCache.jl.git@5519b95a490ff5fe629c4a7aa3b3dfc9160498b3",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "cdfbd54d4b6e6d14495869048fed1f12f30e0e2c"
+            },
+            "homepage": "https://github.com/JuliaCollections/LRUCache.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "DiskArrays",
+            "SPDXID": "SPDXRef-DiskArrays-3c3547ce-8d99-4f5e-a174-61eb10b00ae3",
+            "versionInfo": "0.4.16",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaIO/DiskArrays.jl.git@297ac5efb7c9c7849114eba76111af2814cac8ec",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "f45e76e01e260d3ff81f9ba2d94e6cfb516961f4"
+            },
+            "homepage": "https://github.com/JuliaIO/DiskArrays.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
+        },
+        {
+            "name": "CommonDataModel",
+            "SPDXID": "SPDXRef-CommonDataModel-1fbeeb36-5f17-413c-809b-666fb144f157",
+            "versionInfo": "0.4.1",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/JuliaGeo/CommonDataModel.jl.git@675149c3c06350dabb9a807ca3dd473de8173703",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "7662dd16458146fddaa2bfeed783e3d8bbf5a88c"
             },
             "homepage": "https://github.com/JuliaGeo/CommonDataModel.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -5549,81 +5615,15 @@
             "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
         },
         {
-            "name": "OffsetArrays",
-            "SPDXID": "SPDXRef-OffsetArrays-6fe1bfb0-de20-5000-8ca7-80f57d26f881",
-            "versionInfo": "1.17.0",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaArrays/OffsetArrays.jl.git@117432e406b5c023f665fa73dc26e79ec3630151",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "4466161c151a6592b174394c06acd67ae3286db1"
-            },
-            "homepage": "https://github.com/JuliaArrays/OffsetArrays.jl.git",
-            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "MIT"
-            ],
-            "licenseDeclared": "MIT",
-            "copyrightText": "NOASSERTION",
-            "summary": "This is a Julia package, written in the Julia language.",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "LRUCache",
-            "SPDXID": "SPDXRef-LRUCache-8ac3fa9e-de4c-5943-b1dc-09c6b5f20637",
-            "versionInfo": "1.6.2",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaCollections/LRUCache.jl.git@5519b95a490ff5fe629c4a7aa3b3dfc9160498b3",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "cdfbd54d4b6e6d14495869048fed1f12f30e0e2c"
-            },
-            "homepage": "https://github.com/JuliaCollections/LRUCache.jl.git",
-            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "MIT"
-            ],
-            "licenseDeclared": "MIT",
-            "copyrightText": "NOASSERTION",
-            "summary": "This is a Julia package, written in the Julia language.",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
-            "name": "DiskArrays",
-            "SPDXID": "SPDXRef-DiskArrays-3c3547ce-8d99-4f5e-a174-61eb10b00ae3",
-            "versionInfo": "0.4.16",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaIO/DiskArrays.jl.git@297ac5efb7c9c7849114eba76111af2814cac8ec",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "f45e76e01e260d3ff81f9ba2d94e6cfb516961f4"
-            },
-            "homepage": "https://github.com/JuliaIO/DiskArrays.jl.git",
-            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "MIT"
-            ],
-            "licenseDeclared": "MIT",
-            "copyrightText": "NOASSERTION",
-            "summary": "This is a Julia package, written in the Julia language.",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it."
-        },
-        {
             "name": "NCDatasets",
             "SPDXID": "SPDXRef-NCDatasets-85f8d34a-cbdd-5861-8df4-14fed0d494ab",
-            "versionInfo": "0.14.8",
+            "versionInfo": "0.14.9",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaGeo/NCDatasets.jl.git@be1095e2b767c19529409ec670bcfb01b825d717",
+            "downloadLocation": "git+https://github.com/JuliaGeo/NCDatasets.jl.git@5d5de6613f231d17cecb13a7dcdbb74740134ba8",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "1024da9e9b3850ccfad1939fbab0fa23c3e09762"
+                "packageVerificationCodeValue": "89eadb2f9cd43634ebfd9f5861d03a3b94debd3c"
             },
             "homepage": "https://github.com/JuliaGeo/NCDatasets.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -8659,6 +8659,26 @@
             "relatedSpdxElement": "SPDXRef-CommonDataModel-1fbeeb36-5f17-413c-809b-666fb144f157"
         },
         {
+            "spdxElementId": "SPDXRef-OffsetArrays-6fe1bfb0-de20-5000-8ca7-80f57d26f881",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiskArrays-3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
+        },
+        {
+            "spdxElementId": "SPDXRef-ConstructionBase-187b0558-2788-49d3-abe0-74a17ed4e7c9",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiskArrays-3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
+        },
+        {
+            "spdxElementId": "SPDXRef-LRUCache-8ac3fa9e-de4c-5943-b1dc-09c6b5f20637",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DiskArrays-3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
+        },
+        {
+            "spdxElementId": "SPDXRef-DiskArrays-3c3547ce-8d99-4f5e-a174-61eb10b00ae3",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-CommonDataModel-1fbeeb36-5f17-413c-809b-666fb144f157"
+        },
+        {
             "spdxElementId": "SPDXRef-CommonDataModel-1fbeeb36-5f17-413c-809b-666fb144f157",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-NCDatasets-85f8d34a-cbdd-5861-8df4-14fed0d494ab"
@@ -9057,21 +9077,6 @@
             "spdxElementId": "SPDXRef-NetCDF_jll-7243133f-43d8-5620-bbf4-c2c921802cf3",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-NCDatasets-85f8d34a-cbdd-5861-8df4-14fed0d494ab"
-        },
-        {
-            "spdxElementId": "SPDXRef-OffsetArrays-6fe1bfb0-de20-5000-8ca7-80f57d26f881",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-DiskArrays-3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
-        },
-        {
-            "spdxElementId": "SPDXRef-ConstructionBase-187b0558-2788-49d3-abe0-74a17ed4e7c9",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-DiskArrays-3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
-        },
-        {
-            "spdxElementId": "SPDXRef-LRUCache-8ac3fa9e-de4c-5943-b1dc-09c6b5f20637",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-DiskArrays-3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
         },
         {
             "spdxElementId": "SPDXRef-DiskArrays-3c3547ce-8d99-4f5e-a174-61eb10b00ae3",


### PR DESCRIPTION
Update the Julia Manifest.toml to get the latest dependencies.

__Changed packages__
```
  Installing known registries into `~/.julia`
       Added `General` registry to ~/.julia/registries
    Updating registry at `~/.julia/registries/General.toml`
     Cloning git-repo `https://github.com/visr/PackageCompiler.jl`
    Updating git-repo `https://github.com/visr/PackageCompiler.jl`
     Cloning git-repo `https://github.com/julia-vscode/TestItemRunner.jl.git`
    Updating git-repo `https://github.com/julia-vscode/TestItemRunner.jl.git`
    Updating `~/work/Ribasim/Ribasim/Project.toml`
  [7ed4a6bd] ↑ LinearSolve v3.40.2 ⇒ v3.40.3
  [85f8d34a] ↑ NCDatasets v0.14.8 ⇒ v0.14.9
    Updating `~/work/Ribasim/Ribasim/Manifest.toml`
  [70df07ce] ↑ BracketingNonlinearSolve v1.4.0 ⇒ v1.5.0
  [1fbeeb36] ↑ CommonDataModel v0.3.10 ⇒ v0.4.1
  [7ed4a6bd] ↑ LinearSolve v3.40.2 ⇒ v3.40.3
  [85f8d34a] ↑ NCDatasets v0.14.8 ⇒ v0.14.9
  [8913a72c] ↑ NonlinearSolve v4.11.0 ⇒ v4.12.0
  [be0214bd] ↑ NonlinearSolveBase v1.16.1 ⇒ v2.0.0
  [5959db7a] ↑ NonlinearSolveFirstOrder v1.8.0 ⇒ v1.9.0
  [9a2c21bd] ↑ NonlinearSolveQuasiNewton v1.9.0 ⇒ v1.10.0
  [26075421] ↑ NonlinearSolveSpectralMethods v1.4.0 ⇒ v1.5.0
  [727e6d20] ↑ SimpleNonlinearSolve v2.8.0 ⇒ v2.9.0
  [f269a46b] ↑ TimeZones v1.22.0 ⇒ v1.22.1
        Info We haven't cleaned this depot up for a bit, running Pkg.gc()...
      Active manifest files: 1 found
      Active artifact files: 101 found
      Active scratchspaces: 0 found
     Deleted no artifacts, repos, packages or scratchspaces
```

__Packages still outdated after update__
```
Status `~/work/Ribasim/Ribasim/Project.toml`
⌅ [864edb3b] DataStructures v0.18.22 (<v0.19.1): SPDX
  [9b87118b] PackageCompiler v2.2.1 `https://github.com/visr/PackageCompiler.jl#bundle_less_artifacts` (<v2.2.2)
⌅ [aea7be01] PrecompileTools v1.2.1 (<v1.3.3): julia
```
<details>
<summary>
All package versions
</summary>

```

ADTypes ────────────────────────── v1.18.0
AbstractTrees ──────────────────── v0.4.5
Accessors ──────────────────────── v0.1.42
Adapt ──────────────────────────── v4.4.0
AliasTables ────────────────────── v1.1.3
Aqua ───────────────────────────── v0.8.14
ArgCheck ───────────────────────── v2.5.0
ArnoldiMethod ──────────────────── v0.4.0
ArrayInterface ─────────────────── v7.20.0
ArrayLayouts ───────────────────── v1.11.2
Arrow ──────────────────────────── v2.8.0
ArrowTypes ─────────────────────── v2.3.0
BasicModelInterface ────────────── v0.1.1
BenchmarkTools ─────────────────── v1.6.0
BitFlags ───────────────────────── v0.1.9
BitIntegers ────────────────────── v0.3.5
BitTwiddlingConvenienceFunctions ─ v0.1.6
Blosc_jll ──────────────────────── v1.21.7+0
BracketingNonlinearSolve ───────── v1.5.0
Bzip2_jll ──────────────────────── v1.0.9+0
CFTime ─────────────────────────── v0.2.4
CPUSummary ─────────────────────── v0.2.7
CSV ────────────────────────────── v0.10.15
Cairo_jll ──────────────────────── v1.18.5+0
ChainRulesCore ─────────────────── v1.26.0
ChunkCodecCore ─────────────────── v1.0.0
ChunkCodecLibZlib ──────────────── v1.0.0
ChunkCodecLibZstd ──────────────── v1.0.0
CloseOpenIntervals ─────────────── v0.1.13
CodeTracking ───────────────────── v2.0.1
CodecBzip2 ─────────────────────── v0.8.5
CodecLz4 ───────────────────────── v0.4.6
CodecZlib ──────────────────────── v0.7.8
CodecZstd ──────────────────────── v0.8.6
ColorSchemes ───────────────────── v3.31.0
ColorTypes ─────────────────────── v0.12.1
ColorVectorSpace ───────────────── v0.11.0
Colors ─────────────────────────── v0.13.1
Combinatorics ──────────────────── v1.0.3
CommonDataModel ────────────────── v0.4.1
CommonSolve ────────────────────── v0.2.4
CommonSubexpressions ───────────── v0.3.1
CommonWorldInvalidations ───────── v1.0.0
Compat ─────────────────────────── v4.18.1
Compiler ───────────────────────── v0.1.1
CompositionsBase ───────────────── v0.1.2
ConcreteStructs ────────────────── v0.2.3
ConcurrentUtilities ────────────── v2.5.0
CondaPkg ───────────────────────── v0.2.33
Configurations ─────────────────── v0.17.6
ConstructionBase ───────────────── v1.6.0
Contour ────────────────────────── v0.6.3
CpuId ──────────────────────────── v0.3.1
Crayons ────────────────────────── v4.1.1
DBInterface ────────────────────── v2.6.1
DataAPI ────────────────────────── v1.16.0
DataFrames ─────────────────────── v1.8.0
DataInterpolations ─────────────── v8.6.1
DataStructures ─────────────────── v0.18.22
DataValueInterfaces ────────────── v1.0.0
Dbus_jll ───────────────────────── v1.16.2+0
DelimitedFiles ─────────────────── v1.9.1
DiffEqBase ─────────────────────── v6.190.2
DiffEqCallbacks ────────────────── v4.9.0
DiffResults ────────────────────── v1.1.0
DiffRules ──────────────────────── v1.15.1
DifferentiationInterface ───────── v0.7.8
DiskArrays ─────────────────────── v0.4.16
DisplayAs ──────────────────────── v0.1.6
DocStringExtensions ────────────── v0.9.5
Dualization ────────────────────── v0.6.1
EnumX ──────────────────────────── v1.0.5
EnzymeCore ─────────────────────── v0.8.14
EpollShim_jll ──────────────────── v0.0.20230411+1
ExceptionUnwrapping ────────────── v0.1.11
Expat_jll ──────────────────────── v2.7.1+0
ExprTools ──────────────────────── v0.1.10
ExproniconLite ─────────────────── v0.10.14
FFMPEG ─────────────────────────── v0.4.4
FFMPEG_jll ─────────────────────── v7.1.1+0
FastBroadcast ──────────────────── v0.3.5
FastClosures ───────────────────── v0.3.2
FastPower ──────────────────────── v1.1.3
FileIO ─────────────────────────── v1.17.0
FilePathsBase ──────────────────── v0.9.24
FillArrays ─────────────────────── v1.14.0
FindFirstFunctions ─────────────── v1.4.2
FiniteDiff ─────────────────────── v2.28.1
FixedPointNumbers ──────────────── v0.8.5
Fontconfig_jll ─────────────────── v2.17.1+0
Format ─────────────────────────── v1.3.7
ForwardDiff ────────────────────── v1.2.1
FreeType2_jll ──────────────────── v2.13.4+0
FriBidi_jll ────────────────────── v1.0.17+0
FunctionWrappers ───────────────── v1.1.3
FunctionWrappersWrappers ───────── v0.1.3
Functors ───────────────────────── v0.5.2
GLFW_jll ───────────────────────── v3.4.0+2
GPUArraysCore ──────────────────── v0.2.0
GR ─────────────────────────────── v0.73.17
GR_jll ─────────────────────────── v0.73.17+0
GettextRuntime_jll ─────────────── v0.22.4+0
Ghostscript_jll ────────────────── v9.55.1+0
Glib_jll ───────────────────────── v2.86.0+0
Glob ───────────────────────────── v1.3.1
Graphite2_jll ──────────────────── v1.3.15+0
Graphs ─────────────────────────── v1.13.1
Grisu ──────────────────────────── v1.0.2
HDF5_jll ───────────────────────── v1.14.6+0
HTTP ───────────────────────────── v1.10.17
HarfBuzz_jll ───────────────────── v8.5.1+0
HashArrayMappedTries ───────────── v0.2.0
HiGHS ──────────────────────────── v1.19.0
HiGHS_jll ──────────────────────── v1.11.0+1
Hwloc_jll ──────────────────────── v2.12.2+0
IOCapture ──────────────────────── v0.2.5
IfElse ─────────────────────────── v0.1.1
Infiltrator ────────────────────── v1.9.3
Inflate ────────────────────────── v0.1.5
InlineStrings ──────────────────── v1.4.5
IntelOpenMP_jll ────────────────── v2025.2.0+0
InverseFunctions ───────────────── v0.1.17
InvertedIndices ────────────────── v1.3.1
IrrationalConstants ────────────── v0.2.4
IterTools ──────────────────────── v1.10.0
IteratorInterfaceExtensions ────── v1.0.0
JLD2 ───────────────────────────── v0.6.2
JLFzf ──────────────────────────── v0.1.11
JLLWrappers ────────────────────── v1.7.1
JSON ───────────────────────────── v0.21.4
JSON3 ──────────────────────────── v1.14.3
Jieko ──────────────────────────── v0.2.1
JpegTurbo_jll ──────────────────── v3.1.3+0
JuMP ───────────────────────────── v1.29.1
JuliaInterpreter ───────────────── v0.10.5
Krylov ─────────────────────────── v0.10.2
LAME_jll ───────────────────────── v3.100.3+0
LERC_jll ───────────────────────── v4.0.1+0
LLVMOpenMP_jll ─────────────────── v18.1.8+0
LRUCache ───────────────────────── v1.6.2
LZO_jll ────────────────────────── v2.10.3+0
LaTeXStrings ───────────────────── v1.4.0
Latexify ───────────────────────── v0.16.10
LayoutPointers ─────────────────── v0.1.17
LazilyInitializedFields ────────── v1.3.0
LazyArrays ─────────────────────── v2.6.3
LeftChildRightSiblingTrees ─────── v0.2.1
Libffi_jll ─────────────────────── v3.4.7+0
Libglvnd_jll ───────────────────── v1.7.1+1
Libiconv_jll ───────────────────── v1.18.0+0
Libmount_jll ───────────────────── v2.41.2+0
Libtiff_jll ────────────────────── v4.7.2+0
Libuuid_jll ────────────────────── v2.41.2+0
LicenseCheck ───────────────────── v0.2.2
LineSearch ─────────────────────── v0.1.4
LinearSolve ────────────────────── v3.40.3
LogExpFunctions ────────────────── v0.3.29
LoggingExtras ──────────────────── v1.1.0
LoweredCodeUtils ───────────────── v3.4.4
Lz4_jll ────────────────────────── v1.10.1+0
MKL_jll ────────────────────────── v2025.2.0+0
MPICH_jll ──────────────────────── v4.3.1+0
MPIPreferences ─────────────────── v0.1.11
MPItrampoline_jll ──────────────── v5.5.4+0
MacroTools ─────────────────────── v0.5.16
ManualMemory ───────────────────── v0.1.8
MarkdownTables ─────────────────── v1.1.0
MathOptAnalyzer ────────────────── v0.1.0
MathOptIIS ─────────────────────── v0.1.1
MathOptInterface ───────────────── v1.45.0
MaybeInplace ───────────────────── v0.1.4
MbedTLS ────────────────────────── v1.1.9
Measures ───────────────────────── v0.3.2
MetaGraphsNext ─────────────────── v0.7.4
MicroMamba ─────────────────────── v0.1.14
MicrosoftMPI_jll ───────────────── v10.1.4+3
Missings ───────────────────────── v1.2.0
Mocking ────────────────────────── v0.8.1
Moshi ──────────────────────────── v0.3.7
MuladdMacro ────────────────────── v0.2.4
MultiObjectiveAlgorithms ───────── v1.7.0
MutableArithmetics ─────────────── v1.6.6
NCDatasets ─────────────────────── v0.14.9
NaNMath ────────────────────────── v1.1.3
NetCDF_jll ─────────────────────── v401.900.300+0
NonlinearSolve ─────────────────── v4.12.0
NonlinearSolveBase ─────────────── v2.0.0
NonlinearSolveFirstOrder ───────── v1.9.0
NonlinearSolveQuasiNewton ──────── v1.10.0
NonlinearSolveSpectralMethods ──── v1.5.0
OffsetArrays ───────────────────── v1.17.0
Ogg_jll ────────────────────────── v1.3.6+0
OpenMPI_jll ────────────────────── v5.0.8+0
OpenSSL ────────────────────────── v1.5.0
OpenSSL_jll ────────────────────── v3.5.4+0
OpenSpecFun_jll ────────────────── v0.5.6+0
Opus_jll ───────────────────────── v1.5.2+0
OrderedCollections ─────────────── v1.8.1
OrdinaryDiffEqBDF ──────────────── v1.10.1
OrdinaryDiffEqCore ─────────────── v1.34.0
OrdinaryDiffEqDifferentiation ──── v1.16.1
OrdinaryDiffEqLowOrderRK ───────── v1.6.0
OrdinaryDiffEqNonlinearSolve ───── v1.14.1
OrdinaryDiffEqRosenbrock ───────── v1.18.1
OrdinaryDiffEqSDIRK ────────────── v1.7.0
OrdinaryDiffEqTsit5 ────────────── v1.5.0
OteraEngine ────────────────────── v1.1.3
Pango_jll ──────────────────────── v1.56.4+0
Parsers ────────────────────────── v2.8.3
Pidfile ────────────────────────── v1.3.0
Pixman_jll ─────────────────────── v0.44.2+0
PkgToSoftwareBOM ───────────────── v0.1.13
PlotThemes ─────────────────────── v3.3.0
PlotUtils ──────────────────────── v1.4.3
Plots ──────────────────────────── v1.41.1
Polyester ──────────────────────── v0.7.18
PolyesterWeave ─────────────────── v0.2.2
PooledArrays ───────────────────── v1.4.3
PreallocationTools ─────────────── v0.4.34
PrecompileTools ────────────────── v1.2.1
Preferences ────────────────────── v1.5.0
PrettyTables ───────────────────── v3.0.11
ProgressLogging ────────────────── v0.1.5
PtrArrays ──────────────────────── v1.3.0
PythonCall ─────────────────────── v0.9.28
Qt6Base_jll ────────────────────── v6.8.2+1
Qt6Declarative_jll ─────────────── v6.8.2+1
Qt6ShaderTools_jll ─────────────── v6.8.2+1
Qt6Wayland_jll ─────────────────── v6.8.2+1
RecipesBase ────────────────────── v1.3.4
RecipesPipeline ────────────────── v0.6.12
RecursiveArrayTools ────────────── v3.37.1
Reexport ───────────────────────── v1.2.2
RegistryInstances ──────────────── v0.1.0
RelocatableFolders ─────────────── v1.0.1
Requires ───────────────────────── v1.3.1
Revise ─────────────────────────── v3.9.0
RuntimeGeneratedFunctions ──────── v0.5.15
SIMDTypes ──────────────────────── v0.1.0
SPDX ───────────────────────────── v0.4.1
SQLite ─────────────────────────── v1.6.1
SQLite_jll ─────────────────────── v3.48.0+0
SciMLBase ──────────────────────── v2.120.0
SciMLJacobianOperators ─────────── v0.1.11
SciMLOperators ─────────────────── v1.7.2
SciMLPublic ────────────────────── v1.0.0
SciMLStructures ────────────────── v1.7.0
ScopedValues ───────────────────── v1.5.0
Scratch ────────────────────────── v1.3.0
SentinelArrays ─────────────────── v1.4.8
Setfield ───────────────────────── v1.1.2
Showoff ────────────────────────── v1.0.3
SimpleBufferStream ─────────────── v1.2.0
SimpleNonlinearSolve ───────────── v2.9.0
SimpleTraits ───────────────────── v0.9.5
SimpleUnPack ───────────────────── v1.1.0
SortingAlgorithms ──────────────── v1.2.2
SparseConnectivityTracer ───────── v1.1.0
SparseMatrixColorings ──────────── v0.4.21
SpecialFunctions ───────────────── v2.5.1
StableRNGs ─────────────────────── v1.0.3
Static ─────────────────────────── v1.3.0
StaticArrayInterface ───────────── v1.8.0
StaticArrays ───────────────────── v1.9.15
StaticArraysCore ───────────────── v1.4.3
Statistics ─────────────────────── v1.11.1
StatsAPI ───────────────────────── v1.7.1
StatsBase ──────────────────────── v0.34.6
StrideArraysCore ───────────────── v0.5.8
StringManipulation ─────────────── v0.4.1
StringViews ────────────────────── v1.3.5
StructArrays ───────────────────── v0.7.1
StructTypes ────────────────────── v1.11.0
SymbolicIndexingInterface ──────── v0.3.45
TZJData ────────────────────────── v1.5.0+2025b
TableTraits ────────────────────── v1.0.1
Tables ─────────────────────────── v1.12.1
TensorCore ─────────────────────── v0.1.1
TerminalLoggers ────────────────── v0.1.7
TestEnv ────────────────────────── v1.102.2
TestItems ──────────────────────── v1.0.0
ThreadingUtilities ─────────────── v0.5.5
TimeZones ──────────────────────── v1.22.1
TimerOutputs ───────────────────── v0.5.29
TranscodingStreams ─────────────── v0.11.3
TruncatedStacktraces ───────────── v1.4.0
URIs ───────────────────────────── v1.6.1
UnPack ─────────────────────────── v1.0.2
UnicodeFun ─────────────────────── v0.4.1
UnsafePointers ─────────────────── v1.0.0
Unzip ──────────────────────────── v0.2.0
Vulkan_Loader_jll ──────────────── v1.3.243+0
Wayland_jll ────────────────────── v1.24.0+0
WeakRefStrings ─────────────────── v1.4.2
WorkerUtilities ────────────────── v1.6.1
XML2_jll ───────────────────────── v2.13.9+0
XZ_jll ─────────────────────────── v5.8.1+0
Xorg_libICE_jll ────────────────── v1.1.2+0
Xorg_libSM_jll ─────────────────── v1.2.6+0
Xorg_libX11_jll ────────────────── v1.8.12+0
Xorg_libXau_jll ────────────────── v1.0.13+0
Xorg_libXcursor_jll ────────────── v1.2.4+0
Xorg_libXdmcp_jll ──────────────── v1.1.6+0
Xorg_libXext_jll ───────────────── v1.3.7+0
Xorg_libXfixes_jll ─────────────── v6.0.2+0
Xorg_libXi_jll ─────────────────── v1.8.3+0
Xorg_libXinerama_jll ───────────── v1.1.6+0
Xorg_libXrandr_jll ─────────────── v1.5.5+0
Xorg_libXrender_jll ────────────── v0.9.12+0
Xorg_libpciaccess_jll ──────────── v0.18.1+0
Xorg_libxcb_jll ────────────────── v1.17.1+0
Xorg_libxkbfile_jll ────────────── v1.1.3+0
Xorg_xcb_util_cursor_jll ───────── v0.1.6+0
Xorg_xcb_util_image_jll ────────── v0.4.1+0
Xorg_xcb_util_jll ──────────────── v0.4.1+0
Xorg_xcb_util_keysyms_jll ──────── v0.4.1+0
Xorg_xcb_util_renderutil_jll ───── v0.3.10+0
Xorg_xcb_util_wm_jll ───────────── v0.4.2+0
Xorg_xkbcomp_jll ───────────────── v1.4.7+0
Xorg_xkeyboard_config_jll ──────── v2.44.0+0
Xorg_xtrans_jll ────────────────── v1.6.0+0
Zstd_jll ───────────────────────── v1.5.7+1
eudev_jll ──────────────────────── v3.2.14+0
fzf_jll ────────────────────────── v0.61.1+0
libaec_jll ─────────────────────── v1.1.4+0
libaom_jll ─────────────────────── v3.12.1+0
libass_jll ─────────────────────── v0.17.4+0
libdecor_jll ───────────────────── v0.2.2+0
libevdev_jll ───────────────────── v1.13.4+0
libfdk_aac_jll ─────────────────── v2.0.4+0
libinput_jll ───────────────────── v1.28.1+0
libpng_jll ─────────────────────── v1.6.50+0
libvorbis_jll ──────────────────── v1.3.8+0
libzip_jll ─────────────────────── v1.11.3+0
licensecheck_jll ───────────────── v0.3.101+0
micromamba_jll ─────────────────── v1.5.12+0
mtdev_jll ──────────────────────── v1.1.7+0
oneTBB_jll ─────────────────────── v2022.0.0+0
pixi_jll ───────────────────────── v0.41.3+0
x264_jll ───────────────────────── v10164.0.1+0
x265_jll ───────────────────────── v4.1.0+0
xkbcommon_jll ──────────────────── v1.9.2+0
