### PR TITLE
Set JULIA_CONDAPKG_BACKEND to Null

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -304,3 +304,6 @@ py312 = ["py312"]
 
 [system-requirements]
 linux = "3.10.0"
+
+[activation.env]
+JULIA_CONDAPKG_BACKEND = "Null"


### PR DESCRIPTION
See https://github.com/Deltares/Ribasim/pull/2629/#issuecomment-3387293631

But now setting this for all tasks at once, because we never want to create new enviornments.

This failed again on the same PR in the JuliaC precompilation step.