### PR TITLE
Use `warnings` for replacing node, add test

### DIFF
--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -275,21 +275,15 @@ class MultiNodeModel(NodeModel):
         self,
         node: Node,
         tables: Sequence[TableModel] | None = None,  # type: ignore[type-arg]
-        replace: bool | None = None,
     ) -> NodeData:
         """Add a node and the associated data to the model.
 
-        If a node with the same Node ID already exists, the behavior depends on the `replace` parameter.
+        If a node with the same Node ID already exists, it will be replaced (with a warning).
 
         Parameters
         ----------
         node : Ribasim.Node
         tables : Sequence[TableModel[Any]] | None
-        replace : bool | None
-            Controls replacement behavior when a node with the same ID exists:
-            - None (default): Replace with a warning
-            - True: Replace without warning
-            - False: Raise a ValueError instead of replacing
         """
         if tables is None:
             tables = []
@@ -305,15 +299,11 @@ class MultiNodeModel(NodeModel):
         if node_id is None:
             node_id = self._parent._used_node_ids.new_id()
         elif node_id in self._parent._used_node_ids:
-            if replace is False:
-                raise ValueError(f"Node #{node_id} already exists.")
-            elif replace is None:
-                warnings.warn(
-                    f"Replacing node #{node_id}",
-                    UserWarning,
-                    stacklevel=2,
-                )
-            # If replace is True, silently replace
+            warnings.warn(
+                f"Replacing node #{node_id}",
+                UserWarning,
+                stacklevel=2,
+            )
             # Remove the existing node from all node types and their tables
             self._parent._remove_node_id(node_id)  # type: ignore[attr-defined]
 

--- a/python/ribasim/tests/test_io.py
+++ b/python/ribasim/tests/test_io.py
@@ -1,4 +1,3 @@
-import warnings
 from datetime import datetime
 from pathlib import Path
 
@@ -236,19 +235,9 @@ def test_add_existing():
     # Add a terminal
     model.terminal.add(Node(20, Point(0, 1)))
 
-    # Test replacing with default replace=None (should warn)
+    # Test replacement warning
     with pytest.warns(UserWarning, match="Replacing node #20"):
         model.terminal.add(Node(20, Point(0.5, 1)))
-
-    # Test replacing with replace=False (should raise error)
-    with pytest.raises(ValueError, match="Node #20 already exists"):
-        model.terminal.add(Node(20, Point(1, 1)), replace=False)
-
-    # Test replacing with replace=True (should not warn)
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # Turn warnings into errors
-        # This should not raise because no warning should be emitted
-        model.terminal.add(Node(20, Point(1.5, 1)), replace=True)
 
     # Add user demands with static data
     model.user_demand.add(


### PR DESCRIPTION
This also switches to using the warnings stdlib rather than logging. Uses stacklevel to refer to the add call:

```
UserWarning: Replacing node #11
  model.basin.add(Node(11, Point(0, 1)), [basin.State(level=[1.1])])
```

~~Adds the `replace` kwargs~~
```
        replace : bool | None
            Controls replacement behavior when a node with the same ID exists:
            - None (default): Replace with a warning
            - True: Replace without warning
            - False: Raise an error instead of replacing
```