### PR TITLE
Remove scripts/ tests/ from QGIS zip

### DIFF
--- a/.teamcity/Ribasim/buildTypes/Ribasim_MakeQgisPlugin.kt
+++ b/.teamcity/Ribasim/buildTypes/Ribasim_MakeQgisPlugin.kt
@@ -25,6 +25,9 @@ object Ribasim_MakeQgisPlugin : BuildType({
                 module load pixi
                 pixi run install-ribasim-qgis
 
+                rm --recursive ribasim_qgis/scripts
+                rm --recursive ribasim_qgis/tests
+                rm ribasim_qgis/.coveragerc
                 rsync --verbose --recursive --delete ribasim_qgis/ ribasim_qgis
                 rm --force ribasim_qgis.zip
                 zip -r ribasim_qgis.zip ribasim_qgis


### PR DESCRIPTION
I noticed extra stuff that users don't need.

It isn't that big, but the binary `ribasim_qgis\scripts\__pycache__\enable_plugin.cpython-313.pyc` that was in the current zip might raise some concerns.