### PR TITLE
[delwaq] Allow for isolated basin nodes.

### DIFF
--- a/python/ribasim/ribasim/delwaq/generate.py
+++ b/python/ribasim/ribasim/delwaq/generate.py
@@ -231,10 +231,11 @@ def _setup_graph(nodes, link, evaporate_mass=True):
     for edge in remove_double_boundary:
         G.remove_edge(*edge)
 
-    remove_nodes = []
-    iso = nx.number_of_isolates(G)
-    if iso > 0:
-        remove_nodes.extend(list(nx.isolates(G)))
+    remove_nodes = [
+        node_id
+        for node_id in nx.isolates(G)
+        if G.nodes[node_id]["type"] != "Basin"
+    ]
 
     for node_id in remove_nodes:
         logger.debug(
@@ -541,9 +542,9 @@ def generate(
     # copy is to avoid false positive SettingWithCopyWarning on pandas 2
     volumes = basins[["time", "node_id", "storage"]].copy()
     volumes["riba_node_id"] = volumes["node_id"]
-    volumes.loc[:, "node_id"] = (
-        volumes["node_id"].map(basin_mapping).astype(pd.Int32Dtype())
-    )
+    mapped_node_id = volumes["node_id"].map(basin_mapping)
+    assert mapped_node_id.notna().all(), "basin_mapping is incomplete"
+    volumes.loc[:, "node_id"] = mapped_node_id.astype("int32")
     volumes = volumes.sort_values(by=["time", "node_id"])
     # volumes.to_csv(output_path / "volumes.csv", index=False)  # not needed
     volumes.drop(columns=["node_id", "riba_node_id"], inplace=True)

--- a/python/ribasim/ribasim/delwaq/generate.py
+++ b/python/ribasim/ribasim/delwaq/generate.py
@@ -38,6 +38,7 @@ except ImportError:
 
 import ribasim
 from ribasim.delwaq.util import (
+    check_substance_uniqueness,
     delwaq_dir,
     is_valid_substance,
     strfdelta,
@@ -591,6 +592,8 @@ def generate(
     if model.basin.concentration_state.df is not None:
         initial = model.basin.concentration_state.df
         substances.update(initial.substance.unique())
+
+    check_substance_uniqueness(substances)
 
     # Make a wide table with the initial default concentrations
     # using zero for all user defined substances

--- a/python/ribasim/ribasim/delwaq/generate.py
+++ b/python/ribasim/ribasim/delwaq/generate.py
@@ -232,9 +232,7 @@ def _setup_graph(nodes, link, evaporate_mass=True):
         G.remove_edge(*edge)
 
     remove_nodes = [
-        node_id
-        for node_id in nx.isolates(G)
-        if G.nodes[node_id]["type"] != "Basin"
+        node_id for node_id in nx.isolates(G) if G.nodes[node_id]["type"] != "Basin"
     ]
 
     for node_id in remove_nodes:

--- a/python/ribasim/ribasim/delwaq/parse.py
+++ b/python/ribasim/ribasim/delwaq/parse.py
@@ -33,7 +33,7 @@ def parse(
         dfs = []
         for substance in substances:
             df = (
-                ds[f"ribasim_{substance.replace(' ', '_')}"]
+                ds[f"ribasim_{substance[:20].replace(' ', '_')}"]
                 .to_dataframe()
                 .reset_index()
             )
@@ -41,7 +41,7 @@ def parse(
                 columns={
                     "ribasim_nNodes": "node_id",
                     "nTimesDlwq": "time",
-                    f"ribasim_{substance.replace(' ', '_')}": "concentration",
+                    f"ribasim_{substance[:20].replace(' ', '_')}": "concentration",
                 },
                 inplace=True,
             )
@@ -57,7 +57,7 @@ def parse(
     df = _concat(dfs).reset_index(drop=True)
     df.sort_values(["time", "node_id"], inplace=True)
 
-    ds = df.set_index(["node_id", "substance", "time"]).to_xarray()
+    ds = df.set_index(["time", "substance", "node_id"]).to_xarray()
     ds.to_netcdf(model.results_path / "concentration.nc")
 
     if to_input:

--- a/python/ribasim/ribasim/delwaq/util.py
+++ b/python/ribasim/ribasim/delwaq/util.py
@@ -224,7 +224,6 @@ def is_valid_substance(name: str) -> bool:
         logger.error(
             f"{name} is an invalid substance name; must be at most 20 characters."
         )
-        return False
     if name.find(";") >= 0:
         logger.error(
             f"{name} is an invalid substance name; cannot contain semicolon ;."

--- a/python/ribasim/ribasim/delwaq/util.py
+++ b/python/ribasim/ribasim/delwaq/util.py
@@ -221,8 +221,8 @@ def is_valid_substance(name: str) -> bool:
         logger.error(f"{name} is an invalid substance name; must be ASCII.")
         return False
     if len(name) > 20:
-        logger.error(
-            f"{name} is an invalid substance name; must be at most 20 characters."
+        logger.warning(
+            f"Substance name '{name}' exceeds 20 characters and will be truncated."
         )
     if name.find(";") >= 0:
         logger.error(
@@ -237,3 +237,19 @@ def is_valid_substance(name: str) -> bool:
         return False
 
     return True
+
+
+def check_substance_uniqueness(substances: set[str]) -> None:
+    """Check that substance names are unique when truncated to 20 characters."""
+    truncated: dict[str, list[str]] = {}
+    for name in substances:
+        key = name[:20]
+        truncated.setdefault(key, []).append(name)
+
+    duplicates = {k: v for k, v in truncated.items() if len(v) > 1}
+    if duplicates:
+        msgs = [f"'{k}': {v}" for k, v in duplicates.items()]
+        raise ValueError(
+            "Substance names are not unique when truncated to 20 characters: "
+            + "; ".join(msgs)
+        )

--- a/python/ribasim/tests/test_delwaq.py
+++ b/python/ribasim/tests/test_delwaq.py
@@ -6,6 +6,7 @@ import pytest
 import xarray as xr
 from ribasim import Model
 from ribasim.delwaq import add_tracer, generate, parse, run_delwaq
+from ribasim.delwaq.util import check_substance_uniqueness
 
 delwaq_dir = Path(__file__).parent
 
@@ -65,7 +66,7 @@ def test_offline_delwaq_coupling(tmp_path):
 
     # Ensure concentration.nc uses the expected dimension order
     with xr.open_dataset(results_dir / "concentration.nc") as uds:
-        assert uds["concentration"].dims == ("node_id", "substance", "time")
+        assert uds["concentration"].dims == ("time", "substance", "node_id")
 
 
 @pytest.mark.skipif(
@@ -125,3 +126,13 @@ def test_offline_delwaq_coupling_evaporate_mass(tmp_path):
 def test_invalid_substance_name(basic, name):
     with pytest.raises(ValueError, match="Invalid Delwaq substance"):
         add_tracer(basic, 11, name)
+
+
+def test_substance_uniqueness():
+    """Long names are allowed, but must be unique when truncated to 20 chars."""
+    substances = {"AVeryLongSubstanceName"}
+    check_substance_uniqueness(substances)
+
+    substances = {"AVeryLongSubstanceNameAlpha", "AVeryLongSubstanceNameBeta"}
+    with pytest.raises(ValueError, match="not unique when truncated"):
+        check_substance_uniqueness(substances)

--- a/python/ribasim/tests/test_delwaq.py
+++ b/python/ribasim/tests/test_delwaq.py
@@ -121,9 +121,7 @@ def test_offline_delwaq_coupling_evaporate_mass(tmp_path):
     model.write(tmp_path / "basic/ribasim.toml")
 
 
-@pytest.mark.parametrize(
-    "name", ["Foo;123", "π", "AVeryLongSubstanceName", 'Double"Quote']
-)
+@pytest.mark.parametrize("name", ["Foo;123", "π", 'Double"Quote'])
 def test_invalid_substance_name(basic, name):
     with pytest.raises(ValueError, match="Invalid Delwaq substance"):
         add_tracer(basic, 11, name)


### PR DESCRIPTION
As they're present in the LHM. I've disabled erroring out on too long names, now they will be cut off (which is only problematic if they become non-unique). Currently running Delwaq, which takes a loooong time.