### PR TITLE
Update pixi lockfile

### DIFF
--- a/Ribasim-python.spdx.json
+++ b/Ribasim-python.spdx.json
@@ -6,12 +6,12 @@
     "creators": [
       "Tool: sbom4python-0.12.4"
     ],
-    "created": "2026-02-23T11:55:53Z",
+    "created": "2026-02-23T14:22:14Z",
     "licenseListVersion": "3.27"
   },
   "name": "Python-ribasim",
   "dataLicense": "CC0-1.0",
-  "documentNamespace": "http://spdx.org/spdxdocs/Python-ribasim-6d6b947f-2561-4765-b1ab-081545014eaa",
+  "documentNamespace": "http://spdx.org/spdxdocs/Python-ribasim-2bca8097-fe81-4059-b51d-3c98450ffe69",
   "packages": [
     {
       "SPDXID": "SPDXRef-1-ribasim",
@@ -642,44 +642,22 @@
       ]
     },
     {
-      "SPDXID": "SPDXRef-15-packaging",
-      "name": "packaging",
-      "versionInfo": "26.0",
+      "SPDXID": "SPDXRef-15-",
+      "name": "",
+      "versionInfo": "",
       "primaryPackagePurpose": "LIBRARY",
-      "supplier": "Person: Donald Stufft (donald@stufft.io)",
-      "downloadLocation": "https://pypi.org/project/packaging/26.0/#files",
+      "supplier": "NOASSERTION",
+      "downloadLocation": "https://pypi.org/project///#files",
       "filesAnalyzed": false,
-      "checksums": [
-        {
-          "algorithm": "SHA256",
-          "checksumValue": "b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"
-        }
-      ],
       "licenseConcluded": "NOASSERTION",
       "licenseDeclared": "NOASSERTION",
       "copyrightText": "NOASSERTION",
-      "summary": "Core utilities for Python packages",
-      "releaseDate": "2026-01-21T20:50:37Z",
+      "releaseDate": "2025-12-22T21:06:12Z",
       "externalRefs": [
-        {
-          "referenceCategory": "OTHER",
-          "referenceType": "documentation",
-          "referenceLocator": "https://packaging.pypa.io/"
-        },
-        {
-          "referenceCategory": "OTHER",
-          "referenceType": "vcs",
-          "referenceLocator": "https://github.com/pypa/packaging"
-        },
         {
           "referenceCategory": "PACKAGE-MANAGER",
           "referenceType": "purl",
-          "referenceLocator": "pkg:pypi/packaging@26.0"
-        },
-        {
-          "referenceCategory": "SECURITY",
-          "referenceType": "cpe23Type",
-          "referenceLocator": "cpe:2.3:a:donald_stufft:packaging:26.0:*:*:*:*:*:*:*"
+          "referenceLocator": "pkg:pypi/@"
         }
       ]
     },
