### PR TITLE
Make `is_layer_visible` more robust

### DIFF
--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -262,7 +262,8 @@ class DatasetWidget:
         layer_tree_root = instance.layerTreeRoot()
         assert layer_tree_root is not None
         layer_tree_layer = layer_tree_root.findLayer(layer)
-        assert layer_tree_layer is not None
+        if layer_tree_layer is None:
+            return False
         return layer_tree_layer.setItemVisibilityChecked(visible)
 
     def add_reload_context(self) -> None:


### PR DESCRIPTION
I was looking at results with the time slider, and clicked "Reload Ribasim model". This caused an AssertionError:

```
An error has occurred while executing Python code:

AssertionError
Traceback (most recent call last):
  File "C:\Users/visser_mn/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\ribasim_qgis\widgets\dataset_widget.py", line 654, in _update_arrow_layers
    self._update_arrow_layer(
  File "C:\Users/visser_mn/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\ribasim_qgis\widgets\dataset_widget.py", line 597, in _update_arrow_layer
    or (not force and not self.is_layer_visible(layer))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users/visser_mn/AppData/Roaming/QGIS/QGIS3\profiles\default/python/plugins\ribasim_qgis\widgets\dataset_widget.py", line 254, in is_layer_visible
    assert layer_tree_layer is not None
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

This fixes it.