### PR TITLE
Fix newlines in docs' `run_ribasim` output

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,6 +38,13 @@ jobs:
             git config set --path includeIf.gitdir:"${GIT_DIR}/worktrees/*".path "${CRED_PATH}"
           fi
       - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38 # v3.1.0
+      - name: Cache Delwaq map file
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ribasim
+          key: delwaq-map-${{ github.run_id }}
+          restore-keys: |
+            delwaq-map-
       - uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
         with:
           pixi-version: "latest"

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,5 +1,6 @@
 /.quarto/
 /_site/
+/_freeze/
 /site_libs/
 /reference/python/
 /getting-started/tutorial/crystal-basin/
@@ -8,3 +9,6 @@
 objects.json
 
 **/*.quarto_ipynb
+
+# Quarto/Pandoc per-document output directories (figures, embeds)
+**/*_files/

--- a/docs/_extensions/quarto-ext/include-code-files/include-code-files.lua
+++ b/docs/_extensions/quarto-ext/include-code-files/include-code-files.lua
@@ -4,12 +4,75 @@
 --- License:   MIT – see LICENSE file for details
 
 --- Dedent a line
-local function dedent (line, n)
-  return line:sub(1,n):gsub(" ","") .. line:sub(n+1)
+local function dedent(line, n)
+  return line:sub(1, n):gsub(" ", "") .. line:sub(n + 1)
+end
+
+--- Find snippet start and end.
+--
+--  Use this to populate startline and endline.
+--  This should work like pandocs snippet functionality: https://github.com/owickstrom/pandoc-include-code/tree/master
+local function snippet(cb, fh)
+  if not cb.attributes.snippet then
+    return
+  end
+
+  -- Cannot capture enum: http://lua-users.org/wiki/PatternsTutorial
+  local comment
+  local comment_stop = ""
+  if
+    string.match(cb.attributes.include, ".py$")
+    or string.match(cb.attributes.include, ".jl$")
+    or string.match(cb.attributes.include, ".r$")
+  then
+    comment = "#"
+  elseif string.match(cb.attributes.include, ".o?js$") or string.match(cb.attributes.include, ".css$") then
+    comment = "//"
+  elseif string.match(cb.attributes.include, ".lua$") then
+    comment = "--"
+  elseif string.match(cb.attributes.include, ".html$") then
+    comment = "<!%-%-"
+    comment_stop = " *%-%->"
+  else
+    -- If not known assume that it is something one or two long and not alphanumeric.
+    comment = "%W%W?"
+  end
+
+  local p_start = string.format("^ *%s start snippet %s%s", comment, cb.attributes.snippet, comment_stop)
+  local p_stop = string.format("^ *%s end snippet %s%s", comment, cb.attributes.snippet, comment_stop)
+  local start, stop = nil, nil
+
+  -- Cannot use pairs.
+  local line_no = 1
+  for line in fh:lines() do
+    if start == nil then
+      if string.match(line, p_start) then
+        start = line_no + 1
+      end
+    elseif stop == nil then
+      if string.match(line, p_stop) then
+        stop = line_no - 1
+      end
+    else
+      break
+    end
+    line_no = line_no + 1
+  end
+
+  -- Reset so nothing is broken later on.
+  fh:seek("set")
+
+  -- If start and stop not found, just continue
+  if start == nil or stop == nil then
+    return nil
+  end
+
+  cb.attributes.startLine = tostring(start)
+  cb.attributes.endLine = tostring(stop)
 end
 
 --- Filter function for code blocks
-local function transclude (cb)
+local function transclude(cb)
   if cb.attributes.include then
     local content = ""
     local fh = io.open(cb.attributes.include)
@@ -20,21 +83,23 @@ local function transclude (cb)
       local start = 1
 
       -- change hyphenated attributes to PascalCase
-      for i,pascal in pairs({"startLine", "endLine"})
-      do
-         local hyphen = pascal:gsub("%u", "-%0"):lower()
-         if cb.attributes[hyphen] then
-            cb.attributes[pascal] = cb.attributes[hyphen]
-            cb.attributes[hyphen] = nil
-         end
+      for i, pascal in pairs({ "startLine", "endLine" }) do
+        local hyphen = pascal:gsub("%u", "-%0"):lower()
+        if cb.attributes[hyphen] then
+          cb.attributes[pascal] = cb.attributes[hyphen]
+          cb.attributes[hyphen] = nil
+        end
       end
+
+      -- Overwrite startLine and stopLine with the snippet if any.
+      snippet(cb, fh)
 
       if cb.attributes.startLine then
         cb.attributes.startFrom = cb.attributes.startLine
         start = tonumber(cb.attributes.startLine)
       end
-      for line in fh:lines ("L")
-      do
+
+      for line in fh:lines("L") do
         if cb.attributes.dedent then
           line = dedent(line, cb.attributes.dedent)
         end