@@ -1952,7 +1930,7 @@
     },
     {
       "spdxElementId": "SPDXRef-14-geopandas",
-      "relatedSpdxElement": "SPDXRef-15-packaging",
+      "relatedSpdxElement": "SPDXRef-15-",
       "relationshipType": "DEPENDS_ON"
     },
     {
@@ -2007,7 +1985,7 @@
     },
     {
       "spdxElementId": "SPDXRef-17-matplotlib",
-      "relatedSpdxElement": "SPDXRef-15-packaging",
+      "relatedSpdxElement": "SPDXRef-15-",
       "relationshipType": "DEPENDS_ON"
     },
     {
@@ -2057,7 +2035,7 @@
     },
     {
       "spdxElementId": "SPDXRef-1-ribasim",
-      "relatedSpdxElement": "SPDXRef-15-packaging",
+      "relatedSpdxElement": "SPDXRef-15-",
       "relationshipType": "DEPENDS_ON"
     },
     {
@@ -2072,7 +2050,7 @@
     },
     {
       "spdxElementId": "SPDXRef-27-pandera",
-      "relatedSpdxElement": "SPDXRef-15-packaging",
+      "relatedSpdxElement": "SPDXRef-15-",
       "relationshipType": "DEPENDS_ON"
     },
     {
@@ -2167,7 +2145,7 @@
     },
     {
       "spdxElementId": "SPDXRef-39-pyogrio",
-      "relatedSpdxElement": "SPDXRef-15-packaging",
+      "relatedSpdxElement": "SPDXRef-15-",
       "relationshipType": "DEPENDS_ON"
     },
     {
@@ -2197,7 +2175,7 @@
     },
     {
       "spdxElementId": "SPDXRef-42-xarray",
-      "relatedSpdxElement": "SPDXRef-15-packaging",
+      "relatedSpdxElement": "SPDXRef-15-",
       "relationshipType": "DEPENDS_ON"
     },
     {

--- a/pixi.lock
+++ b/pixi.lock
@@ -137,9 +137,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-2.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffecli-2.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffelib-2.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.7-he838d99_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.26.10-h0363672_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.26.10-h17cb667_0.conda
@@ -743,9 +741,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glog-0.7.1-h468a4a4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.14-hfae3067_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-2.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffecli-2.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffelib-2.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.26.10-hae777ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.26.10-hc24f651_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
@@ -1255,9 +1251,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.14-hec049ff_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-2.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffecli-2.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffelib-2.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gst-plugins-base-1.26.10-hd17a83a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gstreamer-1.26.10-h30d696d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
@@ -1728,9 +1722,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/glog-0.7.1-h3ff59bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gmp-6.3.0-hfeafd45_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.14-hac47afa_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-2.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffecli-2.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffelib-2.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gsl-2.7-hdfb1a43_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.26.10-hf40947b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.26.10-h54009fa_0.conda
@@ -2284,9 +2276,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hbabe93e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-2.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffecli-2.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffelib-2.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.7-he838d99_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.26.10-h0363672_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.26.10-h17cb667_0.conda
@@ -2890,9 +2880,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glog-0.7.1-h468a4a4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h0a1ffab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.14-hfae3067_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-2.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffecli-2.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffelib-2.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.26.10-hae777ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.26.10-hc24f651_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
@@ -3402,9 +3390,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-heb240a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-h7bae524_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.14-hec049ff_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-2.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffecli-2.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffelib-2.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gst-plugins-base-1.26.10-hd17a83a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gstreamer-1.26.10-h30d696d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.16.0-pyhcf101f3_1.conda
@@ -3875,9 +3861,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/glog-0.7.1-h3ff59bf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gmp-6.3.0-hfeafd45_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.14-hac47afa_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-2.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffecli-2.0.0-pyhcf101f3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/griffelib-2.0.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.15.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gsl-2.7-hdfb1a43_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.26.10-hf40947b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.26.10-h54009fa_0.conda
@@ -9238,43 +9222,17 @@ packages:
   purls: []
   size: 96336
   timestamp: 1755102441729
-- conda: https://conda.anaconda.org/conda-forge/noarch/griffe-2.0.0-pyhcf101f3_0.conda
-  sha256: c7c7120acc201584517b9830aa8da600a0bddf7be59b692a442b72bb8424273b
-  md5: 4a58c937b57806b62f0442dc9087dcca
+- conda: https://conda.anaconda.org/conda-forge/noarch/griffe-1.15.0-pyhd8ed1ab_0.conda
+  sha256: 7a42213d6a6dae486c56a835a107fc8704eabf686a2b95adde009e06848426cd
+  md5: 0bc57a76679376b93a489824aa08c294
   depends:
+  - colorama >=0.4
   - python >=3.10
-  - griffelib >=2.0.0,<2.0.1.0a0
-  - griffecli >=2.0.0,<2.0.1.0a0
-  - python
   license: ISC
   purls:
   - pkg:pypi/griffe?source=hash-mapping
-  size: 17184
-  timestamp: 1771834183597
-- conda: https://conda.anaconda.org/conda-forge/noarch/griffecli-2.0.0-pyhcf101f3_0.conda
-  sha256: a5dec02625f9fffffe456ad65b83e0cb58579036e32d74ef6e16ab199ead623e
-  md5: 1f00605b0fb7a5262a98300bbae6014c
-  depends:
-  - python >=3.10
-  - colorama >=0.4
-  - griffelib >=2.0.0,<2.0.1.0a0
-  - python
-  license: ISC
-  purls:
-  - pkg:pypi/griffecli?source=hash-mapping
-  size: 19658
-  timestamp: 1771834183597
-- conda: https://conda.anaconda.org/conda-forge/noarch/griffelib-2.0.0-pyhcf101f3_0.conda
-  sha256: c512737c8eb60f9e47a34fb476fe8541238f88c3fb04d3cbc7ee799e7f5821b3
-  md5: 1f060d75bf6d887a9a62b7750857768d
-  depends:
-  - python >=3.10
-  - python
-  license: ISC
-  purls:
-  - pkg:pypi/griffelib?source=hash-mapping
-  size: 117162
-  timestamp: 1771834183594
+  size: 114576
+  timestamp: 1762806629967
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gsl-2.7-he838d99_0.tar.bz2
   sha256: 132a918b676dd1f533d7c6f95e567abf7081a6ea3251c3280de35ef600e0da87
   md5: fec079ba39c9cca093bf4c00001825de

--- a/pixi.toml
+++ b/pixi.toml
@@ -251,6 +251,7 @@ quarto-render = { cmd = "echo 'Skipping quarto render on ARM64 Linux (Quarto not
 datacompy = ">=0.16"
 geopandas = ">=1.0"
 gh = "*"
+griffe = ">=1,<2"
 hatch = "*"
 hatchling = "*"
 jinja2 = "*"


### PR DESCRIPTION
# Dependencies

<details>
<summary>Explicit dependencies</summary>

|Dependency|Before|After|Change|Environments|
|-|-|-|-|-|
|[gh](https://prefix.dev/channels/conda-forge/packages/gh)|2.86.0|2.87.2|Minor Upgrade|*all*|
|[pydantic-settings](https://prefix.dev/channels/conda-forge/packages/pydantic-settings)|2.12.0|2.13.1|Minor Upgrade|*all*|
|[xarray](https://prefix.dev/channels/conda-forge/packages/xarray)|2026.1.0|2026.2.0|Minor Upgrade|*all*|
|[juliaup](https://prefix.dev/channels/conda-forge/packages/juliaup)|1.19.8|1.19.9|Patch Upgrade|*all envs* on {linux-64, linux-aarch64, win-64}|
|[juliaup](https://prefix.dev/channels/conda-forge/packages/juliaup)|1.19.6|1.19.9|Patch Upgrade|*all envs* on osx-arm64|
|[nbstripout](https://prefix.dev/channels/conda-forge/packages/nbstripout)|0.9.0|0.9.1|Patch Upgrade|*all*|
|[prek](https://prefix.dev/channels/conda-forge/packages/prek)|0.3.2|0.3.3|Patch Upgrade|*all*|
|[pyarrow](https://prefix.dev/channels/conda-forge/packages/pyarrow)|23.0.0|23.0.1|Patch Upgrade|*all envs* on {linux-aarch64, osx-arm64}|
|[ruff](https://prefix.dev/channels/conda-forge/packages/ruff)|0.15.0|0.15.2|Patch Upgrade|*all*|
|[rust](https://prefix.dev/channels/conda-forge/packages/rust)|1.93.0|1.93.1|Patch Upgrade|*all*|
|[typos](https://prefix.dev/channels/conda-forge/packages/typos)|1.43.4|1.43.5|Patch Upgrade|*all*|
|[qgis](https://prefix.dev/channels/conda-forge/packages/qgis)|py313hf834b34_0|py313hd85dc74_1|Only build string|default on linux-64|
|[qgis](https://prefix.dev/channels/conda-forge/packages/qgis)|py313h15ca571_0|py313h7e1e203_1|Only build string|default on win-64|
|[qgis](https://prefix.dev/channels/conda-forge/packages/qgis)|py312hfe3f42a_0|py312hb26ffdd_1|Only build string|py312 on linux-64|
|[qgis](https://prefix.dev/channels/conda-forge/packages/qgis)|py312hb4fe06e_0|py312h4bb217a_1|Only build string|py312 on win-64|

</details>

<details>
<summary>Implicit dependencies</summary>

|Dependency|Before|After|Change|Environments|
|-|-|-|-|-|
|[fribidi](https://prefix.dev/channels/conda-forge/packages/fribidi)||1.0.16|Added|*all envs* on {linux-64, win-64}|
|[griffecli](https://prefix.dev/channels/conda-forge/packages/griffecli)||2.0.0|Added|*all*|
|[griffelib](https://prefix.dev/channels/conda-forge/packages/griffelib)||2.0.0|Added|*all*|
|[pango](https://prefix.dev/channels/conda-forge/packages/pango)||1.56.4|Added|*all envs* on {linux-64, win-64}|
|_libgcc_mutex|0.1||Removed|*all envs* on linux-64|
|[griffe](https://prefix.dev/channels/conda-forge/packages/griffe)|1.15.0|2.0.0|Major Upgrade|*all*|
|[icu](https://prefix.dev/channels/conda-forge/packages/icu)|75.1|78.2|Major Upgrade|*all envs* on {linux-64, win-64}|
|[async-lru](https://prefix.dev/channels/conda-forge/packages/async-lru)|2.1.0|2.2.0|Minor Upgrade|*all*|
|[aws-c-io](https://prefix.dev/channels/conda-forge/packages/aws-c-io)|0.23.3|0.26.1|Minor Upgrade|*all envs* on {linux-aarch64, osx-arm64}|
|[aws-c-mqtt](https://prefix.dev/channels/conda-forge/packages/aws-c-mqtt)|0.13.3|0.14.0|Minor Upgrade|*all envs* on {linux-aarch64, osx-arm64}|
|[aws-crt-cpp](https://prefix.dev/channels/conda-forge/packages/aws-crt-cpp)|0.35.4|0.37.2|Minor Upgrade|*all envs* on {linux-aarch64, osx-arm64}|
|[filelock](https://prefix.dev/channels/conda-forge/packages/filelock)|3.20.3|3.24.3|Minor Upgrade|*all*|
|[fontconfig](https://prefix.dev/channels/conda-forge/packages/fontconfig)|2.15.0|2.17.1|Minor Upgrade|*all*|
|[gst-plugins-base](https://prefix.dev/channels/conda-forge/packages/gst-plugins-base)|1.24.11|1.26.10|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[gstreamer](https://prefix.dev/channels/conda-forge/packages/gstreamer)|1.24.11|1.26.10|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[harfbuzz](https://prefix.dev/channels/conda-forge/packages/harfbuzz)|12.2.0|12.3.2|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libgcrypt-lib](https://prefix.dev/channels/conda-forge/packages/libgcrypt-lib)|1.11.1|1.12.1|Minor Upgrade|*all envs* on linux-64|
|[libgpg-error](https://prefix.dev/channels/conda-forge/packages/libgpg-error)|1.58|1.59|Minor Upgrade|*all envs* on linux-64|
|[libpdal](https://prefix.dev/channels/conda-forge/packages/libpdal)|2.9.3|2.10.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libpdal-arrow](https://prefix.dev/channels/conda-forge/packages/libpdal-arrow)|2.9.3|2.10.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libpdal-core](https://prefix.dev/channels/conda-forge/packages/libpdal-core)|2.9.3|2.10.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libpdal-cpd](https://prefix.dev/channels/conda-forge/packages/libpdal-cpd)|2.9.3|2.10.0|Minor Upgrade|*all envs* on linux-64|
|[libpdal-draco](https://prefix.dev/channels/conda-forge/packages/libpdal-draco)|2.9.3|2.10.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libpdal-e57](https://prefix.dev/channels/conda-forge/packages/libpdal-e57)|2.9.3|2.10.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libpdal-hdf](https://prefix.dev/channels/conda-forge/packages/libpdal-hdf)|2.9.3|2.10.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libpdal-icebridge](https://prefix.dev/channels/conda-forge/packages/libpdal-icebridge)|2.9.3|2.10.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libpdal-nitf](https://prefix.dev/channels/conda-forge/packages/libpdal-nitf)|2.9.3|2.10.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libpdal-pgpointcloud](https://prefix.dev/channels/conda-forge/packages/libpdal-pgpointcloud)|2.9.3|2.10.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libpdal-tiledb](https://prefix.dev/channels/conda-forge/packages/libpdal-tiledb)|2.9.3|2.10.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libpdal-trajectory](https://prefix.dev/channels/conda-forge/packages/libpdal-trajectory)|2.9.3|2.10.0|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[libpq](https://prefix.dev/channels/conda-forge/packages/libpq)|18.1|18.2|Minor Upgrade|*all*|
|[liburing](https://prefix.dev/channels/conda-forge/packages/liburing)|2.12|2.14|Minor Upgrade|*all envs* on linux-64|
|[platformdirs](https://prefix.dev/channels/conda-forge/packages/platformdirs)|4.5.1|4.9.2|Minor Upgrade|*all*|
|[plum-dispatch](https://prefix.dev/channels/conda-forge/packages/plum-dispatch)|2.6.1|2.7.1|Minor Upgrade|*all*|
|[postgresql](https://prefix.dev/channels/conda-forge/packages/postgresql)|18.1|18.2|Minor Upgrade|*all envs* on {linux-64, win-64}|
|[python-librt](https://prefix.dev/channels/conda-forge/packages/python-librt)|0.7.8|0.8.1|Minor Upgrade|*all*|
|[s2n](https://prefix.dev/channels/conda-forge/packages/s2n)|1.6.2|1.7.0|Minor Upgrade|*all envs* on linux-aarch64|
|[typeguard](https://prefix.dev/channels/conda-forge/packages/typeguard)|4.4.4|4.5.1|Minor Upgrade|*all*|
|[virtualenv](https://prefix.dev/channels/conda-forge/packages/virtualenv)|20.36.1|20.38.0|Minor Upgrade|*all*|
|[aws-c-auth](https://prefix.dev/channels/conda-forge/packages/aws-c-auth)|0.9.3|0.9.6|Patch Upgrade|*all envs* on {linux-aarch64, osx-arm64}|
|[aws-c-compression](https://prefix.dev/channels/conda-forge/packages/aws-c-compression)|0.3.1|0.3.2|Patch Upgrade|*all envs* on {linux-aarch64, osx-arm64}|
|[aws-c-event-stream](https://prefix.dev/channels/conda-forge/packages/aws-c-event-stream)|0.5.7|0.5.9|Patch Upgrade|*all envs* on {linux-aarch64, osx-arm64}|
|[aws-c-http](https://prefix.dev/channels/conda-forge/packages/aws-c-http)|0.10.7|0.10.10|Patch Upgrade|*all envs* on {linux-aarch64, osx-arm64}|
|[aws-c-s3](https://prefix.dev/channels/conda-forge/packages/aws-c-s3)|0.11.3|0.11.5|Patch Upgrade|*all envs* on {linux-aarch64, osx-arm64}|
|[aws-checksums](https://prefix.dev/channels/conda-forge/packages/aws-checksums)|0.2.7|0.2.10|Patch Upgrade|*all envs* on {linux-aarch64, osx-arm64}|
|[glib](https://prefix.dev/channels/conda-forge/packages/glib)|2.86.3|2.86.4|Patch Upgrade|*all*|
|[glib-tools](https://prefix.dev/channels/conda-forge/packages/glib-tools)|2.86.3|2.86.4|Patch Upgrade|*all*|
|[juliapkg](https://pypi.org/project/juliapkg)|0.1.22|0.1.23|Patch Upgrade|*all*|
|[libarrow](https://prefix.dev/channels/conda-forge/packages/libarrow)|23.0.0|23.0.1|Patch Upgrade|*all envs* on {linux-aarch64, osx-arm64}|
|[libarrow-acero](https://prefix.dev/channels/conda-forge/packages/libarrow-acero)|23.0.0|23.0.1|Patch Upgrade|*all envs* on {linux-aarch64, osx-arm64}|
|[libarrow-compute](https://prefix.dev/channels/conda-forge/packages/libarrow-compute)|23.0.0|23.0.1|Patch Upgrade|*all envs* on {linux-aarch64, osx-arm64}|
|[libarrow-dataset](https://prefix.dev/channels/conda-forge/packages/libarrow-dataset)|23.0.0|23.0.1|Patch Upgrade|*all envs* on {linux-aarch64, osx-arm64}|
|[libarrow-substrait](https://prefix.dev/channels/conda-forge/packages/libarrow-substrait)|23.0.0|23.0.1|Patch Upgrade|*all envs* on {linux-aarch64, osx-arm64}|
|[libexpat](https://prefix.dev/channels/conda-forge/packages/libexpat)|2.7.3|2.7.4|Patch Upgrade|*all*|
|[libglib](https://prefix.dev/channels/conda-forge/packages/libglib)|2.86.3|2.86.4|Patch Upgrade|*all*|
|[libparquet](https://prefix.dev/channels/conda-forge/packages/libparquet)|23.0.0|23.0.1|Patch Upgrade|*all envs* on {linux-aarch64, osx-arm64}|
|[nh3](https://prefix.dev/channels/conda-forge/packages/nh3)|0.3.2|0.3.3|Patch Upgrade|*all*|
|[nodejs](https://prefix.dev/channels/conda-forge/packages/nodejs)|24.13.0|24.13.1|Patch Upgrade|*all envs* on {linux-64, win-64}|
|[pyarrow-core](https://prefix.dev/channels/conda-forge/packages/pyarrow-core)|23.0.0|23.0.1|Patch Upgrade|*all envs* on {linux-aarch64, osx-arm64}|
|[pyside6](https://prefix.dev/channels/conda-forge/packages/pyside6)|6.10.1|6.10.2|Patch Upgrade|*all envs* on {linux-64, win-64}|
|[qt6-main](https://prefix.dev/channels/conda-forge/packages/qt6-main)|6.10.1|6.10.2|Patch Upgrade|*all envs* on {linux-64, win-64}|
|[rich](https://prefix.dev/channels/conda-forge/packages/rich)|14.3.2|14.3.3|Patch Upgrade|*all*|
|[rust-std-aarch64-apple-darwin](https://prefix.dev/channels/conda-forge/packages/rust-std-aarch64-apple-darwin)|1.93.0|1.93.1|Patch Upgrade|*all envs* on osx-arm64|
|[rust-std-aarch64-unknown-linux-gnu](https://prefix.dev/channels/conda-forge/packages/rust-std-aarch64-unknown-linux-gnu)|1.93.0|1.93.1|Patch Upgrade|*all envs* on linux-aarch64|
|[rust-std-x86_64-pc-windows-msvc](https://prefix.dev/channels/conda-forge/packages/rust-std-x86_64-pc-windows-msvc)|1.93.0|1.93.1|Patch Upgrade|*all envs* on win-64|
|[rust-std-x86_64-unknown-linux-gnu](https://prefix.dev/channels/conda-forge/packages/rust-std-x86_64-unknown-linux-gnu)|1.93.0|1.93.1|Patch Upgrade|*all envs* on linux-64|
|[unicodedata2](https://prefix.dev/channels/conda-forge/packages/unicodedata2)|17.0.0|17.0.1|Patch Upgrade|py312 on *all platforms*|
|[uv](https://prefix.dev/channels/conda-forge/packages/uv)|0.10.2|0.10.4|Patch Upgrade|*all*|
|[_openmp_mutex](https://prefix.dev/channels/conda-forge/packages/_openmp_mutex)|2_gnu|20_gnu|Only build string|*all envs* on {linux-64, linux-aarch64, win-64}|
|[aws-sdk-cpp](https://prefix.dev/channels/conda-forge/packages/aws-sdk-cpp)|h88278f4_10|h98721c9_13|Only build string|*all envs* on linux-aarch64|
|[aws-sdk-cpp](https://prefix.dev/channels/conda-forge/packages/aws-sdk-cpp)|h4e1b0f7_10|h71a6bcd_13|Only build string|*all envs* on osx-arm64|
|[bzip2](https://prefix.dev/channels/conda-forge/packages/bzip2)|hda65f42_8|hda65f42_9|Only build string|*all envs* on linux-64|
|[bzip2](https://prefix.dev/channels/conda-forge/packages/bzip2)|hd037594_8|hd037594_9|Only build string|*all envs* on osx-arm64|
|[bzip2](https://prefix.dev/channels/conda-forge/packages/bzip2)|h4777abc_8|h4777abc_9|Only build string|*all envs* on linux-aarch64|
|[bzip2](https://prefix.dev/channels/conda-forge/packages/bzip2)|h0ad9c76_8|h0ad9c76_9|Only build string|*all envs* on win-64|
|[cairo](https://prefix.dev/channels/conda-forge/packages/cairo)|h3394656_0|he90730b_1|Only build string|*all envs* on linux-64|
|[cairo](https://prefix.dev/channels/conda-forge/packages/cairo)|h5782bbf_0|h477c42c_1|Only build string|*all envs* on win-64|
|[dask](https://prefix.dev/channels/conda-forge/packages/dask)|pyhcf101f3_0|pyhcf101f3_1|Only build string|*all*|
|[distributed](https://prefix.dev/channels/conda-forge/packages/distributed)|pyhcf101f3_0|pyhcf101f3_1|Only build string|*all*|
|[eigen](https://prefix.dev/channels/conda-forge/packages/eigen)|h171cf75_1|h54a6638_1|Only build string|*all envs* on linux-64|
|[eigen](https://prefix.dev/channels/conda-forge/packages/eigen)|h477610d_1|h5112557_1|Only build string|*all envs* on win-64|
|[gcc_impl_linux-64](https://prefix.dev/channels/conda-forge/packages/gcc_impl_linux-64)|h56f5909_17|he420e7e_18|Only build string|*all envs* on linux-64|
|[gcc_impl_linux-aarch64](https://prefix.dev/channels/conda-forge/packages/gcc_impl_linux-aarch64)|h1bda88d_17|hcedddb3_18|Only build string|*all envs* on linux-aarch64|
|[gdal](https://prefix.dev/channels/conda-forge/packages/gdal)|py313h6de05c7_0|py313h6de05c7_1|Only build string|default on win-64|
|[gdal](https://prefix.dev/channels/conda-forge/packages/gdal)|py313h1ee8c46_0|py313h1ee8c46_1|Only build string|default on linux-64|
|[gdal](https://prefix.dev/channels/conda-forge/packages/gdal)|py312h7ee17fb_0|py312h7ee17fb_1|Only build string|py312 on win-64|
|[gdal](https://prefix.dev/channels/conda-forge/packages/gdal)|py312h5fc20e3_0|py312h5fc20e3_1|Only build string|py312 on linux-64|
|[jupyter_events](https://prefix.dev/channels/conda-forge/packages/jupyter_events)|pyh29332c3_0|pyhe01879c_0|Only build string|*all*|
|[libarrow](https://prefix.dev/channels/conda-forge/packages/libarrow)|h258748b_2_cuda|h40b5c2d_2_cpu|Only build string|*all envs* on linux-64|
|[libarrow-acero](https://prefix.dev/channels/conda-forge/packages/libarrow-acero)|h635bf11_2_cuda|h635bf11_2_cpu|Only build string|*all envs* on linux-64|
|[libarrow-compute](https://prefix.dev/channels/conda-forge/packages/libarrow-compute)|h8c2c5c3_2_cuda|h8c2c5c3_2_cpu|Only build string|*all envs* on linux-64|
|[libarrow-dataset](https://prefix.dev/channels/conda-forge/packages/libarrow-dataset)|h635bf11_2_cuda|h635bf11_2_cpu|Only build string|*all envs* on linux-64|
|[libarrow-substrait](https://prefix.dev/channels/conda-forge/packages/libarrow-substrait)|h3f74fd7_2_cuda|h3f74fd7_2_cpu|Only build string|*all envs* on linux-64|
|[libclang13](https://prefix.dev/channels/conda-forge/packages/libclang13)|default_h13b06bd_2|default_h13b06bd_3|Only build string|*all envs* on osx-arm64|
|[libgcc](https://prefix.dev/channels/conda-forge/packages/libgcc)|he0feb66_17|he0feb66_18|Only build string|*all envs* on linux-64|
|[libgcc](https://prefix.dev/channels/conda-forge/packages/libgcc)|hcbb3090_17|hcbb3090_18|Only build string|*all envs* on osx-arm64|
|[libgcc](https://prefix.dev/channels/conda-forge/packages/libgcc)|h8ee18e1_17|h8ee18e1_18|Only build string|*all envs* on win-64|
|[libgcc](https://prefix.dev/channels/conda-forge/packages/libgcc)|h8acb6b2_17|h8acb6b2_18|Only build string|*all envs* on linux-aarch64|
|[libgcc-devel_linux-64](https://prefix.dev/channels/conda-forge/packages/libgcc-devel_linux-64)|hcc6f6b0_117|hcc6f6b0_118|Only build string|*all envs* on linux-64|
|[libgcc-devel_linux-aarch64](https://prefix.dev/channels/conda-forge/packages/libgcc-devel_linux-aarch64)|h55c397f_117|h55c397f_118|Only build string|*all envs* on linux-aarch64|
|[libgcc-ng](https://prefix.dev/channels/conda-forge/packages/libgcc-ng)|he9431aa_17|he9431aa_18|Only build string|*all envs* on linux-aarch64|
|[libgcc-ng](https://prefix.dev/channels/conda-forge/packages/libgcc-ng)|h69a702a_17|h69a702a_18|Only build string|*all envs* on linux-64|
|[libgdal](https://prefix.dev/channels/conda-forge/packages/libgdal)|h8233c4f_0|h8233c4f_1|Only build string|*all envs* on linux-64|
|[libgdal](https://prefix.dev/channels/conda-forge/packages/libgdal)|h14234a7_0|h14234a7_1|Only build string|*all envs* on win-64|
|[libgdal-core](https://prefix.dev/channels/conda-forge/packages/libgdal-core)|h99a1ccd_0|h99a1ccd_1|Only build string|*all envs* on linux-aarch64|
|[libgdal-core](https://prefix.dev/channels/conda-forge/packages/libgdal-core)|h779b996_0|h779b996_1|Only build string|*all envs* on osx-arm64|
|[libgfortran](https://prefix.dev/channels/conda-forge/packages/libgfortran)|he9431aa_17|he9431aa_18|Only build string|*all envs* on linux-aarch64|
|[libgfortran](https://prefix.dev/channels/conda-forge/packages/libgfortran)|h69a702a_17|h69a702a_18|Only build string|*all envs* on linux-64|
|[libgfortran](https://prefix.dev/channels/conda-forge/packages/libgfortran)|h07b0088_17|h07b0088_18|Only build string|*all envs* on osx-arm64|
|[libgfortran5](https://prefix.dev/channels/conda-forge/packages/libgfortran5)|hdae7583_17|hdae7583_18|Only build string|*all envs* on osx-arm64|
|[libgfortran5](https://prefix.dev/channels/conda-forge/packages/libgfortran5)|h68bc16d_17|h68bc16d_18|Only build string|*all envs* on linux-64|
|[libgfortran5](https://prefix.dev/channels/conda-forge/packages/libgfortran5)|h1b7bec0_17|h1b7bec0_18|Only build string|*all envs* on linux-aarch64|
|[libgomp](https://prefix.dev/channels/conda-forge/packages/libgomp)|he0feb66_17|he0feb66_18|Only build string|*all envs* on linux-64|
|[libgomp](https://prefix.dev/channels/conda-forge/packages/libgomp)|h8ee18e1_17|h8ee18e1_18|Only build string|*all envs* on win-64|
|[libgomp](https://prefix.dev/channels/conda-forge/packages/libgomp)|h8acb6b2_17|h8acb6b2_18|Only build string|*all envs* on linux-aarch64|
|[libparquet](https://prefix.dev/channels/conda-forge/packages/libparquet)|h7376487_2_cuda|h7376487_2_cpu|Only build string|*all envs* on linux-64|
|[libsanitizer](https://prefix.dev/channels/conda-forge/packages/libsanitizer)|he19c465_17|he19c465_18|Only build string|*all envs* on linux-aarch64|
|[libsanitizer](https://prefix.dev/channels/conda-forge/packages/libsanitizer)|h90f66d4_17|h90f66d4_18|Only build string|*all envs* on linux-64|
|[libsqlite](https://prefix.dev/channels/conda-forge/packages/libsqlite)|h0c1763c_0|hf4e2dac_0|Only build string|*all envs* on linux-64|
|[libstdcxx](https://prefix.dev/channels/conda-forge/packages/libstdcxx)|hef695bb_17|hef695bb_18|Only build string|*all envs* on linux-aarch64|
|[libstdcxx](https://prefix.dev/channels/conda-forge/packages/libstdcxx)|h934c35e_17|h934c35e_18|Only build string|*all envs* on linux-64|
|[libstdcxx-devel_linux-64](https://prefix.dev/channels/conda-forge/packages/libstdcxx-devel_linux-64)|hd446a21_117|hd446a21_118|Only build string|*all envs* on linux-64|
|[libstdcxx-devel_linux-aarch64](https://prefix.dev/channels/conda-forge/packages/libstdcxx-devel_linux-aarch64)|ha7b1723_117|ha7b1723_118|Only build string|*all envs* on linux-aarch64|
|[libstdcxx-ng](https://prefix.dev/channels/conda-forge/packages/libstdcxx-ng)|hdf11a46_17|hdf11a46_18|Only build string|*all envs* on linux-64|
|[libstdcxx-ng](https://prefix.dev/channels/conda-forge/packages/libstdcxx-ng)|hdbbeba8_17|hdbbeba8_18|Only build string|*all envs* on linux-aarch64|
|[libxml2](https://prefix.dev/channels/conda-forge/packages/libxml2)|h26afc86_0|he237659_1|Only build string|*all envs* on linux-64|
|[libxml2](https://prefix.dev/channels/conda-forge/packages/libxml2)|ha29bfb0_0|h779ef1b_1|Only build string|*all envs* on win-64|
|[libxml2-16](https://prefix.dev/channels/conda-forge/packages/libxml2-16)|ha9997c6_0|hca6bf5a_1|Only build string|*all envs* on linux-64|
|[libxml2-16](https://prefix.dev/channels/conda-forge/packages/libxml2-16)|h06f855e_0|h3cfd58e_1|Only build string|*all envs* on win-64|
|[libxml2-devel](https://prefix.dev/channels/conda-forge/packages/libxml2-devel)|h26afc86_0|he237659_1|Only build string|*all envs* on linux-64|
|[libxml2-devel](https://prefix.dev/channels/conda-forge/packages/libxml2-devel)|ha29bfb0_0|h779ef1b_1|Only build string|*all envs* on win-64|
|[proj](https://prefix.dev/channels/conda-forge/packages/proj)|hfb14a63_2|hfb14a63_3|Only build string|*all envs* on osx-arm64|
|[proj](https://prefix.dev/channels/conda-forge/packages/proj)|he0df7b0_2|he0df7b0_3|Only build string|*all envs* on linux-64|
|[proj](https://prefix.dev/channels/conda-forge/packages/proj)|hd30e2cd_2|hd30e2cd_3|Only build string|*all envs* on win-64|
|[proj](https://prefix.dev/channels/conda-forge/packages/proj)|hd211770_2|hd211770_3|Only build string|*all envs* on linux-aarch64|
|[pyarrow-core](https://prefix.dev/channels/conda-forge/packages/pyarrow-core)|py313hfe0801a_0_cuda|py313h98bfbea_0_cpu|Only build string|default on linux-64|
|[pyarrow-core](https://prefix.dev/channels/conda-forge/packages/pyarrow-core)|py312hfa4fb80_0_cuda|py312h2054cf2_0_cpu|Only build string|py312 on linux-64|
|[pytokens](https://prefix.dev/channels/conda-forge/packages/pytokens)|py313h6688731_0|py313h6688731_1|Only build string|default on osx-arm64|
|[pytokens](https://prefix.dev/channels/conda-forge/packages/pytokens)|py313h62ef0ea_0|py313h62ef0ea_1|Only build string|default on linux-aarch64|
|[pytokens](https://prefix.dev/channels/conda-forge/packages/pytokens)|py313h5fd188c_0|py313h5fd188c_1|Only build string|default on win-64|
|[pytokens](https://prefix.dev/channels/conda-forge/packages/pytokens)|py313h54dd161_0|py313h54dd161_1|Only build string|default on linux-64|
|[pytokens](https://prefix.dev/channels/conda-forge/packages/pytokens)|py312he5662c2_0|py312he5662c2_1|Only build string|py312 on win-64|
|[pytokens](https://prefix.dev/channels/conda-forge/packages/pytokens)|py312hd41f8a7_0|py312hd41f8a7_1|Only build string|py312 on linux-aarch64|
|[pytokens](https://prefix.dev/channels/conda-forge/packages/pytokens)|py312hb3ab3e3_0|py312hb3ab3e3_1|Only build string|py312 on osx-arm64|
|[pytokens](https://prefix.dev/channels/conda-forge/packages/pytokens)|py312h5253ce2_0|py312h5253ce2_1|Only build string|py312 on linux-64|
|[pyzmq](https://prefix.dev/channels/conda-forge/packages/pyzmq)|py312h4552c38_0|py312hdf0a211_2|Only build string|*all envs* on linux-aarch64|
|[pyzmq](https://prefix.dev/channels/conda-forge/packages/pyzmq)|py312hfb55c3c_0|py312hda471dd_2|Only build string|*all envs* on linux-64|
|[pyzmq](https://prefix.dev/channels/conda-forge/packages/pyzmq)|py312hbb5da91_0|py312h343a6d4_2|Only build string|*all envs* on win-64|
|[pyzmq](https://prefix.dev/channels/conda-forge/packages/pyzmq)|py312hd65ceae_0|py312h022ad19_2|Only build string|*all envs* on osx-arm64|
|[qt-main](https://prefix.dev/channels/conda-forge/packages/qt-main)|hb098fff_6|he584256_7|Only build string|*all envs* on win-64|
|[qt-main](https://prefix.dev/channels/conda-forge/packages/qt-main)|h3c3fd16_6|hc240232_7|Only build string|*all envs* on linux-64|
|[qtwebkit](https://prefix.dev/channels/conda-forge/packages/qtwebkit)|hf6b0a6a_19|h88b4fcc_20|Only build string|*all envs* on win-64|
|[qtwebkit](https://prefix.dev/channels/conda-forge/packages/qtwebkit)|h8c5e15c_19|h78f6ad5_20|Only build string|*all envs* on linux-64|
|[send2trash](https://prefix.dev/channels/conda-forge/packages/send2trash)|pyha191276_0|pyha191276_1|Only build string|*all envs* on {linux-64, linux-aarch64}|
|[send2trash](https://prefix.dev/channels/conda-forge/packages/send2trash)|pyh6dadd2b_0|pyh6dadd2b_1|Only build string|*all envs* on win-64|
|[send2trash](https://prefix.dev/channels/conda-forge/packages/send2trash)|pyh5552912_0|pyh5552912_1|Only build string|*all envs* on osx-arm64|
|[sqlite](https://prefix.dev/channels/conda-forge/packages/sqlite)|hbc0de68_0|h04a0ce9_0|Only build string|*all envs* on linux-64|
|[xerces-c](https://prefix.dev/channels/conda-forge/packages/xerces-c)|h988505b_0|hd9031aa_1|Only build string|*all envs* on linux-64|

</details>

[^1]: **Bold** means explicit dependency.
[^2]: Dependency got downgraded.

