### PR TITLE
Finalize progress bar

### DIFF
--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -30,7 +30,7 @@ using DifferentiationInterface:
 using ForwardDiff: derivative as forward_diff
 
 # Algorithms for solving ODEs.
-using OrdinaryDiffEqCore: OrdinaryDiffEqCore, get_du
+using OrdinaryDiffEqCore: OrdinaryDiffEqCore, get_du, log_step!
 using OrdinaryDiffEqDifferentiation:
     WOperator, OrdinaryDiffEqDifferentiation, dolinsolve, jacobian2W!
 import ADTypes

--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -248,8 +248,29 @@ function solve!(model::Model)::Model
     else
         SciMLBase.solve!(integrator)
     end
+    final_progress!(model)
     check_error!(integrator)
     comptime = canonicalize(Millisecond(round(Int, comptime_s * 1000)))
     @info "Computation time: $comptime"
     return model
+end
+
+"""
+Update the progress bar after the simulation.
+
+TODO upstream https://github.com/Deltares/Ribasim/issues/2663
+"""
+function final_progress!(model::Model)::Nothing
+    integrator = model.integrator
+    log_step!(
+        integrator.opts.progress_name,
+        integrator.opts.progress_id,
+        integrator.opts.progress_message,
+        integrator.dt,
+        integrator.u,
+        integrator.p,
+        integrator.t,
+        integrator.sol.prob.tspan,
+    )
+    return nothing
 end


### PR DESCRIPTION
Fixes the symptoms of #2663. Probably good to keep that open as a reminder to upstream this, because we are using a OrdinaryDiffEqCore internal function here. Still I'd like to get this in before the release to avoid users thinking their simulation is still ongoing.