### PR TITLE
Add millisecond precision to fake `last_change`

### DIFF
--- a/python/ribasim/ribasim/__init__.py
+++ b/python/ribasim/ribasim/__init__.py
@@ -12,7 +12,7 @@ from ribasim.model import Model
 
 set_gdal_config_options(
     {
-        "OGR_CURRENT_DATE": fake_date,  # %Y-%m-%dT%H:%M:%fZ
+        "OGR_CURRENT_DATE": fake_date,  # %Y-%m-%dT%H:%M:%S.%fZ
     }
 )
 

--- a/python/ribasim/ribasim/db_utils.py
+++ b/python/ribasim/ribasim/db_utils.py
@@ -4,7 +4,7 @@ from sqlite3 import Connection, connect
 
 # A fixed date for `last_change` fields in the metadata tables in a geopackage
 # so the hash of the geopackage doesn't change when regenerated.
-fake_date = "2022-02-22T20:22:02Z"  # %Y-%m-%dT%H:%M:%fZ
+fake_date = "2022-02-22T20:22:02.000Z"  # %Y-%m-%dT%H:%M:%S.%fZ
 
 
 def esc_id(identifier: str) -> str:


### PR DESCRIPTION
@gijsber is trying to load our GeoPackage into FEWS, but the Java libraries don't like it that we don't have millisecond precision in our database.

<img width="826" height="168" alt="Screenshot 2026-03-10 111228" src="https://github.com/user-attachments/assets/01b0946a-6be2-4dd5-b388-b27b53829caf" />

@evetion can you confirm if I 000 is the right millisecond, or does it need more 2s?

From https://github.com/Deltares/Ribasim/pull/2765