### PR TITLE
Improve GitHub Actions secure usage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      all-actions:
+        patterns:
+          - "*"
 # - package-ecosystem: "julia"
 #   directory: "/"
 #   schedule:

--- a/.github/workflows/core_testmodels.yml
+++ b/.github/workflows/core_testmodels.yml
@@ -31,9 +31,9 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/cache@v3
-      - uses: prefix-dev/setup-pixi@v0.9.5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: julia-actions/cache@9a93c5fb3e9c1c20b60fc80a478cae53e38618a4 # v3.0.2
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: "latest"
       - name: Prepare pixi

--- a/.github/workflows/core_tests.yml
+++ b/.github/workflows/core_tests.yml
@@ -30,9 +30,9 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/cache@v3
-      - uses: prefix-dev/setup-pixi@v0.9.5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: julia-actions/cache@9a93c5fb3e9c1c20b60fc80a478cae53e38618a4 # v3.0.2
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: "latest"
       - name: Prepare pixi
@@ -45,7 +45,7 @@ jobs:
           JULIA_NUM_THREADS: 2
       - name: Upload allocation debug files
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: allocation-debug-${{ matrix.os }}-${{ matrix.arch }}-${{ github.run_id }}
           path: |
@@ -54,10 +54,10 @@ jobs:
             **/allocation_analysis_*.log
           retention-days: 7
           if-no-files-found: ignore
-      - uses: julia-actions/julia-processcoverage@v1
+      - uses: julia-actions/julia-processcoverage@03114f09f119417c3242a9fb6e0b722676aedf38 # v1.2.2
         with:
           directories: core/src
-      - uses: codecov/codecov-action@v6
+      - uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,14 +13,14 @@ concurrency:
 # needed to allow julia-actions/cache to delete old caches that it has created
 permissions:
   actions: write
-  contents: write
-  pages: write
+  contents: read
 jobs:
   publish:
     name: Docs Julia
     runs-on: ubuntu-latest
     timeout-minutes: 120
     permissions:
+      actions: write
       contents: write
     steps:
       - name: Configure Git for quarto-publish

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Propagate git credentials for v6
         run: |
           # Propagate git credentials to worktrees (required for actions/checkout@v6)
@@ -37,8 +37,8 @@ jobs:
             CRED_PATH=$(git config get --path includeIf.gitdir:"${GIT_DIR}".path)
             git config set --path includeIf.gitdir:"${GIT_DIR}/worktrees/*".path "${CRED_PATH}"
           fi
-      - uses: julia-actions/cache@v3
-      - uses: prefix-dev/setup-pixi@v0.9.5
+      - uses: julia-actions/cache@9a93c5fb3e9c1c20b60fc80a478cae53e38618a4 # v3.0.2
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: "latest"
       - name: Prepare pixi

--- a/.github/workflows/julia_auto_update.yml
+++ b/.github/workflows/julia_auto_update.yml
@@ -11,10 +11,10 @@ jobs:
   auto-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - uses: prefix-dev/setup-pixi@v0.9.5
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: "latest"
       - name: Update Julia manifest file
@@ -24,7 +24,7 @@ jobs:
           pixi run generate-sbom-ribasim-core
         env:
           JULIA_PKG_PRECOMPILE_AUTO: "0"
-      - uses: peter-evans/create-pull-request@v8
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.CI_PR_PAT }}
           branch: update/julia-manifest

--- a/.github/workflows/julia_auto_update.yml
+++ b/.github/workflows/julia_auto_update.yml
@@ -5,6 +5,8 @@ on:
     - cron: "0 3 2 * *"
   # on demand
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   auto-update:
     runs-on: ubuntu-latest

--- a/.github/workflows/pixi_auto_update.yml
+++ b/.github/workflows/pixi_auto_update.yml
@@ -11,9 +11,9 @@ jobs:
   pixi-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up pixi
-        uses: prefix-dev/setup-pixi@v0.9.5
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: "latest"
           run-install: false
@@ -23,7 +23,7 @@ jobs:
           pixi update --json | pixi exec pixi-diff-to-markdown >> diff.md
           pixi run generate-sbom-ribasim-python
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.CI_PR_PAT }}
           commit-message: Update pixi lockfile

--- a/.github/workflows/pixi_auto_update.yml
+++ b/.github/workflows/pixi_auto_update.yml
@@ -1,7 +1,6 @@
 name: Update Pixi lockfile
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 on:
   schedule:
     # At 03:00 on day 3 of the month

--- a/.github/workflows/prek_auto_update.yml
+++ b/.github/workflows/prek_auto_update.yml
@@ -5,6 +5,8 @@ on:
     - cron: "0 3 3 * *"
   # on demand
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   auto-update:
     runs-on: ubuntu-latest

--- a/.github/workflows/prek_auto_update.yml
+++ b/.github/workflows/prek_auto_update.yml
@@ -11,8 +11,8 @@ jobs:
   auto-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: "latest"
       - name: Update prek hooks
@@ -22,7 +22,7 @@ jobs:
       - name: Run prek on all files
         run: pixi run prek-run
         continue-on-error: true
-      - uses: peter-evans/create-pull-request@v8
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.CI_PR_PAT }}
           branch: update/prek

--- a/.github/workflows/prek_check.yml
+++ b/.github/workflows/prek_check.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   prek:
     runs-on: ubuntu-latest

--- a/.github/workflows/prek_check.yml
+++ b/.github/workflows/prek_check.yml
@@ -11,8 +11,8 @@ jobs:
   prek:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: "latest"
       - name: Install prek hooks

--- a/.github/workflows/python_codegen.yml
+++ b/.github/workflows/python_codegen.yml
@@ -11,6 +11,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   codegen:
     name: Codegen

--- a/.github/workflows/python_codegen.yml
+++ b/.github/workflows/python_codegen.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: "latest"
       - name: Prepare pixi

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -29,13 +29,13 @@ jobs:
           - py312
           - pandas2
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: "latest"
       - name: Test Ribasim Python
         run: pixi run --environment ${{ matrix.pixi-environment }} test-ribasim-python-cov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -11,6 +11,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   test:
     name: ${{ matrix.pixi-environment }} - ${{ matrix.os }}

--- a/.github/workflows/qgis.yml
+++ b/.github/workflows/qgis.yml
@@ -8,6 +8,8 @@ on:
     paths: ["ribasim_qgis/**", "pixi.toml", "pixi.lock"]
   merge_group:
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   test-qgis:
     name: "Test"

--- a/.github/workflows/qgis.yml
+++ b/.github/workflows/qgis.yml
@@ -18,13 +18,13 @@ jobs:
       run:
         working-directory: .docker
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: "latest"
       - name: Run tests
         run: pixi run test-ribasim-qgis-docker
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -18,8 +18,8 @@ jobs:
     name: Typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: prefix-dev/setup-pixi@v0.9.5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           pixi-version: "latest"
       - name: Run typecheck

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -11,6 +11,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
 jobs:
   typecheck:
     name: Typecheck


### PR DESCRIPTION
See separate commits

https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions
https://github.com/suzuki-shunsuke/pinact

This will probably make dependabot submit an action update PR every week. Therefore we group the updates together now, instead of one per action.