### PR TITLE
Fix relative path to Ribasim source

### DIFF
--- a/core/test/Project.toml
+++ b/core/test/Project.toml
@@ -36,7 +36,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 
 [sources]
-Ribasim = {path = "core"}
+Ribasim = {path = ".."}
 
 [compat]
 Aqua = "0.8"


### PR DESCRIPTION
From the test Project.toml it is one level up. Perhaps this worked because at the root Project the path is correct.