### PR TITLE
Fix invalid binding errors reported by JETLS.

### DIFF
--- a/core/src/allocation_util.jl
+++ b/core/src/allocation_util.jl
@@ -217,7 +217,7 @@ function analyze_scaling(
     (; problem, subnetwork_id) = allocation_model
 
     log_path = results_path(config, RESULTS_FILENAME.allocation_analysis_scaling)
-    @debug "Running allocation numerics analysis for $subnetwork_id, at t = $t, for full summary see $file_name."
+    @debug "Running allocation numerics analysis for $subnetwork_id, at t = $t, for full summary see $log_path."
 
     # Perform numerics analysis
     data_numerical = MathOptAnalyzer.analyze(
@@ -440,7 +440,7 @@ function has_external_demand(
         node_id::NodeID,
     )::Tuple{Bool, NodeID}
     demand_id = if node isa Basin
-        node.level_demand_id[node_id.idx]
+        level_demand_id = node.level_demand_id[node_id.idx]
         return !iszero(level_demand_id.idx), level_demand_id
     elseif hasfield(typeof(node), :flow_demand_id)
         node.flow_demand_id[node_id.idx]

--- a/core/src/callback.jl
+++ b/core/src/callback.jl
@@ -692,8 +692,8 @@ function set_new_control_state!(
 end
 
 """
-Get a value for a condition. Currently supports getting levels from basins and flows
-from flow boundaries.
+Get a value for a condition. Currently supports getting levels from Basins and flows
+from FlowBoundaries.
 """
 function get_value(subvariable::SubVariable, p::Parameters, du::CVector, t::Float64)
     (; flow_boundary, level_boundary, basin) = p.p_independent
@@ -708,7 +708,7 @@ function get_value(subvariable::SubVariable, p::Parameters, du::CVector, t::Floa
             level = level_boundary.level[listen_node_id.idx](t + look_ahead)
         else
             error(
-                "Level condition node '$node_id' is neither a basin nor a level boundary.",
+                "Level condition node '$listen_node_id' is neither a Basin nor a LevelBoundary.",
             )
         end
         value = level
@@ -717,7 +717,7 @@ function get_value(subvariable::SubVariable, p::Parameters, du::CVector, t::Floa
         if listen_node_id.type == NodeType.FlowBoundary
             value = flow_boundary.flow_rate[listen_node_id.idx](t + look_ahead)
         else
-            error("Flow condition node $listen_node_id is not a flow boundary.")
+            error("Flow condition node $listen_node_id is not a FlowBoundary.")
         end
 
     elseif startswith(variable, "concentration_external.")

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -1461,7 +1461,7 @@ function Subgrid(db::DB, config::Config, basin::Basin)
             push!(subgrid.interpolations_static, hh_itp)
             push!(subgrid.level, NaN)
         else
-            @error "Invalid Basin static subgrid table for $id."
+            @error "Invalid Basin static subgrid table for $node_id."
             errors = true
         end
     end
@@ -1503,7 +1503,7 @@ function Subgrid(db::DB, config::Config, basin::Basin)
                 push!(lookup_time, seconds_since(t, config.starttime))
                 push!(subgrid.interpolations_time, hh_itp)
             else
-                @error "Invalid Basin time subgrid table for $id, time = $time_group."
+                @error "Invalid Basin time subgrid table for $node_id, time = $t."
                 errors = true
             end
         end
@@ -1512,7 +1512,7 @@ function Subgrid(db::DB, config::Config, basin::Basin)
             itp_first = subgrid.interpolations_time[first(lookup_index)]
             itp_last = subgrid.interpolations_time[last(lookup_index)]
             if !((itp_first.t == itp_last.t) && (itp_first.u == itp_last.u))
-                @error "For $id with cyclic_time the first and last h(h) relations for subgrid_id $subgrid_id are not equal."
+                @error "For $node_id with cyclic_time the first and last h(h) relations for subgrid_id $subgrid_id are not equal."
                 errors = true
             end
             pop!(subgrid.interpolations_time)

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -490,7 +490,7 @@ function get_cache_ref(
         if listen
             if node_id.type ∉ conservative_nodetypes
                 errors = true
-                @error "Cannot listen to flow_rate of $node_id, the node type must be one of $conservative_node_types."
+                @error "Cannot listen to flow_rate of $node_id, the node type must be one of $conservative_nodetypes."
                 CacheRef()
             else
                 # Index in the state vector (inflow)

--- a/core/src/write.jl
+++ b/core/src/write.jl
@@ -90,7 +90,7 @@ Write all results to the Arrow files as specified in the model configuration.
 """
 function write_results_netcdf(model::Model)::Model
     (; config) = model
-    (; results, experimental) = model.config
+    (; experimental) = model.config
 
     # state
     data = basin_state_data(model; table = false)


### PR DESCRIPTION
Invalid log messages are not fatal, and not always tested. Luckily JETLS can find them pretty easily.