### PR TITLE
Let run_ribasim use RIBASIM_EXE if set

### DIFF
--- a/docs/getting-started/tutorial/irrigation-demand.qmd
+++ b/docs/getting-started/tutorial/irrigation-demand.qmd
@@ -188,7 +188,6 @@ model.link.add(weir, sea, name="sea")
 ```{python}
 toml_path = base_dir / "Crystal-2/ribasim.toml"
 model.write(toml_path)
-cli_path = "ribasim"
 ```
 
 ### Plot model and run

--- a/docs/getting-started/tutorial/natural-flow.qmd
+++ b/docs/getting-started/tutorial/natural-flow.qmd
@@ -237,7 +237,6 @@ Name the output file `Crystal-1/ribasim.toml`:
 ```{python}
 toml_path = base_dir / "Crystal-1/ribasim.toml"
 model.write(toml_path)
-cli_path = "ribasim"
 ```
 
 After running `model.write` a subfolder `Crystal-1` is created, which contains the model input data and configuration:
@@ -257,7 +256,7 @@ From Python you can run it with:
 run_ribasim(toml_path)
 ```
 
-By default it will search for `ribasim` in the PATH, but you can supply the `cli_path` keyword argument which points to the `ribasim` executable: `run_ribasim(toml_path, cli_path="bin/ribasim/ribasim.exe")`. Use `run_ribasim(version=True)` to check the version.
+By default it will search for `ribasim` in the PATH, but you can supply the `ribasim_exe` keyword argument which points to the `ribasim` executable: `run_ribasim(toml_path, ribasim_exe="bin/ribasim/ribasim.exe")`. Use `run_ribasim(version=True)` to check the version.
 
 ### Post-processing results
 Read the Arrow files and plot the simulated flows from different links and the levels and storages at our confluence point:


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/2782.

For consistency with the RIBASIM_EXE environment variable and Ribasim-NL, I also renamed the run_ribasim argument from `cli_path` to `ribasim_exe`. The former is kept for now with a deprecation warning.

The order is:
1. `ribasim_exe` argument
2. `RIBASIM_EXE` environment variable
3. `PATH`
