### PR TITLE
Add compat for root-only deps, run dependabot on root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "julia"
-    directories:
-      - "/core"
+    directory: "/"
     schedule:
       interval: "weekly"

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,6 @@ Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 BasicModelInterface = "59605e27-edc0-445a-b93d-c09a3a50b330"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 CodecZstd = "6b39b394-51ab-5f42-8807-6242bab2b4c2"
-Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 Configurations = "5218b696-f38b-4ac9-8b61-a12ec717816d"
 DBInterface = "a10d1c49-ce27-4219-8d33-6db1a4562965"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -77,7 +76,6 @@ TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 TerminalLoggers = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-TestEnv = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
@@ -86,8 +84,13 @@ PackageCompiler = {rev = "bundle_less_artifacts_v1.12", url = "https://github.co
 Ribasim = {path = "core"}
 
 [compat]
+OpenSSL_jll = "3.5.4"
+OteraEngine = "1.1.3"
+PackageCompiler = "2.2.4"
 PkgToSoftwareBOM = "0.1.17"
+Plots = "1.41.4"
 PythonCall = "=0.9.31"
+Revise = "3.13.1"
 
 [preferences.Ribasim]
 precompile_workload = false


### PR DESCRIPTION
I wasn't happy with dependabot PRs like
- https://github.com/Deltares/Ribasim/pull/2831
- https://github.com/Deltares/Ribasim/pull/2830

These added compat entries to deps that already had compat entries elsewhere in the workspace.
I suspect it may work better to run dependabot on the root. So I directly added current entries for root-only deps, and removed 2 that we don't use.