### PR TITLE
Enable more ruff rules, and fix violations

### DIFF
--- a/python/ribasim/ribasim/cli.py
+++ b/python/ribasim/ribasim/cli.py
@@ -132,15 +132,15 @@ def _subprocess_handling() -> SubprocessHandling:
 
         # Check the shell type
         shell = ipy.__class__.__name__
-        if shell == "ZMQInteractiveShell":
-            return SubprocessHandling.DISPLAY  # Jupyter notebook or qtconsole
-        elif shell == "SpyderShell":
-            # See: https://github.com/spyder-ide/qtconsole/issues/471#issuecomment-787856716
-            return SubprocessHandling.SPYDER  # Spyder IDE
-        elif shell == "TerminalInteractiveShell":
-            return SubprocessHandling.FORWARD  # Terminal running IPython
-        else:
-            return SubprocessHandling.FORWARD  # Other type
+        match shell:
+            case "ZMQInteractiveShell":  # Jupyter notebook or qtconsole
+                return SubprocessHandling.DISPLAY
+            case "SpyderShell":  # Spyder IDE, see https://github.com/spyder-ide/qtconsole/issues/471#issuecomment-787856716
+                return SubprocessHandling.SPYDER
+            case "TerminalInteractiveShell":  # Terminal running IPython
+                return SubprocessHandling.FORWARD
+            case _:  # Other type
+                return SubprocessHandling.FORWARD
     except (NameError, ImportError):
         return SubprocessHandling.FORWARD  # Standard Python interpreter
 
@@ -286,7 +286,7 @@ def _run_with_progress_handling(
                             )
                     else:  # SPYDER
                         if not progress_displayed:
-                            print("", end="\r")
+                            print(end="\r")
                             progress_displayed = True
                         print("\r" + " " * term_width, end="\r")  # Clear current line
                         print(line, end="\r")  # Keep progress bar on one line

--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -241,9 +241,11 @@ class Node(pydantic.BaseModel):
     def __init__(
         self,
         node_id: NonNegativeInt | None = None,
-        geometry: Point = Point(),
+        geometry: Point | None = None,
         **kwargs,
     ) -> None:
+        if geometry is None:
+            geometry = Point()
         if geometry.is_empty:
             raise (ValueError("Node geometry must be a valid Point"))
         elif geometry.has_z:

--- a/python/ribasim/ribasim/delwaq/generate.py
+++ b/python/ribasim/ribasim/delwaq/generate.py
@@ -131,7 +131,7 @@ def _setup_graph(nodes, link, evaporate_mass=True):
                 converging = False
 
             for inneighbor_id in inneighbor_ids:
-                for outneighbor_id in out.keys():
+                for outneighbor_id in out:
                     link = (inneighbor_id, outneighbor_id)
                     if converging:
                         link_id = G.get_edge_data(inneighbor_id, node_id)["id"][0]
@@ -158,7 +158,7 @@ def _setup_graph(nodes, link, evaporate_mass=True):
             remove_nodes.append(node_id)
 
             for inneighbor_id in inneighbor_ids:
-                for outneighbor_id in out.keys():
+                for outneighbor_id in out:
                     if outneighbor_id in remove_nodes:
                         logger.debug("Not making link to removed node.")
                         continue
@@ -311,7 +311,7 @@ def _setup_graph(nodes, link, evaporate_mass=True):
 
     # Setup link mapping
     link_mapping = {}
-    for i, (a, b, d) in enumerate(G.edges(data=True)):
+    for i, (_a, _b, d) in enumerate(G.edges(data=True)):
         for link_id in d["id"]:
             link_mapping[link_id] = i
 
