### PR TITLE
[delwaq] Drop required graph and substance state variables

### DIFF
--- a/docs/guide/delwaq.qmd
+++ b/docs/guide/delwaq.qmd
@@ -66,7 +66,7 @@ from ribasim.delwaq import generate
 # The default path is the delwaq folder next to the toml
 output_path = Path("../../generated_testmodels/basic/delwaq")
 
-graph, substances = generate(model, output_path)
+generate(model, output_path)
 ```
 
 This call produces a handful of files in the user defined folder. Let's take a look at them:
@@ -77,49 +77,20 @@ list(output_path.iterdir())
 
 These files form a complete Delwaq simulation, and can be run by either pointing DIMR to the `dimr_config.xml` file or pointing Delwaq to the `delwaq.inp` file.
 
-Note that the call to `generate` produces two output variables; `graph` and `substances` that are required for parsing the results of the Delwaq model later on. Nonetheless, we can also inspect them here, and inspect the created Delwaq network.
+The call to `generate` also writes a `ribasim.nc` file in the output folder. Besides the Delwaq network mesh, it stores the mapping between Delwaq and Ribasim node IDs and the list of substances. These are everything `parse` needs to map the Delwaq results back to the original Ribasim model, so no extra variables have to be passed between `generate` and `parse`.
 
-```{python}
-substances  # list of substances, as will be present in the Delwaq netcdf output
-```
+The substances stored are a combination of user input (`Cl` and `Tracer` in the input tables), a `Continuity` tracer, and tracers for all nodetypes in the Ribasim model. The latter tracers allow for deeper inspection of the Ribasim model, such as debugging the mass balance by plotting fraction graphs.
 
-As you can see, the complete substances list is a combination of user input (`Cl` and `Tracer` in the input tables), a `Continuity` tracer, and tracers for all nodetypes in the Ribasim model. The latter tracers allow for deeper inspection of the Ribasim model, such as debugging the mass balance by plotting fraction graphs. Let's inspect the `graph` next, which is the Delwaq network that was created from the Ribasim model:
-
-```{python}
-import matplotlib.pyplot as plt
-import networkx as nx
-
-# Let's draw the graph
-fig, ax = plt.subplots(1, 2, figsize=(10, 5))
-nx.draw(
-    graph,
-    pos={k: v["pos"] for k, v in graph.nodes(data=True)},
-    with_labels=True,
-    labels={k: k for k, v in graph.nodes(data=True)},
-    ax=ax[0],
-)
-ax[0].set_title("Delwaq node IDs")
-nx.draw(
-    graph,
-    pos={k: v["pos"] for k, v in graph.nodes(data=True)},
-    with_labels=True,
-    labels={k: v["id"] for k, v in graph.nodes(data=True)},
-    ax=ax[1],
-)
-ax[1].set_title("Ribasim node IDs")
-fig.suptitle("Delwaq network");
-```
-
-Here we plotted the Delwaq network twice, with the node IDs as used by Delwaq on the left hand side, and the corresponding Ribasim node IDs on the right hand side.
-As you can see, the Delwaq network is very similar to the Ribasim network, with some notable changes:
+The Delwaq network that `generate` builds from the Ribasim model is very similar to the Ribasim network, with some notable changes:
 
 - All non-Basin or non-boundary types are removed (e.g. no more Pumps or TabulatedRatingCurves)
-- Basin boundaries are split into separate nodes and links (drainage, precipitation, and evaporation, as indicated by the duplicated Basin IDs on the right hand side)
+- Basin boundaries are split into separate nodes and links (drainage, precipitation, and evaporation)
 - All node IDs have been renumbered, with boundaries being negative, and Basins being positive.
 
 ## Parsing the results
-With Delwaq having run, we can now parse the results using `ribasim.delwaq.parse`. This function requires either a path to a toml file, or a Model instance, as well as the `graph` and `substances` variables that were output by `ribasim.delwaq.generate`.
+With Delwaq having run, we can now parse the results using `ribasim.delwaq.parse`. This function requires either a path to a toml file, or a Model instance. The mapping and substances needed to interpret the results are read from the `ribasim.nc` file written by `ribasim.delwaq.generate`.
 You can optionally set the path to the results folder of the Delwaq simulation, if you overrode the default during `ribasim.delwaq.generate`.
+
 
 ```{python}
 #| include: false
