### PR TITLE
Accept plain pd.DataFrame in TableModel.df typing

### DIFF
--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -403,11 +403,14 @@ class TableModel[TableT: _BaseSchema](FileModel, ChildModel):
     are represented by a filepath, and are ChildModels, as they're contained in a NodeModel.
     """
 
-    df: DataFrame[TableT] | None = Field(default=None, exclude=True, repr=False)
+    df: DataFrame[TableT] | pd.DataFrame | None = Field(
+        default=None, exclude=True, repr=False
+    )
     _sort_keys: list[str] = PrivateAttr(default=[])
 
     model_config = ConfigDict(
         extra="allow",
+        arbitrary_types_allowed=True,
     )
 
     def __eq__(self, other: object) -> bool:
@@ -709,12 +712,14 @@ class TableModel[TableT: _BaseSchema](FileModel, ChildModel):
     def tableschema(cls) -> TableT:
         """Retrieve Pandera Schema.
 
-        The type of the field `df` is known to always be an DataFrame[TableT]]] | None
+        The schema type is extracted from the annotation of the `df` field,
+        which contains a parameterized pandera type (e.g. DataFrame[TableT]) in the union.
         """
         optionalfieldtype = cls.model_fields["df"].annotation
-        fieldtype = optionalfieldtype.__args__[0]  # pyrefly: ignore[missing-attribute]
-        T: TableT = fieldtype.__args__[0]
-        return T
+        for arg in optionalfieldtype.__args__:  # pyrefly: ignore[missing-attribute]
+            if hasattr(arg, "__args__") and arg.__args__:
+                return arg.__args__[0]
+        raise TypeError(f"Could not determine table schema for {cls}")
 
     @classmethod
     def columns(cls) -> list[str]:

--- a/python/ribasim/tests/test_schemas.py
+++ b/python/ribasim/tests/test_schemas.py
@@ -1,3 +1,6 @@
+import subprocess
+import sys
+import textwrap
 from unittest.mock import patch
 
 import pandas as pd
@@ -61,3 +64,47 @@ def test_column_rename():
     assert_frame_equal(df, pd.DataFrame({"link_type": [1]}))
     df = pd.DataFrame({"link_type": [2]})
     assert_frame_equal(df, _rename_column(df, "edge_type", "link_type"))
+
+
+def test_df_accepts_plain_dataframe(basic):
+    """Assigning a pd.DataFrame (e.g. from pd.concat) to a TableModel.df should work."""
+    static = basic.manning_resistance.static
+    original_df = static.df
+    assert original_df is not None
+
+    # pd.concat returns a plain pd.DataFrame, not a pandera DataFrame
+    new_df = pd.concat([original_df], ignore_index=True)
+    assert type(new_df) is pd.DataFrame
+
+    static.df = new_df
+    assert static.df is not None
+    assert len(static.df) == len(original_df)
+
+    # Pandera validation must still run: missing columns are added, index is coerced
+    assert "control_state" in static.df.columns
+    assert static.df.index.dtype == "int32"
+
+
+def test_df_accepts_plain_dataframe_typing(tmp_path):
+    """Pyrefly should not report bad-assignment when assigning pd.DataFrame to TableModel.df."""
+    snippet = tmp_path / "check_df_typing.py"
+    snippet.write_text(
+        textwrap.dedent("""\
+            import pandas as pd
+            from ribasim.input_base import TableModel
+            from ribasim.schemas import ManningResistanceStaticSchema
+
+            table = TableModel[ManningResistanceStaticSchema]()
+            table.df = pd.DataFrame()
+        """),
+        encoding="utf-8",
+    )
+    result = subprocess.run(
+        [sys.executable, "-m", "pyrefly", "check", str(snippet)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert "bad-assignment" not in result.stdout, result.stdout
+    assert "bad-assignment" not in result.stderr, result.stderr


### PR DESCRIPTION
This avoids typing issues like:

```
  ERROR `pandas.core.frame.DataFrame` is not assignable to attribute `df` with type `pandera.typing.pandas.DataFrame[ManningResistanceStaticSchema] | None` [bad-assignment]
     --> src\ribasim_nl\ribasim_nl\profiles\implement.py:299:50
      |
  299 |       ribasim_model.manning_resistance.static.df = pd.concat(
      |  __________________________________________________^
  300 | |         [ribasim_model.manning_resistance.static.df, manning_static], ignore_index=True
  301 | |     )
      | |_____^
```

## Changes

### input_base.py
- Widen `TableModel.df` type from `DataFrame[TableT] | None` to `DataFrame[TableT] | pd.DataFrame | None` so that plain `pd.DataFrame` values are accepted by type checkers
- Add `arbitrary_types_allowed=True` to `model_config` since Pydantic can't generate a schema for bare `pd.DataFrame` without it
- Update `tableschema()` to find the pandera type by iterating over the union args, since the annotation is no longer a simple two-member union

Pandera validation is preserved because `DataFrame[TableT]` comes first in the union — Pydantic tries it before falling through to `pd.DataFrame`.

### test_schemas.py
- `test_df_accepts_plain_dataframe`: runtime test that `pd.concat` result can be assigned to `.df` and pandera validation still runs (missing columns added, index coerced)
- `test_df_accepts_plain_dataframe_typing`: runs pyrefly on a snippet to assert no `bad-assignment` error