### PR TITLE
[Delwaq] Change system timer, and verbosity control.

### DIFF
--- a/python/ribasim/ribasim/delwaq/generate.py
+++ b/python/ribasim/ribasim/delwaq/generate.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from ribasim import Model, nodes
+from ribasim.config import Verbosity
 from ribasim.utils import (
     MissingOptionalModule,
     _concat,
@@ -647,6 +648,7 @@ def generate(
                 nexchanges=total_exchanges,
                 substances=sorted(substances),
                 ribasim_version=ribasim.__version__,
+                loglevel=loglevel(model.logging.verbosity),
             )
         )
 
@@ -696,6 +698,22 @@ def add_tracer(
         nt.concentration = table
     else:
         nt.concentration = pd.concat([nt.concentration.df, table.df], ignore_index=True)
+
+
+def loglevel(verbosity: Verbosity) -> int:
+    if verbosity == Verbosity.debug:
+        # administration of monitoring locations, boundary link administration,
+        # boundary names and IDs, boundary time lags, waste load names and IDs,
+        # specific information on cells where defaults are overridden
+        # any variable time step specification
+        return 9
+    elif verbosity == Verbosity.info:
+        # grid layouts, dispersion IDs and fields, boundary types,
+        # waste load types, names of constants, parameters, functions, segment functions
+        return 2
+    else:
+        # only very basic output + substance names
+        return 1
 
 
 if __name__ == "__main__":

--- a/python/ribasim/ribasim/delwaq/template/delwaq.inp.j2
+++ b/python/ribasim/ribasim/delwaq/template/delwaq.inp.j2
@@ -1,6 +1,6 @@
 1000 80 ';'
 ;DELWAQ_VERSION_4.910                               ; Delwaq version number
-;PRINT_OUTPUT_OPTION_9                              ; Debug level
+;PRINT_OUTPUT_OPTION_{{ loglevel }}                              ; Debug level
 
 ; TEMPLATE FILE FOR WATER QUALITY CALCULATION
 ; First input block
@@ -22,7 +22,7 @@
 
 ;###############################################################################
 ; Second input block
-1 'DDHHMMSS' 'DDHHMMSS'                         ; system clock
+86400 'DDHHMMSS' 'DDHHMMSS'                         ; system clock
 ; Integration options:
 15.70 											    ; integration option, no balance keywords yet
 


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim-NL/issues/534

Also adds verbosity control based on the verbosity of the Ribasim model. Currently it is set to debug, which becomes very slow for large models, as it prints all individual boundaries + timeseries.