@@ -135,7 +106,7 @@ urllib.request.urlretrieve(
 ```{python}
 from ribasim.delwaq import parse
 
-nmodel_nc = parse(model, graph, substances, to_input=False)
+nmodel_nc = parse(model, output_path, to_input=False)
 
 concentration_nc = toml_path.parent / "results" / "concentration.nc"
 concentration_nc
@@ -146,13 +117,13 @@ By default (`to_input=False`), the parsed model writes the Delwaq tracer results
 
 ```{python}
 # Parse Delwaq results and also populate Basin / concentration_external for plotting
-nmodel = parse(model, graph, substances, to_input=True)
+nmodel = parse(model, output_path, to_input=True)
 ```
 
 ```{python}
 display(nmodel.basin.concentration_external)
-print(substances)
 t = nmodel.basin.concentration_external.df
+print(sorted(t.substance.unique()))
 # Show the first available timestep
 t[t.time == t.time.unique()[0]]
 ```

--- a/pixi.toml
+++ b/pixi.toml
@@ -118,6 +118,7 @@ upload-node-icons = "python utils/write_node_icons.py --upload"
 tests = { depends-on = ["lint", "test-ribasim-python", "test-ribasim-core"] }
 delwaq = { cmd = "pytest --basetemp=python/ribasim/ribasim/delwaq/model python/ribasim/tests/test_delwaq.py" }
 gen-delwaq = { cmd = "python python/ribasim/ribasim/delwaq/generate.py" }
+parse-delwaq = { cmd = "python python/ribasim/ribasim/delwaq/parse.py" }
 model-integration-test = { cmd = "julia --project=core --eval 'using Pkg; Pkg.test(allow_reresolve=false, test_args=[\"integration\"])'", depends-on = [
     { task = "s3-download", args = [
         "hws_2025_4_0/",

--- a/python/ribasim/ribasim/delwaq/README.md
+++ b/python/ribasim/ribasim/delwaq/README.md
@@ -19,9 +19,9 @@ from util import run_delwaq
 
 toml_path = Path("generated_testmodels/basic/ribasim.toml")
 
-graph, substances = generate(toml_path)
+generate(toml_path)
 run_delwaq()
-model = parse(toml_path, graph, substances)
+model = parse(toml_path)
 ```
 
 The resulting Ribasim model will have an updated `model.basin.concentration_external` table with the Delwaq output.

--- a/python/ribasim/ribasim/delwaq/generate.py
+++ b/python/ribasim/ribasim/delwaq/generate.py
@@ -7,7 +7,7 @@ import shutil
 from collections import defaultdict
 from datetime import timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import Any, cast
 
 from ribasim import Model, nodes
 from ribasim.config import Verbosity
@@ -16,9 +16,6 @@ from ribasim.utils import (
     _concat,
     _pascal_to_snake,
 )
-
-if TYPE_CHECKING:
-    import networkx as nx_types
 
 try:
     import networkx as _nx
@@ -395,7 +392,7 @@ def _setup_boundaries(model, node_mapping):
 def generate(
     model: Path | Model,
     output_path: Path | None = None,
-) -> tuple["nx_types.DiGraph", set[str]]:
+) -> Model:
     """Generate a Delwaq model from a Ribasim model and results."""
     # Read in model and results
     if not isinstance(model, Model):
@@ -465,14 +462,16 @@ def generate(
             )
         )
 
-    # Generate mesh and write to NetCDF, adding attributes to avoid Delwaq warnings
+    # Generate mesh and write to NetCDF, adding attributes to avoid Delwaq warnings.
+    # The dataset is written further down, once the substance set is complete, so
+    # the graph mapping (node_id <-> ribasim_node_id) and substances are stored
+    # alongside the mesh for parsing the results back.
     uds = ugrid(G, crs=model.crs)
     grid = uds.ugrid.grid
     dataset = uds.ugrid.to_dataset(optional_attributes=True)
     grid_name = cast(Any, grid).name
     dataset[grid_name].attrs["node_id"] = grid.node_dimension
     dataset[grid_name].attrs["node_long_name"] = "Node dimension of 1D network"
-    dataset.to_netcdf(output_path / "ribasim.nc")
 
     # Generate area and flows
     # File format is int32, float32 based
