### PR TITLE
Recommend Pixi VSCode Extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,15 +1,16 @@
 {
     "recommendations": [
-        "julialang.language-julia",
-        "ms-python.python",
-        "ms-python.mypy-type-checker",
         "charliermarsh.ruff",
+        "julialang.language-julia",
+        "ms-python.mypy-type-checker",
+        "ms-python.python",
+        "ms-toolsai.jupyter",
         "njpwerner.autodocstring",
         "quarto.quarto",
-        "tamasfe.even-better-toml",
+        "renan-r-santos.pixi-code",
         "samuelcolvin.jinjahtml",
-        "yy0931.vscode-sqlite3-editor",
         "streetsidesoftware.code-spell-checker",
-        "ms-toolsai.jupyter",
+        "tamasfe.even-better-toml",
+        "yy0931.vscode-sqlite3-editor",
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -82,5 +82,8 @@
         "."
     ],
     "python.testing.pytestEnabled": true,
-    "python.testing.unittestEnabled": false
+    "python.testing.unittestEnabled": false,
+    "python-envs.defaultEnvManager": "renan-r-santos.pixi-code:pixi",
+    "python-envs.defaultPackageManager": "renan-r-santos.pixi-code:pixi",
+    "python-envs.pythonProjects": []
 }


### PR DESCRIPTION
And tell the python environment extension to use it.

https://github.com/renan-r-santos/pixi-code/
https://github.com/microsoft/vscode-python-environments

There is a lot changing related to python environments in VSCode. Yesterday it suddently wouldn't find my environment, despite starting with `pixi run code .` But this helped. I suggest keeping `open-vscode.bat` as well for the time being. I don't think this does any harm even if you don't use the environments extension. I do have it enabled now, with:

```json
"python.useEnvironmentsExtension": true
```