### PR TITLE
Rename project to workspace in pixi.toml

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "Ribasim"
 version = "2025.6.0"
 description = "Water resources modeling"


### PR DESCRIPTION
The `project` field is deprecated. Use `workspace` instead. This shows on each pixi call on new pixi versions:

```
 WARN Encountered 1 warning while parsing the manifest:
  ⚠ The `project` field is deprecated. Use `workspace` instead.
    ╭─[C:\ProgramData\DevDrives\repo\ribasim\Ribasim\pixi.toml:1:1]       
  1 │ ╭─▶ [project]
  2 │ │   name = "Ribasim"
  3 │ │   version = "2025.6.0"
  4 │ │   description = "Water resources modeling"
  5 │ │   authors = ["Deltares and contributors <ribasim.info@deltares.nl>"]
  6 │ │   channels = ["conda-forge"]
  7 │ │   platforms = ["win-64", "linux-64", "osx-arm64", "linux-aarch64"]
  8 │ │   readme = "README.md"
  9 │ │   license = "MIT"
 10 │ │   license-file = "LICENSE"
 11 │ │   homepage = "https://ribasim.org/"
 12 │ │   documentation = "https://ribasim.org/"
 13 │ ├─▶ repository = "https://github.com/Deltares/Ribasim"
    · ╰──── replace this with 'workspace'
 14 │
    ╰────
```