@@ -595,6 +594,11 @@ def generate(
 
     check_substance_uniqueness(substances)
 
+    # Store the complete substance set alongside the mesh and write ribasim.nc,
+    # so parse() can recover the substances and the node mapping from this file.
+    dataset["substances"] = ("substance", sorted(substances))
+    dataset.to_netcdf(output_path / "ribasim.nc")
+
     # Make a wide table with the initial default concentrations
     # using zero for all user defined substances
     icdf = pd.DataFrame(
@@ -678,9 +682,9 @@ def generate(
             )
         )
 
-    # Return the graph with original links and the substances
-    # so we can parse the results back to the original model
-    return G, substances
+    # Return the model so the results can be parsed back. The graph mapping and
+    # substances needed by parse() are stored in output_path / "ribasim.nc".
+    return model
 
 
 def add_tracer(
@@ -764,6 +768,4 @@ if __name__ == "__main__":
         log_level = logging.INFO
     logging.basicConfig(level=log_level)
 
-    graph, substances = generate(
-        args.toml_path, args.toml_path.parent / args.output_path
-    )
+    generate(args.toml_path, args.toml_path.parent / args.output_path)

--- a/python/ribasim/ribasim/delwaq/generate.py
+++ b/python/ribasim/ribasim/delwaq/generate.py
@@ -1,4 +1,19 @@
-"""Setup a Delwaq model from a Ribasim model and results."""
+"""
+Generate Delwaq input from Ribasim results.
+
+Can be used as a command line tool:
+
+usage: generate.py [-h] [--output_path OUTPUT_PATH] [-v] toml_path
+
+positional arguments:
+  toml_path             The path to the Ribasim TOML file.
+
+options:
+  -h, --help            show this help message and exit
+  --output_path OUTPUT_PATH
+                        The relative path to store the Delwaq model.
+  -v, --verbose         Increase verbosity (-v for info, -vv for debug).
+"""
 
 import argparse
 import csv

--- a/python/ribasim/ribasim/delwaq/parse.py
+++ b/python/ribasim/ribasim/delwaq/parse.py
@@ -10,23 +10,45 @@ from ribasim.utils import _concat
 
 def parse(
     model: Path | ribasim.Model,
-    graph,
-    substances,
-    output_folder=None,
-    *,
+    output_folder: str | Path | None = None,
+    *args,
     to_input: bool = False,
 ) -> ribasim.Model:
+    # parse() used to take (model, graph, substances, output_folder); the graph
+    # mapping and substances are now read from the ribasim.nc file written by
+    # generate(), so those arguments are no longer needed.
+    if args or not isinstance(output_folder, (str, Path, type(None))):
+        raise TypeError(
+            "parse() no longer takes `graph` and `substances` arguments; they are "
+            "read from the `ribasim.nc` file written by generate(). "
+            "Call parse(model, output_folder=..., to_input=...) instead."
+        )
+
     if not isinstance(model, ribasim.Model):
         model = ribasim.Model.read(model)
     else:
         model = model.model_copy(deep=True)
 
     # Output of Delwaq
-    if output_folder is None:
+    if isinstance(output_folder, (str, Path)):
+        folder = Path(output_folder)
+    else:
         assert model.filepath is not None
-        output_folder = model.filepath.parent / "delwaq"
-    with xr.open_dataset(output_folder / "delwaq_map.nc") as ds:
-        mapping = dict(graph.nodes(data="id"))
+        folder = model.filepath.parent / "delwaq"
+
+    # Recover the node mapping (Delwaq segment -> original Ribasim node_id) and
+    # the substances from the mesh file written by generate().
+    with xr.open_dataset(folder / "ribasim.nc") as nc:
+        mapping = dict(
+            zip(
+                nc["node_id"].to_numpy(),
+                nc["ribasim_node_id"].to_numpy(),
+                strict=True,
+            )
+        )
+        substances = set(nc["substances"].to_numpy().astype(str))
+
+    with xr.open_dataset(folder / "delwaq_map.nc") as ds:
         # Continuity is a (default) tracer representing the mass balance
         substances.add("Continuity")
 

--- a/python/ribasim/ribasim/delwaq/parse.py
+++ b/python/ribasim/ribasim/delwaq/parse.py
@@ -1,4 +1,19 @@
-"""Read a Delwaq model generated from a Ribasim model and inject the results back to Ribasim."""
+"""
+Parse Delwaq results from `generate` and save the results back to Ribasim.
+
+Can be used as a command line tool:
+
+usage: parse.py [-h] [--output_path OUTPUT_PATH] [-v] toml_path
+
+positional arguments:
+  toml_path             The path to the Ribasim TOML file.
+
+options:
+  -h, --help            show this help message and exit
+  --output_path OUTPUT_PATH
+                        The relative path to the Delwaq output.
+  -v, --verbose         Increase verbosity (-v for info, -vv for debug).
+"""
 
 import argparse
 import logging
@@ -94,7 +109,9 @@ def parse(
 if __name__ == "__main__":
     # Parse Delwaq output
 
-    parser = argparse.ArgumentParser(description="Parse Delwaq output.")
+    parser = argparse.ArgumentParser(
+        description="Parse Delwaq results from `generate` and save the results back to Ribasim."
+    )
     parser.add_argument(
         "toml_path", type=Path, help="The path to the Ribasim TOML file."
     )

--- a/python/ribasim/ribasim/delwaq/parse.py
+++ b/python/ribasim/ribasim/delwaq/parse.py
@@ -1,5 +1,7 @@
 """Read a Delwaq model generated from a Ribasim model and inject the results back to Ribasim."""
 
+import argparse
+import logging
 from pathlib import Path
 
 import xarray as xr
@@ -87,3 +89,35 @@ def parse(
         model.basin.concentration_external = df
 
     return model
+
+
+if __name__ == "__main__":
+    # Parse Delwaq output
+
+    parser = argparse.ArgumentParser(description="Parse Delwaq output.")
+    parser.add_argument(
+        "toml_path", type=Path, help="The path to the Ribasim TOML file."
+    )
+    parser.add_argument(
+        "--output_path",
+        type=Path,
+        help="The relative path to the Delwaq output.",
+        default="delwaq",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase verbosity (-v for info, -vv for debug).",
+    )
+    args = parser.parse_args()
+
+    log_level = logging.WARNING
+    if args.verbose >= 2:
+        log_level = logging.DEBUG
+    elif args.verbose >= 1:
+        log_level = logging.INFO
+    logging.basicConfig(level=log_level)
+
+    parse(args.toml_path, args.toml_path.parent / args.output_path)

--- a/python/ribasim/ribasim/delwaq/util.py
+++ b/python/ribasim/ribasim/delwaq/util.py
@@ -136,6 +136,8 @@ def ugrid(G, crs=None) -> "xugrid_types.UgridDataset":
     node_df = pd.DataFrame(G.nodes(), columns=["node_id"])
     node_df["x"] = [i[1] for i in G.nodes(data="x")]
     node_df["y"] = [i[1] for i in G.nodes(data="y")]
+    # Original Ribasim node_id, to map Delwaq segments back when parsing
+    node_df["ribasim_node_id"] = [i[1] for i in G.nodes(data="id")]
     node_df = node_df[node_df.node_id > 0].reset_index(drop=True)
     node_df.set_index("node_id", drop=False, inplace=True)
     node_df.sort_index(inplace=True)
@@ -145,6 +147,7 @@ def ugrid(G, crs=None) -> "xugrid_types.UgridDataset":
     ].reset_index(drop=True)
 
     node_id = node_df.node_id.to_numpy()
+    ribasim_node_id = node_df.ribasim_node_id.to_numpy()
     link_id = link_df.index.to_numpy()
     from_node_id = link_df.from_node_id.to_numpy()
     to_node_id = link_df.to_node_id.to_numpy()
@@ -175,6 +178,7 @@ def ugrid(G, crs=None) -> "xugrid_types.UgridDataset":
 
     uds = xugrid.UgridDataset(None, grid)
     uds = uds.assign_coords(node_id=(node_dim, node_id))
+    uds = uds.assign_coords(ribasim_node_id=(node_dim, ribasim_node_id))
     uds = uds.assign_coords(link_id=(link_dim, link_id))
     uds = uds.assign_coords(from_node_id=(link_dim, from_node_id))
     uds = uds.assign_coords(to_node_id=(link_dim, to_node_id))

--- a/python/ribasim/tests/test_delwaq.py
+++ b/python/ribasim/tests/test_delwaq.py
@@ -30,9 +30,9 @@ def test_offline_delwaq_coupling(tmp_path):
 
     # With evaporation of mass disabled
     model.solver.evaporate_mass = False
-    graph, substances = generate(model, model_dir)
+    generate(model, model_dir)
     run_delwaq(model_dir)
-    model = parse(model, graph, substances, model_dir, to_input=True)
+    model = parse(model, model_dir, to_input=True)
 
     df = model.basin.concentration_external.df
     assert df is not None
@@ -91,9 +91,9 @@ def test_offline_delwaq_coupling_evaporate_mass(tmp_path):
     add_tracer(model, 15, "Bar")
     add_tracer(model, 15, "Terrible' &%20Name")
 
-    graph, substances = generate(model, model_dir)
+    generate(model, model_dir)
     run_delwaq(model_dir)
-    model = parse(model, graph, substances, model_dir, to_input=True)
+    model = parse(model, model_dir, to_input=True)
 
     df = model.basin.concentration_external.df
     assert df is not None


### PR DESCRIPTION
So users can just do `generate`, run Delwaq, and run `parse`, instead of having to keep their session open, or rerun `generate` to have the mandatory variables for `parse`.

I have dropped the visualization from the docs, but the description is still there, as is the printer substances (just a bit later). I'm currently testing this approach on the latest LHM, I can confirm the presence of (good looking) variables in the `ribasim.nc`.

CC @DanielTollenaar 