### PR TITLE
Use RIBASIM_HOME everywhere

### DIFF
--- a/build/tests/test_cli.py
+++ b/build/tests/test_cli.py
@@ -8,7 +8,8 @@ import ribasim
 import ribasim_testmodels
 from ribasim.cli import run_ribasim
 
-executable = Path(__file__).parents[1] / "ribasim/bin/ribasim"
+ribasim_home = Path(__file__).parents[1] / "ribasim"
+executable = ribasim_home / "bin/ribasim"
 
 
 @pytest.mark.parametrize(
@@ -102,13 +103,13 @@ def test_threads_env_var(tmp_path):
 
 
 def test_run_ribasim_basic(tmp_path):
-    """Test run_ribasim() with a basic model using ribasim_exe."""
+    """Test run_ribasim() with a basic model using ribasim_home."""
     model = ribasim_testmodels.basic_model()
     toml_path = tmp_path / "ribasim.toml"
     model.write(toml_path)
 
     # Should run successfully
-    run_ribasim(toml_path, ribasim_exe=executable)
+    run_ribasim(toml_path, ribasim_home=ribasim_home)
 
     # Check that results were produced
     results_path = tmp_path / "results" / "basin.nc"
@@ -122,7 +123,7 @@ def test_run_ribasim_with_threads(tmp_path):
     model.write(toml_path)
 
     # Pass threads kwarg
-    run_ribasim(toml_path, ribasim_exe=executable, threads=2)
+    run_ribasim(toml_path, ribasim_home=ribasim_home, threads=2)
 
     # Check that threads were set correctly in the log
     log_path = tmp_path / "results" / "ribasim.log"
@@ -133,7 +134,7 @@ def test_run_ribasim_with_threads(tmp_path):
 
 def test_run_ribasim_version(capfd):
     """Test run_ribasim() with version=True."""
-    run_ribasim(version=True, ribasim_exe=executable)
+    run_ribasim(version=True, ribasim_home=ribasim_home)
 
     # Capture the output
     captured = capfd.readouterr()
@@ -155,12 +156,12 @@ def test_run_ribasim_not_on_path(tmp_path):
     toml_path = tmp_path / "ribasim.toml"
     model.write(toml_path)
 
-    # Save and clear PATH and RIBASIM_EXE
+    # Save and clear PATH and RIBASIM_HOME
     old_path = os.environ.get("PATH", "")
-    old_ribasim_exe = os.environ.get("RIBASIM_EXE")
+    old_ribasim_home = os.environ.get("RIBASIM_HOME")
     os.environ["PATH"] = ""
-    if old_ribasim_exe is not None:
-        del os.environ["RIBASIM_EXE"]
+    if old_ribasim_home is not None:
+        del os.environ["RIBASIM_HOME"]
 
     try:
         with pytest.raises(
@@ -170,26 +171,26 @@ def test_run_ribasim_not_on_path(tmp_path):
             run_ribasim(toml_path)
     finally:
         os.environ["PATH"] = old_path
-        if old_ribasim_exe is not None:
-            os.environ["RIBASIM_EXE"] = old_ribasim_exe
+        if old_ribasim_home is not None:
+            os.environ["RIBASIM_HOME"] = old_ribasim_home
 
 
-def test_run_ribasim_with_ribasim_exe(tmp_path):
-    """Test run_ribasim() uses RIBASIM_EXE environment variable."""
+def test_run_ribasim_with_ribasim_home(tmp_path):
+    """Test run_ribasim() uses RIBASIM_HOME environment variable."""
     model = ribasim_testmodels.basic_model()
     toml_path = tmp_path / "ribasim.toml"
     model.write(toml_path)
 
-    # Save current RIBASIM_EXE and PATH
-    old_ribasim_exe = os.environ.get("RIBASIM_EXE")
+    # Save current RIBASIM_HOME and PATH
+    old_ribasim_home = os.environ.get("RIBASIM_HOME")
     old_path = os.environ.get("PATH", "")
 
     try:
-        # Set RIBASIM_EXE to the executable path and clear PATH
-        os.environ["RIBASIM_EXE"] = str(executable)
-        os.environ["PATH"] = ""  # Clear PATH to ensure RIBASIM_EXE is used
+        # Set RIBASIM_HOME to the home directory and clear PATH
+        os.environ["RIBASIM_HOME"] = str(ribasim_home)
+        os.environ["PATH"] = ""  # Clear PATH to ensure RIBASIM_HOME is used
 
-        # Should find executable via RIBASIM_EXE
+        # Should find executable via RIBASIM_HOME
         run_ribasim(toml_path)
 
         # Check that results were produced
@@ -198,40 +199,40 @@ def test_run_ribasim_with_ribasim_exe(tmp_path):
     finally:
         # Restore environment
         os.environ["PATH"] = old_path
-        if old_ribasim_exe is not None:
-            os.environ["RIBASIM_EXE"] = old_ribasim_exe
+        if old_ribasim_home is not None:
+            os.environ["RIBASIM_HOME"] = old_ribasim_home
         else:
-            os.environ.pop("RIBASIM_EXE", None)
+            os.environ.pop("RIBASIM_HOME", None)
 
 
-def test_run_ribasim_ribasim_exe_invalid_path(tmp_path):
-    """Test run_ribasim() raises FileNotFoundError with invalid RIBASIM_EXE."""
+def test_run_ribasim_ribasim_home_invalid_path(tmp_path):
+    """Test run_ribasim() raises FileNotFoundError with invalid RIBASIM_HOME."""
     model = ribasim_testmodels.basic_model()
     toml_path = tmp_path / "ribasim.toml"
     model.write(toml_path)
 
-    # Save current RIBASIM_EXE and PATH
-    old_ribasim_exe = os.environ.get("RIBASIM_EXE")
+    # Save current RIBASIM_HOME and PATH
+    old_ribasim_home = os.environ.get("RIBASIM_HOME")
     old_path = os.environ.get("PATH", "")
 
     try:
-        # Set invalid RIBASIM_EXE
-        invalid_path = tmp_path / "nonexistent" / "ribasim"
-        os.environ["RIBASIM_EXE"] = str(invalid_path)
-        os.environ["PATH"] = ""  # Clear PATH to ensure RIBASIM_EXE is used
+        # Set invalid RIBASIM_HOME
+        invalid_path = tmp_path / "nonexistent"
+        os.environ["RIBASIM_HOME"] = str(invalid_path)
+        os.environ["PATH"] = ""  # Clear PATH to ensure RIBASIM_HOME is used
 
         with pytest.raises(
             FileNotFoundError,
-            match=r"Ribasim CLI executable not found at RIBASIM_EXE=",
+            match=r"Ribasim CLI executable not found at RIBASIM_HOME=",
         ):
             run_ribasim(toml_path)
     finally:
         # Restore environment
         os.environ["PATH"] = old_path
-        if old_ribasim_exe is not None:
-            os.environ["RIBASIM_EXE"] = old_ribasim_exe
+        if old_ribasim_home is not None:
+            os.environ["RIBASIM_HOME"] = old_ribasim_home
         else:
-            os.environ.pop("RIBASIM_EXE", None)
+            os.environ.pop("RIBASIM_HOME", None)
 
 
 def test_run_ribasim_invalid_model(tmp_path):
@@ -241,7 +242,7 @@ def test_run_ribasim_invalid_model(tmp_path):
     model.write(toml_path)
 
     with pytest.raises(subprocess.CalledProcessError):
-        run_ribasim(toml_path, ribasim_exe=executable)
+        run_ribasim(toml_path, ribasim_home=ribasim_home)
 
 
 def test_run_ribasim_in_notebook(tmp_path, monkeypatch):
@@ -257,7 +258,7 @@ def test_run_ribasim_in_notebook(tmp_path, monkeypatch):
     monkeypatch.setattr(cli, "_subprocess_handling", lambda: SubprocessHandling.DISPLAY)
 
     # Should run successfully using the notebook path
-    run_ribasim(toml_path, ribasim_exe=executable)
+    run_ribasim(toml_path, ribasim_home=ribasim_home)
 
     # Check that results were produced
     results_path = tmp_path / "results" / "basin.nc"
@@ -277,7 +278,7 @@ def test_run_ribasim_in_spyder(tmp_path, monkeypatch):
     monkeypatch.setattr(cli, "_subprocess_handling", lambda: SubprocessHandling.SPYDER)
 
     # Should run successfully using the Spyder path
-    run_ribasim(toml_path, ribasim_exe=executable)
+    run_ribasim(toml_path, ribasim_home=ribasim_home)
 
     # Check that results were produced
     results_path = tmp_path / "results" / "basin.nc"

--- a/docs/getting-started/install.qmd
+++ b/docs/getting-started/install.qmd
@@ -107,10 +107,10 @@ To download the Ribasim core manually, download the appropriate zip file for you
 
 Note that we currently only support and provide binaries for Windows and Linux, for the x86_64 architecture.
 
-After downloading, extract/unzip the zip file to a directory of your choice, for example `C:\bin\ribasim\`.
+After downloading, extract/unzip the zip file to a directory of your choice, for example `C:\ribasim\`.
 Unless you add it to the Path as instructed below, we recommend avoiding spaces in the path.
 
-To check whether the installation was performed successfully, open a terminal and go to the path where the executable is for example `C:\bin\ribasim\`.
+To check whether the installation was performed successfully, open a terminal and go to the path where the executable is for example `C:\ribasim\`.
 If you are using cmd.exe type `ribasim --help`, or for PowerShell `./ribasim`.
 
 This will give the following message if it is installed correctly:
@@ -129,34 +129,32 @@ Options:
 
 If you used the installation script, Ribasim is already on your PATH. For manual installations, you can add the Ribasim executable directory to your Windows Path environment variable.
 
-The Path environment variable tells Windows where to look for programs when you type their name in a terminal. By adding Ribasim to your Path, you can type `ribasim` from any folder instead of having to navigate to the Ribasim folder first or typing the full path like `C:\bin\ribasim\ribasim.exe`.
+The Path environment variable tells Windows where to look for programs when you type their name in a terminal. By adding Ribasim to your Path, you can type `ribasim` from any folder instead of having to navigate to the Ribasim folder first or typing the full path like `C:\ribasim\bin\ribasim.exe`.
 
    - Search "Environment Variables" in the Windows search bar
    - Click "Edit the system environment variables"
    - Click on the "Advanced" tab
    - Click the "Environment Variables..." button at the bottom
    - In the top section "User variables", scroll down and find "Path", then click "Edit..."
-   - Click "New" and enter the full path to your Ribasim directory (e.g., `C:\bin\ribasim`, not `C:\bin\ribasim\ribasim.exe`)
+   - Click "New" and enter the full path to your Ribasim bin directory (e.g., `C:\ribasim\bin`)
    - Click "OK" three times to close all dialogs
    - Close any open terminals/command prompts and open a new one
 
-## RIBASIM_EXE environment variable {#ribasim-exe}
+## RIBASIM_HOME environment variable {#ribasim-home}
 
-The QGIS plugin and the Python `run_ribasim` function look for the Ribasim executable in the following order:
+The [`run_ribasim`](/reference/python/run_ribasim.qmd#ribasim.run_ribasim) function in Ribasim Python looks for the Ribasim executable in the following order:
 
-1. The `RIBASIM_EXE` environment variable (if set)
+1. The `RIBASIM_HOME` environment variable (if set)
 2. The system `PATH`
 
-If Ribasim is on your PATH but cannot be found (this can happen because QGIS may not inherit your user PATH), you can set the `RIBASIM_EXE` environment variable to point directly to the Ribasim executable.
-
-To set `RIBASIM_EXE`:
+To set `RIBASIM_HOME`:
 
 - Search "Environment Variables" in the Windows search bar
 - Click "Edit the system environment variables"
 - Click the "Environment Variables..." button
 - In the top section "User variables", click "New..."
-- Set Variable name to `RIBASIM_EXE`
-- Set Variable value to the **full path to the executable** (e.g., `C:\bin\ribasim\ribasim.exe`)
+- Set Variable name to `RIBASIM_HOME`
+- Set Variable value to the **path to the Ribasim home directory** (e.g., `C:\ribasim`, the folder which contains a `bin` directory with `ribasim.exe`)
 - Click "OK" three times to close all dialogs
 - Restart QGIS for the change to take effect
 

--- a/docs/getting-started/tutorial/natural-flow.qmd
+++ b/docs/getting-started/tutorial/natural-flow.qmd
@@ -251,13 +251,13 @@ Now run the model. You can open a terminal and run it from there. For example:
 ribasim Crystal-1/ribasim.toml
 ```
 
-From Python you can run it with:
+From Python you can run it with [`run_ribasim`](/reference/python/run_ribasim.qmd#ribasim.run_ribasim).
 
 ```{python}
 run_ribasim(toml_path)
 ```
 
-By default it will search for `ribasim` in the PATH, but you can supply the `ribasim_exe` keyword argument which points to the `ribasim` executable: `run_ribasim(toml_path, ribasim_exe="bin/ribasim/ribasim.exe")`. Use `run_ribasim(version=True)` to check the version.
+By default it will search for `ribasim` in the PATH, but you can supply the `ribasim_home` keyword argument which points to the Ribasim home directory: `run_ribasim(toml_path, ribasim_home="path/to/ribasim")`. Use `run_ribasim(version=True)` to check the version.
 
 ### Post-processing results
 Read the Arrow files and plot the simulated flows from different links and the levels and storages at our confluence point:

--- a/docs/guide/qgis.qmd
+++ b/docs/guide/qgis.qmd
@@ -26,8 +26,8 @@ When the simulation completes successfully, the model results are automatically 
 
 ![](https://s3.deltares.nl/ribasim/doc-image/qgis/run-model-dialog.png){fig-align="left"}
 
-For QGIS to find the Ribasim executable, it must be configured via `RIBASIM_EXE`.
-See the [install section](/getting-started/install.qmd#ribasim-exe) for details.
+For QGIS to find the Ribasim executable, it must be configured via `RIBASIM_HOME`.
+See the [install section](/getting-started/install.qmd#ribasim-home) for details.
 
 # Inspect a (large) model {#sec-inspect}
 

--- a/python/ribasim/ribasim/cli.py
+++ b/python/ribasim/ribasim/cli.py
@@ -52,13 +52,13 @@ def _resolve_executable(executable: str | Path, error_msg: str = "") -> Path:
     return Path(cli)
 
 
-def _find_cli(ribasim_exe: str | Path | None = None) -> Path:
-    """Find the Ribasim CLI executable on ribasim_exe or the PATH.
+def _find_cli(ribasim_home: str | Path | None = None) -> Path:
+    """Find the Ribasim CLI executable in ribasim_home or the PATH.
 
     Parameters
     ----------
-    ribasim_exe : str | Path | None, optional
-        Path to the Ribasim CLI executable. If None, first checks the RIBASIM_EXE
+    ribasim_home : str | Path | None, optional
+        Path to the Ribasim home directory. If None, first checks the RIBASIM_HOME
         environment variable, then searches the PATH.
 
     Returns
@@ -69,25 +69,25 @@ def _find_cli(ribasim_exe: str | Path | None = None) -> Path:
     Raises
     ------
     FileNotFoundError
-        If the Ribasim CLI is not found via RIBASIM_EXE or on the PATH (when ribasim_exe is None),
-        or if the executable is not found at the specified ribasim_exe.
+        If the Ribasim CLI is not found via RIBASIM_HOME or on the PATH (when ribasim_home is None),
+        or if the executable is not found at the specified ribasim_home.
     """
-    if ribasim_exe is not None:
-        # Use ribasim_exe argument if provided
-        ribasim_exe = Path(ribasim_exe)
+    if ribasim_home is not None:
+        # Use ribasim_home argument if provided
+        ribasim_exe = Path(ribasim_home) / "bin/ribasim"
         return _resolve_executable(
             ribasim_exe,
             f"Ribasim CLI executable not found at '{ribasim_exe.resolve()}'. "
             "Please ensure the path is correct.",
         )
     else:
-        # Else check RIBASIM_EXE environment variable
-        if (ribasim_exe_env := os.environ.get("RIBASIM_EXE")) is not None:
-            ribasim_exe = Path(ribasim_exe_env)
+        # Else check RIBASIM_HOME environment variable
+        if (ribasim_home_env := os.environ.get("RIBASIM_HOME")) is not None:
+            ribasim_exe = Path(ribasim_home_env) / "bin/ribasim"
 
             return _resolve_executable(
                 ribasim_exe,
-                f"Ribasim CLI executable not found at RIBASIM_EXE='{ribasim_exe.resolve()}'. "
+                f"Ribasim CLI executable not found at RIBASIM_HOME='{ribasim_home_env}'. "
                 "Please ensure the path is correct.",
             )
         else:
@@ -96,7 +96,7 @@ def _find_cli(ribasim_exe: str | Path | None = None) -> Path:
                 "ribasim",
                 "Ribasim CLI executable 'ribasim' not found. "
                 "Please ensure Ribasim is installed and available on your PATH, "
-                "or set the RIBASIM_EXE environment variable.",
+                "or set the RIBASIM_HOME environment variable.",
             )
 
 
@@ -147,7 +147,7 @@ def _subprocess_handling() -> SubprocessHandling:
 def run_ribasim(
     toml_path: str | Path | None = None,
     *,
-    ribasim_exe: str | Path | None = None,
+    ribasim_home: str | Path | None = None,
     version: bool = False,
     threads: int | None = None,
 ) -> None:
@@ -158,9 +158,9 @@ def run_ribasim(
     toml_path : str | Path | None, optional
         Path to the TOML file.
         Required unless version=True.
-    ribasim_exe : str | Path | None, optional
-        Path to the Ribasim CLI executable. If not provided, first checks the
-        RIBASIM_EXE environment variable, then searches PATH.
+    ribasim_home : str | Path | None, optional
+        Path to the Ribasim home directory. If not provided, first checks the
+        RIBASIM_HOME environment variable, then searches PATH.
     version : bool, default False
         Print version
     threads : int | None, optional
@@ -169,7 +169,7 @@ def run_ribasim(
     Raises
     ------
     FileNotFoundError
-        If the Ribasim CLI is not found via RIBASIM_EXE or on PATH (when ribasim_exe is not provided),
+        If the Ribasim CLI is not found via RIBASIM_HOME or on PATH (when ribasim_home is not provided),
         or the toml_path does not exist.
     ValueError
         If neither toml_path nor version is provided.
@@ -179,7 +179,7 @@ def run_ribasim(
     Examples
     --------
     >>> run_ribasim("model.toml")
-    >>> run_ribasim("model.toml", ribasim_exe="/path/to/ribasim")
+    >>> run_ribasim("model.toml", ribasim_home="/path/to/ribasim")
     >>> run_ribasim(version=True)
     """
     # Build command arguments
@@ -201,7 +201,7 @@ def run_ribasim(
     else:
         raise ValueError("Provide a toml_path, or set version=True")
 
-    cli = _find_cli(ribasim_exe)
+    cli = _find_cli(ribasim_home)
     handling = _subprocess_handling()
 
     if handling == SubprocessHandling.FORWARD:

--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -397,9 +397,9 @@ class DatasetWidget:
     def _find_ribasim_cli(message_bar) -> Path | None:
         """Find the Ribasim CLI executable.
 
-        First checks the RIBASIM_EXE environment variable, then searches PATH.
-        RIBASIM_EXE must be the full path to the executable file, e.g.,
-        `C:/bin/ribasim/bin/ribasim.exe` on Windows.
+        First checks the RIBASIM_HOME environment variable, then searches PATH.
+        RIBASIM_HOME must be the path to the Ribasim home directory, e.g.,
+        `C:/ribasim` on Windows.
 
         This is useful when QGIS does not inherit the user's PATH environment
         variable, which happens in the default Windows installation.
@@ -414,14 +414,15 @@ class DatasetWidget:
         Path | None
             Path to the Ribasim CLI executable, or None if not found.
         """
-        # Check RIBASIM_EXE environment variable
-        if (ribasim_exe_env := os.environ.get("RIBASIM_EXE")) is not None:
-            ribasim_exe = Path(ribasim_exe_env)
+        # Check RIBASIM_HOME environment variable
+        if (ribasim_home_env := os.environ.get("RIBASIM_HOME")) is not None:
+            ribasim_home = Path(ribasim_home_env)
+            ribasim_exe = ribasim_home / "bin/ribasim"
             cli = shutil.which(ribasim_exe.name, path=str(ribasim_exe.parent))
             if cli is None:
                 message_bar.pushMessage(
                     "Error",
-                    f"Ribasim CLI executable not found at RIBASIM_EXE='{ribasim_exe.resolve()}'. "
+                    f"Ribasim not found at RIBASIM_HOME='{ribasim_home.resolve()}'. "
                     "Please ensure the path is correct.",
                     level=Qgis.MessageLevel.Critical,
                 )
@@ -435,9 +436,9 @@ class DatasetWidget:
 
         message_bar.pushMessage(
             "Error",
-            "Ribasim CLI executable 'ribasim' not found. "
+            "Ribasim not found. "
             "Please ensure Ribasim is installed and available on your PATH, "
-            "or set the RIBASIM_EXE environment variable.",
+            "or set the RIBASIM_HOME environment variable.",
             level=Qgis.MessageLevel.Critical,
         )
         return None


### PR DESCRIPTION
Closes https://github.com/Deltares/Ribasim/issues/2869.

This is breaking in that it changes the `run_ribasim` kwarg `ribasim_exe` to `ribasim_home`.
