### PR TITLE
Exit QGIS better in Docker test

### DIFF
--- a/ribasim_qgis/scripts/qgis_testrunner.py
+++ b/ribasim_qgis/scripts/qgis_testrunner.py
@@ -104,7 +104,8 @@ sys.path.append(QDir.current().path())
 
 def __exit_qgis(exit_code: int):
     """Exit QGIS application with the given exit code."""
-    QgsApplication.exitQgis(exit_code)
+    QgsApplication.exitQgis()
+    sys.exit(exit_code)
 
 
 def __run_test():


### PR DESCRIPTION
I recently saw QGIS failing sometimes, like on https://github.com/Deltares/Ribasim/actions/runs/21882547840/job/63168786273?pr=2891.

```
Ran 4 tests in 0.008s

OK
Coverage report skipped: No data to report.
QGIS died on signal 11Aborted (core dumped)
```

Let's try this. Idea based on https://gis.stackexchange.com/questions/250933/using-exitqgis-in-pyqgis