### PR TITLE
Docs: cross reference global and local `source_priority`

### DIFF
--- a/docs/reference/usage.qmd
+++ b/docs/reference/usage.qmd
@@ -73,7 +73,7 @@ There are the following interpolation settings:
 - `flow_boundary`: The interpolation type of flow boundary timeseries. This is `linear` by default, but can also be set to `block`.
 - `block_transition_period`: When an interpolation type is set to `block`, this parameter determines an interval in time on either side of each data point which is used to smooth the transition between data points. See also the [documentation](https://docs.sciml.ai/DataInterpolations/dev/methods/#Smoothed-Constant-Interpolation) for this interpolation type.
 
-## Allocation settings {#allocation-settings}
+## Allocation settings {#sec-allocation-settings}
 There are the following allocation settings:
 - `timestep`: A float value in seconds which dictates the update interval for allocations;
 - `source_priority`: An integer per source type for the allocation algorithm. The available source types are: `user_demand`, `boundary`, `level_demand`, `flow_demand`, and `subnetwork_inlet`.


### PR DESCRIPTION
I was reading the TOML section, and had forgotten that it can also be set per node.