### PR TITLE
Pass profile path for QGIS (plugins).

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -148,19 +148,9 @@ publish-ribasim-python = { cmd = "twine upload dist/*", cwd = "python/ribasim", 
 publish-ribasim-api = { cmd = "twine upload dist/*", cwd = "python/ribasim_api", depends-on = [
     "build-ribasim-api-wheel",
 ] }
-# QGIS
-qgis = "qgis --profiles-path .pixi/qgis_env"
-install-ribasim-qgis = "python ribasim_qgis/scripts/install_ribasim_qgis.py"
-install-imod-qgis = "python ribasim_qgis/scripts/install_qgis_plugin.py iMOD && python ribasim_qgis/scripts/enable_plugin.py imodqgis"
-install-plugin-reloader-qgis = "python ribasim_qgis/scripts/install_qgis_plugin.py \"Plugin Reloader\" && python ribasim_qgis/scripts/enable_plugin.py plugin_reloader"
-install-debugvs-qgis = "python ribasim_qgis/scripts/install_qgis_plugin.py debugvs==0.7 && python ribasim_qgis/scripts/enable_plugin.py debug_vs"
+
+
 test-ribasim-qgis-docker = { cmd = "sh ./test.sh", cwd = ".docker" }
-install-qgis-plugins = { depends-on = [
-    "install-plugin-reloader-qgis",
-    "install-ribasim-qgis",
-    "install-imod-qgis",
-    "install-debugvs-qgis",
-] }
 test-ribasim-qgis-ui = { cmd = "python ribasim_qgis/scripts/run_qgis_ui_tests.py", depends-on = [
     "install-ribasim-qgis",
 ] }
@@ -187,6 +177,46 @@ migrate-model = "python utils/migrate_model.py"
 filter-model = "python utils/filter_model.py"
 # Release
 github-release = "python utils/github-release.py"
+
+# QGIS
+[tasks.qgis]
+args = [{ "arg" = "profile_path", "default" = ".pixi/qgis_env" }]
+cmd = "qgis --profiles-path {{ profile_path }}"
+
+[tasks.install-ribasim-qgis]
+args = [{ "arg" = "profile_path", "default" = ".pixi/qgis_env" }]
+cmd = "python ribasim_qgis/scripts/install_ribasim_qgis.py {{ profile_path }}"
+
+[tasks.install-qgis-plugin]
+args = [
+    { "arg" = "package" },
+    { "arg" = "package_name" },
+    { "arg" = "profile_path", "default" = ".pixi/qgis_env" },
+]
+cmd = "python ribasim_qgis/scripts/install_qgis_plugin.py {{ package }} {{ profile_path }} && python ribasim_qgis/scripts/enable_plugin.py {{ package_name }} {{ profile_path }}"
+
+[tasks.install-qgis-plugins]
+args = [{ "arg" = "profile_path", "default" = ".pixi/qgis_env" }]
+depends-on = [
+    { "task" = "install-qgis-plugin", "args" = [
+        "Plugin\\ Reloader",
+        "plugin_reloader",
+        " {{ profile_path }} ",
+    ] },
+    { "task" = "install-ribasim-qgis", "args" = [
+        " {{ profile_path }} ",
+    ] },
+    { "task" = "install-qgis-plugin", "args" = [
+        "iMOD",
+        "imodqgis",
+        " {{ profile_path }} ",
+    ] },
+    { "task" = "install-qgis-plugin", "args" = [
+        "debugvs==0.7",
+        "debug_vs",
+        " {{ profile_path }} ",
+    ] },
+]
 
 [tasks.generate-sbom-ribasim-core]
 cmd = "julia --project --check-bounds=yes -- utils/generate-sbom.jl"

--- a/ribasim_qgis/scripts/enable_plugin.py
+++ b/ribasim_qgis/scripts/enable_plugin.py
@@ -3,8 +3,8 @@ import sys
 from pathlib import Path
 
 
-def enable_plugin(plugin_name: str) -> None:
-    config_file = Path(".pixi/qgis_env/profiles/default/QGIS/QGIS3.ini")
+def enable_plugin(plugin_name: str, profile_path: str) -> None:
+    config_file = Path(profile_path) / "QGIS/QGIS3.ini"
     config_file.parent.mkdir(parents=True, exist_ok=True)
     config_file.touch()
 
@@ -22,5 +22,5 @@ def enable_plugin(plugin_name: str) -> None:
 
 
 if __name__ == "__main__":
-    print(f"Enabling QGIS plugin {sys.argv[1]}")
-    enable_plugin(sys.argv[1])
+    print(f"Enabling QGIS plugin {sys.argv[1]} in profile {sys.argv[2]}")
+    enable_plugin(sys.argv[1], sys.argv[2])

--- a/ribasim_qgis/scripts/install_qgis_plugin.py
+++ b/ribasim_qgis/scripts/install_qgis_plugin.py
@@ -5,8 +5,8 @@ import sys
 from pathlib import Path
 
 
-def install_qgis_plugin(plugin_name: str):
-    plugin_path = Path(".pixi/qgis_env/profiles/default/python/plugins")
+def install_qgis_plugin(plugin_name: str, profile_path: str) -> None:
+    plugin_path = Path(profile_path) / "python/plugins"
     plugin_path.mkdir(parents=True, exist_ok=True)
 
     try:
@@ -22,5 +22,5 @@ def install_qgis_plugin(plugin_name: str):
 
 
 if __name__ == "__main__":
-    print(f"Installing QGIS plugin {sys.argv[1]}")
-    install_qgis_plugin(sys.argv[1])
+    print(f"Installing QGIS plugin {sys.argv[1]} to profile {sys.argv[2]}")
+    install_qgis_plugin(sys.argv[1], sys.argv[2])

--- a/ribasim_qgis/scripts/install_ribasim_qgis.py
+++ b/ribasim_qgis/scripts/install_ribasim_qgis.py
@@ -1,21 +1,22 @@
+import sys
 from pathlib import Path
 
 from enable_plugin import enable_plugin
 
-target_path = Path("ribasim_qgis").absolute()
-plugins_path = Path(".pixi/qgis_env/profiles/default/python/plugins")
-source_path = plugins_path / "ribasim_qgis"
+if __name__ == "__main__":
+    target_path = Path("ribasim_qgis").absolute()
+    plugins_path = Path(sys.argv[1]) / "python/plugins"
+    source_path = plugins_path / "ribasim_qgis"
 
-styles_source_path = target_path / "core" / "styles"
-styles_target_path = Path("python/ribasim/ribasim/styles").absolute()
+    styles_source_path = target_path / "core" / "styles"
+    styles_target_path = Path("python/ribasim/ribasim/styles").absolute()
 
-# Symlink ribasim_qgis styles to ribasim styles
-styles_source_path.unlink(missing_ok=True)
-styles_source_path.symlink_to(styles_target_path, target_is_directory=True)
+    # Symlink ribasim_qgis styles to ribasim styles
+    styles_source_path.unlink(missing_ok=True)
+    styles_source_path.symlink_to(styles_target_path, target_is_directory=True)
 
-# Symlink qgis_env to ribasim_qgis, and hence qgis_env styles to ribasim styles
-plugins_path.mkdir(parents=True, exist_ok=True)
-source_path.unlink(missing_ok=True)
-source_path.symlink_to(target_path, target_is_directory=True)
-
-enable_plugin("ribasim_qgis")
+    # Symlink qgis_env to ribasim_qgis, and hence qgis_env styles to ribasim styles
+    plugins_path.mkdir(parents=True, exist_ok=True)
+    source_path.unlink(missing_ok=True)
+    source_path.symlink_to(target_path, target_is_directory=True)
+    enable_plugin("ribasim_qgis", sys.argv[1])


### PR DESCRIPTION
QGIS should "just" work for mac if you have it in your path (`pixi global install --environment qgis qgis pandas` @simulutions). So this PR is more for passing a profile path, maybe more of an advanced use case requested by @visr.