### PR TITLE
Add edge_coordinates attributes to generate.py

### DIFF
--- a/python/ribasim/ribasim/delwaq/generate.py
+++ b/python/ribasim/ribasim/delwaq/generate.py
@@ -356,9 +356,9 @@ def generate(
             )
         )
 
-    # Generate mesh and write to NetCDF
+    # Generate mesh and write to NetCDF, adding optional attributes to avoid Delwaq warnings
     uds = ugrid(G)
-    uds.ugrid.to_netcdf(output_path / "ribasim.nc")
+    uds.ugrid.to_dataset(optional_attributes=True).to_netcdf(output_path / "ribasim.nc")
 
     # Generate area and flows
     # File format is int32, float32 based


### PR DESCRIPTION
Fixes a part of #1946.

This option currently only adds edge coordinates:

https://github.com/Deltares/xugrid/blob/4e3851385ba43db89191e923ea19922ad467c531/xugrid/ugrid/ugrid1d.py#L265-L266

The warning about this missing is now gone, but the node_id and node_long_name warnings remain:

```
 Warning: retrieving attribute node_id failed --          -43
 Warning: retrieving attribute node_long_name failed --          -43
 One or more mesh attributes missing -
 this may cause problems in some postprocessing programs
```
