### PR TITLE
Update to pyrefly v1, ignore bad-override

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -530,7 +530,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-stubs-5.15.6.0-pyhb6d5dde_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.17.0-py313h7033f15_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqtwebkit-5.15.11-py313h938ae94_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-0.63.1-h2b88eb6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-1.0.0-h2b88eb6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.0-py313hcd51b16_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
@@ -1150,7 +1150,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyqt-5.15.11-py313h7cbc9b8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-stubs-5.15.6.0-pyhb6d5dde_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyqt5-sip-12.17.0-py313he352c24_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyrefly-0.63.1-h7baeb35_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyrefly-1.0.0-h7baeb35_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyside6-6.11.0-py313h83050ec_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
@@ -1724,7 +1724,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqt-5.15.11-py313h003178d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-stubs-5.15.6.0-pyhb6d5dde_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqt5-sip-12.17.0-py313h0e822ff_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-0.63.1-h4dd0d4f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-1.0.0-h4dd0d4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
@@ -2318,7 +2318,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-stubs-5.15.6.0-pyhb6d5dde_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.17.0-py313hfe59770_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyqtwebkit-5.15.11-py313h1048830_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyrefly-0.63.1-hfe91638_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyrefly-1.0.0-hfe91638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.11.0-py313h0c3c3c1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
@@ -3026,7 +3026,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-stubs-5.15.6.0-pyhb6d5dde_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.17.0-py313h7033f15_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqtwebkit-5.15.11-py313h938ae94_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-0.63.1-h2b88eb6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-1.0.0-h2b88eb6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.0-py313hcd51b16_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
@@ -3650,7 +3650,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyqt-5.15.11-py313h7cbc9b8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-stubs-5.15.6.0-pyhb6d5dde_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyqt5-sip-12.17.0-py313he352c24_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyrefly-0.63.1-h7baeb35_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyrefly-1.0.0-h7baeb35_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyside6-6.11.0-py313h83050ec_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
@@ -4229,7 +4229,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqt-5.15.11-py313h003178d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-stubs-5.15.6.0-pyhb6d5dde_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqt5-sip-12.17.0-py313h0e822ff_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-0.63.1-h4dd0d4f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-1.0.0-h4dd0d4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
@@ -4828,7 +4828,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-stubs-5.15.6.0-pyhb6d5dde_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.17.0-py313hfe59770_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyqtwebkit-5.15.11-py313h1048830_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyrefly-0.63.1-hfe91638_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyrefly-1.0.0-hfe91638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.11.0-py313h0c3c3c1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
@@ -5531,7 +5531,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-stubs-5.15.6.0-pyhb6d5dde_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.17.0-py312h1289d80_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqtwebkit-5.15.11-py312h82c0db2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-0.63.1-h2b88eb6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-1.0.0-h2b88eb6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.0-py312h50ac2ff_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
@@ -6151,7 +6151,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyqt-5.15.11-py312hc13527c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-stubs-5.15.6.0-pyhb6d5dde_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyqt5-sip-12.17.0-py312h1ab2c47_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyrefly-0.63.1-h7baeb35_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyrefly-1.0.0-h7baeb35_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyside6-6.11.0-py312hfc1e6cc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
@@ -6725,7 +6725,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqt-5.15.11-py312h6612b97_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-stubs-5.15.6.0-pyhb6d5dde_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqt5-sip-12.17.0-py312h455b684_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-0.63.1-h4dd0d4f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-1.0.0-h4dd0d4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-7.1.0-pyhcf101f3_0.conda
@@ -7319,7 +7319,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyqt-stubs-5.15.6.0-pyhb6d5dde_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.17.0-py312hbb81ca0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyqtwebkit-5.15.11-py312h7eb3e20_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyrefly-0.63.1-hfe91638_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyrefly-1.0.0-hfe91638_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.11.0-py312ha7d0d2e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-9.0.3-pyhc364b38_1.conda
@@ -29765,9 +29765,9 @@ packages:
   purls: []
   size: 126327
   timestamp: 1759598462673
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-0.63.1-h2b88eb6_0.conda
-  sha256: 48a9eb96d6b31dd87d015c17dabf6284f95b3421582adf57854de7f9fcdd2dbf
-  md5: 3f4336a7341a7e10b7b75d6199f0c439
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-1.0.0-h2b88eb6_0.conda
+  sha256: 225d491c94a6962b92377154b33b424cb0cc30aa2fe0b433c6c110d05da7283d
+  md5: 132a1bc9d31e17d6e12d7188ca7ddfb8
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
@@ -29776,11 +29776,11 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 10917123
-  timestamp: 1777456494879
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyrefly-0.63.1-h7baeb35_0.conda
-  sha256: 37e26cb10ad9af0ea4e43cf7f70150d22c0cbc6443c65c516bc033bf1f06fd16
-  md5: 0ae6b5dc7e7994cd7c520cf7ed622a19
+  size: 10962615
+  timestamp: 1778629320799
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyrefly-1.0.0-h7baeb35_0.conda
+  sha256: 80936adfe18fd17b7193f4958f5519502f68efe47181ba0a0961470665b5bd8c
+  md5: ef7d72bb1f9dbd43a1f67cb1125869e2
   depends:
   - libgcc >=14
   constrains:
