### PR TITLE
[delwaq] Limit Delwaq endtime for partially failed Ribasim runs.

### DIFF
--- a/python/ribasim/ribasim/delwaq/generate.py
+++ b/python/ribasim/ribasim/delwaq/generate.py
@@ -360,9 +360,17 @@ def generate(
 
     evaporate_mass = model.solver.evaporate_mass
 
-    basins = pd.read_feather(model.results_path / "basin.arrow")
-    flows = pd.read_feather(model.results_path / "flow.arrow")
-    endtime = min(basins.time.max(), flows.time.max())
+    basin_fn = model.results_path / "basin.arrow"
+    assert basin_fn.exists(), f"Missing results file {basin_fn}."
+    basins = pd.read_feather(basin_fn)
+
+    flow_fn = model.results_path / "flow.arrow"
+    assert flow_fn.exists(), f"Missing results file {flow_fn}."
+    flows = pd.read_feather(flow_fn)
+
+    assert len(basins) > 0, "Empty basin results file."
+    assert len(flows) > 0, "Empty flows results file."
+    endtime = basins.time.max()
 
     if output_path is None:
         assert model.filepath is not None
@@ -583,8 +591,7 @@ def generate(
     shutil.copy(dimrc, output_path / "dimr_config.xml")
 
     # Write main Delwaq input file
-
-    if model.endtime > endtime:
+    if (model.endtime - timestep) > endtime:
         logger.warning(
             f"Model endtime {model.endtime} is later than the result time {endtime}, adjusting endtime."
         )


### PR DESCRIPTION
@jvleeuwen00 it turns out that the LHM model runs quite fine, but since the LHM model I used only had results untill 22-12 (it crashed then), Delwaq went a bit crazy after that date. This PR should fix it, and you should be free to use the LHM for water quality calculations.