### PR TITLE
Merge infiltration and evaporation states

### DIFF
--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -72,7 +72,7 @@ function BMI.get_value_ptr(model::Model, name::String)::Vector{Float64}
     elseif name == "basin.surface_runoff"
         basin.vertical_flux.surface_runoff::Vector{Float64}
     elseif name == "basin.cumulative_infiltration"
-        unsafe_array(u.infiltration)::Vector{Float64}
+        basin.cumulative_infiltration::Vector{Float64}
     elseif name == "basin.cumulative_drainage"
         basin.cumulative_drainage::Vector{Float64}
     elseif name == "basin.cumulative_surface_runoff"

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -22,8 +22,7 @@ const state_components = (
     :user_demand_outflow,
     :linear_resistance,
     :manning_resistance,
-    :evaporation,
-    :infiltration,
+    :outward_forcing,
     :integral,
 )
 const n_components = length(state_components)
@@ -378,6 +377,8 @@ In-memory storage of saved mean flows for writing to results.
 - `precipitation`: The exact integrated mean precipitation
 - `surface_runoff`: The exact integrated mean surface_runoff
 - `drainage`: The exact integrated mean drainage
+- `infiltration`: The infiltration derived from `outward_forcing`
+- `evaporation`: The evaporation derived from `outward_forcing`
 - `concentration`: Concentrations for each Basin and substance
 - `balance_error`: The (absolute) water balance error
 - `relative_error`: The relative water balance error
@@ -391,6 +392,8 @@ In-memory storage of saved mean flows for writing to results.
     precipitation::Vector{Float64}
     surface_runoff::Vector{Float64}
     drainage::Vector{Float64}
+    infiltration::Vector{Float64}
+    evaporation::Vector{Float64}
     concentration::Matrix{Float64}
     storage_rate::Vector{Float64} = zero(precipitation)
     balance_error::Vector{Float64} = zero(precipitation)
@@ -511,6 +514,13 @@ Requirements:
     cumulative_precipitation_saveat::Vector{Float64} = zeros(length(node_id))
     cumulative_surface_runoff_saveat::Vector{Float64} = zeros(length(node_id))
     cumulative_drainage_saveat::Vector{Float64} = zeros(length(node_id))
+    # Derived from outward_forcing
+    cumulative_infiltration::Vector{Float64} = zeros(length(node_id))
+    cumulative_evaporation::Vector{Float64} = zeros(length(node_id))
+    cumulative_infiltration_saveat::Vector{Float64} = zeros(length(node_id))
+    cumulative_evaporation_saveat::Vector{Float64} = zeros(length(node_id))
+    infiltration_update::Vector{Float64} = zeros(length(node_id))
+    evaporation_update::Vector{Float64} = zeros(length(node_id))
     # Basin profile interpolations
     storage_to_level::Vector{StorageToLevelType} =
         Vector{StorageToLevelType}(undef, length(node_id))

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -61,9 +61,9 @@ function get_scalar_interpolation(
     time::AbstractVector,
     node_id::NodeID,
     param::Symbol;
-    default_value::Float64=0.0,
-    interpolation_type::Type{<:AbstractInterpolation}=ConstantInterpolation,
-    cyclic_time::Bool=false,
+    default_value::Float64 = 0.0,
+    interpolation_type::Type{<:AbstractInterpolation} = ConstantInterpolation,
+    cyclic_time::Bool = false,
 )::interpolation_type
     rows = searchsorted(time.node_id, node_id)
     parameter = getproperty(time, param)[rows]
