### PR TITLE
Override QGIS task cancel

### DIFF
--- a/ribasim_qgis/widgets/task.py
+++ b/ribasim_qgis/widgets/task.py
@@ -1,5 +1,6 @@
 """QgsTask for running Ribasim simulations in the background."""
 
+import contextlib
 import re
 import subprocess
 from pathlib import Path
@@ -86,6 +87,17 @@ class RibasimTask(QgsTask):
             )
             self.exit_code = -1
             return False
+
+    def cancel(self) -> None:
+        """Cancel the task by terminating the subprocess.
+
+        Overridden so that a hanging pipe (e.g. after a segfault) gets closed,
+        unblocking the stdout read loop in run().
+        """
+        super().cancel()
+        if self.process is not None:
+            with contextlib.suppress(OSError):
+                self.process.kill()
 
     def finished(self, result: bool) -> None:
         """Emit completion signal on the main thread."""


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/3048

The actual segfault no longer appears after merging https://github.com/Deltares/Ribasim/pull/3026.
This does still happen: https://github.com/Deltares/Ribasim/issues/3049

I ran this with the ribasim.exe of the release so I can trigger the segfault. With this the segfault does appear in the running dialog, so it is clear it crashed, but the task is not automatically cancelled. Claude says the problem is: `for line in proc.stdout` blocks waiting for data. After a segfault on Windows, the pipe can hang indefinitely — the process is dead but the pipe read never returns.

We could implement something elaborate to avoid the hang altogether, but since segfaults are luckily rare I went for the more minimal fix, which is to support cancelling the task from QGIS.

@verheem since we don't see the segfault anymore you can probably disregard https://github.com/Deltares/Ribasim/issues/3048#issuecomment-4396622746, and focus only on https://github.com/Deltares/Ribasim/issues/3049 for the patch release.