### PR TITLE
Simplify `NodeType.T(s::Symbol)`

### DIFF
--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -67,11 +67,7 @@ end
 
 # Support creating a NodeType enum instance from a symbol or string
 function NodeType.T(s::Symbol)::NodeType.T
-    symbol_map = EnumX.symbol_map(NodeType.T)
-    for (sym, val) in symbol_map
-        sym == s && return NodeType.T(val)
-    end
-    throw(ArgumentError("Invalid value for NodeType: $s"))
+    return getfield(NodeType, s)
 end
 
 NodeType.T(str::AbstractString) = NodeType.T(Symbol(str))

--- a/docs/guide/delwaq.qmd
+++ b/docs/guide/delwaq.qmd
@@ -124,12 +124,20 @@ You can optionally set the path to the results folder of the Delwaq simulation, 
 ```{python}
 #| include: false
 # For documentation purposes, we will download the generated map file
-import urllib.request
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
-urllib.request.urlretrieve(
-    "https://s3.deltares.nl/ribasim/doc-image/delwaq/delwaq_map.nc",
-    output_path / "delwaq_map.nc",
-)
+url = "https://s3.deltares.nl/ribasim/doc-image/delwaq/delwaq_map.nc"
+dest = output_path / "delwaq_map.nc"
+
+session = requests.Session()
+retries = Retry(total=5, backoff_factor=1, status_forcelist=[502, 503, 504])
+session.mount("https://", HTTPAdapter(max_retries=retries))
+
+response = session.get(url, timeout=30)
+response.raise_for_status()
+dest.write_bytes(response.content)
 ```
 
 ```{python}


### PR DESCRIPTION
This is faster, simpler and doesn't rely on EnumX internals.

See https://github.com/fredrikekre/EnumX.jl/issues/10