### PR TITLE
Docs: overwrite `run_ribasim`

### DIFF
--- a/docs/getting-started/examples.qmd
+++ b/docs/getting-started/examples.qmd
@@ -5,16 +5,6 @@ jupyter: python3
 
 This is an overview of example codes to set-up and run models.
 
-```{python}
-#| eval: false
-from ribasim import run_ribasim
-```
-
-```{python}
-#| include: false
-%run ../run_ribasim.py
-```
-
 # Basic model with static forcing
 
 ```{python}
@@ -31,7 +21,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from ribasim import Allocation, Model, Node, Solver
+from ribasim import Allocation, Model, Node, Solver, run_ribasim
 from ribasim.config import Experimental
 from ribasim.nodes import (
     basin,
@@ -49,6 +39,11 @@ from ribasim.nodes import (
     user_demand,
 )
 from shapely.geometry import Point
+```
+
+```{python}
+#| include: false
+%run ../run_ribasim.py
 ```
 
 ```{python}

--- a/docs/getting-started/tutorial/irrigation-demand.qmd
+++ b/docs/getting-started/tutorial/irrigation-demand.qmd
@@ -4,23 +4,13 @@ jupyter: python3
 ---
 
 ```{python}
-#| eval: false
-from ribasim import run_ribasim
-```
-
-```{python}
-#| include: false
-%run ../../run_ribasim.py
-```
-
-```{python}
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import pandas as pd
 import plotly.express as px
 import xarray as xr
-from ribasim import Model, Node
+from ribasim import Model, Node, run_ribasim
 from ribasim.nodes import (
     basin,
     flow_boundary,
@@ -28,6 +18,11 @@ from ribasim.nodes import (
     user_demand,
 )
 from shapely.geometry import Point
+```
+
+```{python}
+#| include: false
+%run ../../run_ribasim.py
 ```
 
 ```{python}

--- a/docs/getting-started/tutorial/natural-flow.qmd
+++ b/docs/getting-started/tutorial/natural-flow.qmd
@@ -3,16 +3,6 @@ title: Natural flow
 jupyter: python3
 ---
 
-```{python}
-#| eval: false
-from ribasim import run_ribasim
-```
-
-```{python}
-#| include: false
-%run ../../run_ribasim.py
-```
-
 # Introduction
 Welcome to Ribasim!
 This tutorial will help you get started with the basics of using Ribasim for river basin simulation.
@@ -63,9 +53,14 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import pandas as pd
 import xarray as xr
-from ribasim import Model, Node
+from ribasim import Model, Node, run_ribasim
 from ribasim.nodes import basin, flow_boundary, tabulated_rating_curve
 from shapely.geometry import Point
+```
+
+```{python}
+#| include: false
+%run ../../run_ribasim.py
 ```
 
 ### Setup paths and model configuration

--- a/docs/getting-started/tutorial/reservoir.qmd
+++ b/docs/getting-started/tutorial/reservoir.qmd
@@ -4,23 +4,13 @@ jupyter: python3
 ---
 
 ```{python}
-#| eval: false
-from ribasim import run_ribasim
-```
-
-```{python}
-#| include: false
-%run ../../run_ribasim.py
-```
-
-```{python}
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import pandas as pd
 import plotly.express as px
 import xarray as xr
-from ribasim import Model, Node
+from ribasim import Model, Node, run_ribasim
 from ribasim.nodes import (
     basin,
     flow_boundary,
@@ -28,6 +18,11 @@ from ribasim.nodes import (
     user_demand,
 )
 from shapely.geometry import Point
+```
+
+```{python}
+#| include: false
+%run ../../run_ribasim.py
 ```
 
 ```{python}

--- a/docs/guide/delwaq.qmd
+++ b/docs/guide/delwaq.qmd
@@ -3,16 +3,6 @@ title: Ribasim Delwaq coupling
 jupyter: python3
 ---
 
-```{python}
-#| eval: false
-from ribasim import run_ribasim
-```
-
-```{python}
-#| include: false
-%run ../run_ribasim.py
-```
-
 In order to generate the Delwaq input files, we need a completed Ribasim simulation (typically one with a results folder) that ideally also includes some substances and initial concentrations. Let's take the basic test model for example, which already has set some initial concentrations.
 
 All testmodels can be [downloaded from here](/getting-started/install.qmd).
@@ -30,7 +20,7 @@ assert toml_path.is_file()
 This Ribasim model already has substance concentrations for `Cl` and `Tracer` in the input tables, and we will use these to generate the Delwaq input files.
 
 ```{python}
-from ribasim import Model
+from ribasim import Model, run_ribasim
 
 model = Model.read(toml_path)
 
@@ -39,6 +29,11 @@ display(model.basin.concentration)  # basin boundaries
 display(model.flow_boundary.concentration)  # flow boundaries
 display(model.level_boundary.concentration)  # level boundaries
 model.plot();  # for later comparison
+```
+
+```{python}
+#| include: false
+%run ../run_ribasim.py
 ```
 
 ```{python}

--- a/docs/run_ribasim.py
+++ b/docs/run_ribasim.py
@@ -8,10 +8,9 @@ import Ribasim, and define the `run_ribasim` function.
 In a file where multiple simulations are run this has the benefit
 of only needing to start Julia once, compared to `subprocess.run`.
 
-Since Ribasim Python also has `run_ribasim`, we can include
-this script in a hidden evaluated cell, and put `from ribasim import run_ribasim`
-in a visible unevaluated cell. That way we can run this version on CI but
-it looks like we run the Ribasim Python version.
+Since Ribasim Python also has `run_ribasim`, we can include this script
+in a hidden evaluated cell, after `from ribasim import run_ribasim`.
+That way we can run this version on CI but it looks like we run the Ribasim Python version.
 """
 
 from pathlib import Path


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/2700

We overwrite the ribasim function with our hidden function that runs the julia code, so we don't need to have a ribasim binary at doc build time.