@@ -29788,11 +29788,11 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 10686255
-  timestamp: 1777456514807
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-0.63.1-h4dd0d4f_0.conda
-  sha256: e0933d68ce1029cdcb7e230d25842ee6fd3727dbdb99b7345015ef30a83c4b2d
-  md5: fe446e9df8d6c1aa074d88b4c4bf5055
+  size: 10757120
+  timestamp: 1778629337327
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-1.0.0-h4dd0d4f_0.conda
+  sha256: 34dd964342267b5d93674eefe37055b8915943de60d43b4e36a08b9642319f46
+  md5: b0b2e5d34dba70dfad3955a59e611b46
   depends:
   - __osx >=11.0
   constrains:
@@ -29800,11 +29800,11 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 10255363
-  timestamp: 1777456625606
-- conda: https://conda.anaconda.org/conda-forge/win-64/pyrefly-0.63.1-hfe91638_0.conda
-  sha256: 8eea36b083267d1face3dbd40d232f108ecc1b6269a32bdab939c4130987e40d
-  md5: 931bc20bf880d6416dd0552926f1a3e7
+  size: 10330096
+  timestamp: 1778629356792
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyrefly-1.0.0-hfe91638_0.conda
+  sha256: 5d3cfd0fea530480f197badbc00403d7c1592814540180c23acdef5f900e3284
+  md5: 8952e9b92b28b7c6bdc953d8711957bd
   depends:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
@@ -29812,8 +29812,8 @@ packages:
   license: MIT
   license_family: MIT
   purls: []
-  size: 11228604
-  timestamp: 1777456532953
+  size: 11351129
+  timestamp: 1778629351360
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.0-py312h50ac2ff_2.conda
   sha256: 768c4934fff390f7a8c7cc780dec576af7876e308bc24de406bdf81281f19daa
   md5: 013718f42467861794fd1844a93978be

--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -124,7 +124,7 @@ class BaseModel(PydanticBaseModel):
         input data has already been validated at construction time.
         """
         original = cls.__setattr__
-        cls.__setattr__ = _bypass_setattr
+        cls.__setattr__ = _bypass_setattr  # pyrefly: ignore[bad-override]
         try:
             yield
         finally:


### PR DESCRIPTION
We could consider setting `preset = "strict"` in `pyrefly.toml` as well, then we also get errors for all missing annotations, [implicit-any-parameter], for instance. 235 errors total. For now sticking with default.

https://github.com/facebook/pyrefly/releases/tag/1.0.0
https://pyrefly.org/blog/v1.0/

```
ERROR Class member `BaseModel.__setattr__` overrides parent class `BaseModel` in an inconsistent manner [bad-override]
   --> python\ribasim\ribasim\input_base.py:127:13
    |
127 |         cls.__setattr__ = _bypass_setattr
    |             ^^^^^^^^^^^
    |
  `BaseModel.__setattr__` has type `(self: BaseModel, name: str, value: Any, /) -> None`, which is not assignable to `(self: BaseModel, name: str, value: Any, /) -> None`, the type of `BaseModel.__setattr__`
 INFO 1 error (26 suppressed, 9 warnings not shown)
 ```