### PR TITLE
Set QGIS plugin prefix

### DIFF
--- a/ribasim_qgis/resources.qrc
+++ b/ribasim_qgis/resources.qrc
@@ -1,5 +1,5 @@
 <RCC>
-    <qresource prefix="/plugins/qgistim" >
+    <qresource prefix="/plugins/ribasim_qgis" >
         <file>icon.png</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
I don't understand what this does. But this seems better.

Also for https://github.com/Deltares/imod-qgis/blob/main/imodqgis/resources.qrc this is imod_plugin which is neither the name set in metadata.txt (iMOD) nor the folder name (imodqgis).