### PR TITLE
Use TimeZones.jl v 1.22.2

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2503,9 +2503,9 @@ version = "0.5.5"
 
 [[deps.TimeZones]]
 deps = ["Artifacts", "Dates", "Downloads", "InlineStrings", "Mocking", "Printf", "Scratch", "TZJData", "Unicode", "p7zip_jll"]
-git-tree-sha1 = "06f4f1f3e8ff09e42e59b043a747332e88e01aba"
+git-tree-sha1 = "d422301b2a1e294e3e4214061e44f338cafe18a2"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
-version = "1.22.1"
+version = "1.22.2"
 weakdeps = ["RecipesBase"]
 
     [deps.TimeZones.extensions]


### PR DESCRIPTION
Avoids writing to our installation directory on load.
https://github.com/JuliaTime/TimeZones.jl/issues/498