### PR TITLE
Fix integration test

### DIFF
--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -2030,7 +2030,15 @@ the final NamedTuple.
 function typed_columntable(table, ::Type{T})::NamedTuple where {T <: Table}
     names_T = fieldnames(T)
     types_T = fieldtypes(T)
+    n_row = isempty(table) ? 0 : length(first(values(table)))
     for (name, target_type) in zip(names_T, types_T)
+        if !haskey(table, name)
+            if Missing <: target_type
+                table[name] = fill(missing, n_row)
+            else
+                throw(ArgumentError("Missing required column $(name) for table $(T)."))
+            end
+        end
         col = table[name]
         if eltype(col) !== target_type
             target = Vector{target_type}(undef, length(col))


### PR DESCRIPTION
https://github.com/Deltares/Ribasim/pull/3033 broke the integration tests:

```
HWS model integration test: Error During Test at /opt/teamcityagent/work/ecd2b8f9b25b1609/ribasim/core/integration_test/hws_integration_test.jl:2
    Got exception outside of a @test
    LoadError: KeyError: key :allocation_controlled not found
    Stacktrace:
      [1] getindex
        @ /opt/teamcityagent/work/ecd2b8f9b25b1609/.julia/packages/OrderedCollections/Xihhq/src/ordered_dict.jl:387 [inlined]
      [2] typed_columntable(table::OrderedCollections.OrderedDict{Symbol, AbstractVector}, ::Type{Ribasim.Schema.TabulatedRatingCurve.Static})
        @ Ribasim /opt/teamcityagent/work/ecd2b8f9b25b1609/ribasim/core/src/read.jl:2034
      [3] load_data(db::SQLite.DB, config::Ribasim.config.Config, table_type::Type{Ribasim.Schema.TabulatedRatingCurve.Static})
        @ Ribasim /opt/teamcityagent/work/ecd2b8f9b25b1609/ribasim/core/src/read.jl:2004
      [4] load_structvector(db::SQLite.DB, config::Ribasim.config.Config, ::Type{Ribasim.Schema.TabulatedRatingCurve.Static})
        @ Ribasim /opt/teamcityagent/work/ecd2b8f9b25b1609/ribasim/core/src/read.jl:2056
      [5] Ribasim.TabulatedRatingCurve(db::SQLite.DB, config::Ribasim.config.Config, graph::MetaGraphsNext.MetaGraph{Int64, Graphs.SimpleGraphs.SimpleDiGraph{Int64}, Ribasim.NodeID, Ribasim.NodeMetadata, Ribasim.LinkMetadata, @NamedTuple{node_ids::Dict{Int32, OrderedCollections.OrderedSet{Ribasim.NodeID}}, saveat::Float64, internal_flow_links::Vector{Ribasim.LinkMetadata}, external_flow_links::Vector{Ribasim.LinkMetadata}, flow_link_map::SparseArrays.SparseMatrixCSC{Bool, Int64}}, Returns{Float64}, Float64})
        @ Ribasim /opt/teamcityagent/work/ecd2b8f9b25b1609/ribasim/core/src/read.jl:395
      [6] Ribasim.Parameters(db::SQLite.DB, config::Ribasim.config.Config)
        @ Ribasim /opt/teamcityagent/work/ecd2b8f9b25b1609/ribasim/core/src/read.jl:1619
      [7] Ribasim.Model(config::Ribasim.config.Config)
        @ Ribasim /opt/teamcityagent/work/ecd2b8f9b25b1609/ribasim/core/src/model.jl:141
      [8] run
        @ /opt/teamcityagent/work/ecd2b8f9b25b1609/ribasim/core/src/main.jl:11 [inlined]
      [9] run(config_path::String)
        @ Ribasim /opt/teamcityagent/work/ecd2b8f9b25b1609/ribasim/core/src/main.jl:8
     [10] top-level scope
        @ /opt/teamcityagent/work/ecd2b8f9b25b1609/ribasim/core/integration_test/hws_integration_test.jl:10
```

