### PR TITLE
remove dangling listen links

### DIFF
--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -340,9 +340,47 @@ class Model(FileModel, ParentModel):
         self._remove_node_id(node_id)
         self.link._remove_node_id(node_id)
 
+    def _remove_dangling_listen_links(self, control_node_id: int) -> None:
+        """Check if this control node still has control links. If not, remove all listen links.
+
+        Args:
+            control_node_id (int): The ID of the control node to check for dangling listen links.
+        """
+        if self.link.df is None or self.node.df is None:
+            return
+
+        has_remaining_control_links = (
+            (self.link.df["link_type"] == "control")
+            & (self.link.df["from_node_id"] == control_node_id)
+        ).any()
+
+        # If there are remaining control links, we keep the listen links.
+        if has_remaining_control_links:
+            return
+
+        # There are no remaining control links, so we collect all listen links pointing to this control node
+        listen_link_ids = self.link.df.index[
+            (self.link.df["link_type"] == "listen")
+            & (self.link.df["to_node_id"] == control_node_id)
+        ].tolist()
+
+        #  And remove them
+        for listen_link_id in listen_link_ids:
+            self.link._remove_link_id(listen_link_id)
+
     def remove_link(self, link_id: int) -> None:
         """Remove a link from the model."""
+        if self.link.df is None or link_id not in self.link.df.index:
+            return
+
+        removed_link = self.link.df.loc[link_id]
         self.link._remove_link_id(link_id)
+
+        if removed_link["link_type"] != "control":
+            return
+
+        control_node_id = int(removed_link["from_node_id"])
+        self._remove_dangling_listen_links(control_node_id)
 
     def _nodes(self) -> Generator[NodeModel, None, None]:
         """Return all non-empty NodeModel instances."""

--- a/python/ribasim/tests/test_model.py
+++ b/python/ribasim/tests/test_model.py
@@ -130,7 +130,7 @@ def test_control_link_adds_listen_links(discrete_control_of_pid_control):
     listen_links = model.link.df.loc[model.link.df["link_type"] == "listen"]
     assert len(listen_links) == 2
     assert set(
-        zip(listen_links["from_node_id"], listen_links["to_node_id"], strict=False)
+        zip(listen_links["from_node_id"], listen_links["to_node_id"], strict=True)
     ) == {
         (3, 6),
         (1, 7),
@@ -159,12 +159,12 @@ def test_write_adds_missing_listen_links(discrete_control_of_pid_control, tmp_pa
         df = pd.read_sql_query(query, connection)
 
     assert len(df) == 2
-    written_pairs = set(zip(df["from_node_id"], df["to_node_id"], strict=False))
+    written_pairs = set(zip(df["from_node_id"], df["to_node_id"], strict=True))
     assert written_pairs == {(3, 6), (1, 7)}
 
 
-def test_remove_control_node_removes_listen_links(discrete_control_of_pid_control):
-    """Removing a control node removes all links connected to it, including listen links."""
+def test_remove_control_link_removes_listen_links(discrete_control_of_pid_control):
+    """Removing a control link removes listen links attached to that control node."""
     model = discrete_control_of_pid_control
     assert model.link.df is not None
 
@@ -172,22 +172,37 @@ def test_remove_control_node_removes_listen_links(discrete_control_of_pid_contro
         zip(
             model.link.df.loc[model.link.df["link_type"] == "listen", "from_node_id"],
             model.link.df.loc[model.link.df["link_type"] == "listen", "to_node_id"],
-            strict=False,
+            strict=True,
         )
     )
     assert (3, 6) in listen_pairs_before
+    assert (1, 7) in listen_pairs_before
 
-    model.remove_node(6)
+    control_link_mask = (
+        (model.link.df["link_type"] == "control")
+        & (model.link.df["from_node_id"] == 6)
+        & (model.link.df["to_node_id"] == 2)
+    )
+    control_link_ids = model.link.df.index[control_link_mask].tolist()
+    assert len(control_link_ids) == 1
+    model.remove_link(control_link_ids[0])
 
     assert model.link.df is not None
-    assert (model.link.df["from_node_id"] == 6).sum() == 0
-    assert (model.link.df["to_node_id"] == 6).sum() == 0
+    remaining_control_pairs = set(
+        zip(
+            model.link.df.loc[model.link.df["link_type"] == "control", "from_node_id"],
+            model.link.df.loc[model.link.df["link_type"] == "control", "to_node_id"],
+            strict=True,
+        )
+    )
+    assert (6, 2) not in remaining_control_pairs
+    assert (7, 6) in remaining_control_pairs
 
     listen_pairs_after = set(
         zip(
             model.link.df.loc[model.link.df["link_type"] == "listen", "from_node_id"],
             model.link.df.loc[model.link.df["link_type"] == "listen", "to_node_id"],
-            strict=False,
+            strict=True,
         )
     )
     assert (3, 6) not in listen_pairs_after


### PR DESCRIPTION
Since we implicitly add the required listen links to control links, we should also implicitly remove them if a control node has no control link anymore.  fixes #2976. 