### PR TITLE
add skip_fair_fraction to Allocation struct

### DIFF
--- a/core/src/allocation_optim.jl
+++ b/core/src/allocation_optim.jl
@@ -831,7 +831,7 @@ function parse_allocations!(
             is_user_demand ? node_id : get_external_demand_id(p_independent, node_id)
 
         for (demand_priority_idx, demand_priority) in enumerate(demand_priorities_all)
-            !has_demand_priority[node_id.idx, demand_priority_idx] && continue
+            !has_demand_priority[demand_id.idx, demand_priority_idx] && continue
             allocated_flow =
                 max(0, JuMP.value(node_allocated[node_id, demand_priority]) * scaling.flow)
             push!(

--- a/core/src/allocation_optim.jl
+++ b/core/src/allocation_optim.jl
@@ -719,7 +719,7 @@ function optimize_multi_objective!(
     for metadata in objectives.objective_metadata
         (; expression_first, expression_second, type, demand_priority_idx) = metadata
 
-        # First expression
+        # Optimize the absolute error in the system
         JuMP.@objective(problem, Min, expression_first)
         JuMP.optimize!(problem)
         push!(
@@ -727,15 +727,15 @@ function optimize_multi_objective!(
             JuMP.@constraint(problem, expression_first == JuMP.objective_value(problem))
         )
 
-        # Second expression
-        JuMP.@objective(problem, Min, expression_second)
-        JuMP.optimize!(problem)
-        push!(
-            temporary_constraints,
-            JuMP.@constraint(problem, expression_second == JuMP.objective_value(problem),)
-        )
+        # # Optimize sum of errors for fair distribution of resources
+        # JuMP.@objective(problem, Min, expression_second)
+        # JuMP.optimize!(problem)
+        # push!(
+        #     temporary_constraints,
+        #     JuMP.@constraint(problem, expression_second == JuMP.objective_value(problem),)
+        # )
 
-        # Source priority
+        # Optimize for source priorities
         JuMP.@objective(problem, Min, source_priority_expression)
         JuMP.optimize!(problem)
 

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -316,6 +316,7 @@ record_control: A record of all flow rates assigned to pumps and outlets by allo
     primary_network_connections::OrderedDict{Int32, Vector{Tuple{NodeID, NodeID}}} =
         OrderedDict()
     demand_priorities_all::Vector{Int32} = []
+    skip_fair_fraction::Vector{Bool} = []
     record_demand::Vector{DemandRecordDatum} = []
     record_flow::Vector{FlowRecordDatum} = []
     record_control::Vector{AllocationControlRecordDatum} = []

--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -614,7 +614,7 @@ class NodeModel(ChildModel):
     """Base class to handle combining the tables for a single node type."""
 
     @model_serializer(mode="wrap")
-    def set_modeld(
+    def set_model(
         self, serializer: Callable[["NodeModel"], dict[str, object]]
     ) -> dict[str, object]:
         content = serializer(self)


### PR DESCRIPTION
To solve directional flow in allocation, for example polder level management in the most general case, where water may be allocated from boezem to polder but not the other way around, we need the possibility to skip the fair fraction objective. This may be relevant in the LHM