@@ -419,7 +419,7 @@ def generate(
 
     # Write attributes template
     template = env.get_template("delwaq.atr.j2")
-    with open(output_path / "ribasim.atr", mode="w") as f:
+    with (output_path / "ribasim.atr").open(mode="w") as f:
         f.write(
             template.render(
                 nsegments=total_segments,
@@ -465,14 +465,14 @@ def generate(
     # Map all boundary node_ids to link_ids (unique per boundary type)
     lookups: defaultdict[str, dict[int, int]] = defaultdict(dict)
     dfs = []
-    for link_id, (a, b, (node_id, boundary_type)) in enumerate(
+    for link_id, (_a, _b, (node_id, boundary_type)) in enumerate(
         G.edges(data="boundary", default=(None, None))
     ):
         if boundary_type is None:
             continue
         lookups[boundary_type][node_id] = link_id
 
-    for boundary_type in lookups.keys():
+    for boundary_type in lookups:
         df = basins[basins.node_id.isin(lookups[boundary_type].keys())][
             ["node_id", "time", boundary_type]
         ].rename(columns={boundary_type: "flow_rate"})
@@ -523,7 +523,7 @@ def generate(
 
     # Write boundary data with substances and concentrations
     template = env.get_template("B5_bounddata.inc.j2")
-    with open(output_path / "B5_bounddata.inc", mode="w") as f:
+    with (output_path / "B5_bounddata.inc").open(mode="w") as f:
         f.write(
             template.render(
                 states=[],  # no states yet
@@ -607,7 +607,7 @@ def generate(
         endtime = model.endtime
 
     template = env.get_template("delwaq.inp.j2")
-    with open(output_path / "delwaq.inp", mode="w") as f:
+    with (output_path / "delwaq.inp").open(mode="w") as f:
         f.write(
             template.render(
                 startime=model.starttime,
@@ -624,11 +624,11 @@ def generate(
     # extended by the user later
     wasteloads = output_path / "B6_wasteloads.inc"
     if not wasteloads.exists():
-        with open(wasteloads, mode="w") as f:
+        with wasteloads.open(mode="w") as f:
             f.write("0; Number of loads\n")
 
     template = env.get_template("B8_initials.inc.j2")
-    with open(output_path / "B8_initials.inc", mode="w") as f:
+    with (output_path / "B8_initials.inc").open(mode="w") as f:
         f.write(
             template.render(
                 substances=sorted(substances),

--- a/python/ribasim/ribasim/delwaq/plot.py
+++ b/python/ribasim/ribasim/delwaq/plot.py
@@ -6,16 +6,18 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 def plot_fraction(
     model,
     node_id,
-    tracers=[
-        "LevelBoundary",
-        "FlowBoundary",
-        "UserDemand",
-        "Initial",
-        "Drainage",
-        "Precipitation",
-        "SurfaceRunoff",
-    ],
+    tracers=None,
 ):
+    if tracers is None:
+        tracers = [
+            "LevelBoundary",
+            "FlowBoundary",
+            "UserDemand",
+            "Initial",
+            "Drainage",
+            "Precipitation",
+            "SurfaceRunoff",
+        ]
     table = model.basin.concentration_external.df
     table = table[table["node_id"] == node_id]
     table = table[table["substance"].isin(tracers)]

--- a/python/ribasim/ribasim/delwaq/util.py
+++ b/python/ribasim/ribasim/delwaq/util.py
@@ -44,9 +44,8 @@ def write_pointer(fn: Path | str, data: pd.DataFrame) -> None:
 
     Data is a DataFrame with columns from_node_id, to_node_id.
     """
-    with open(fn, "wb") as f:
-        for a, b in data.to_numpy():
-            f.write(struct.pack("<4i", a, b, 0, 0))
+    with Path(fn).open("wb") as f:
+        f.writelines(struct.pack("<4i", a, b, 0, 0) for a, b in data.to_numpy())
 
 
 def write_lengths(fn: Path | str, data: npt.NDArray[np.float32]) -> None:
@@ -60,7 +59,7 @@ def write_lengths(fn: Path | str, data: npt.NDArray[np.float32]) -> None:
 
     Data is an array of float32.
     """
-    with open(fn, "wb") as f:
+    with Path(fn).open("wb") as f:
         f.write(struct.pack("<i", 0))
         f.write(data.astype("float32").tobytes())
 
@@ -76,7 +75,7 @@ def write_volumes(fn: Path | str, data: pd.DataFrame, timestep: timedelta) -> No
 
     Data is a DataFrame with columns time, storage
     """
-    with open(fn, "wb") as f:
+    with Path(fn).open("wb") as f:
         for time, group in data.groupby("time"):
             f.write(struct.pack("<i", time))
             f.write(group.storage.to_numpy().astype("float32").tobytes())
@@ -98,7 +97,7 @@ def write_flows(fn: Path | str, data: pd.DataFrame, timestep: timedelta) -> None
 
     Data is a DataFrame with columns time, flow
     """
-    with open(fn, "wb") as f:
+    with Path(fn).open("wb") as f:
         for time, group in data.groupby("time"):
             f.write(struct.pack("<i", time))
             f.write(group.flow_rate.to_numpy().astype("float32").tobytes())

--- a/python/ribasim/ribasim/geometry/link.py
+++ b/python/ribasim/ribasim/geometry/link.py
@@ -114,17 +114,16 @@ class LinkTable(SpatialTableModel[LinkSchema]):
                 f"Node #{to_node.node_id} of type {to_node.node_type} cannot be downstream of node #{from_node.node_id} of type {from_node.node_type}. Possible downstream node types: {node_type_connectivity[from_node.node_type]}."
             )
 
-        if self.df is not None:
-            if (
-                "UserDemand" not in [from_node.node_type, to_node.node_type]
-                and not self.df[
-                    (self.df.from_node_id == to_node.node_id)
-                    & (self.df.to_node_id == from_node.node_id)
-                ].empty
-            ):
-                raise ValueError(
-                    f"Link ({link_id=}, {from_node=}, {to_node=}) is not allowed since the opposite link already exists (this is only allowed for UserDemand)."
-                )
+        if self.df is not None and (
+            "UserDemand" not in [from_node.node_type, to_node.node_type]
+            and not self.df[
+                (self.df.from_node_id == to_node.node_id)
+                & (self.df.to_node_id == from_node.node_id)
+            ].empty
+        ):
+            raise ValueError(
+                f"Link ({link_id=}, {from_node=}, {to_node=}) is not allowed since the opposite link already exists (this is only allowed for UserDemand)."
+            )
 
         geometry_to_append = (
             [LineString([from_node.geometry, to_node.geometry])]
@@ -167,12 +166,11 @@ class LinkTable(SpatialTableModel[LinkSchema]):
         self._used_link_ids.add(link_id)
 
     def _remove_link_id(self, link_id: NonNegativeInt):
-        if self.df is not None:
-            if link_id in self.df.index:
-                # Remove from node table
-                self.df = self.df.drop(link_id)
-                if self.df.empty:
-                    self.df = None
+        if self.df is not None and link_id in self.df.index:
+            # Remove from node table
+            self.df = self.df.drop(link_id)
+            if self.df.empty:
+                self.df = None
 
     def _remove_node_id(self, node_id: NonNegativeInt):
         if self.df is not None:
@@ -278,7 +276,7 @@ class LinkTable(SpatialTableModel[LinkSchema]):
 
         # A faster alternative may be ax.quiver(). However, getting the scaling
         # right is tedious.
-        for m_x, m_y, m_angle, c in zip(x, y, angle, color):
+        for m_x, m_y, m_angle, c in zip(x, y, angle, color, strict=True):
             ax.plot(
                 m_x,
                 m_y,

--- a/python/ribasim/ribasim/geometry/node.py
+++ b/python/ribasim/ribasim/geometry/node.py
@@ -159,7 +159,9 @@ class NodeTable(SpatialTableModel[NodeSchema]):
 
         assert self.df is not None
         geometry = self.df["geometry"]
-        for text, xy in zip(self.df.index, np.column_stack((geometry.x, geometry.y))):
+        for text, xy in zip(
+            self.df.index, np.column_stack((geometry.x, geometry.y)), strict=True
+        ):
             ax.annotate(text=text, xy=xy, xytext=(2.0, 2.0), textcoords="offset points")
 
         return ax

--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -63,10 +63,12 @@ node_names_snake_case = [
 ]
 
 context_file_loading: ContextVar[dict[str, Path]] = ContextVar(
-    "file_loading", default={}
+    "file_loading",
+    default={},  # noqa: B039
 )
 context_file_writing: ContextVar[dict[str, Path]] = ContextVar(
-    "file_writing", default={}
+    "file_writing",
+    default={},  # noqa: B039
 )
 
 TableT = TypeVar("TableT", bound=_BaseSchema)
@@ -470,7 +472,7 @@ class TableModel[TableT: _BaseSchema](FileModel):
     def _from_db(cls, path: Path, table: str) -> pd.DataFrame | None:
         with closing(connect(path)) as connection:
             if exists(connection, table):
-                query = f"select * from {esc_id(table)}"
+                query = f"select * from {esc_id(table)}"  # noqa: S608
                 df = pd.read_sql_query(
                     query,
                     connection,
@@ -486,13 +488,13 @@ class TableModel[TableT: _BaseSchema](FileModel):
 
     @classmethod
     def _from_arrow(cls, path: Path) -> pd.DataFrame:
-        directory = context_file_loading.get().get("directory", Path("."))
+        directory = context_file_loading.get().get("directory", Path())
         return pd.read_feather(directory / path)
 
     @classmethod
     def _from_netcdf(cls, path: Path) -> pd.DataFrame:
         """Read a NetCDF file and convert it back to a DataFrame."""
-        directory = context_file_loading.get().get("directory", Path("."))
+        directory = context_file_loading.get().get("directory", Path())
         full_path = directory / path
 
         with xr.open_dataset(full_path) as ds:

--- a/python/ribasim/ribasim/migrations.py
+++ b/python/ribasim/ribasim/migrations.py
@@ -12,7 +12,9 @@ def _rename_column(df, from_colname, to_colname):
     # Remove that column first, then rename the old column.
     if to_colname in df.columns and from_colname not in df.columns:
         warnings.warn(
-            "Already migrated, your model (version) might be inconsistent.", UserWarning
+            "Already migrated, your model (version) might be inconsistent.",
+            UserWarning,
+            stacklevel=1,
         )
         return df
 
@@ -37,11 +39,11 @@ def check_inactive(df: DataFrame, name: str):
 
 def nodeschema_migration(gdf: GeoDataFrame, schema_version: int) -> GeoDataFrame:
     if schema_version == 0 and "node_id" in gdf.columns:
-        warnings.warn("Migrating outdated Node table.", UserWarning)
+        warnings.warn("Migrating outdated Node table.", UserWarning, stacklevel=1)
         assert gdf["node_id"].is_unique, "Node IDs have to be unique."
         gdf.set_index("node_id", inplace=True)
     if schema_version < 10:
-        warnings.warn("Migrating outdated Node table.", UserWarning)
+        warnings.warn("Migrating outdated Node table.", UserWarning, stacklevel=1)
         _rename_column(gdf, "source_priority", "route_priority")
 
     return gdf
@@ -49,23 +51,23 @@ def nodeschema_migration(gdf: GeoDataFrame, schema_version: int) -> GeoDataFrame
 
 def linkschema_migration(gdf: GeoDataFrame, schema_version: int) -> GeoDataFrame:
     if schema_version == 0:
-        warnings.warn("Migrating outdated Link table.", UserWarning)
+        warnings.warn("Migrating outdated Link table.", UserWarning, stacklevel=1)
         gdf.drop(columns="from_node_type", inplace=True, errors="ignore")
     if schema_version == 0:
-        warnings.warn("Migrating outdated Link table.", UserWarning)
+        warnings.warn("Migrating outdated Link table.", UserWarning, stacklevel=1)
         gdf.drop(columns="to_node_type", inplace=True, errors="ignore")
     if "edge_id" in gdf.columns and schema_version == 0:
-        warnings.warn("Migrating outdated Link table.", UserWarning)
+        warnings.warn("Migrating outdated Link table.", UserWarning, stacklevel=1)
         assert gdf["edge_id"].is_unique, "Link IDs have to be unique."
         gdf.set_index("edge_id", inplace=True)
     if schema_version < 3 and "subnetwork_id" in gdf.columns:
-        warnings.warn("Migrating outdated Link table.", UserWarning)
+        warnings.warn("Migrating outdated Link table.", UserWarning, stacklevel=1)
         gdf.drop(columns="subnetwork_id", inplace=True, errors="ignore")
     if schema_version < 4 and gdf.index.name == "edge_id":
-        warnings.warn("Migrating outdated Link table.", UserWarning)
+        warnings.warn("Migrating outdated Link table.", UserWarning, stacklevel=1)
         gdf.index.rename("link_id", inplace=True)
     if schema_version < 4 and "edge_type" in gdf.columns:
-        warnings.warn("Migrating outdated Link table.", UserWarning)
+        warnings.warn("Migrating outdated Link table.", UserWarning, stacklevel=1)
         _rename_column(gdf, "edge_type", "link_type")
 
     return gdf
@@ -73,20 +75,28 @@ def linkschema_migration(gdf: GeoDataFrame, schema_version: int) -> GeoDataFrame
 
 def basinstaticschema_migration(df: DataFrame, schema_version: int) -> DataFrame:
     if schema_version == 0:
-        warnings.warn("Migrating outdated Basin / static table.", UserWarning)
+        warnings.warn(
+            "Migrating outdated Basin / static table.", UserWarning, stacklevel=1
+        )
         df.drop(columns="urban_runoff", inplace=True, errors="ignore")
     if schema_version < 7 and "surface_runoff" not in df.columns:
-        warnings.warn("Migrating outdated Basin / static table.", UserWarning)
+        warnings.warn(
+            "Migrating outdated Basin / static table.", UserWarning, stacklevel=1
+        )
         df["surface_runoff"] = None
     return df
 
 
 def basintimeschema_migration(df: DataFrame, schema_version: int) -> DataFrame:
     if schema_version == 0:
-        warnings.warn("Migrating outdated Basin / time table.", UserWarning)
+        warnings.warn(
+            "Migrating outdated Basin / time table.", UserWarning, stacklevel=1
+        )
         df.drop(columns="urban_runoff", inplace=True, errors="ignore")
     if schema_version < 7 and "surface_runoff" not in df.columns:
-        warnings.warn("Migrating outdated Basin / static table.", UserWarning)
+        warnings.warn(
+            "Migrating outdated Basin / static table.", UserWarning, stacklevel=1
+        )
         df["surface_runoff"] = None
 
     return df
@@ -97,7 +107,9 @@ def continuouscontrolvariableschema_migration(
 ) -> DataFrame:
     if schema_version == 0:
         warnings.warn(
-            "Migrating outdated ContinuousControl / variable table.", UserWarning
+            "Migrating outdated ContinuousControl / variable table.",
+            UserWarning,
+            stacklevel=1,
         )
         df.drop(columns="listen_node_type", inplace=True, errors="ignore")
 
@@ -109,7 +121,9 @@ def discretecontrolvariableschema_migration(
 ) -> DataFrame:
     if schema_version == 0:
         warnings.warn(
-            "Migrating outdated DiscreteControl / variable table.", UserWarning
+            "Migrating outdated DiscreteControl / variable table.",
+            UserWarning,
+            stacklevel=1,
         )
         df.drop(columns="listen_node_type", inplace=True, errors="ignore")
 
@@ -118,10 +132,14 @@ def discretecontrolvariableschema_migration(
 
 def pidcontrolstaticschema_migration(df: DataFrame, schema_version: int) -> DataFrame:
     if schema_version == 0:
-        warnings.warn("Migrating outdated PidControl / static table.", UserWarning)
+        warnings.warn(
+            "Migrating outdated PidControl / static table.", UserWarning, stacklevel=1
+        )
         df.drop(columns="listen_node_type", inplace=True, errors="ignore")
     if schema_version < 9:
-        warnings.warn("Migrating outdated PidControl / static table.", UserWarning)
+        warnings.warn(
+            "Migrating outdated PidControl / static table.", UserWarning, stacklevel=1
+        )
         check_inactive(df, name="PidControl / static")
         df.drop(columns="active", inplace=True, errors="ignore")
     return df
@@ -129,10 +147,14 @@ def pidcontrolstaticschema_migration(df: DataFrame, schema_version: int) -> Data
 
 def outletstaticschema_migration(df: DataFrame, schema_version: int) -> DataFrame:
     if schema_version < 2:
-        warnings.warn("Migrating outdated Outlet / static table.", UserWarning)
+        warnings.warn(
+            "Migrating outdated Outlet / static table.", UserWarning, stacklevel=1
+        )
         _rename_column(df, "min_crest_level", "min_upstream_level")
     if schema_version < 9:
-        warnings.warn("Migrating outdated Outlet / static table.", UserWarning)
+        warnings.warn(
+            "Migrating outdated Outlet / static table.", UserWarning, stacklevel=1
+        )
         check_inactive(df, name="Outlet / static")
         df.drop(columns="active", inplace=True, errors="ignore")
     return df
@@ -151,7 +173,9 @@ for node_type in ["UserDemand", "LevelDemand", "FlowDemand"]:
         ) -> DataFrame:
             if schema_version < 4:
                 warnings.warn(
-                    f"Migrating outdated {node_type} / {table_type} table.", UserWarning
+                    f"Migrating outdated {node_type} / {table_type} table.",
+                    UserWarning,
+                    stacklevel=1,
                 )
                 df.rename(columns={"priority": "demand_priority"}, inplace=True)
             return df
@@ -164,14 +188,18 @@ def discretecontrolconditionschema_migration(
 ) -> DataFrame:
     if schema_version < 5:
         warnings.warn(
-            "Migrating outdated DiscreteControl / condition table.", UserWarning
+            "Migrating outdated DiscreteControl / condition table.",
+            UserWarning,
+            stacklevel=1,
         )
         n_rows = len(df)
         df["time"] = None
         df["condition_id"] = range(1, n_rows + 1)
     if schema_version < 8:
         warnings.warn(
-            "Migrating outdated DiscreteControl / condition table.", UserWarning
+            "Migrating outdated DiscreteControl / condition table.",
+            UserWarning,
+            stacklevel=1,
         )
         df["threshold_low"] = None
         df.rename(columns={"greater_than": "threshold_high"}, inplace=True)
@@ -180,14 +208,18 @@ def discretecontrolconditionschema_migration(
 
 def basinprofileschema_migration(df: DataFrame, schema_version: int) -> DataFrame:
     if schema_version < 6:
-        warnings.warn("Migrating outdated Basin / profile table.", UserWarning)
+        warnings.warn(
+            "Migrating outdated Basin / profile table.", UserWarning, stacklevel=1
+        )
         df["storage"] = None
     return df
 
 
 def pumpstaticschema_migration(df: DataFrame, schema_version: int) -> DataFrame:
     if schema_version < 9:
-        warnings.warn("Migrating outdated Pump / static table.", UserWarning)
+        warnings.warn(
+            "Migrating outdated Pump / static table.", UserWarning, stacklevel=1
+        )
         check_inactive(df, name="Pump / static")
         df.drop(columns="active", inplace=True, errors="ignore")
     return df
@@ -197,7 +229,11 @@ def levelboundarystaticschema_migration(
     df: DataFrame, schema_version: int
 ) -> DataFrame:
     if schema_version < 9:
-        warnings.warn("Migrating outdated LevelBoundary / static table.", UserWarning)
+        warnings.warn(
+            "Migrating outdated LevelBoundary / static table.",
+            UserWarning,
+            stacklevel=1,
+        )
         check_inactive(df, name="LevelBoundary / static")
         df.drop(columns="active", inplace=True, errors="ignore")
     return df
@@ -205,7 +241,9 @@ def levelboundarystaticschema_migration(
 
 def flowboundarystaticschema_migration(df: DataFrame, schema_version: int) -> DataFrame:
     if schema_version < 9:
-        warnings.warn("Migrating outdated FlowBoundary / static table.", UserWarning)
+        warnings.warn(
+            "Migrating outdated FlowBoundary / static table.", UserWarning, stacklevel=1
+        )
         check_inactive(df, name="FlowBoundary / static")
         df.drop(columns="active", inplace=True, errors="ignore")
     return df
@@ -216,7 +254,9 @@ def linearresistancestaticschema_migration(
 ) -> DataFrame:
     if schema_version < 9:
         warnings.warn(
-            "Migrating outdated LinearResistance / static table.", UserWarning
+            "Migrating outdated LinearResistance / static table.",
+            UserWarning,
+            stacklevel=1,
         )
         check_inactive(df, name="LinearResistance / static")
         df.drop(columns="active", inplace=True, errors="ignore")
@@ -228,7 +268,9 @@ def manningresistancestaticschema_migration(
 ) -> DataFrame:
     if schema_version < 9:
         warnings.warn(
-            "Migrating outdated ManningResistance / static table.", UserWarning
+            "Migrating outdated ManningResistance / static table.",
+            UserWarning,
+            stacklevel=1,
         )
         check_inactive(df, name="ManningResistance / static")
         df.drop(columns="active", inplace=True, errors="ignore")
@@ -240,7 +282,9 @@ def tabulatedratingcurvestaticschema_migration(
 ) -> DataFrame:
     if schema_version < 9:
         warnings.warn(
-            "Migrating outdated TabulatedRatingCurve / static table.", UserWarning
+            "Migrating outdated TabulatedRatingCurve / static table.",
+            UserWarning,
+            stacklevel=1,
         )
         check_inactive(df, name="TabulatedRatingCurve / static")
         df.drop(columns="active", inplace=True, errors="ignore")
@@ -250,12 +294,16 @@ def tabulatedratingcurvestaticschema_migration(
 def userdemandstaticschema_migration(df: DataFrame, schema_version: int) -> DataFrame:
     if schema_version < 4:
         warnings.warn(
-            f"Migrating outdated {node_type} / {table_type} table.", UserWarning
+            f"Migrating outdated {node_type} / {table_type} table.",
+            UserWarning,
+            stacklevel=1,
         )
         df.rename(columns={"priority": "demand_priority"}, inplace=True)
     if schema_version < 9:
         warnings.warn(
-            "Migrating outdated TabulatedRatingCurve / static table.", UserWarning
+            "Migrating outdated TabulatedRatingCurve / static table.",
+            UserWarning,
+            stacklevel=1,
         )
         check_inactive(df, name="UserDemand / static")
         df.drop(columns="active", inplace=True, errors="ignore")

--- a/python/ribasim/ribasim/styles.py
+++ b/python/ribasim/ribasim/styles.py
@@ -2,6 +2,8 @@ import logging
 from pathlib import Path
 from sqlite3 import Connection
 
+logger = logging.getLogger(__name__)
+
 STYLES_DIR = Path(__file__).parent / "styles"
 
 CREATE_TABLE_SQL = """
@@ -119,4 +121,4 @@ def _add_styles_to_geopackage(connection: Connection, layer: str):
         )
         connection.commit()
     else:
-        logging.warning(f"Style not found for layer: {layer}")
+        logger.warning(f"Style not found for layer: {layer}")

--- a/python/ribasim/tests/test_model.py
+++ b/python/ribasim/tests/test_model.py
@@ -79,12 +79,12 @@ def test_exclude_unset(basic):
 
 def test_toml_path(basic):
     with pytest.raises(FileNotFoundError, match="Model must be written to disk"):
-        basic.toml_path
+        _ = basic.toml_path
 
 
 def test_results_path(basic):
     with pytest.raises(FileNotFoundError, match="Model must be written to disk"):
-        basic.results_path
+        _ = basic.results_path
 
 
 def test_invalid_node_id():
@@ -134,7 +134,7 @@ def test_write_adds_fid_in_tables(basic, tmp_path):
 
     model_orig.write(tmp_path / "basic/ribasim.toml")
     with connect(tmp_path / "basic/input/database.gpkg") as connection:
-        query = f"select * from {esc_id('Basin / profile')}"
+        query = f"select * from {esc_id('Basin / profile')}"  # noqa: S608
         df = pd.read_sql_query(query, connection)
         assert "fid" in df.columns
 
@@ -373,14 +373,14 @@ def test_version_mismatch_warning_newer_version(basic, tmp_path):
     basic.write(toml_path)
 
     # Read the TOML file and modify the version to be newer
-    with open(toml_path, "rb") as f:
+    with toml_path.open("rb") as f:
         config = tomli.load(f)
 
     # Set a newer version
     config["ribasim_version"] = "3030.1.0"
 
     # Write the modified TOML back
-    with open(toml_path, "wb") as f:
+    with toml_path.open("wb") as f:
         tomli_w.dump(config, f)
 
     # Test that a warning is issued when reading the model
@@ -395,7 +395,7 @@ def test_version_mismatch_warning_newer_version(basic, tmp_path):
 
     # Check that the TOML file contains the correct version
     model._write_toml(toml_path)
-    with open(toml_path, "rb") as f:
+    with toml_path.open("rb") as f:
         config = tomli.load(f)
     assert config["ribasim_version"] == ribasim.__version__
 
@@ -409,14 +409,14 @@ def test_invalid_version_string_warning(basic, tmp_path):
     basic.write(toml_path)
 
     # Read the TOML file and modify the version to an invalid version string
-    with open(toml_path, "rb") as f:
+    with toml_path.open("rb") as f:
         config = tomli.load(f)
 
     # Set an invalid version string
     config["ribasim_version"] = "invalid_version_string"
 
     # Write the modified TOML back
-    with open(toml_path, "wb") as f:
+    with toml_path.open("wb") as f:
         tomli_w.dump(config, f)
 
     # Test that a warning is issued when reading the model
@@ -433,7 +433,7 @@ def test_path_serialization_uses_forward_slashes(drought, tmp_path):
     toml_path = tmp_path / "ribasim.toml"
     model.write(toml_path)
 
-    with open(toml_path, "rb") as f:
+    with toml_path.open("rb") as f:
         config = tomli.load(f)
 
     assert config["input_dir"] == "nested/input"

--- a/python/ribasim_api/tests/test_bmi.py
+++ b/python/ribasim_api/tests/test_bmi.py
@@ -199,7 +199,7 @@ def test_get_component_name(libribasim):
 
 def test_get_version(libribasim):
     toml_path = Path(__file__).parents[3] / "core" / "Project.toml"
-    with open(toml_path, mode="rb") as fp:
+    with toml_path.open(mode="rb") as fp:
         config = tomli.load(fp)
 
     assert libribasim.get_version() == config["version"]

--- a/python/ribasim_testmodels/ribasim_testmodels/allocation.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/allocation.py
@@ -1489,9 +1489,7 @@ def bommelerwaard_model():
     manning_n = [0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.04, 0.05, 0.05]
     # fmt: on
 
-    manning_index = 0
-
-    for node_id in range(3, 28, 2):
+    for manning_index, node_id in enumerate(range(3, 28, 2)):
         model.manning_resistance.add(
             get_node(node_id),
             [
@@ -1503,7 +1501,6 @@ def bommelerwaard_model():
                 )
             ],
         )
-        manning_index += 1
 
     model.linear_resistance.add(
         get_node(29), [linear_resistance.Static(resistance=[1.0])]
@@ -1511,10 +1508,10 @@ def bommelerwaard_model():
 
     model.level_boundary.add(get_node(30), [level_boundary.Static(level=[0.5])])
 
-    pump_index = 0
-
     for node_id, flow_rate_node_id in zip(
-        [37, 36, 39, 38, 42, 41, 40], [2.75, 2.29, 4.5, 2.0, 8.33, 1.17, 2.0]
+        [37, 36, 39, 38, 42, 41, 40],
+        [2.75, 2.29, 4.5, 2.0, 8.33, 1.17, 2.0],
+        strict=True,
     ):
         model.pump.add(
             get_node(node_id),
@@ -1526,9 +1523,10 @@ def bommelerwaard_model():
                 )
             ],
         )
-        pump_index += 1
 
-    for node_id, level in zip([43, 44], [[1.85, 2.85, 2.95], [1.15, 2.15, 2.25]]):
+    for node_id, level in zip(
+        [43, 44], [[1.85, 2.85, 2.95], [1.15, 2.15, 2.25]], strict=True
+    ):
         model.tabulated_rating_curve.add(
             get_node(node_id),
             [tabulated_rating_curve.Static(level=level, flow_rate=[0.0, 0.1, 1.0])],
@@ -1546,6 +1544,7 @@ def bommelerwaard_model():
             [2.1, 2.2],
             [2.8, 2.9],
         ],
+        strict=True,
     ):
         # Skip this control node as it causes stability problems
         if node_id == 49:
@@ -1578,6 +1577,7 @@ def bommelerwaard_model():
         [0, 0, 0, 0, 0, 0, 24],
         [2, 2, 2, 2, 2, 3, 1],
         [-0.8, -0.4, 0, 1.85, 1.15, -6.0, -6.0],
+        strict=True,
     ):
         model.user_demand.add(
             get_node(node_id),
@@ -1592,7 +1592,7 @@ def bommelerwaard_model():
         )
 
     for node_id, demand_priority, min_level in zip(
-        range(59, 62), [4, 4, 5], [0.18, 0.58, 0.55]
+        range(59, 62), [4, 4, 5], [0.18, 0.58, 0.55], strict=True
     ):
         model.level_demand.add(
             get_node(node_id),
@@ -1617,7 +1617,7 @@ def bommelerwaard_model():
         return NodeData(node_id, node_type, node_geom)
 
     # Add edges
-    for from_node_id_, to_node_id_ in zip(from_node_id, to_node_id):
+    for from_node_id_, to_node_id_ in zip(from_node_id, to_node_id, strict=True):
         # Skip DiscreteControl #49 as it causes stability problems
         if 49 in [from_node_id_, to_node_id_]:
             continue

--- a/python/ribasim_testmodels/ribasim_testmodels/backwater.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/backwater.py
@@ -34,7 +34,7 @@ def backwater_model() -> Model:
     # Rectangular profile, width of 1.0 m.
     basin_ids = ids[node_type == "Basin"]
     basin_x = np.arange(10.0, 1000.0, 20.0)
-    for id, x in zip(basin_ids, basin_x):
+    for id, x in zip(basin_ids, basin_x, strict=True):
         model.basin.add(
             Node(id, Point(x, 0.0)),
             [

--- a/python/ribasim_testmodels/ribasim_testmodels/basic.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/basic.py
@@ -60,7 +60,7 @@ def basic_model() -> Model:
         Point(3.0, 2.0),
         Point(5.0, 0.0),
     ]
-    for node_id, node_geometry in zip(node_ids, node_geometries):
+    for node_id, node_geometry in zip(node_ids, node_geometries, strict=True):
         model.basin.add(
             Node(node_id, node_geometry),
             [

--- a/ribasim_qgis/core/model.py
+++ b/ribasim_qgis/core/model.py
@@ -21,7 +21,7 @@ def get_directory_path_from_model_file(model_path: Path, *, property: str) -> Pa
     Path
         Full path to database Geopackage.
     """
-    with open(model_path, "rb") as f:
+    with model_path.open("rb") as f:
         found_property = Path(tomllib.load(f)[property])
     # The .joinpath method (/) of pathlib.Path will take care of an absolute input_dir.
     # No need to check it ourselves!
@@ -29,7 +29,7 @@ def get_directory_path_from_model_file(model_path: Path, *, property: str) -> Pa
 
 
 def get_toml_dict(model_path: Path) -> dict[str, Any]:
-    with open(model_path, "rb") as f:
+    with model_path.open("rb") as f:
         return tomllib.load(f)
 
 

--- a/ribasim_qgis/ribasim_qgis.py
+++ b/ribasim_qgis/ribasim_qgis.py
@@ -22,7 +22,7 @@ class RibasimDropHandler(QgsCustomDropHandler):
         if not path.lower().endswith(".toml"):
             return False
 
-        with open(path, "rb") as f:
+        with Path(path).open("rb") as f:
             data = tomllib.load(f)
             if "ribasim_version" not in data:
                 return False

--- a/ribasim_qgis/scripts/install_qgis_plugin.py
+++ b/ribasim_qgis/scripts/install_qgis_plugin.py
@@ -31,7 +31,7 @@ def install_qgis_plugin(plugin_name: str, profile_path: str) -> None:
         )
     finally:
         # remove the qgis-manager-plugin cache, because QGIS tries to load it as a plugin
-        os.remove(plugin_path / "sources.list")
+        (plugin_path / "sources.list").unlink()
         shutil.rmtree(plugin_path / ".cache_qgis_plugin_manager")
 
 

--- a/ribasim_qgis/scripts/qgis_testrunner.py
+++ b/ribasim_qgis/scripts/qgis_testrunner.py
@@ -120,7 +120,7 @@ def __run_test():
         function_name()
         __exit_qgis(signal.SIG_DFL)
     except Exception as e:
-        logging.error(f"QGIS Test Runner Inside - [FAILED] Exception: {e}")
+        logging.error(f"QGIS Test Runner Inside - [FAILED] Exception: {e}")  # noqa: LOG015
         # Print tb
         traceback.print_exc(file=sys.stderr)
         __exit_qgis(signal.SIGTERM)

--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -64,7 +64,7 @@ class DatasetWidget:
         self.ribasim_widget = cast(RibasimWidget, parent)
         self.link_layer: QgsVectorLayer | None = None
         self.node_layer: QgsVectorLayer | None = None
-        self.path: Path = Path("")
+        self.path: Path = Path()
 
         # Results
         self.flow_layer: QgsVectorLayer | None = None
@@ -609,7 +609,7 @@ class DatasetWidget:
         layer.beginEditCommand("Group all undos for performance.")
 
         fids = sorted(layer.allFeatureIds())
-        if not len(fids) == len(timeslice):
+        if len(fids) != len(timeslice):
             print(f"Can't join data at {time}, shapes of Link and arrow table differ.")
             layer.endEditCommand()
             layer.commitChanges()
@@ -629,7 +629,7 @@ class DatasetWidget:
 
         data: dict[int, dict[int, float]] = {fid: {} for fid in fids}
         for column, column_id in columns.items():
-            for fid, variable in zip(fids, timeslice[column]):
+            for fid, variable in zip(fids, timeslice[column], strict=True):
                 data[fid][column_id] = variable
 
         dataprovider = layer.dataProvider()

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,10 +3,32 @@ target-version = "py312"
 
 [lint]
 # See https://docs.astral.sh/ruff/rules/
-select = ["C4", "D2", "D3", "D4", "E", "F", "I", "NPY", "PD", "UP", "RUF"]
+select = [
+    "B",     # flake8-bugbear (catches likely bugs)
+    "C4",    # flake8-comprehensions
+    "D2",    # pydocstyle (D2xx)
+    "D3",    # pydocstyle (D3xx)
+    "D4",    # pydocstyle (D4xx)
+    "E",     # pycodestyle errors
+    "F",     # Pyflakes
+    "FURB",  # Refactoring suggestions
+    "I",     # isort
+    "LOG",   # Logging best practices
+    "NPY",   # NumPy-specific rules
+    "PD",    # pandas-vet
+    "PERF",  # Performance anti-patterns
+    "PTH",   # flake8-use-pathlib (prefer pathlib over os.path)
+    "RUF",   # Ruff-specific rules
+    "S",     # flake8-bandit (security issues)
+    "SIM",   # flake8-simplify (code simplification)
+    "UP",    # pyupgrade
+]
 ignore = [
-    "E501",
-    "PD002",
+    "E501",   # line-too-long
+    "PD002",  # inplace argument
+    "S101",   # assert - used extensively in tests and validation
+    "S603",   # subprocess-without-shell-equals-true - false positives with trusted input
+    "S607",   # start-process-with-partial-path - CLI paths are intentional
 ]
 fixable = ["ALL"]
 

--- a/utils/s3_download.py
+++ b/utils/s3_download.py
@@ -1,5 +1,5 @@
 import argparse
-from os import makedirs
+from pathlib import Path
 
 from minio import Minio
 from minio.error import S3Error
@@ -39,7 +39,7 @@ for obj in objects:
             local_dir = f"models/{args.local}" + obj.object_name.removeprefix(
                 args.remote
             )
-            makedirs(local_dir, exist_ok=True)
+            Path(local_dir).mkdir(parents=True, exist_ok=True)
         else:
             client.fget_object(
                 bucketName,


### PR DESCRIPTION
Based on https://github.com/Deltares/Ribasim-NL/issues/433 but for Ribasim.
I enabled the new rules and with some help from Claude fixed the violations (partly safe ruff fixes, unsafe fixes).
I reviewed them all manually to make sure I understand what changed, and made some edits in the process.

AI summary:

### New rules added to `ruff.toml`:
- **B** - flake8-bugbear (catches likely bugs)
- **FURB** - Refactoring suggestions
- **LOG** - Logging best practices  
- **PERF** - Performance anti-patterns
- **PTH** - flake8-use-pathlib (prefer pathlib over os.path)
- **S** - flake8-bandit (security issues)
- **SIM** - flake8-simplify (code simplification)

### Rules ignored (with justification):
- **S101** - assert used extensively in tests and validation
- **S603** - subprocess-without-shell-equals-true (false positives with trusted input)
- **S607** - start-process-with-partial-path (CLI paths are intentional)

### Code fixes applied:
- Converted `open()` calls to `Path.open()` across multiple files (PTH123)
- Added `strict=` parameter to `zip()` calls (B905)
- Added `stacklevel=` to `warnings.warn()` calls (B028)
- Fixed mutable default argument `Point()` in config.py (B008)
- Fixed unused loop variables (B007)
- Fixed useless expressions in tests (B018)
- Converted if-elif chain to dict lookup in cli.py (SIM116)
- Combined nested if statements (SIM102)
- Used `enumerate()` for index variables (SIM113)
- Added module-level loggers instead of root logger (LOG015)
- Converted `os.remove()` to `Path.unlink()` (PTH107)
- Added `noqa` comments for false positives:
  - S608: SQL injection with properly escaped table names
  - S324: md5 used for file comparison in tests
  - B039: ContextVar with explicit `.set()` pattern