### PR TITLE
Remove global workload preference

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.5"
 manifest_format = "2.0"
-project_hash = "26542586f8af377af869d7ce9db546cfa94e31b3"
+project_hash = "786233d61b1d8d10e772c102cb74a416609d3477"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "f7304359109c768cf32dc5fa2d371565bb63b68a"

--- a/Project.toml
+++ b/Project.toml
@@ -62,7 +62,6 @@ PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
 PkgToSoftwareBOM = "6254a0f9-6143-4104-aa2e-fd339a2830a6"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Ribasim = "aac5e3d9-0b8f-4d4f-8241-b1a7a9632635"
@@ -93,6 +92,3 @@ PkgToSoftwareBOM = "0.1.17"
 Plots = "1.41.4"
 PythonCall = "=0.9.31"
 Revise = "3.13.1"
-
-[preferences.Ribasim]
-precompile_workload = false

--- a/build/build.jl
+++ b/build/build.jl
@@ -1,8 +1,6 @@
 using TOML
 using LibGit2
 using JuliaC
-using Preferences: set_preferences!, delete_preferences!
-using UUIDs: UUID
 import Pkg
 
 function (@main)(_)::Cint
@@ -10,12 +8,6 @@ function (@main)(_)::Cint
     license_file = "LICENSE"
     output_dir = "build/ribasim"
     git_repo = "."
-
-    # Set release options in core/LocalPreferences.toml
-    uuid = UUID("aac5e3d9-0b8f-4d4f-8241-b1a7a9632635")  # Ribasim
-    Pkg.activate("core")
-    set_preferences!(uuid, "precompile_workload" => true; force = true)
-    Pkg.activate(".")
 
     rm(output_dir; force = true, recursive = true)
 
@@ -57,11 +49,6 @@ function (@main)(_)::Cint
     ribasim = Sys.iswindows() ? "ribasim.exe" : "ribasim"
     mkpath("build/ribasim/bin")
     cp("build/cli/target/release/$ribasim", "build/ribasim/bin/$ribasim"; force = true)
-
-    # Restore development options in core/LocalPreferences.toml
-    Pkg.activate("core")
-    delete_preferences!(uuid, "precompile_workload"; force = true)
-    Pkg.activate(".")
 
     return 0
 end

--- a/core/Project.toml
+++ b/core/Project.toml
@@ -44,7 +44,6 @@ OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
-Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
@@ -95,7 +94,6 @@ OrdinaryDiffEqRosenbrock = "1.22"
 OrdinaryDiffEqSDIRK = "1.11"
 OrdinaryDiffEqTsit5 = "1.9"
 PrecompileTools = "1.2.1"
-Preferences = "1.4.3"
 Printf = "1"
 SQLite = "1.5.1"
 SciMLBase = "2.36"
@@ -111,6 +109,3 @@ julia = "1.12"
 
 [preferences.LinearSolve]
 LoadMKL_JLL = false
-
-[preferences.Ribasim]
-precompile_workload = false


### PR DESCRIPTION
Usually you want to run a model anyway, so running the workload during development is not bad.
And if you still prefer to disable it you can set it in `LocalPreferences.toml`, which is gitignored.

https://julialang.github.io/PrecompileTools.jl/stable/#Package-developers:-reducing-the-cost-of-precompilation-during-development