@@ -45,18 +110,21 @@ local function transclude (cb)
         end
         number = number + 1
       end
+
       fh:close()
     end
+
     -- remove key-value pair for used keys
     cb.attributes.include = nil
     cb.attributes.startLine = nil
     cb.attributes.endLine = nil
     cb.attributes.dedent = nil
+
     -- return final code block
     return pandoc.CodeBlock(content, cb.attr)
   end
 end
 
 return {
-  { CodeBlock = transclude }
+  { CodeBlock = transclude },
 }

--- a/docs/guide/delwaq.qmd
+++ b/docs/guide/delwaq.qmd
@@ -123,21 +123,32 @@ You can optionally set the path to the results folder of the Delwaq simulation, 
 
 ```{python}
 #| include: false
-# For documentation purposes, we will download the generated map file
+# For documentation purposes, we download the pre-generated Delwaq map file from
+# S3 (uploaded by CI from the latest successful run on main). S3 is generally
+# reliable but occasionally unreachable for a few minutes, so if the download
+# fails we fall back to a persistent cached copy (cached across CI runs via
+# actions/cache, see docs.yml) and emit a warning visible in the render log.
+import shutil
+import warnings
+from pathlib import Path
+
 import requests
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
 url = "https://s3.deltares.nl/ribasim/doc-image/delwaq/delwaq_map.nc"
 dest = output_path / "delwaq_map.nc"
+cache_file = Path.home() / ".cache" / "ribasim" / "delwaq_map.nc"
+cache_file.parent.mkdir(parents=True, exist_ok=True)
 
-session = requests.Session()
-retries = Retry(total=5, backoff_factor=1, status_forcelist=[502, 503, 504])
-session.mount("https://", HTTPAdapter(max_retries=retries))
+try:
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    cache_file.write_bytes(response.content)
+except requests.exceptions.RequestException as e:
+    if not cache_file.exists():
+        raise RuntimeError(f"Could not download {url} and no cached copy is available") from e
+    warnings.warn(f"Download of {url} failed ({e}); using cached copy at {cache_file}")
 
-response = session.get(url, timeout=30)
-response.raise_for_status()
-dest.write_bytes(response.content)
+shutil.copyfile(cache_file, dest)
 ```
 
 ```{python}

--- a/docs/reference/usage.qmd
+++ b/docs/reference/usage.qmd
@@ -1,7 +1,7 @@
 ---
 title: "Usage"
 filters:
-  - include-code-files
+  - ../_extensions/quarto-ext/include-code-files/include-code-files.lua
 ---
 
 

--- a/docs/run_ribasim.py
+++ b/docs/run_ribasim.py
@@ -13,14 +13,42 @@ in a hidden evaluated cell, after `from ribasim import run_ribasim`.
 That way we can run this version on CI but it looks like we run the Ribasim Python version.
 """
 
+import re
 from pathlib import Path
 
 from juliacall import Main as jl
 
 jl.seval("import Ribasim")
 
+# Run Ribasim while capturing all of its terminal output into a single buffer.
+# Letting juliacall stream straight to stdout causes blank lines in the rendered
+# Quarto HTML: each line arrives as a separate Jupyter stream message, and
+# Quarto adds a blank line after every line that contains ANSI color codes.
+# Capturing the output and printing it once, with the ANSI codes stripped,
+# avoids both problems.
+_run_captured = jl.seval("""
+function (toml_path)
+    pipe = Pipe()
+    Base.link_pipe!(pipe; reader_supports_async = true, writer_supports_async = true)
+    buffer = IOBuffer()
+    reader = @async write(buffer, pipe)
+    retcode = redirect_stdout(pipe) do
+        redirect_stderr(pipe) do
+            Ribasim.main(toml_path)
+        end
+    end
+    close(pipe.in)
+    wait(reader)
+    return String(take!(buffer)), retcode
+end
+""")
+
+# Matches ANSI escape sequences (colors, cursor movement, etc.).
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
+
 
 def run_ribasim(toml_path: str | Path) -> None:
     """Run a Ribasim simulation via juliacall."""
-    retcode = jl.Ribasim.main(str(toml_path))
-    assert retcode == 0, f"Simulation failed: {toml_path}"
+    output, retcode = _run_captured(str(toml_path))
+    print(_ANSI_RE.sub("", str(output)), end="")
+    assert int(retcode) == 0, f"Simulation failed: {toml_path}"


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/2979

Strips ANSI escape sequences that triggered newlines, at the cost of colors and bold text, but keeping it simple.

Also updates the quarto filter we use, and refer to it in a less bugged way, with a relative path.

Now looks like:

<img width="583" height="785" alt="Screenshot 2026-06-15 163156" src="https://github.com/user-attachments/assets/22753d5f-613a-49ae-abf0-604a2fe8e8c0" />
