### PR TITLE
fix bug in allocation meuse model

### DIFF
--- a/core/src/allocation_init.jl
+++ b/core/src/allocation_init.jl
@@ -561,6 +561,11 @@ function add_secondary_network_demand!(
     connecting_links =
         vcat(sort!(collect(values(allocation.primary_network_connections)))...)
 
+    if isempty(connecting_links)
+        # No secondary network connections, nothing to do
+        return nothing
+    end
+
     # Define decision variables: flow allocated to secondary networks
     # (scaling.flow * m^3/s, values to be filled in before optimizing)
     d = 2.0 # Example demand (scaling.flow * m^3/s, values to be filled in before optimizing)
@@ -595,9 +600,10 @@ function add_secondary_network_demand!(
             secondary_network_error[
                 link = connecting_links,
                 DemandPriorityIterator(link, p_independent),
-                [:first, :second],
+                objective_ord = [:first, :second],
             ] ≤
-            1
+            1,
+        base_name = "secondary_network_error",
     )
 
     # Define constraints: error terms
@@ -656,7 +662,7 @@ function add_demand_objectives!(
 
         # Add UserDemand, FlowDemand and secondary network errors
         error_collections = [user_demand_error, flow_demand_error]
-        if is_primary_network(subnetwork_id)
+        if is_primary_network(subnetwork_id) && haskey(problem, :secondary_network_error)
             secondary_network_error = problem[:secondary_network_error]
             push!(error_collections, secondary_network_error)
         end
@@ -765,7 +771,7 @@ function add_demand_objectives!(
     )
 
     # If this is the primary network, also add fairness constraints for secondary network demands
-    if is_primary_network(subnetwork_id)
+    if is_primary_network(subnetwork_id) && haskey(problem, :secondary_network_error)
         secondary_demand_error = problem[:secondary_network_error]
         # Sort connections for deterministic problem generation
         connecting_links =
@@ -938,7 +944,7 @@ function has_demand_priority_subnetwork(
     (; demand_priorities_all) = allocation
     (;
         user_demand_ids_subnetwork,
-        node_ids_subnetwork_with_flow_demand,
+        flow_demand_ids_subnetwork,
         level_demand_ids_subnetwork,
     ) = node_ids_in_subnetwork
 
@@ -948,7 +954,7 @@ function has_demand_priority_subnetwork(
         has_demand_priority .|= view(user_demand.has_demand_priority, node_id.idx, :)
     end
 
-    for node_id in node_ids_subnetwork_with_flow_demand
+    for node_id in flow_demand_ids_subnetwork
         has_demand_priority .|= view(flow_demand.has_demand_priority, node_id.idx, :)
     end
 

--- a/core/src/allocation_optim.jl
+++ b/core/src/allocation_optim.jl
@@ -891,9 +891,6 @@ function parse_allocations!(
             is_user_demand ? node_id : get_external_demand_id(p_independent, node_id)
 
         for (demand_priority_idx, demand_priority) in enumerate(demand_priorities_all)
-            # if size(has_demand_priority) == (3, 3)
-            #     println("found!")
-            # end
             !has_demand_priority[demand_id.idx, demand_priority_idx] && continue
             allocated_flow =
                 max(0, JuMP.value(node_allocated[node_id, demand_priority]) * scaling.flow)

--- a/core/src/allocation_optim.jl
+++ b/core/src/allocation_optim.jl
@@ -891,7 +891,10 @@ function parse_allocations!(
             is_user_demand ? node_id : get_external_demand_id(p_independent, node_id)
 
         for (demand_priority_idx, demand_priority) in enumerate(demand_priorities_all)
-            !has_demand_priority[node_id.idx, demand_priority_idx] && continue
+            # if size(has_demand_priority) == (3, 3)
+            #     println("found!")
+            # end
+            !has_demand_priority[demand_id.idx, demand_priority_idx] && continue
             allocated_flow =
                 max(0, JuMP.value(node_allocated[node_id, demand_priority]) * scaling.flow)
             push!(
@@ -905,7 +908,7 @@ function parse_allocations!(
                     demand[demand_id.idx, demand_priority_idx],
                     allocated_flow,
                     # NOTE: The supplied amount lags one allocation period behind
-                    cumulative_supplied_volume[inflow_link[node_id.idx].link] /
+                    cumulative_supplied_volume[inflow_link[demand_id.idx].link] /
                         Δt_allocation,
                 ),
             )


### PR DESCRIPTION
fixes #3045 

The meuse model with allocation on revealed some bugs in the allocation code: the allocation controlled node id was mixed up with flow demand node id's. 

Another bug was that the type of the subnetwork objective was not recognized when there was no subnetwork. 