### PR TITLE
Fix `starttime < endtime` validation

### DIFF
--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -102,14 +102,13 @@ function get_diff_eval(du::CVector, u::CVector, p::Parameters, solver::Solver)
 end
 
 function Model(config_path::AbstractString)::Model
-    config = Config(config_path)
-    if !valid_config(config)
-        error("Invalid configuration in TOML.")
-    end
-    return Model(config)
+    return Model(Config(config_path))
 end
 
 function Model(config::Config)::Model
+    if !valid_config(config)
+        error("Invalid configuration in TOML.")
+    end
     mkpath(results_path(config))
     check_result_netcdf_files_writable!(config)
     db_path = database_path(config)

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -171,6 +171,12 @@ class Model(FileModel, ParentModel):
         return v
 
     @model_validator(mode="after")
+    def _validate_time_window(self) -> Self:
+        if self.starttime >= self.endtime:
+            raise ValueError("The model starttime must be before the endtime.")
+        return self
+
+    @model_validator(mode="after")
     def _ensure_topology_tables_are_present(self) -> Self:
         if self.link.df is None:
             self.link.df = GeoDataFrame[LinkSchema](

--- a/python/ribasim/tests/test_model.py
+++ b/python/ribasim/tests/test_model.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 from sqlite3 import connect
 
@@ -46,6 +47,17 @@ def test_solver():
 
     with pytest.raises(ValidationError):
         Solver(saveat="a")
+
+
+def test_time_window_validation(basic):
+    model = basic
+    with pytest.raises(ValidationError, match="starttime must be before the endtime"):
+        model.endtime = model.starttime
+        model.model_validate(model.model_dump())
+
+    with pytest.raises(ValidationError, match="starttime must be before the endtime"):
+        model.endtime = model.starttime - datetime.timedelta(days=1)
+        model.model_validate(model.model_dump())
 
 
 def test_parent_relationship(basic):


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/3028

We had this check in Julia already, only not on the path taken by the CLI...

Not it is covered:

```
┌ Error: The model starttime must be before the endtime.
└ @ Ribasim c:\ProgramData\DevDrive\repo\ribasim\Ribasim\core\src\validation.jl:271
ERROR: Invalid configuration in TOML.
Stacktrace:
  [1] error(s::String)
    @ Base .\error.jl:44
  [2] Ribasim.Model(config::Ribasim.config.Config)
    @ Ribasim c:\ProgramData\DevDrive\repo\ribasim\Ribasim\core\src\model.jl:110
```

And added Python validation as well.