@@ -75,8 +75,8 @@ function get_scalar_interpolation(
     return interpolation_type(
         parameter,
         times;
-        extrapolation=cyclic_time ? Periodic : ConstantExtrapolation,
-        cache_parameters=true,
+        extrapolation = cyclic_time ? Periodic : ConstantExtrapolation,
+        cache_parameters = true,
     )
 end
 
@@ -120,9 +120,9 @@ function qh_interpolation(
     return PCHIPInterpolation(
         flow_rate,
         level;
-        extrapolation_left=ConstantExtrapolation,
-        extrapolation_right=Linear,
-        cache_parameters=true,
+        extrapolation_left = ConstantExtrapolation,
+        extrapolation_right = Linear,
+        cache_parameters = true,
     )
 end
 
@@ -131,7 +131,7 @@ Find the index of element x in a sorted collection a.
 Returns the index of x if it exists, or nothing if it doesn't.
 If x occurs more than once, throw an error.
 """
-function findsorted(a, x)::Union{Int,Nothing}
+function findsorted(a, x)::Union{Int, Nothing}
     r = searchsorted(a, x)
     return if isempty(r)
         nothing
@@ -183,7 +183,7 @@ function get_storage(p::Parameters, node_id::NodeID, t::Number)::Float64
 end
 
 "Return the bottom elevation of the basin with index i, or nothing if it doesn't exist"
-function basin_bottom(basin::Basin, node_id::NodeID)::Tuple{Bool,Float64}
+function basin_bottom(basin::Basin, node_id::NodeID)::Tuple{Bool, Float64}
     return if node_id.type == NodeType.Basin
         # get level(storage) interpolation function
         level_discrete = basin_levels(basin, node_id.idx)
@@ -199,10 +199,10 @@ Replace the truth states in the logic mapping which contain wildcards with
 all possible explicit truth states.
 """
 function expand_logic_mapping(
-    logic_mapping::Vector{Dict{String,String}},
+    logic_mapping::Vector{Dict{String, String}},
     node_ids::Vector{NodeID},
-)::Vector{Dict{Vector{Bool},String}}
-    logic_mapping_expanded = [Dict{Vector{Bool},String}() for _ in eachindex(node_ids)]
+)::Vector{Dict{Vector{Bool}, String}}
+    logic_mapping_expanded = [Dict{Vector{Bool}, String}() for _ in eachindex(node_ids)]
     pattern = r"^[TF\*]+$"
 
     for node_id in node_ids
@@ -279,8 +279,8 @@ Base.size(fv::FlatVector) = (length(fv),)
 function Base.getindex(fv::FlatVector, i::Int)
     veclen = length(first(fv.v))
     d, r = divrem(i - 1, veclen)
-    v = fv.v[d+1]
-    return v[r+1]
+    v = fv.v[d + 1]
+    return v[r + 1]
 end
 
 "Construct a FlatVector from one of the fields of SavedFlow."
@@ -294,7 +294,7 @@ FlatVector(v::Vector{Matrix{Float64}}) = FlatVector(vec.(v))
 Function that goes smoothly from 0 to 1 in the interval [0,threshold],
 and is constant outside this interval.
 """
-function reduction_factor(x::T, threshold::Real)::T where {T<:Real}
+function reduction_factor(x::T, threshold::Real)::T where {T <: Real}
     return if x < 0
         zero(T)
     elseif x < threshold
@@ -370,7 +370,7 @@ function get_all_demand_priorities(db::DB, config::Config;)::Vector{Int32}
     end
 end
 
-const control_type_mapping = Dict{NodeType.T,ContinuousControlType.T}(
+const control_type_mapping = Dict{NodeType.T, ContinuousControlType.T}(
     NodeType.PidControl => ContinuousControlType.PID,
     NodeType.ContinuousControl => ContinuousControlType.Continuous,
 )
@@ -459,7 +459,7 @@ function set_initial_allocation_cumulative_volume!(integrator)::Nothing
                 fixed_area * vertical_flux.precipitation[node_id.idx] +
                 vertical_flux.surface_runoff[node_id.idx] +
                 vertical_flux.drainage[node_id.idx]
-            forcing_negative = du.evaporation[node_id.idx] + du.infiltration[node_id.idx]
+            forcing_negative = du.outward_forcing[node_id.idx]
             cumulative_forcing_volume[node_id] =
                 (forcing_positive * Δt_allocation, forcing_negative * Δt_allocation)
         end
@@ -494,14 +494,14 @@ function get_cache_ref(
     node_id::NodeID,
     variable::String,
     state_ranges::StateTuple{UnitRange{Int}};
-    listen::Bool=true,
-)::Tuple{CacheRef,Bool}
+    listen::Bool = true,
+)::Tuple{CacheRef, Bool}
     errors = false
 
     ref = if node_id.type == NodeType.Basin && variable == "level"
-        CacheRef(; type=CacheType.basin_level, node_id.idx)
+        CacheRef(; type = CacheType.basin_level, node_id.idx)
     elseif node_id.type == NodeType.Basin && variable == "storage"
-        CacheRef(; type=CacheType.basin_storage, node_id.idx)
+        CacheRef(; type = CacheType.basin_storage, node_id.idx)
     elseif variable == "flow_rate" && node_id.type != NodeType.FlowBoundary
         if listen
             if node_id.type ∉ conservative_nodetypes
@@ -511,7 +511,7 @@ function get_cache_ref(
             else
                 # Index in the state vector (inflow)
                 idx = get_state_index(state_ranges, node_id)
-                CacheRef(; idx, from_du=true)
+                CacheRef(; idx, from_du = true)
             end
         else
             type = if node_id.type == NodeType.Pump
@@ -576,7 +576,7 @@ function set_discrete_controlled_variable_refs!(
     for nodetype in propertynames(p_independent)
         node = getfield(p_independent, nodetype)
         if node isa AbstractParameterNode && hasfield(typeof(node), :control_mapping)
-            control_mapping::Dict{Tuple{NodeID,String},ControlStateUpdate} =
+            control_mapping::Dict{Tuple{NodeID, String}, ControlStateUpdate} =
                 node.control_mapping
 
             for ((node_id, control_state), control_state_update) in control_mapping
@@ -625,7 +625,7 @@ function set_target_ref!(
     for (i, (id, variable)) in enumerate(zip(node_id, controlled_variable))
         controlled_node_id = only(outneighbor_labels_type(graph, id, LinkType.control))
         ref, error =
-            get_cache_ref(controlled_node_id, variable, state_ranges; listen=false)
+            get_cache_ref(controlled_node_id, variable, state_ranges; listen = false)
         target_ref[i] = ref
         errors |= error
     end
@@ -681,19 +681,18 @@ get_level_from_storage(basin::Basin, state_idx::Int, storage::GradientTracer) = 
 
 "Create a NamedTuple of the node IDs per state component in the state order"
 function state_node_ids(
-    p::Union{ParametersIndependent,NamedTuple},
+    p::Union{ParametersIndependent, NamedTuple},
 )::StateTuple{Vector{NodeID}}
     (;
-        tabulated_rating_curve=p.tabulated_rating_curve.node_id,
-        pump=p.pump.node_id,
-        outlet=p.outlet.node_id,
-        user_demand_inflow=p.user_demand.node_id,
-        user_demand_outflow=p.user_demand.node_id,
-        linear_resistance=p.linear_resistance.node_id,
-        manning_resistance=p.manning_resistance.node_id,
-        evaporation=p.basin.node_id,
-        infiltration=p.basin.node_id,
-        integral=p.pid_control.node_id,
+        tabulated_rating_curve = p.tabulated_rating_curve.node_id,
+        pump = p.pump.node_id,
+        outlet = p.outlet.node_id,
+        user_demand_inflow = p.user_demand.node_id,
+        user_demand_outflow = p.user_demand.node_id,
+        linear_resistance = p.linear_resistance.node_id,
+        manning_resistance = p.manning_resistance.node_id,
+        outward_forcing = p.basin.node_id,
+        integral = p.pid_control.node_id,
     )
 end
 
@@ -733,8 +732,8 @@ function build_flow_to_storage(
     n_states::Int,
     basin::Basin,
     connector_nodes::NamedTuple,
-)::SparseMatrixCSC{Float64,Int}
-    (; user_demand_inflow, user_demand_outflow, evaporation, infiltration) = state_ranges
+)::SparseMatrixCSC{Float64, Int}
+    (; user_demand_inflow, user_demand_outflow, outward_forcing) = state_ranges
     n_basins = length(basin.node_id)
     flow_to_storage = spzeros(n_basins, n_states)
 
@@ -761,12 +760,10 @@ function build_flow_to_storage(
         end
     end
 
-    flow_to_storage_evaporation = view(flow_to_storage, :, evaporation)
-    flow_to_storage_infiltration = view(flow_to_storage, :, infiltration)
+    flow_to_storage_outward_forcing = view(flow_to_storage, :, outward_forcing)
 
     for i in 1:n_basins
-        flow_to_storage_evaporation[i, i] = -1.0
-        flow_to_storage_infiltration[i, i] = -1.0
+        flow_to_storage_outward_forcing[i, i] = -1.0
     end
 
     return flow_to_storage
@@ -780,7 +777,7 @@ Only for horizontal flows, which are assumed to come first in the state vector.
 function get_state_flow_links(
     graph::MetaGraph,
     nodes::NamedTuple,
-)::Tuple{Vector{LinkMetadata},Vector{LinkMetadata}}
+)::Tuple{Vector{LinkMetadata}, Vector{LinkMetadata}}
     (; user_demand) = nodes
     state_inflow_link = LinkMetadata[]
     state_outflow_link = LinkMetadata[]
@@ -838,8 +835,8 @@ Can return nothing for node types that do not have a state, like Terminal.
 function get_state_index(
     state_ranges::StateTuple{UnitRange{Int}},
     id::NodeID;
-    inflow::Bool=true,
-)::Union{Int,Nothing}
+    inflow::Bool = true,
+)::Union{Int, Nothing}
     component_name = if id.type == NodeType.UserDemand
         inflow ? :user_demand_inflow : :user_demand_outflow
     else
@@ -857,10 +854,10 @@ end
 "Get the state index of the to-node of the link if it exists, otherwise the from-node."
 function get_state_index(
     state_ranges::StateTuple{UnitRange{Int}},
-    link::Tuple{NodeID,NodeID},
-)::Union{Int,Nothing}
+    link::Tuple{NodeID, NodeID},
+)::Union{Int, Nothing}
     idx = get_state_index(state_ranges, link[2])
-    isnothing(idx) ? get_state_index(state_ranges, link[1]; inflow=false) : idx
+    isnothing(idx) ? get_state_index(state_ranges, link[1]; inflow = false) : idx
 end
 
 """
@@ -936,7 +933,7 @@ address to data of the requested length, and it will not prevent the input array
 being freed.
 """
 function unsafe_array(
-    A::SubArray{Float64,1,Vector{Float64},Tuple{UnitRange{Int64}},true},
+    A::SubArray{Float64, 1, Vector{Float64}, Tuple{UnitRange{Int64}}, true},
 )::Vector{Float64}
     GC.@preserve A unsafe_wrap(Array, pointer(A), length(A))
 end
@@ -1036,7 +1033,7 @@ function get_timeseries_tstops(itp::AbstractInterpolation, t_end::Float64)::Vect
             # Because of floating point errors last(transition_ts) = first(transition_ts) + T
             # does not always hold exactly, so to prevent that these become separate
             # very close tstops we only use the last time point of the period in the last period
-            append!(tstops, filter(t -> 0 ≤ t ≤ t_end, transition_ts[1:(end-1)] .+ i * T))
+            append!(tstops, filter(t -> 0 ≤ t ≤ t_end, transition_ts[1:(end - 1)] .+ i * T))
         end
     end
 
@@ -1065,7 +1062,11 @@ function ranges(lengths::Vector{<:Integer})
     return ranges
 end
 
-function get_interpolation_vec(interpolation_type::String, block_transition_period::Float64, node_id::Vector{NodeID})::Vector
+function get_interpolation_vec(
+    interpolation_type::String,
+    block_transition_period::Float64,
+    node_id::Vector{NodeID},
+)::Vector
     type = if interpolation_type == "linear"
         ScalarLinearInterpolation
     elseif interpolation_type == "block"
@@ -1129,19 +1130,19 @@ function eval_time_interp(
     end
 end
 
-function trivial_constant_itp(; val=0.0)
-    ConstantInterpolation([val, val], [0.0, 1.0]; extrapolation=ConstantExtrapolation)
+function trivial_constant_itp(; val = 0.0)
+    ConstantInterpolation([val, val], [0.0, 1.0]; extrapolation = ConstantExtrapolation)
 end
 
 function trivial_allocation_itp_fill(
     demand_priorities,
     node_id;
-    val=0.0,
+    val = 0.0,
 )::Vector{Vector{ScalarConstantInterpolation}}
     return [fill(trivial_constant_itp(; val), length(demand_priorities)) for _ in node_id]
 end
 
-function finitemaximum(u::AbstractVector; init=0)
+function finitemaximum(u::AbstractVector; init = 0)
     # Find the maximum finite value in the vector
     max_val = init
     for val in u
@@ -1155,7 +1156,7 @@ end
 function initialize_concentration_itp(
     n_substance,
     substance_idx_node_type;
-    continuity_tracer=true,
+    continuity_tracer = true,
 )::Vector{ScalarConstantInterpolation}
     # Default: concentration of 0
     concentration_itp = fill(zero_constant_itp, n_substance)
@@ -1182,7 +1183,7 @@ function filtered_constant_interpolation(
         ConstantInterpolation(
             values[mask],
             seconds_since.(times[mask], config.starttime);
-            extrapolation=cyclic_time ? Periodic : ConstantExtrapolation,
+            extrapolation = cyclic_time ? Periodic : ConstantExtrapolation,
         )
     else
         zero_constant_itp
@@ -1196,7 +1197,7 @@ function get_concentration_itp(
     substance_idx_node_type,
     cyclic_times,
     config;
-    continuity_tracer=true,
+    continuity_tracer = true,
 )::Vector{Vector{ScalarConstantInterpolation}}
     concentration_itp = [
         initialize_concentration_itp(

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -356,30 +356,18 @@ function basin_data(model::Model; table::Bool = true)
 
     nbasin = length(data.node_id)
     ntsteps = length(data.time) - 1
-    nrows = nbasin * ntsteps
 
     inflow_rate = FlatVector(saved.flow.saveval, :inflow)
     outflow_rate = FlatVector(saved.flow.saveval, :outflow)
     drainage = FlatVector(saved.flow.saveval, :drainage)
-    infiltration = zeros(nrows)
-    evaporation = zeros(nrows)
     precipitation = FlatVector(saved.flow.saveval, :precipitation)
+    infiltration = FlatVector(saved.flow.saveval, :infiltration)
+    evaporation = FlatVector(saved.flow.saveval, :evaporation)
     surface_runoff = FlatVector(saved.flow.saveval, :surface_runoff)
     storage_rate = FlatVector(saved.flow.saveval, :storage_rate)
     balance_error = FlatVector(saved.flow.saveval, :balance_error)
     relative_error = FlatVector(saved.flow.saveval, :relative_error)
     convergence = FlatVector(saved.flow.saveval, :basin_convergence)
-
-    idx_row = 0
-    for saved_flow in saved.flow.saveval
-        saved_evaporation = view(saved_flow.flow, state_ranges.evaporation)
-        saved_infiltration = view(saved_flow.flow, state_ranges.infiltration)
-        for (evaporation_, infiltration_) in zip(saved_evaporation, saved_infiltration)
-            idx_row += 1
-            evaporation[idx_row] = evaporation_
-            infiltration[idx_row] = infiltration_
-        end
-    end
 
     time = data.time[begin:(end - 1)]
     node_id = Int32.(data.node_id)

--- a/core/test/bmi_test.jl
+++ b/core/test/bmi_test.jl
@@ -101,7 +101,7 @@ end
     inflow = BMI.get_value_ptr(model, "user_demand.cumulative_inflow")
     day = 86400.0
     BMI.update_until(model, 2day)
-    @test inflow ≈ [2e-3 * day, 3e-3 * day] atol = 1e-3
+    @test inflow ≈ [2e-3 * day, 3e-3 * day] atol = 2e-3
     demand[1] = 3e-3
     BMI.update_until(model, 3day)
     @test inflow[1] ≈ 5e-3 * day atol = 2e-3

--- a/core/test/utils_test.jl
+++ b/core/test/utils_test.jl
@@ -263,8 +263,8 @@ end
 
     # rows, cols, _ = findnz(jac_prototype)
     #! format: off
-    rows_expected = [1, 2, 3, 6, 7, 9, 13, 1, 2, 3, 4, 6, 7, 9, 10, 13, 14, 1, 2, 3, 4, 5, 6, 7, 9, 11, 13, 15, 2, 3, 4, 5, 10, 11, 14, 15, 3, 4, 5, 11, 15, 1, 2, 3, 6, 7, 9, 13, 1, 2, 3, 6, 7, 8, 9, 12, 13, 7, 8, 12, 1, 2, 3, 6, 7, 9, 13, 2, 4, 10, 14, 3, 4, 5, 11, 15, 7, 8, 12, 1, 2, 3, 6, 7, 9, 13, 2, 4, 10, 14, 3, 4, 5, 11, 15]
-    cols_expected = [1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10, 11, 11, 11, 11, 11, 12, 12, 12, 13, 13, 13, 13, 13, 13, 13, 14, 14, 14, 14, 15, 15, 15, 15, 15]
+    rows_expected = [1, 2, 3, 6, 7, 9, 1, 2, 3, 4, 6, 7, 9, 10, 1, 2, 3, 4, 5, 6, 7, 9, 11, 2, 3, 4, 5, 10, 11, 3, 4, 5, 11, 1, 2, 3, 6, 7, 9, 1, 2, 3, 6, 7, 8, 9, 7, 8, 1, 2, 3, 6, 7, 9, 2, 4, 10, 3, 4, 5, 11]
+    cols_expected = [1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 8, 8, 9, 9, 9, 9, 9, 9, 10, 10, 10, 11, 11, 11, 11]
     #! format: on
     jac_prototype_expected =
         sparse(rows_expected, cols_expected, true, size(jac_prototype)...)
@@ -284,8 +284,8 @@ end
     jac_prototype, _, _ = Ribasim.get_diff_eval(du0, u0, p, config.solver)
 
     #! format: off
-    rows_expected = [1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6, 1, 2]
-    cols_expected = [1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 5, 6]
+    rows_expected = [1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2]
+    cols_expected = [1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 4, 5]
     #! format: on
     jac_prototype_expected =
         sparse(rows_expected, cols_expected, true, size(jac_prototype)...)
@@ -387,8 +387,7 @@ end
     state_ranges = getaxes(model.integrator.u)
     n_basins = length(basin.node_id)
 
-    @test flow_to_storage[:, state_ranges.evaporation] == -I
-    @test flow_to_storage[:, state_ranges.infiltration] == -I
+    @test flow_to_storage[:, state_ranges.outward_forcing] == -I
 
     for node_name in
         [:tabulated_rating_curve, :pump, :outlet, :linear_resistance, :manning_resistance]


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/2614

I made a small adjustment to the original idea in the issue. The infiltration is still computed as suggested there, but then the result is clamped with the bounds that used to be in `flow_limiter!`. Then the infiltration is computed as the difference between the total outgoing forcing and the infiltration. Since this value can technically be negative it is clamped to 0.0 which can break the water balance, but I think that is highly unlikely to happen.

Rather surprisingly, this doesn't seem to give a significant speedup.