### PR TITLE
QGIS plot and guide improvements

### DIFF
--- a/docs/dev/qgis_test_plan.qmd
+++ b/docs/dev/qgis_test_plan.qmd
@@ -93,7 +93,7 @@ Intended behavior: The same model is loaded twice, but there is only a connectio
 
 ## Basin timeseries on node selection
 
-- Change the variable to "level": _Variable changes to "level", placeholder says "Select Basin nodes and/or links on the map to plot timeseries."_.
+- Change the variable to "level": _Variable changes to "level", placeholder says "Select nodes and/or links on the map to plot timeseries."_.
 - Select one or more Basin nodes on the map: _Level timeseries appear for the selected nodes_.
 
 ## Variable selection

--- a/docs/getting-started/install.qmd
+++ b/docs/getting-started/install.qmd
@@ -150,10 +150,10 @@ The [`run_ribasim`](/reference/python/run_ribasim.qmd#ribasim.run_ribasim) funct
 
 The Ribasim QGIS plugin uses the following order:
 
-1. **Set Ribasim home** (Plugins → Ribasim → Set Ribasim home)
+1. **Set Ribasim home** (QGIS → Plugins → Ribasim → Set Ribasim home)
 2. The `RIBASIM_HOME` environment variable (if set)
 3. The system `PATH`
-4. `%LOCALAPPDATA%\Microsoft\WindowsApps` (Windows)
+4. `%LOCALAPPDATA%\Microsoft\WindowsApps` (on Windows)
 
 To set `RIBASIM_HOME`:
 
@@ -166,7 +166,10 @@ To set `RIBASIM_HOME`:
 - Click "OK" three times to close all dialogs
 - Restart QGIS for the change to take effect
 
-You can also set Ribasim home directly in QGIS via Plugins → Ribasim → Set Ribasim home.
+You can also set Ribasim home directly in QGIS via Plugins → Ribasim → Set Ribasim home,
+Or click on the Ribasim icon on the toolbar, select **Set Ribasim home**.
+
+![](https://s3.deltares.nl/ribasim/doc-image/qgis/toolbar-run.png){fig-align="left"}
 
 # Install Ribasim Python {#sec-install-python}
 

--- a/docs/guide/qgis.qmd
+++ b/docs/guide/qgis.qmd
@@ -33,10 +33,10 @@ When the simulation completes successfully, the model results are automatically 
 
 QGIS resolves the Ribasim executable in this order:
 
-1. **Set Ribasim home** (Plugins → Ribasim → Set Ribasim home)
-2. `RIBASIM_HOME`
-3. `PATH`
-4. `%LOCALAPPDATA%\Microsoft\WindowsApps` (Windows)
+1. **Set Ribasim home** (QGIS → Plugins → Ribasim → Set Ribasim home)
+2. The `RIBASIM_HOME` environment variable (if set)
+3. The system `PATH`
+4. `%LOCALAPPDATA%\Microsoft\WindowsApps` (on Windows)
 
 See the [install section](/getting-started/install.qmd#ribasim-home) for details.
 
@@ -55,20 +55,33 @@ Click on the Ribasim icon on the toolbar, select **Timeseries results**.
 ![](https://s3.deltares.nl/ribasim/doc-image/qgis/toolbar-results.png){fig-align="left"}
 
 This will open a plotting pane.
-If you have results, it will select the flow results by default.
-These are available on links.
-Select the Link layer.
+If you have results, it will select the level and flow_rate variables by default.
+You can select other variables in the dropdown menu.
+Clicking the `node` or `link` buttons allows you to select what you want to plot on the map.
 
-![](https://s3.deltares.nl/ribasim/doc-image/qgis/select-link-layer.png){fig-align="left"}
+![](https://s3.deltares.nl/ribasim/doc-image/qgis/select-timeseries-results.png){fig-align="left"}
 
+Select the `link` button.
 Now select the links that you want to see the timeseries of.
 Whenever the selection changes, the plot updates.
 You can use {{< kbd Shift+Click >}} to select multiple links, or {{< kbd Ctrl+Click >}} ({{< kbd Cmd+Click >}} on macOS) to toggle links on and off.
 
-![](https://s3.deltares.nl/ribasim/doc-image/qgis/select-link-flow.png){fig-align="left"}
+![](https://s3.deltares.nl/ribasim/doc-image/qgis/timeseries-plot-flow.png){fig-align="left"}
 
-Per result file you can select one or more variables to plot.
-Note that Basin results are only available on Basins, which means you have to select the Node layer first, and then select the Basin nodes you wish to see.
+Flow rates can also be plotted from the nodes.
+Depending on the node type, you will see a simple flow rate (e.g. Pump), or separate inflow and outflow rates, summed if there are multiple incoming or outgoing links (e.g. Basin).
+
+You can select multiple variables to plot at the same time, they are grouped by unit.
+Note that Basin results are only available on Basins, which means you have to select the `node` button first, and then select the Basin nodes you wish to see.
+Select one Basin, and choose the variable `water balance` to see:
+
+![](https://s3.deltares.nl/ribasim/doc-image/qgis/timeseries-plot-water-balance.png){fig-align="left"}
+
+Select one link, and if you have concentration results, you can choose the variable `fractional flow` to see which tracers the flow consists of:
+
+![](https://s3.deltares.nl/ribasim/doc-image/qgis/timeseries-plot-fractional-flow.png){fig-align="left"}
+
+Under the variable → concentration dropdown menu you can select another set of tracers if they are available.
 
 # Reloading models {#sec-reload}
 

--- a/docs/reference/node/observation.qmd
+++ b/docs/reference/node/observation.qmd
@@ -1,12 +1,12 @@
 ---
-title: "![](/assets/node-icons/Observation.svg){height=20} Observation / time"
+title: "![](/assets/node-icons/Observation.svg){height=20} Observation"
 ---
 
 An Observation node is used to attach time series of observed or reference data to a node in the network. These are not used in the simulation core, but are available for visualization, validation, or post-processing.
 
-Observation nodes can be linked to Basin and connector nodes with an observation link.
-The link direction is always from the Observation node to the observed node.
-An Observation node can connect to 0 or 1 nodes, but can hold multiple observed variables for a single node.
+Observation nodes can be linked to Basins and connector nodes.
+This is done with an observation link, whose direction is always from the Observation node to the observed node.
+An Observation node connects to at most one other node, but may carry multiple variables for that node.
 
 # Tables
 
@@ -15,24 +15,27 @@ An Observation node can connect to 0 or 1 nodes, but can hold multiple observed 
 column   | type     | unit   | restriction
 -------- | -------- | ------ | -----------
 node_id  | Int32    | -      |
-variable | String   | -      | Name of the observed variable (e.g. "level", "flow_rate")
+variable | String   | -      | Name of the Ribasim variable being observed (e.g. "level", "flow_rate"), see [Results](reference/usage.qmd#sec-results)
 time     | DateTime | -      | Timestamp of the observation
-value    | Float64  | -      | Value of the observation
+value    | Float64  | -      | Value of the observation, unit equal to Ribasim variable
 
 # Examples
 
-This example shows two Observation nodes observing a Basin and a TabulatedRatingCurve. The table below shows the time series for both nodes:
+This example shows two Observation nodes (#1 and #2) observing a Basin and a TabulatedRatingCurve.
+The table below shows the time series for both nodes:
 
-| node_id | variable   | time                | value |
-| ------- | ---------- | ------------------- | ----- |
-| 1       | level      | 2020-01-01 00:00:00 | 0.5   |
-| 1       | level      | 2020-02-01 00:00:00 | 0.3   |
-| 1       | level      | 2020-03-01 00:00:00 | 0.4   |
-| 2       | flow_rate  | 2020-01-01 00:00:00 | 0.0   |
-| 2       | flow_rate  | 2020-02-01 00:00:00 | 0.05  |
-| 2       | flow_rate  | 2020-03-01 00:00:00 | 0.1   |
+| node_id | variable  | time                | value |
+| ------- | --------- | ------------------- | ----- |
+| 1       | level     | 2020-01-01 00:00:00 | 0.5   |
+| 1       | level     | 2020-02-01 00:00:00 | 0.3   |
+| 1       | level     | 2020-03-01 00:00:00 | 0.4   |
+| 2       | flow_rate | 2020-01-01 00:00:00 | 0.0   |
+| 2       | flow_rate | 2020-02-01 00:00:00 | 0.05  |
+| 2       | flow_rate | 2020-03-01 00:00:00 | 0.1   |
 
 # Notes
 
 - Observation nodes are not included in the simulation graph and do not affect results.
 - They are intended for reference, validation, or visualization purposes only.
+- Flow links cannot be observed directly; link to the connector node with variable `flow_rate` instead.
+- Non-conservative nodes don't have `flow_rate`; specify either `inflow_rate` or `outflow_rate` for e.g. Basin or UserDemand.

--- a/ribasim_qgis/tests/test_plot_widget.py
+++ b/ribasim_qgis/tests/test_plot_widget.py
@@ -37,16 +37,11 @@ def test_plot_widget_preload_variables():
         "basin": {"level": "m", "storage": "m3"},
         "flow": {"flow_rate": "m3 s-1"},
     }
-    widget.preload_variables(available, units, defaults={"basin": "level"})
+    widget.preload_variables(available, units, defaults={"basin": ["level"]})
     assert widget._available == available
     assert widget._units == units
-    assert widget._defaults == {"basin": "level"}
-    assert set(widget._var_menu.checked_variables()) == {"basin / level"}
-    assert widget._menu_to_key == {
-        "basin / level": ("basin", "level"),
-        "basin / storage": ("basin", "storage"),
-        "flow / flow_rate": ("flow", "flow_rate"),
-    }
+    assert widget._defaults == {"basin": ["level"]}
+    assert set(widget._var_menu.checked_keys()) == {("basin", "level")}
 
 
 def test_plot_widget_preload_multiple_defaults():
@@ -56,12 +51,42 @@ def test_plot_widget_preload_multiple_defaults():
         "basin": ["level", "storage"],
         "flow": ["flow_rate"],
     }
-    defaults = {"basin": "level", "flow": "flow_rate"}
+    defaults = {"basin": ["level"], "flow": ["flow_rate"]}
     widget.preload_variables(available, defaults=defaults)
-    assert set(widget._var_menu.checked_variables()) == {
-        "basin / level",
-        "flow / flow_rate",
+    assert set(widget._var_menu.checked_keys()) == {
+        ("basin", "level"),
+        ("flow", "flow_rate"),
     }
+
+
+def test_plot_widget_flow_rate_group_toggles_all_constituents():
+    """The synthetic 'flow_rate' root checkbox toggles all three keys."""
+    widget = PlotWidget()
+    available = {
+        "basin": ["level", "inflow_rate", "outflow_rate"],
+        "flow": ["flow_rate"],
+    }
+    defaults = {
+        "basin": ["level", "inflow_rate", "outflow_rate"],
+        "flow": ["flow_rate"],
+    }
+    widget.preload_variables(available, defaults=defaults)
+
+    # Default-on: level + flow_rate group => 4 keys.
+    assert set(widget._var_menu.checked_keys()) == {
+        ("basin", "level"),
+        ("basin", "inflow_rate"),
+        ("basin", "outflow_rate"),
+        ("flow", "flow_rate"),
+    }
+
+    # All basin variables are constituents of root groups, so no basin
+    # submenu is created.
+    submenu_titles = {
+        action.menu().title() for action in widget._var_menu.actions() if action.menu()
+    }
+    assert "basin" not in submenu_titles
+    assert "flow" not in submenu_titles
 
 
 def test_plot_widget_set_data_and_redraw():
@@ -73,10 +98,10 @@ def test_plot_widget_set_data_and_redraw():
         "basin": {"level": "m"},
         "flow": {"flow_rate": "m3 s-1"},
     }
-    widget.preload_variables(available, units=units, defaults={"basin": "level"})
+    widget.preload_variables(available, units=units, defaults={"basin": ["level"]})
     widget._var_menu.populate(
         widget._available,
-        {"basin / level", "flow / flow_rate"},
+        {("basin", "level"), ("flow", "flow_rate")},
         widget._defaults,
         widget._water_balance_enabled,
     )
@@ -88,12 +113,12 @@ def test_plot_widget_set_data_and_redraw():
     plot_data: PlotData = {
         "basin": {
             "level": {
-                "#1": (time, basin_values),
+                "Basin #1": (time, basin_values),
             }
         },
         "flow": {
             "flow_rate": {
-                "#3": (time, flow_values),
+                "Link #3": (time, flow_values),
             }
         },
     }
@@ -108,11 +133,11 @@ def test_plot_widget_clear():
     widget = PlotWidget()
 
     available = {"basin": ["level"]}
-    widget.preload_variables(available, defaults={"basin": "level"})
+    widget.preload_variables(available, defaults={"basin": ["level"]})
 
     time = np.array(["2020-01-01", "2020-01-02"])
     values = np.array([1.0, 2.0])
-    widget.set_data({"basin": {"level": {"#1": (time, values)}}})
+    widget.set_data({"basin": {"level": {"Basin #1": (time, values)}}})
 
     widget.clear()
     assert widget._plot_data == {}
@@ -123,13 +148,13 @@ def test_plot_widget_clear():
 def test_plot_widget_empty_data_shows_placeholder():
     widget = PlotWidget()
     available = {"basin": ["level"]}
-    widget.preload_variables(available, defaults={"basin": "level"})
+    widget.preload_variables(available, defaults={"basin": ["level"]})
     widget.set_data({})
     assert widget._placeholder.isVisibleTo(widget)
     assert not widget._web_view.isVisibleTo(widget)
 
 
-def test_plot_widget_legend_includes_file_and_variable(monkeypatch):
+def test_plot_widget_legend_uses_entity_and_variable(monkeypatch):
     captured_figures = []
 
     def _capture_plot(fig, **kwargs):
@@ -142,11 +167,11 @@ def test_plot_widget_legend_includes_file_and_variable(monkeypatch):
     widget.preload_variables(
         {"basin": ["level"], "flow": ["level"]},
         units={"basin": {"level": "m"}, "flow": {"level": "m"}},
-        defaults={"basin": "level"},
+        defaults={"basin": ["level"]},
     )
     widget._var_menu.populate(
         widget._available,
-        {"basin / level", "flow / level"},
+        {("basin", "level"), ("flow", "level")},
         widget._defaults,
         widget._water_balance_enabled,
     )
@@ -154,14 +179,14 @@ def test_plot_widget_legend_includes_file_and_variable(monkeypatch):
     time = np.array(["2020-01-01", "2020-01-02"])
     widget.set_data(
         {
-            "basin": {"level": {"#1": (time, np.array([1.0, 2.0]))}},
-            "flow": {"level": {"#9": (time, np.array([3.0, 4.0]))}},
+            "basin": {"level": {"Basin #1": (time, np.array([1.0, 2.0]))}},
+            "flow": {"level": {"Link #9": (time, np.array([3.0, 4.0]))}},
         }
     )
 
     assert len(captured_figures) == 1
     names = {trace.name for trace in captured_figures[0].data}
-    assert names == {"basin / level #1", "flow / level #9"}
+    assert names == {"Basin #1 level", "Link #9 level"}
 
 
 def test_plot_widget_groups_unitless_into_no_unit_subplot(monkeypatch):
@@ -177,11 +202,11 @@ def test_plot_widget_groups_unitless_into_no_unit_subplot(monkeypatch):
     widget.preload_variables(
         {"basin": ["level", "state"]},
         units={"basin": {"level": "m", "state": ""}},
-        defaults={"basin": "level"},
+        defaults={"basin": ["level"]},
     )
     widget._var_menu.populate(
         widget._available,
-        {"basin / level", "basin / state"},
+        {("basin", "level"), ("basin", "state")},
         widget._defaults,
         widget._water_balance_enabled,
     )
@@ -190,8 +215,8 @@ def test_plot_widget_groups_unitless_into_no_unit_subplot(monkeypatch):
     widget.set_data(
         {
             "basin": {
-                "level": {"#1": (time, np.array([1.0, 2.0]))},
-                "state": {"#1": (time, np.array([0.0, 1.0]))},
+                "level": {"Basin #1": (time, np.array([1.0, 2.0]))},
+                "state": {"Basin #1": (time, np.array([0.0, 1.0]))},
             }
         }
     )
@@ -217,15 +242,15 @@ def test_plot_widget_basin_water_balance_preset_applies_signs(monkeypatch):
     time = np.array(["2020-01-01", "2020-01-02"])
     plot_data = {
         "basin": {
-            "inflow_rate": {"#1": (time, np.array([10.0, 11.0]))},
-            "precipitation": {"#1": (time, np.array([1.0, 2.0]))},
-            "surface_runoff": {"#1": (time, np.array([3.0, 4.0]))},
-            "drainage": {"#1": (time, np.array([5.0, 6.0]))},
-            "outflow_rate": {"#1": (time, np.array([7.0, 8.0]))},
-            "storage_rate": {"#1": (time, np.array([9.0, 10.0]))},
-            "evaporation": {"#1": (time, np.array([11.0, 12.0]))},
-            "infiltration": {"#1": (time, np.array([13.0, 14.0]))},
-            "balance_error": {"#1": (time, np.array([15.0, 16.0]))},
+            "inflow_rate": {"Basin #1": (time, np.array([10.0, 11.0]))},
+            "precipitation": {"Basin #1": (time, np.array([1.0, 2.0]))},
+            "surface_runoff": {"Basin #1": (time, np.array([3.0, 4.0]))},
+            "drainage": {"Basin #1": (time, np.array([5.0, 6.0]))},
+            "outflow_rate": {"Basin #1": (time, np.array([7.0, 8.0]))},
+            "storage_rate": {"Basin #1": (time, np.array([9.0, 10.0]))},
+            "evaporation": {"Basin #1": (time, np.array([11.0, 12.0]))},
+            "infiltration": {"Basin #1": (time, np.array([13.0, 14.0]))},
+            "balance_error": {"Basin #1": (time, np.array([15.0, 16.0]))},
         }
     }
     units = {
@@ -276,8 +301,8 @@ def test_plot_widget_basin_water_balance_preset_requires_single_basin():
         {
             "basin": {
                 "inflow_rate": {
-                    "#1": (time, np.array([1.0, 2.0])),
-                    "#2": (time, np.array([3.0, 4.0])),
+                    "Basin #1": (time, np.array([1.0, 2.0])),
+                    "Basin #2": (time, np.array([3.0, 4.0])),
                 }
             }
         }
@@ -303,11 +328,11 @@ def test_plot_widget_basin_water_balance_preset_includes_other_selected_variable
 
     widget.preload_variables(
         {"basin": ["inflow_rate"], "flow": ["flow_rate"]},
-        defaults={"flow": "flow_rate"},
+        defaults={"flow": ["flow_rate"]},
     )
     widget._var_menu.populate(
         widget._available,
-        {"flow / flow_rate"},
+        {("flow", "flow_rate")},
         widget._defaults,
         widget._water_balance_enabled,
     )
@@ -316,11 +341,11 @@ def test_plot_widget_basin_water_balance_preset_includes_other_selected_variable
     widget.set_data(
         {
             "basin": {
-                "inflow_rate": {"#1": (time, np.array([10.0, 11.0]))},
-                "outflow_rate": {"#1": (time, np.array([7.0, 8.0]))},
+                "inflow_rate": {"Basin #1": (time, np.array([10.0, 11.0]))},
+                "outflow_rate": {"Basin #1": (time, np.array([7.0, 8.0]))},
             },
             "flow": {
-                "flow_rate": {"#9": (time, np.array([2.0, 3.0]))},
+                "flow_rate": {"Link #9": (time, np.array([2.0, 3.0]))},
             },
         },
         units={
@@ -331,7 +356,7 @@ def test_plot_widget_basin_water_balance_preset_includes_other_selected_variable
 
     assert len(captured_figures) == 1
     names = [trace.name for trace in captured_figures[0].data]
-    assert names == ["- outflow_rate", "+ inflow_rate", "flow / flow_rate #9"]
+    assert names == ["- outflow_rate", "+ inflow_rate", "Link #9 flow_rate"]
     assert captured_figures[0].layout.yaxis2.title.text == "m3 s-1"
 
 
@@ -339,7 +364,7 @@ def test_plot_widget_combined_menu_has_presets_and_file_submenus():
     widget = PlotWidget()
     widget.preload_variables(
         {"basin": ["level", "storage", "state"], "flow": ["flow_rate", "q"]},
-        defaults={"basin": "level"},
+        defaults={"basin": ["level"]},
     )
 
     root_checkbox_texts = {
@@ -458,11 +483,11 @@ def test_plot_widget_fractional_storage_preset_plots_default_tracers(monkeypatch
     time = np.array(["2020-01-01", "2020-01-02"])
     plot_data = {
         "concentration": {
-            "LevelBoundary": {"#1": (time, np.array([0.1, 0.2]))},
-            "FlowBoundary": {"#1": (time, np.array([0.3, 0.4]))},
-            "Initial": {"#1": (time, np.array([0.5, 0.3]))},
-            "Drainage": {"#1": (time, np.array([0.05, 0.05]))},
-            "Precipitation": {"#1": (time, np.array([0.05, 0.05]))},
+            "LevelBoundary": {"Basin #1": (time, np.array([0.1, 0.2]))},
+            "FlowBoundary": {"Basin #1": (time, np.array([0.3, 0.4]))},
+            "Initial": {"Basin #1": (time, np.array([0.5, 0.3]))},
+            "Drainage": {"Basin #1": (time, np.array([0.05, 0.05]))},
+            "Precipitation": {"Basin #1": (time, np.array([0.05, 0.05]))},
         }
     }
 
@@ -491,8 +516,8 @@ def test_plot_widget_fractional_storage_preset_requires_single_node():
         {
             "concentration": {
                 "LevelBoundary": {
-                    "#1": (time, np.array([0.5, 0.5])),
-                    "#2": (time, np.array([0.5, 0.5])),
+                    "Basin #1": (time, np.array([0.5, 0.5])),
+                    "Basin #2": (time, np.array([0.5, 0.5])),
                 }
             }
         }
@@ -520,7 +545,7 @@ def test_plot_widget_fractional_storage_preset_uses_selected_substances(monkeypa
     # Check only LevelBoundary in the concentration submenu.
     widget._var_menu.populate(
         widget._available,
-        {"concentration / LevelBoundary"},
+        {("concentration", "LevelBoundary")},
         widget._defaults,
         widget._water_balance_enabled,
         widget._fractional_storage_enabled,
@@ -531,9 +556,9 @@ def test_plot_widget_fractional_storage_preset_uses_selected_substances(monkeypa
     widget.set_data(
         {
             "concentration": {
-                "LevelBoundary": {"#1": (time, np.array([0.5, 0.6]))},
-                "FlowBoundary": {"#1": (time, np.array([0.3, 0.2]))},
-                "Initial": {"#1": (time, np.array([0.2, 0.2]))},
+                "LevelBoundary": {"Basin #1": (time, np.array([0.5, 0.6]))},
+                "FlowBoundary": {"Basin #1": (time, np.array([0.3, 0.2]))},
+                "Initial": {"Basin #1": (time, np.array([0.2, 0.2]))},
             }
         },
     )
@@ -571,9 +596,9 @@ def test_plot_widget_fractional_storage_distinct_from_regular_concentration(
     widget._var_menu.populate(
         widget._available,
         {
-            "concentration / LevelBoundary",
-            "concentration / FlowBoundary",
-            "basin / level",
+            ("concentration", "LevelBoundary"),
+            ("concentration", "FlowBoundary"),
+            ("basin", "level"),
         },
         widget._defaults,
         widget._water_balance_enabled,
@@ -585,11 +610,11 @@ def test_plot_widget_fractional_storage_distinct_from_regular_concentration(
     widget.set_data(
         {
             "concentration": {
-                "LevelBoundary": {"#1": (time, np.array([0.5, 0.6]))},
-                "FlowBoundary": {"#1": (time, np.array([0.5, 0.4]))},
+                "LevelBoundary": {"Basin #1": (time, np.array([0.5, 0.6]))},
+                "FlowBoundary": {"Basin #1": (time, np.array([0.5, 0.4]))},
             },
             "basin": {
-                "level": {"#1": (time, np.array([2.0, 2.1]))},
+                "level": {"Basin #1": (time, np.array([2.0, 2.1]))},
             },
         },
         units={"basin": {"level": "m"}},
@@ -602,7 +627,7 @@ def test_plot_widget_fractional_storage_distinct_from_regular_concentration(
     # concentration line traces.
     assert "LevelBoundary" in names
     assert "FlowBoundary" in names
-    assert "basin / level #1" in names
+    assert "Basin #1 level" in names
     # Ensure the concentration substances are in the stacked area, not lines.
     for trace in fig.data:
         if trace.name in ("LevelBoundary", "FlowBoundary"):
@@ -644,7 +669,7 @@ def test_plot_widget_fractional_flow_plots_multiplied_values(monkeypatch):
     widget.set_data(
         {
             "flow": {
-                "flow_rate": {"#42": (time, np.array([10.0, 20.0]))},
+                "flow_rate": {"Link #42": (time, np.array([10.0, 20.0]))},
             },
         },
         units={"flow": {"flow_rate": "m3 s-1"}},
@@ -680,8 +705,8 @@ def test_plot_widget_fractional_flow_requires_single_link():
         {
             "flow": {
                 "flow_rate": {
-                    "#1": (time, np.array([5.0, 6.0])),
-                    "#2": (time, np.array([3.0, 4.0])),
+                    "Link #1": (time, np.array([5.0, 6.0])),
+                    "Link #2": (time, np.array([3.0, 4.0])),
                 },
             },
         },
@@ -756,7 +781,7 @@ def test_plot_widget_fractional_flow_junction(monkeypatch):
     widget.set_data(
         {
             "flow": {
-                "flow_rate": {"#1": (time, np.array([10.0, 20.0]))},
+                "flow_rate": {"Link #1": (time, np.array([10.0, 20.0]))},
             },
         },
         units={"flow": {"flow_rate": "m3 s-1"}},
@@ -812,7 +837,7 @@ def test_plot_widget_fractional_flow_traverses_connector(monkeypatch):
     widget.set_data(
         {
             "flow": {
-                "flow_rate": {"#1": (time, np.array([10.0, 20.0]))},
+                "flow_rate": {"Link #1": (time, np.array([10.0, 20.0]))},
             },
         },
     )
@@ -858,7 +883,7 @@ def test_plot_widget_fractional_flow_sign_flip(monkeypatch):
     widget.set_data(
         {
             "flow": {
-                "flow_rate": {"#1": (time, np.array([10.0, -10.0]))},
+                "flow_rate": {"Link #1": (time, np.array([10.0, -10.0]))},
             },
         },
     )
@@ -937,7 +962,7 @@ def test_plot_widget_fractional_flow_connector_to_junction(monkeypatch):
     widget.set_data(
         {
             "flow": {
-                "flow_rate": {"#1": (time, np.array([10.0, 20.0]))},
+                "flow_rate": {"Link #1": (time, np.array([10.0, 20.0]))},
             },
         },
         units={"flow": {"flow_rate": "m3 s-1"}},

--- a/ribasim_qgis/tests/test_ribasim_cli_lookup.py
+++ b/ribasim_qgis/tests/test_ribasim_cli_lookup.py
@@ -44,7 +44,7 @@ def test_ribasim_home_setting_roundtrip(monkeypatch):
     assert DatasetWidget.get_ribasim_home_setting() is None
 
 
-def test_last_model_dir_setting_roundtrip(monkeypatch):
+def test_last_model_path_setting_roundtrip(monkeypatch):
     store: dict[str, str] = {}
 
     class FakeQgsSettings:
@@ -61,12 +61,12 @@ def test_last_model_dir_setting_roundtrip(monkeypatch):
         "ribasim_qgis.widgets.dataset_widget.QgsSettings", FakeQgsSettings
     )
 
-    assert DatasetWidget.get_last_model_dir_setting() is None
+    assert DatasetWidget.get_last_model_path_setting() is None
 
-    expected = Path("C:/models/basic")
-    DatasetWidget.set_last_model_dir_setting(expected)
+    expected = Path("C:/models/basic/ribasim.toml")
+    DatasetWidget.set_last_model_path_setting(expected)
 
-    assert DatasetWidget.get_last_model_dir_setting() == expected
+    assert DatasetWidget.get_last_model_path_setting() == expected
 
 
 def test_open_model_uses_last_model_dir_for_dialog(monkeypatch):
@@ -75,8 +75,8 @@ def test_open_model_uses_last_model_dir_for_dialog(monkeypatch):
 
     monkeypatch.setattr(
         DatasetWidget,
-        "get_last_model_dir_setting",
-        staticmethod(lambda: Path("C:/models/basic")),
+        "get_last_model_path_setting",
+        staticmethod(lambda: Path("C:/models/basic/ribasim.toml")),
     )
 
     captured: dict[str, str] = {}
@@ -96,13 +96,13 @@ def test_open_model_uses_last_model_dir_for_dialog(monkeypatch):
     assert Path(captured["directory"]) == Path("C:/models/basic")
 
 
-def test_open_model_stores_parent_directory(monkeypatch):
+def test_open_model_stores_model_path(monkeypatch):
     widget = DatasetWidget.__new__(DatasetWidget)
 
     captured: dict[str, Path] = {}
     monkeypatch.setattr(
         DatasetWidget,
-        "set_last_model_dir_setting",
+        "set_last_model_path_setting",
         staticmethod(lambda path: captured.__setitem__("path", path)),
     )
     monkeypatch.setattr(DatasetWidget, "set_current_time_extent", lambda self: None)
@@ -113,7 +113,7 @@ def test_open_model_stores_parent_directory(monkeypatch):
     widget._open_model("C:/models/basic/ribasim.toml")
 
     assert widget.path == Path("C:/models/basic/ribasim.toml")
-    assert captured["path"] == Path("C:/models/basic")
+    assert captured["path"] == Path("C:/models/basic/ribasim.toml")
 
 
 def test_find_ribasim_cli_uses_setting_first(monkeypatch):

--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -4,6 +4,7 @@ A widget that displays the available input layers in the GeoPackage.
 It also allows enabling or disabling individual elements for a computation.
 """
 
+import contextlib
 import os
 import re
 import shutil
@@ -13,6 +14,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any, cast
 
+import numpy as np
 from qgis.core import (
     Qgis,
     QgsApplication,
@@ -68,14 +70,51 @@ _ID_COLUMNS: dict[str, str] = {
     "concentration": "node_id",
 }
 
-# Default variable to select per file when no previous selection exists.
-_DEFAULT_VARIABLES: dict[str, str] = {
-    "basin": "level",
-    "flow": "flow_rate",
+# Mapping from result file name to the entity type used as legend prefix.
+_ENTITY_BY_FILE: dict[str, str] = {
+    "basin": "Basin",
+    "flow": "Link",
+    "concentration": "Basin",
 }
 
+# Default variables to select per file when no previous selection exists.
+_DEFAULT_VARIABLES: dict[str, list[str]] = {
+    "basin": ["level", "inflow_rate", "outflow_rate"],
+    "flow": ["flow_rate"],
+}
+
+# Non-Basin node types whose flow_rate is taken from their outgoing flow link.
+# These nodes are conservative (inflow == outflow), so the outgoing link
+# flow_rate represents the node's flow_rate.
+_FLOW_RATE_FROM_OUTGOING_LINK: frozenset[str] = frozenset(
+    {
+        "TabulatedRatingCurve",
+        "LinearResistance",
+        "ManningResistance",
+        "Pump",
+        "Outlet",
+        "FlowBoundary",
+    }
+)
+
+# Non-conservative node types: inflow and outflow can differ, so we plot both
+# the incoming and outgoing flow links as separate traces.
+_FLOW_RATE_FROM_INCOMING_AND_OUTGOING_LINKS: frozenset[str] = frozenset({"UserDemand"})
+
+# Node types with potentially multiple incoming flow links whose summed
+# inflow we plot. ``Terminal`` only has incoming flow; ``Junction`` is
+# conservative so the inflow sum equals the outflow sum.
+_FLOW_RATE_FROM_INCOMING_LINKS_SUM: frozenset[str] = frozenset({"Terminal", "Junction"})
+
+# Node types with potentially multiple incoming and outgoing flow links
+# where inflow and outflow may differ. We plot the sum of incoming and the
+# sum of outgoing links as separate traces.
+_FLOW_RATE_FROM_INCOMING_AND_OUTGOING_LINKS_SUM: frozenset[str] = frozenset(
+    {"LevelBoundary"}
+)
+
 RIBASIM_HOME_SETTING = "ribasim/home"
-RIBASIM_LAST_MODEL_DIR_SETTING = "ribasim/last_model_dir"
+RIBASIM_LAST_MODEL_PATH_SETTING = "ribasim/last_model_path"
 
 _ANSI_ESCAPE_RE = re.compile(r"\x1B(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1B\\))")
 
@@ -168,7 +207,8 @@ class DatasetWidget:
             # pyrefly: ignore[missing-attribute]
             rel.RelationStrength.Composition
         )
-        rel.addFieldPair(fk, "node_id")
+        # Both layers use the same field name for their primary key.
+        rel.addFieldPair(fk, fk)
         rel.generateId()
         instance = QgsProject.instance()
         assert instance is not None
@@ -204,10 +244,6 @@ class DatasetWidget:
 
         link = nodes.pop("Link")
         self.add_item_to_qgis(link)
-        self.add_relationship(
-            link.layer, node.layer.id(), "LinkFromNode", "from_node_id"
-        )
-        self.add_relationship(link.layer, node.layer.id(), "LinkToNode", "to_node_id")
 
         # Add the remaining layers
         for table_name, node_layer in nodes.items():
@@ -258,7 +294,8 @@ class DatasetWidget:
     def open_model(self, path=None) -> None:
         """Open a Ribasim model file."""
         if not path:
-            start_dir = self.get_last_model_dir_setting()
+            last_path = self.get_last_model_path_setting()
+            start_dir = last_path.parent if last_path is not None else None
             path, _ = QFileDialog.getOpenFileName(
                 self.ribasim_widget,
                 "Select file",
@@ -270,7 +307,7 @@ class DatasetWidget:
     def _open_model(self, path: str) -> None:
         if path != "":  # Empty string in case of cancel button press
             self.path = Path(path)
-            self.set_last_model_dir_setting(self.path.parent)
+            self.set_last_model_path_setting(self.path)
             self.set_current_time_extent()
             self.load_geopackage()
             self.add_topology_context()
@@ -424,15 +461,15 @@ class DatasetWidget:
         settings.remove(RIBASIM_HOME_SETTING)
 
     @staticmethod
-    def get_last_model_dir_setting() -> Path | None:
+    def get_last_model_path_setting() -> Path | None:
         settings = QgsSettings()
-        value = settings.value(RIBASIM_LAST_MODEL_DIR_SETTING, "", type=str)
+        value = settings.value(RIBASIM_LAST_MODEL_PATH_SETTING, "", type=str)
         return Path(value) if value else None
 
     @staticmethod
-    def set_last_model_dir_setting(path: Path) -> None:
+    def set_last_model_path_setting(path: Path) -> None:
         settings = QgsSettings()
-        settings.setValue(RIBASIM_LAST_MODEL_DIR_SETTING, str(path))
+        settings.setValue(RIBASIM_LAST_MODEL_PATH_SETTING, str(path))
 
     @staticmethod
     def get_ribasim_cli_from_home(ribasim_home: Path) -> Path | None:
@@ -684,6 +721,10 @@ class DatasetWidget:
             )
             assert self.basin_layer is not None
             self._edit_result_layer(result, self.basin_layer)
+            self.add_relationship(
+                self.basin_layer, node_layer.id(), "BasinResult", fk="node_id"
+            )
+            self._sync_selection_to_result(node_layer, self.basin_layer, "node_id")
 
         result = self.results.get("concentration")
         if result is not None:
@@ -692,6 +733,15 @@ class DatasetWidget:
             )
             assert self.concentration_layer is not None
             self._edit_result_layer(result, self.concentration_layer)
+            self.add_relationship(
+                self.concentration_layer,
+                node_layer.id(),
+                "ConcentrationResult",
+                fk="node_id",
+            )
+            self._sync_selection_to_result(
+                node_layer, self.concentration_layer, "node_id"
+            )
 
     def _set_link_results(self) -> None:
         link_layer = self.ribasim_widget.link_layer
@@ -705,6 +755,44 @@ class DatasetWidget:
             assert self.flow_layer is not None
             self.set_layer_visible(self.flow_layer, True)
             self._edit_result_layer(result, self.flow_layer)
+            self.add_relationship(
+                self.flow_layer, link_layer.id(), "FlowResult", fk="link_id"
+            )
+            self._sync_selection_to_result(link_layer, self.flow_layer, "link_id")
+
+    @staticmethod
+    def _sync_selection_to_result(
+        source_layer: QgsVectorLayer,
+        result_layer: QgsVectorLayer,
+        fk: str,
+    ) -> None:
+        """Mirror the selection in *source_layer* to *result_layer*.
+
+        Selecting Node/Link features in the (possibly hidden) input layer
+        highlights the corresponding Basin/Flow features in the spatial
+        results, so users can see which ones are selected via the standard
+        QGIS yellow highlight.
+        """
+
+        def on_selection_changed(_selected_fids: list[int]) -> None:
+            try:
+                fk_values = {int(feat[fk]) for feat in source_layer.selectedFeatures()}
+            except RuntimeError:
+                # source_layer was deleted underneath us.
+                return
+            if not fk_values:
+                with contextlib.suppress(RuntimeError):
+                    result_layer.removeSelection()
+                return
+            expr = f'"{fk}" IN ({",".join(str(v) for v in fk_values)})'
+            request = QgsFeatureRequest().setFilterExpression(expr)
+            try:
+                target_fids = [feat.id() for feat in result_layer.getFeatures(request)]  # pyrefly: ignore[not-iterable]
+                result_layer.selectByIds(target_fids)
+            except RuntimeError:
+                return
+
+        source_layer.selectionChanged.connect(on_selection_changed)
 
     def _duplicate_layer(
         self,
@@ -869,12 +957,14 @@ class DatasetWidget:
         node_layer = self.ribasim_widget.node_layer
         link_layer = self.ribasim_widget.link_layer
 
-        # Gather selected node IDs
-        selected_node_ids: list[int] = []
+        # Gather selected nodes as (node_id, node_type) tuples.
+        selected_nodes: list[tuple[int, str]] = []
         if node_layer is not None:
             for fid in node_layer.selectedFeatureIds():
                 feat = node_layer.getFeature(fid)
-                selected_node_ids.append(feat["node_id"])
+                selected_nodes.append((int(feat["node_id"]), str(feat["node_type"])))
+
+        selected_node_ids = [node_id for node_id, _ in selected_nodes]
 
         # Gather selected link IDs
         selected_link_ids: list[int] = []
@@ -893,6 +983,7 @@ class DatasetWidget:
             if not ids:
                 continue
 
+            entity = _ENTITY_BY_FILE.get(name, "")
             # Build id -> column-index mapping (O(1) lookup)
             id_to_idx = {int(v): i for i, v in enumerate(result.ids)}
             time_strings = result.time.strftime("%Y-%m-%dT%H:%M:%S").to_numpy()
@@ -903,12 +994,17 @@ class DatasetWidget:
                 for sel_id in ids:
                     idx = id_to_idx.get(sel_id)
                     if idx is not None:
-                        traces[f"#{sel_id}"] = (time_strings, arr[:, idx])
+                        trace_key = f"{entity} #{sel_id}" if entity else f"#{sel_id}"
+                        traces[trace_key] = (time_strings, arr[:, idx])
                 if traces:
                     vars_data[var_name] = traces
 
             if vars_data:
                 plot_data[name] = vars_data
+
+        # Inject flow_rate traces derived from outgoing links for selected
+        # non-Basin conservative nodes (e.g. TabulatedRatingCurve).
+        self._inject_node_flow_rate_traces(plot_data, selected_nodes, link_layer)
 
         # Collect units from results
         units: dict[str, dict[str, str]] = {
@@ -918,3 +1014,117 @@ class DatasetWidget:
             self.plot_widget.set_data(plot_data, units)
         else:
             self.plot_widget.clear()
+
+    def _inject_node_flow_rate_traces(
+        self,
+        plot_data: PlotData,
+        selected_nodes: list[tuple[int, str]],
+        link_layer: Any,
+    ) -> None:
+        """Add flow.nc flow_rate traces for selected non-Basin nodes.
+
+        Four cases:
+
+        * Conservative single-link nodes (e.g. ``TabulatedRatingCurve``):
+          show the outgoing flow link as the node's flow_rate.
+        * Non-conservative single-link nodes (e.g. ``UserDemand``): show
+          the incoming and outgoing flow links separately.
+        * Multi-link inflow-only nodes (``Terminal``, ``Junction``): show
+          the sum of all incoming flow links.
+        * Multi-link non-conservative nodes (``LevelBoundary``): show the
+          sum of incoming and the sum of outgoing flow links separately.
+        """
+        flow_result = self.results.get("flow")
+        if flow_result is None or link_layer is None:
+            return
+        flow_arr = flow_result.variables.get("flow_rate")
+        if flow_arr is None:
+            return
+
+        link_id_to_idx = {int(v): i for i, v in enumerate(flow_result.ids)}
+        time_strings = flow_result.time.strftime("%Y-%m-%dT%H:%M:%S").to_numpy()
+
+        new_traces: VariableTraces = {}
+        for node_id, node_type in selected_nodes:
+            if node_type in _FLOW_RATE_FROM_OUTGOING_LINK:
+                outgoing = self._connected_flow_columns(
+                    link_layer, node_id, "from", link_id_to_idx, flow_arr
+                )
+                if outgoing:
+                    new_traces[f"{node_type} #{node_id} flow_rate"] = (
+                        time_strings,
+                        outgoing[0],
+                    )
+            elif node_type in _FLOW_RATE_FROM_INCOMING_AND_OUTGOING_LINKS:
+                incoming = self._connected_flow_columns(
+                    link_layer, node_id, "to", link_id_to_idx, flow_arr
+                )
+                outgoing = self._connected_flow_columns(
+                    link_layer, node_id, "from", link_id_to_idx, flow_arr
+                )
+                if incoming:
+                    new_traces[f"{node_type} #{node_id} inflow_rate"] = (
+                        time_strings,
+                        incoming[0],
+                    )
+                if outgoing:
+                    new_traces[f"{node_type} #{node_id} outflow_rate"] = (
+                        time_strings,
+                        outgoing[0],
+                    )
+            elif node_type in _FLOW_RATE_FROM_INCOMING_LINKS_SUM:
+                incoming = self._connected_flow_columns(
+                    link_layer, node_id, "to", link_id_to_idx, flow_arr
+                )
+                if incoming:
+                    new_traces[f"{node_type} #{node_id} inflow_rate"] = (
+                        time_strings,
+                        np.sum(incoming, axis=0),
+                    )
+            elif node_type in _FLOW_RATE_FROM_INCOMING_AND_OUTGOING_LINKS_SUM:
+                incoming = self._connected_flow_columns(
+                    link_layer, node_id, "to", link_id_to_idx, flow_arr
+                )
+                outgoing = self._connected_flow_columns(
+                    link_layer, node_id, "from", link_id_to_idx, flow_arr
+                )
+                if incoming:
+                    new_traces[f"{node_type} #{node_id} inflow_rate"] = (
+                        time_strings,
+                        np.sum(incoming, axis=0),
+                    )
+                if outgoing:
+                    new_traces[f"{node_type} #{node_id} outflow_rate"] = (
+                        time_strings,
+                        np.sum(outgoing, axis=0),
+                    )
+
+        if not new_traces:
+            return
+        flow_vars = plot_data.setdefault("flow", {})
+        flow_rate_traces = flow_vars.setdefault("flow_rate", {})
+        flow_rate_traces.update(new_traces)
+
+    @staticmethod
+    def _connected_flow_columns(
+        link_layer: Any,
+        node_id: int,
+        direction: str,
+        link_id_to_idx: dict[int, int],
+        flow_arr: np.ndarray,
+    ) -> list[np.ndarray]:
+        """Return flow_rate columns for flow links connected to *node_id*.
+
+        *direction* is ``"from"`` for outgoing links (``from_node_id``) and
+        ``"to"`` for incoming links (``to_node_id``).
+        """
+        column = "from_node_id" if direction == "from" else "to_node_id"
+        request = QgsFeatureRequest().setFilterExpression(
+            f'"{column}" = {node_id} AND "link_type" = \'flow\''
+        )
+        columns: list[np.ndarray] = []
+        for feat in link_layer.getFeatures(request):
+            idx = link_id_to_idx.get(int(feat["link_id"]))
+            if idx is not None:
+                columns.append(flow_arr[:, idx])
+        return columns

--- a/ribasim_qgis/widgets/plot_widget.py
+++ b/ribasim_qgis/widgets/plot_widget.py
@@ -139,7 +139,7 @@ VariableTraces = dict[str, Trace]
 # Full plot payload: file -> variable -> traces.
 PlotData = dict[str, dict[str, VariableTraces]]
 
-_PLACEHOLDER_DEFAULT = "Select Basin nodes and/or links on the map to plot timeseries."
+_PLACEHOLDER_DEFAULT = "Select nodes and/or links on the map to plot timeseries."
 _PLACEHOLDER_WATER_BALANCE = (
     "Basin water balance requires exactly one Basin node selection."
 )
@@ -149,9 +149,6 @@ _PLACEHOLDER_FRACTIONAL_STORAGE = (
 _PLACEHOLDER_FRACTIONAL_FLOW = "Fractional flow requires exactly one link selection."
 _PLACEHOLDER_FRACTIONAL_FLOW_NO_BASIN = (
     "Fractional flow: could not find a Basin on either side of the selected link."
-)
-_PLACEHOLDER_FRACTIONAL_FLOW_NO_CONCENTRATION = (
-    "Fractional flow: no concentration data found for the resolved Basin side(s)."
 )
 
 _TRAVERSABLE_NODE_TYPES: frozenset[str] = frozenset(
@@ -185,10 +182,20 @@ _BASIN_WATER_BALANCE_TERMS: tuple[tuple[str, int], ...] = (
 )
 _BASIN_WATER_BALANCE_ERROR_TERM = "balance_error"
 
-_ROOT_VARIABLES: tuple[str, ...] = (
-    "basin / level",
-    "basin / storage",
-    "flow / flow_rate",
+# Synthetic root variable groups: a single root checkbox toggles the listed
+# (file, variable) keys together.  Group constituents are hidden from their
+# file submenus, so the only way to toggle them is via the group checkbox.
+_ROOT_VARIABLE_GROUPS: tuple[tuple[str, tuple[tuple[str, str], ...]], ...] = (
+    ("level", (("basin", "level"),)),
+    ("storage", (("basin", "storage"),)),
+    (
+        "flow_rate",
+        (
+            ("basin", "inflow_rate"),
+            ("basin", "outflow_rate"),
+            ("flow", "flow_rate"),
+        ),
+    ),
 )
 
 _PLOT_LAYOUT = {
@@ -209,20 +216,22 @@ class _PlotMenu(QMenu):
         super().__init__(parent)
         self.setContentsMargins(10, 5, 5, 5)
         self._checkboxes: list[QCheckBox] = []
-        self._variables: list[str] = []
+        # Per-checkbox list of (file, variable) keys controlled by it.
+        # Singleton tuple for submenu items, multi-element for root groups.
+        self._checkbox_keys: list[tuple[tuple[str, str], ...]] = []
 
     def populate(
         self,
         available: dict[str, list[str]],
-        previously_checked: set[str],
-        defaults: dict[str, str] | None = None,
+        previously_checked: set[tuple[str, str]],
+        defaults: dict[str, list[str]] | None = None,
         water_balance_enabled: bool = False,
         fractional_storage_enabled: bool = False,
         fractional_flow_enabled: bool = False,
     ) -> None:
         self.clear()
         self._checkboxes = []
-        self._variables = []
+        self._checkbox_keys = []
         checked_state = cast(int, Qt.CheckState.Checked)
 
         wb_cb = QCheckBox("water balance")
@@ -255,62 +264,74 @@ class _PlotMenu(QMenu):
         self.addSeparator()
 
         defaults = defaults or {}
-        root_variables: set[str] = set()
-        for label in _ROOT_VARIABLES:
-            file_name, variable = label.split(" / ", 1)
-            if file_name in available and variable in available[file_name]:
-                root_variables.add(label)
-        for label in sorted(root_variables):
-            _, variable = label.split(" / ", 1)
-            cb = QCheckBox(variable)
-            if label in previously_checked:
+        default_keys = {
+            (file_name, var) for file_name, vars_ in defaults.items() for var in vars_
+        }
+
+        # Root group checkboxes; each toggles one or more (file, var) keys.
+        # Constituents are hidden from submenus regardless of availability.
+        grouped_keys: set[tuple[str, str]] = set()
+        has_root = False
+        for label, group in _ROOT_VARIABLE_GROUPS:
+            available_keys = tuple(
+                (file_name, var)
+                for file_name, var in group
+                if file_name in available and var in available[file_name]
+            )
+            if not available_keys:
+                continue
+            grouped_keys.update(group)
+            cb = QCheckBox(label)
+            if previously_checked & set(available_keys):
                 cb.setChecked(True)
             self._checkboxes.append(cb)
-            self._variables.append(label)
+            self._checkbox_keys.append(available_keys)
             action = QWidgetAction(self)
             action.setDefaultWidget(cb)
             self.addAction(action)
+            has_root = True
 
-        if root_variables:
+        if has_root:
             self.addSeparator()
 
         for file_name in sorted(available):
             variables_for_submenu = [
                 variable
                 for variable in sorted(available[file_name])
-                if f"{file_name} / {variable}" not in root_variables
+                if (file_name, variable) not in grouped_keys
             ]
             if not variables_for_submenu:
                 continue
             submenu = self.addMenu(file_name)
             for variable in variables_for_submenu:
-                label = f"{file_name} / {variable}"
                 cb = QCheckBox(variable)
-                if label in previously_checked:
+                if (file_name, variable) in previously_checked:
                     cb.setChecked(True)
                 self._checkboxes.append(cb)
-                self._variables.append(label)
+                self._checkbox_keys.append(((file_name, variable),))
                 action = QWidgetAction(submenu)
                 action.setDefaultWidget(cb)
                 submenu.addAction(action)
 
         if not any(cb.isChecked() for cb in self._checkboxes) and self._checkboxes:
-            default_labels = {
-                f"{file_name} / {default_var}"
-                for file_name, default_var in defaults.items()
-            }
-            for i, label in enumerate(self._variables):
-                if label in default_labels:
-                    self._checkboxes[i].setChecked(True)
+            for cb, cb_keys in zip(self._checkboxes, self._checkbox_keys, strict=True):
+                if any(key in default_keys for key in cb_keys):
+                    cb.setChecked(True)
             if not any(cb.isChecked() for cb in self._checkboxes):
                 self._checkboxes[0].setChecked(True)
 
-    def checked_variables(self) -> list[str]:
-        return [
-            label
-            for label, cb in zip(self._variables, self._checkboxes, strict=True)
-            if cb.isChecked()
-        ]
+    def checked_keys(self) -> list[tuple[str, str]]:
+        """Return the flat, deduplicated list of currently checked keys."""
+        seen: set[tuple[str, str]] = set()
+        keys: list[tuple[str, str]] = []
+        for cb, cb_keys in zip(self._checkboxes, self._checkbox_keys, strict=True):
+            if not cb.isChecked():
+                continue
+            for key in cb_keys:
+                if key not in seen:
+                    seen.add(key)
+                    keys.append(key)
+        return keys
 
 
 class PlotWidget(QWidget):
@@ -388,11 +409,13 @@ class PlotWidget(QWidget):
 
         self._node_button = QToolButton()
         self._node_button.setText("node")
+        self._node_button.setCheckable(True)
         self._node_button.clicked.connect(self._activate_node_selection)
         row.addWidget(self._node_button)
 
         self._link_button = QToolButton()
         self._link_button.setText("link")
+        self._link_button.setCheckable(True)
         self._link_button.clicked.connect(self._activate_link_selection)
         row.addWidget(self._link_button)
 
@@ -434,10 +457,60 @@ class PlotWidget(QWidget):
         self._units: dict[str, dict[str, str]] = {}
         # Available variables per file: {file_name: [var1, var2, ...]}
         self._available: dict[str, list[str]] = {}
-        # Default variable per file: {file_name: variable}
-        self._defaults: dict[str, str] = {}
-        # Variable menu mapping: "file / variable" -> (file, variable)
-        self._menu_to_key: dict[str, tuple[str, str]] = {}
+        # Default variables per file: {file_name: [variable, ...]}
+        self._defaults: dict[str, list[str]] = {}
+
+        # Keep node/link buttons in sync with the active layer and map tool.
+        if self._iface is not None:
+            self._iface.currentLayerChanged.connect(self._sync_layer_buttons)
+            canvas = self._iface.mapCanvas()
+            if canvas is not None:
+                canvas.mapToolSet.connect(self._on_map_tool_set)
+
+    def showEvent(self, a0):
+        """Activate the select tool (and the node layer if neither is active)."""
+        super().showEvent(a0)
+        if self._iface is None:
+            return
+        active = self._iface.activeLayer()
+        node_layer = self._node_layer_getter() if self._node_layer_getter else None
+        link_layer = self._link_layer_getter() if self._link_layer_getter else None
+        if active is not node_layer and active is not link_layer:
+            # _activate_selection_target also activates the select tool.
+            self._activate_node_selection()
+        else:
+            self._activate_qgis_select_tool()
+            self._sync_layer_buttons(active)
+
+    def _on_map_tool_set(self, *_args: Any) -> None:
+        """Slot for QgsMapCanvas.mapToolSet (signal signature varies)."""
+        self._sync_layer_buttons()
+
+    def _is_select_tool_active(self) -> bool:
+        if self._iface is None:
+            return False
+        action = self._iface.actionSelect()
+        return action is not None and action.isChecked()
+
+    def _sync_layer_buttons(self, layer: Any | None = None) -> None:
+        """Update node/link button checked state.
+
+        Buttons are only checked when the matching layer is active *and*
+        the QGIS select tool is currently the active map tool.
+        """
+        if self._iface is None:
+            return
+        if layer is None:
+            layer = self._iface.activeLayer()
+        node_layer = self._node_layer_getter() if self._node_layer_getter else None
+        link_layer = self._link_layer_getter() if self._link_layer_getter else None
+        select_active = self._is_select_tool_active()
+        self._node_button.setChecked(
+            select_active and layer is node_layer and node_layer is not None
+        )
+        self._link_button.setChecked(
+            select_active and layer is link_layer and link_layer is not None
+        )
 
     # --- Public API ---
 
@@ -450,7 +523,7 @@ class PlotWidget(QWidget):
         self,
         available: dict[str, list[str]],
         units: dict[str, dict[str, str]] | None = None,
-        defaults: dict[str, str] | None = None,
+        defaults: dict[str, list[str]] | None = None,
     ) -> None:
         """Pre-populate variable dropdown without trace data.
 
@@ -461,37 +534,18 @@ class PlotWidget(QWidget):
         units:
             file_name -> variable -> unit string.
         defaults:
-            file_name -> default variable to check.
+            file_name -> list of default variables to check.
         """
         if not self.plotting_supported:
             return
         self._available = available
         self._units = units or {}
         self._defaults = defaults or {}
-        previously_checked_labels = set(self._var_menu.checked_variables())
-        previously_checked_keys = {
-            self._menu_to_key[label]
-            for label in previously_checked_labels
-            if label in self._menu_to_key
-        }
-
-        menu_to_key: dict[str, tuple[str, str]] = {}
-        for file_name, file_variables in self._available.items():
-            for variable in sorted(file_variables):
-                label = f"{file_name} / {variable}"
-                menu_to_key[label] = (file_name, variable)
-
-        self._menu_to_key = menu_to_key
-
-        checked_labels = {
-            label
-            for label, key in self._menu_to_key.items()
-            if key in previously_checked_keys
-        }
+        previously_checked_keys = set(self._var_menu.checked_keys())
 
         self._var_menu.populate(
             self._available,
-            checked_labels,
+            previously_checked_keys,
             self._defaults,
             self._water_balance_enabled,
             self._fractional_storage_enabled,
@@ -557,12 +611,17 @@ class PlotWidget(QWidget):
         self, layer_getter: Callable[[], Any | None] | None
     ) -> None:
         if self._iface is None or layer_getter is None:
+            self._sync_layer_buttons()
             return
         layer = layer_getter()
         if layer is None:
+            self._sync_layer_buttons()
             return
         self._iface.setActiveLayer(layer)
         self._activate_qgis_select_tool()
+        # If the layer was already active, currentLayerChanged isn't emitted,
+        # so re-sync explicitly to keep the clicked button pressed.
+        self._sync_layer_buttons()
 
     def _activate_qgis_select_tool(self) -> None:
         if self._iface is None:
@@ -572,11 +631,7 @@ class PlotWidget(QWidget):
             action.trigger()
 
     def _selected_keys(self) -> list[tuple[str, str]]:
-        return [
-            self._menu_to_key[label]
-            for label in self._var_menu.checked_variables()
-            if label in self._menu_to_key
-        ]
+        return self._var_menu.checked_keys()
 
     def _to_plotly_xy(
         self, x: np.ndarray, y: np.ndarray
@@ -624,7 +679,13 @@ class PlotWidget(QWidget):
             unit_key = unit or "(no unit)"
             for trace_name, (x, y) in var_traces.items():
                 x_data, y_data = self._to_plotly_xy(x, y)
-                legend_name = f"{file_name} / {var} {trace_name}"
+                # Entity-only trace names ("Basin #3", "Link #4") end with a
+                # digit; node-injected traces already encode the variable
+                # (e.g. "UserDemand #5 inflow_rate") and need no suffix.
+                if trace_name[-1:].isdigit():
+                    legend_name = f"{trace_name} {var}"
+                else:
+                    legend_name = trace_name
                 traces_by_unit[unit_key].append(
                     go.Scatter(
                         x=x_data,
@@ -1231,15 +1292,21 @@ class PlotWidget(QWidget):
             self._show_placeholder(self._placeholder_for_current_preset())
             return
 
-        # Need exactly one link in flow data.
+        # Need exactly one link in flow data. Trace names that don't start
+        # with `"Link #"` originate from a node selection (e.g.
+        # `"TabulatedRatingCurve #5"`) and are ignored here.
         flow_data = self._plot_data.get("flow", {})
-        flow_rate_traces = flow_data.get("flow_rate", {})
+        flow_rate_traces = {
+            name: trace
+            for name, trace in flow_data.get("flow_rate", {}).items()
+            if name.startswith("Link #")
+        }
         if len(flow_rate_traces) != 1:
             self._show_placeholder(_PLACEHOLDER_FRACTIONAL_FLOW)
             return
 
         trace_name = next(iter(flow_rate_traces))
-        link_id = int(trace_name.lstrip("#"))
+        link_id = int(trace_name.removeprefix("Link #"))
         flow_time, flow_values = flow_rate_traces[trace_name]
 
         # Resolve both endpoints to Basins (traversing connectors).

--- a/ribasim_qgis/widgets/ribasim_widget.py
+++ b/ribasim_qgis/widgets/ribasim_widget.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from qgis.core import (
+    Qgis,
     QgsAbstractVectorLayerLabeling,
     QgsCoordinateReferenceSystem,
     QgsLayerTreeGroup,
@@ -94,11 +95,52 @@ class RibasimWidget(QWidget):
         self.__dataset_widget.run_action(path, self.group)
 
     def reload_model(self) -> None:
-        """Reload the currently loaded Ribasim model."""
-        path = str(self.__dataset_widget.path)
-        if not path or self.group is None:
+        """Reload the currently loaded Ribasim model.
+
+        If no model is currently loaded (or its layer group has been
+        removed), fall back to the last opened model recorded in the
+        QGIS settings. If that path no longer exists, show a message.
+        """
+        current_path = self.__dataset_widget.path
+
+        # The user may have deleted the layer group while keeping the
+        # widget alive; accessing the wrapped C++ object then raises.
+        group_alive = self.group is not None
+        if group_alive:
+            try:
+                _ = cast(QgsLayerTreeGroup, self.group).parent()
+            except RuntimeError as e:
+                if e.args and e.args[0] == PYQT_DELETED_ERROR:
+                    self.group = None
+                    group_alive = False
+                else:
+                    raise
+
+        if current_path != Path() and group_alive:
+            self.__dataset_widget.reload_action(str(current_path), self.group)
             return
-        self.__dataset_widget.reload_action(path, self.group)
+
+        last_path = DatasetWidget.get_last_model_path_setting()
+        if last_path is not None and last_path.exists():
+            self.__dataset_widget.open_model(str(last_path))
+            return
+
+        message_bar = self.iface.messageBar()
+        if message_bar is None:
+            return
+        if last_path is None:
+            text = "No Ribasim model has been opened in this QGIS profile yet."
+        else:
+            text = (
+                f"Last opened Ribasim model not found: {last_path}. "
+                "Open a model via Plugins > Ribasim > Open Ribasim model."
+            )
+        message_bar.pushMessage(
+            "Ribasim",
+            text,
+            level=cast(Qgis.MessageLevel, Qgis.MessageLevel.Warning),
+            duration=5,
+        )
 
     # QGIS layers
     # -----------
@@ -127,7 +169,6 @@ class RibasimWidget(QWidget):
         self.create_subgroup(name, "Input")
         self.create_subgroup(name, "Results", visible=False)
         assert self.group is not None
-        self.group.setIsMutuallyExclusive(True)
 
     def add_to_group(self, maplayer: Any, destination: str, on_top: bool):
         """Try to add to a group.


### PR DESCRIPTION
**Plot dock**
- Stop selecting all connecting links when selecting a node
- When plotting a Basin, show inflow and outflow rate rather than all connected links by default. This was done by removing the relation from Node to Link. It made it impossible to control which links you want to select if you also are selecting nodes.
- Allow plotting flow rates on non-Basin nodes, to align with Observation and Control nodes:
  - `TabulatedRatingCurve`, `LinearResistance`, `ManningResistance`, `Pump`, `Outlet`, `FlowBoundary` → outgoing-link flow.
  - `UserDemand` → separate inflow_rate and outflow_rate from its single in/out links.
  - `Terminal`, `Junction` → summed inflow_rate.
  - `LevelBoundary` → summed inflow_rate and summed outflow_rate.
- Legend format unified: `Basin #3 level`, `Link #4 flow_rate`, `TabulatedRatingCurve #5 flow_rate`, etc. (was `flow / flow_rate #4` and similar).
- Opening the plot dock activates the Node layer if neither Node nor Link is currently active. The "node" / "link" buttons are checkable and reflect the active layer; selecting an unrelated layer in QGIS leaves both unchecked.

**Open / Reload Ribasim model**
- Now remembers the full TOML path of the last-opened model (not just the directory). Opening still defaults the file dialog to that directory.
- "Reload Ribasim model" with no model loaded now opens the last-used model. If its layer group was deleted, it gracefully opens it again instead of crashing. If the path is gone or no model was ever opened, a warning appears in the message bar.

**Layers panel**
- The model layer group is no longer mutually exclusive — Input and Results can be visible at the same time. That makes it easier to for instance show the flow results and the Node layer.
- New relations Node↔Basin, Node↔Concentration, Link↔Flow with selection mirroring: selecting Node/Link features highlights the corresponding Basin/Flow features in the spatial result layers (yellow highlight), even when the input layer is hidden, so users can analyze the spatial results and the timeseries at the same time.

**QGIS guide**
- Update all the screenshots
- Update and expand the timeseries results section, show water balance and fractional flow plots.

**Observation node docs**
- Document Observation variable, fixes https://github.com/Deltares/Ribasim/issues/2957

<img width="903" height="569" alt="timeseries-plot-flow" src="https://github.com/user-attachments/assets/d9d839af-2a6c-480c-a188-e0e071430642" />
