### PR TITLE
Test logging extra info

### DIFF
--- a/core/src/logging.jl
+++ b/core/src/logging.jl
@@ -48,16 +48,8 @@ function log_startup(config, toml_path::AbstractString)::Nothing
     if model_version != ribasim_version
         @warn "Version mismatch, this will likely fail. Ribasim only supports running simulations with the same Ribasim version it was generated with." model_version ribasim_version
     end
-    @info "Starting a Ribasim simulation at $(now())." toml_path ribasim_version starttime endtime threads
-
-    # Log runtime environment diagnostics
-    bindir = Sys.BINDIR
-    ribasim_home = dirname(bindir)
-    julia_cmd = string(Base.julia_cmd())
-    julia_args = ARGS
-    julia_version = string(VERSION)
-    exec_path = Base.julia_exename()
-    @info "Runtime environment." bindir ribasim_home julia_cmd julia_args julia_version exec_path
+    ribasim_home = dirname(Sys.BINDIR)
+    @info "Starting a Ribasim simulation at $(now())." toml_path ribasim_version ribasim_home starttime endtime threads
 
     if any(config.experimental)
         @warn "The following *experimental* features are enabled: $(showexperimental(config))"


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/2885

Draft, I just put some options and started a TeamCity build to see what these return.

EDIT: results running the binary installed from ZIP:

```
┌ Info: Runtime environment.
│   bindir = "C:\\ProgramData\\DevDrives\\bin\\ribasim-log\\bin"
│   ribasim_home = "C:\\ProgramData\\DevDrives\\bin\\ribasim-log"
│   julia_cmd = "`'C:\\ProgramData\\DevDrives\\bin\\ribasim-log\\bin\\julia.exe' -C native '-JC:\\ProgramData\\DevDrives\\bin\\ribasim-log\\bin\\libribasim.dll' -g1`"
│   julia_args = String[]
│   julia_version = "1.12.5"
└   exec_path = "julia.exe"
```

And from MSIX:

```
┌ Info: Runtime environment.
│   bindir = "C:\\Program Files\\WindowsApps\\Deltares.Ribasim_2026.1.0.1_x64__m018s8shtq18w\\bin"
│   ribasim_home = "C:\\Program Files\\WindowsApps\\Deltares.Ribasim_2026.1.0.1_x64__m018s8shtq18w"
│   julia_cmd = "`'C:\\Program Files\\WindowsApps\\Deltares.Ribasim_2026.1.0.1_x64__m018s8shtq18w\\bin\\julia.exe' -C native '-JC:\\Program Files\\WindowsApps\\Deltares.Ribasim_2026.1.0.1_x64__m018s8shtq18w\\bin\\libribasim.dll' -g1`"
│   julia_args = String[]
│   julia_version = "1.12.5"
└   exec_path = "julia.exe"
```

And from the Julia REPL (this is the way the logging will look like):

```
┌ Info: Starting a Ribasim simulation at 2026-02-17T12:39:04.402.
│   toml_path = "c:\\ProgramData\\DevDrives\\repo\\ribasim\\Ribasim\\generated_testmodels\\basic\\ribasim.toml"
│   ribasim_version = "2026.1.0-rc1"
│   ribasim_home = "C:\\ProgramData\\DevDrives\\.julia\\juliaup\\julia-1.12.5+0.x64.w64.mingw32"
│   starttime = 2020-01-01T00:00:00
│   endtime = 2021-01-01T00:00:00
└   threads = 12
```

The latter has no ribasim.exe, so pointing to julia.exe makes sense.