### PR TITLE
Fix remaining DelWAQ netCDF warnings

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -5,5 +5,6 @@
 /tutorial/crystal-basin/
 guide/data/
 *.html
-*.quarto_ipynb
 objects.json
+
+**/*.quarto_ipynb

--- a/python/ribasim/ribasim/delwaq/generate.py
+++ b/python/ribasim/ribasim/delwaq/generate.py
@@ -356,9 +356,9 @@ def generate(
             )
         )
 
-    # Generate mesh and write to NetCDF
+    # Generate mesh and write to NetCDF, adding optional attributes to avoid Delwaq warnings
     uds = ugrid(G)
-    uds.ugrid.to_netcdf(output_path / "ribasim.nc")
+    uds.ugrid.to_dataset(optional_attributes=True).to_netcdf(output_path / "ribasim.nc")
 
     # Generate area and flows
     # File format is int32, float32 based

--- a/python/ribasim/ribasim/delwaq/generate.py
+++ b/python/ribasim/ribasim/delwaq/generate.py
@@ -356,9 +356,13 @@ def generate(
             )
         )
 
-    # Generate mesh and write to NetCDF, adding optional attributes to avoid Delwaq warnings
+    # Generate mesh and write to NetCDF, adding attributes to avoid Delwaq warnings
     uds = ugrid(G)
-    uds.ugrid.to_dataset(optional_attributes=True).to_netcdf(output_path / "ribasim.nc")
+    grid = uds.ugrid.grid
+    dataset = uds.ugrid.to_dataset(optional_attributes=True)
+    dataset[grid.name].attrs["node_id"] = grid.node_dimension
+    dataset[grid.name].attrs["node_long_name"] = "Node dimension of 1D network"
+    dataset.to_netcdf(output_path / "ribasim.nc")
 
     # Generate area and flows
     # File format is int32, float32 based


### PR DESCRIPTION
Follow up of #2619, fixes #1946.

Implements https://github.com/Deltares/Ribasim/issues/1946#issuecomment-3376328165

This removes the remaining two warnings.

Though in the logging it still says:

```
  Number of WARNINGS            :     2
  Number of ERRORS during input :     0
```

But I guess that refers to other warnings that are not logged to the terminal.