### PR TITLE
Add Observation support to QGIS plot widget

### DIFF
--- a/docs/dev/qgis_test_plan.qmd
+++ b/docs/dev/qgis_test_plan.qmd
@@ -120,6 +120,15 @@ Intended behavior: The same model is loaded twice, but there is only a connectio
 
 - With a plot showing, deselect all features from all layers: _Plot clears and the placeholder reappears_.
 
+## Observation comparison
+
+- Load the `generated_testmodels/observation` model and run it so results are available.
+- Open the plotting pane, select the `node` button, and click an Observation node: _The observed series is drawn in black and the matching simulated series in red, on the same unit-grouped subplot_.
+- Zoom or pan the plot, then click a different Observation node (keeping the same variable groups): _The plot updates without flicker and the zoom/pan is retained_.
+- Click the "Reset axes" button in the plot toolbar: _The x-axis returns to the simulated period (TOML `starttime`/`endtime`), not the full observed span_.
+- Briefly deselect (e.g. a misclick) and reselect a node: _The plot returns with the previous zoom retained_.
+- Open the same model **without** running it (no results): _Selecting an Observation node still plots the observed series on its own, for level and flow variables_.
+
 # Tutorial tests
 
 ## Perform tutorial in documentation

--- a/docs/guide/qgis.qmd
+++ b/docs/guide/qgis.qmd
@@ -89,6 +89,11 @@ Select one link, and if you have concentration results, you can choose the varia
 
 Under the variable → concentration dropdown menu you can select another set of tracers if they are available.
 
+If your model has [Observation](/reference/node/observation.qmd) nodes, select the `node` button and click an Observation node to compare its observed and simulated timeseries.
+The observed series (read from the input) is drawn in black, and the corresponding simulated series in red.
+
+![](https://s3.deltares.nl/ribasim/doc-image/qgis/timeseries-plot-observation.png){fig-align="left"}
+
 # Spatial results {#sec-spatial-results}
 
 The timeseries results show the change of selected nodes and links over time.

--- a/python/ribasim_testmodels/ribasim_testmodels/observation.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/observation.py
@@ -9,7 +9,7 @@ from shapely.geometry import Point
 
 
 def observation_model() -> ribasim.Model:
-    """Model with two Observation nodes."""
+    """Model with three Observation nodes, one of which is unlinked."""
     model = ribasim.Model(
         starttime=datetime(2020, 1, 1),
         endtime=datetime(2021, 1, 1),
@@ -39,13 +39,40 @@ def observation_model() -> ribasim.Model:
 
     term = model.terminal.add(Node(3, Point(2.0, 0.0)))
 
+    # Observed level time series spanning the year before and after the
+    # simulated period (2020), with several timestamps that deliberately do not
+    # coincide with the daily 00:00 simulated output.
+    obs_level_time = pd.to_datetime(
+        [
+            "2019-01-01 00:00:00",
+            "2019-07-01 06:00:00",
+            "2020-01-01 00:00:00",
+            "2020-02-15 12:30:00",
+            "2020-06-20 18:45:00",
+            "2020-09-10 09:15:00",
+            "2021-01-01 00:00:00",
+            "2021-07-01 06:00:00",
+            "2022-01-01 00:00:00",
+        ]
+    )
+    # Observed levels are close to the simulated ones: the Basin starts near
+    # 0.045 m and rises to roughly 0.30-0.35 m during 2020. The values outside
+    # the simulated period (2019, 2021, 2022) stay in that same plausible range.
+    obs_level_value = [0.33, 0.34, 0.05, 0.31, 0.35, 0.36, 0.34, 0.33, 0.34]
+
+    # Observed outflow rate of the (non-conservative) Basin, close to the
+    # simulated values (order 1e-5 m3/s).
+    obs_outflow_time = pd.date_range("2020-01-01", periods=3, freq="MS")
+    obs_outflow_value = [3.0e-7, 1.25e-5, 1.55e-5]
+
     obs_level = model.observation.add(
         Node(4, Point(0.1, 0.2)),
         [
             observation.Time(
-                variable=["level", "level", "level"],
-                time=pd.date_range("2020-01-01", periods=3, freq="MS"),
-                value=[0.5, 0.3, 0.4],
+                variable=["level"] * len(obs_level_time)
+                + ["outflow_rate"] * len(obs_outflow_time),
+                time=list(obs_level_time) + list(obs_outflow_time),
+                value=obs_level_value + obs_outflow_value,
             ),
         ],
     )
@@ -56,7 +83,19 @@ def observation_model() -> ribasim.Model:
             observation.Time(
                 variable=["flow_rate", "flow_rate", "flow_rate"],
                 time=pd.date_range("2020-01-01", periods=3, freq="MS"),
-                value=[0.0, 0.05, 0.1],
+                value=[3.0e-7, 1.25e-5, 1.55e-5],
+            ),
+        ],
+    )
+
+    # Observation node with observed data but no link to the model.
+    model.observation.add(
+        Node(6, Point(2.1, 0.2)),
+        [
+            observation.Time(
+                variable=["level", "level", "level"],
+                time=pd.date_range("2020-01-01", periods=3, freq="MS"),
+                value=[0.30, 0.32, 0.34],
             ),
         ],
     )

--- a/ribasim_qgis/core/netcdf.py
+++ b/ribasim_qgis/core/netcdf.py
@@ -7,11 +7,16 @@ natural 2-D NumPy shape (n_times x n_ids).
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from functools import cached_property
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
 from osgeo import gdal
+
+# Plotly x-axis time format. Result and observation traces share this encoding
+# so they align on a common time axis.
+TIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
 
 @dataclass
@@ -34,6 +39,11 @@ class NetCDFResult:
     ids: np.ndarray
     variables: dict[str, np.ndarray]
     units: dict[str, str]
+
+    @cached_property
+    def time_strings(self) -> np.ndarray:
+        """The time index formatted as plotly-ready ISO strings."""
+        return self.time.strftime(TIME_FORMAT).to_numpy()
 
 
 def _read_time(root_group) -> pd.DatetimeIndex:

--- a/ribasim_qgis/core/observations.py
+++ b/ribasim_qgis/core/observations.py
@@ -1,0 +1,91 @@
+"""
+Read Ribasim Observation input data from the model GeoPackage.
+
+Unlike the NetCDF readers in :mod:`ribasim_qgis.core.netcdf`, this module reads
+*input* data: the ``Observation / time`` table holds user-provided observed
+timeseries, keyed by ``node_id`` and ``variable``. These can be plotted
+alongside the simulated results for comparison.
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from ribasim_qgis.core.geopackage import sqlite3_cursor
+from ribasim_qgis.core.netcdf import TIME_FORMAT
+
+# Name of the observation timeseries table in the GeoPackage.
+OBSERVATION_TABLE = "Observation / time"
+
+# A single timeseries: (time strings, values).
+ObservationSeries = tuple[np.ndarray, np.ndarray]
+
+
+@dataclass
+class Observations:
+    """Observed timeseries read from the ``Observation / time`` table.
+
+    Attributes
+    ----------
+    data:
+        Mapping ``node_id -> variable -> (time_strings, values)``.
+    variables:
+        The set of all variable names present across all observation nodes.
+    """
+
+    data: dict[int, dict[str, ObservationSeries]] = field(default_factory=dict)
+    variables: set[str] = field(default_factory=set)
+
+    def series(self, node_id: int, variable: str) -> ObservationSeries | None:
+        """Return the ``(time_strings, values)`` series, or None if absent."""
+        return self.data.get(node_id, {}).get(variable)
+
+
+def _table_exists(cursor, name: str) -> bool:
+    cursor.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (name,),
+    )
+    return cursor.fetchone() is not None
+
+
+def read_observations(gpkg_path: Path) -> Observations | None:
+    """Read the ``Observation / time`` table into an :class:`Observations`.
+
+    Returns ``None`` if the GeoPackage has no observation table or it is empty.
+    """
+    if not gpkg_path.is_file():
+        return None
+
+    with sqlite3_cursor(gpkg_path) as cursor:
+        if not _table_exists(cursor, OBSERVATION_TABLE):
+            return None
+        cursor.execute(
+            # OBSERVATION_TABLE is a trusted module constant, not user input.
+            f'SELECT node_id, variable, time, value FROM "{OBSERVATION_TABLE}" '  # noqa: S608
+            "ORDER BY node_id, variable, time"
+        )
+        rows = cursor.fetchall()
+
+    if not rows:
+        return None
+
+    df = pd.DataFrame(rows, columns=["node_id", "variable", "time", "value"])
+    df["time"] = pd.to_datetime(df["time"])
+
+    observations = Observations()
+    # Build per (node_id, variable) series from the time-sorted frame.
+    for node_id in df["node_id"].unique():
+        node_frame = df[df["node_id"] == node_id]
+        per_variable: dict[str, ObservationSeries] = {}
+        for variable in node_frame["variable"].unique():
+            var_frame = node_frame[node_frame["variable"] == variable]
+            time_strings = var_frame["time"].dt.strftime(TIME_FORMAT).to_numpy()
+            values = var_frame["value"].to_numpy(dtype=float)
+            per_variable[str(variable)] = (time_strings, values)
+            observations.variables.add(str(variable))
+        observations.data[int(node_id)] = per_variable
+
+    return observations

--- a/ribasim_qgis/tests/test_observations.py
+++ b/ribasim_qgis/tests/test_observations.py
@@ -1,0 +1,106 @@
+"""Tests for ribasim_qgis.core.observations — reading Observation input data."""
+
+import sqlite3
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from ribasim_qgis.core.observations import (
+    OBSERVATION_TABLE,
+    Observations,
+    read_observations,
+)
+
+
+def _write_observation_gpkg(path: Path, rows: list[tuple]) -> None:
+    """Create a minimal sqlite GeoPackage with an ``Observation / time`` table."""
+    con = sqlite3.connect(path)
+    try:
+        con.execute(
+            f'CREATE TABLE "{OBSERVATION_TABLE}" ('
+            "fid INTEGER PRIMARY KEY, node_id INTEGER, variable TEXT, "
+            "time TIMESTAMP, value REAL)"
+        )
+        con.executemany(
+            # OBSERVATION_TABLE is a trusted module constant, not user input.
+            f'INSERT INTO "{OBSERVATION_TABLE}" '  # noqa: S608
+            "(node_id, variable, time, value) VALUES (?, ?, ?, ?)",
+            rows,
+        )
+        con.commit()
+    finally:
+        con.close()
+
+
+@pytest.fixture
+def observation_gpkg(tmp_path: Path) -> Path:
+    path = tmp_path / "database.gpkg"
+    _write_observation_gpkg(
+        path,
+        [
+            (4, "level", "2020-01-01 00:00:00", 0.5),
+            (4, "level", "2020-02-01 00:00:00", 0.3),
+            (4, "level", "2020-03-01 00:00:00", 0.4),
+            (5, "flow_rate", "2020-01-01 00:00:00", 0.0),
+            (5, "flow_rate", "2020-02-01 00:00:00", 0.05),
+        ],
+    )
+    return path
+
+
+def test_read_observations_returns_observations(observation_gpkg: Path):
+    observations = read_observations(observation_gpkg)
+    assert isinstance(observations, Observations)
+
+
+def test_read_observations_variables(observation_gpkg: Path):
+    observations = read_observations(observation_gpkg)
+    assert observations is not None
+    assert observations.variables == {"level", "flow_rate"}
+
+
+def test_read_observations_data_grouping(observation_gpkg: Path):
+    observations = read_observations(observation_gpkg)
+    assert observations is not None
+    assert set(observations.data) == {4, 5}
+    assert set(observations.data[4]) == {"level"}
+    assert set(observations.data[5]) == {"flow_rate"}
+
+
+def test_read_observations_series_values(observation_gpkg: Path):
+    observations = read_observations(observation_gpkg)
+    assert observations is not None
+    times, values = observations.data[4]["level"]
+    np.testing.assert_array_equal(
+        times,
+        ["2020-01-01T00:00:00", "2020-02-01T00:00:00", "2020-03-01T00:00:00"],
+    )
+    np.testing.assert_allclose(values, [0.5, 0.3, 0.4])
+
+
+def test_observations_series_helper(observation_gpkg: Path):
+    observations = read_observations(observation_gpkg)
+    assert observations is not None
+    series = observations.series(5, "flow_rate")
+    assert series is not None
+    _, values = series
+    np.testing.assert_allclose(values, [0.0, 0.05])
+    assert observations.series(99, "level") is None
+    assert observations.series(4, "missing") is None
+
+
+def test_read_observations_missing_file(tmp_path: Path):
+    assert read_observations(tmp_path / "nope.gpkg") is None
+
+
+def test_read_observations_no_table(tmp_path: Path):
+    path = tmp_path / "empty.gpkg"
+    sqlite3.connect(path).close()
+    assert read_observations(path) is None
+
+
+def test_read_observations_empty_table(tmp_path: Path):
+    path = tmp_path / "empty_table.gpkg"
+    _write_observation_gpkg(path, [])
+    assert read_observations(path) is None

--- a/ribasim_qgis/tests/test_plot_widget.py
+++ b/ribasim_qgis/tests/test_plot_widget.py
@@ -976,3 +976,236 @@ def test_plot_widget_fractional_flow_connector_to_junction(monkeypatch):
     for trace in fig.data:
         if trace.name == "Tracer":
             assert np.allclose(trace.y, np.array([6.8, 13.6]))
+
+
+def test_plot_widget_observation_grouped_with_results():
+    """A single root checkbox toggles both result and observation variables."""
+    widget = PlotWidget()
+    available = {
+        "basin": ["level"],
+        "observation": ["level"],
+    }
+    units = {
+        "basin": {"level": "m"},
+        "observation": {"level": "m"},
+    }
+    widget.preload_variables(available, units=units, defaults={"basin": ["level"]})
+
+    # The 'level' root checkbox toggles both basin and observation level.
+    assert set(widget._var_menu.checked_keys()) == {
+        ("basin", "level"),
+        ("observation", "level"),
+    }
+
+    # No observation submenu: its 'level' is a grouped constituent.
+    submenu_titles = {
+        action.menu().title() for action in widget._var_menu.actions() if action.menu()
+    }
+    assert "observation" not in submenu_titles
+
+
+def test_plot_widget_renders_observed_and_simulated_observation_traces(monkeypatch):
+    """Observed and simulated observation traces render on a shared unit subplot."""
+    captured_figures = []
+
+    def _capture_plot(fig, **kwargs):
+        captured_figures.append(fig)
+        return "<div></div>"
+
+    monkeypatch.setattr("ribasim_qgis.widgets.plot_widget.po.plot", _capture_plot)
+
+    widget = PlotWidget()
+    widget.preload_variables(
+        {"observation": ["level"]},
+        units={"observation": {"level": "m"}},
+        defaults={"observation": ["level"]},
+    )
+    widget._var_menu.populate(
+        widget._available,
+        {("observation", "level")},
+        widget._defaults,
+        widget._water_balance_enabled,
+    )
+
+    time = np.array(["2020-01-01", "2020-01-02"])
+    widget.set_data(
+        {
+            "observation": {
+                "level": {
+                    "Observation #4 observed level": (time, np.array([0.5, 0.3])),
+                    "Observation #4 simulated level": (time, np.array([0.4, 0.35])),
+                }
+            }
+        },
+        units={"observation": {"level": "m"}},
+    )
+
+    assert len(captured_figures) == 1
+    fig = captured_figures[0]
+    names = {trace.name for trace in fig.data}
+    assert names == {
+        "Observation #4 observed level",
+        "Observation #4 simulated level",
+    }
+    # Both share the same unit subplot.
+    assert fig.layout.yaxis.title.text == "m"
+
+
+def test_plot_widget_observation_trace_colors(monkeypatch):
+    """Observed traces render black, simulated traces render red."""
+    captured_figures = []
+
+    def _capture_plot(fig, **kwargs):
+        captured_figures.append(fig)
+        return "<div></div>"
+
+    monkeypatch.setattr("ribasim_qgis.widgets.plot_widget.po.plot", _capture_plot)
+
+    widget = PlotWidget()
+    widget.preload_variables(
+        {"observation": ["level"]},
+        units={"observation": {"level": "m"}},
+        defaults={"observation": ["level"]},
+    )
+    widget._var_menu.populate(
+        widget._available,
+        {("observation", "level")},
+        widget._defaults,
+        widget._water_balance_enabled,
+    )
+
+    time = np.array(["2020-01-01", "2020-01-02"])
+    widget.set_data(
+        {
+            "observation": {
+                "level": {
+                    "Observation #4 observed level": (time, np.array([0.5, 0.3])),
+                    "Observation #4 simulated level": (time, np.array([0.4, 0.35])),
+                }
+            }
+        },
+        units={"observation": {"level": "m"}},
+    )
+
+    assert len(captured_figures) == 1
+    colors = {trace.name: trace.line.color for trace in captured_figures[0].data}
+    assert colors["Observation #4 observed level"] == "black"
+    assert colors["Observation #4 simulated level"] == "red"
+
+
+def test_plot_widget_observation_only_flow_rate_checked_by_default(monkeypatch):
+    """Without results, a non-first observation group still renders by default.
+
+    The flow_rate root group is only reachable here via its observation
+    constituent. It must be default-checked, not just the first ('level') group.
+    """
+    captured_figures = []
+
+    def _capture_plot(fig, **kwargs):
+        captured_figures.append(fig)
+        return "<div></div>"
+
+    monkeypatch.setattr("ribasim_qgis.widgets.plot_widget.po.plot", _capture_plot)
+
+    widget = PlotWidget()
+    # Mirror DatasetWidget: observation variables are passed as defaults so each
+    # available observation root group is checked, even without results.
+    widget.preload_variables(
+        {"observation": ["flow_rate", "level"]},
+        units={"observation": {}},
+        defaults={"observation": ["flow_rate", "level"]},
+    )
+
+    time = np.array(["2020-01-01", "2020-01-02"])
+    widget.set_data(
+        {
+            "observation": {
+                "level": {
+                    "Observation #4 observed level": (time, np.array([0.5, 0.3])),
+                },
+                "flow_rate": {
+                    "Observation #5 observed flow_rate": (time, np.array([0.0, 0.05])),
+                },
+            }
+        },
+        units={"observation": {}},
+    )
+
+    assert captured_figures
+    names = {trace.name for trace in captured_figures[-1].data}
+    assert "Observation #5 observed flow_rate" in names
+    assert "Observation #4 observed level" in names
+
+
+def test_plot_widget_defaults_x_axis_to_simulated_period(monkeypatch):
+    """Plots open on the simulated period, not the full (longer) data span."""
+    captured_figures = []
+
+    def _capture_plot(fig, **kwargs):
+        captured_figures.append(fig)
+        return "<div></div>"
+
+    monkeypatch.setattr("ribasim_qgis.widgets.plot_widget.po.plot", _capture_plot)
+
+    widget = PlotWidget()
+    widget.preload_variables(
+        {"observation": ["level"]},
+        units={"observation": {"level": "m"}},
+        defaults={"observation": ["level"]},
+    )
+    widget._var_menu.populate(
+        widget._available,
+        {("observation", "level")},
+        widget._defaults,
+        widget._water_balance_enabled,
+    )
+    widget.set_simulated_period("2020-01-01T00:00:00", "2020-12-31T00:00:00")
+
+    # Observed series runs well past the simulated end.
+    time = np.array(["2020-06-01T00:00:00", "2021-06-01T00:00:00"])
+    widget.set_data(
+        {
+            "observation": {
+                "level": {
+                    "Observation #4 observed level": (time, np.array([0.5, 0.3])),
+                }
+            }
+        },
+        units={"observation": {"level": "m"}},
+    )
+
+    assert len(captured_figures) == 1
+    fig = captured_figures[0]
+    assert tuple(fig.layout.xaxis.range) == (
+        "2020-01-01T00:00:00",
+        "2020-12-31T00:00:00",
+    )
+
+
+def test_plot_widget_simulated_period_can_be_cleared(monkeypatch):
+    """Clearing the simulated period restores auto-ranging (no explicit range)."""
+    captured_figures = []
+
+    def _capture_plot(fig, **kwargs):
+        captured_figures.append(fig)
+        return "<div></div>"
+
+    monkeypatch.setattr("ribasim_qgis.widgets.plot_widget.po.plot", _capture_plot)
+
+    widget = PlotWidget()
+    widget.preload_variables(
+        {"basin": ["level"]},
+        units={"basin": {"level": "m"}},
+        defaults={"basin": ["level"]},
+    )
+    widget.set_simulated_period("2020-01-01T00:00:00", "2020-12-31T00:00:00")
+    widget.set_simulated_period(None, None)
+
+    time = np.array(["2020-06-01T00:00:00", "2020-07-01T00:00:00"])
+    widget.set_data(
+        {"basin": {"level": {"Basin #1": (time, np.array([0.5, 0.3]))}}},
+        units={"basin": {"level": "m"}},
+    )
+
+    assert len(captured_figures) == 1
+    assert captured_figures[0].layout.xaxis.range is None

--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -49,6 +49,7 @@ from ribasim_qgis.core.model import (
     get_toml_dict,
 )
 from ribasim_qgis.core.netcdf import (
+    TIME_FORMAT,
     NetCDFResult,
     read_basin_nc,
     read_concentration_nc,
@@ -58,6 +59,7 @@ from ribasim_qgis.core.nodes import (
     STYLE_DIR,
     load_nodes_from_geopackage,
 )
+from ribasim_qgis.core.observations import Observations, read_observations
 from ribasim_qgis.widgets.plot_widget import PlotData, PlotWidget, Trace, VariableTraces
 from ribasim_qgis.widgets.task import RibasimTask
 
@@ -113,6 +115,13 @@ _FLOW_RATE_FROM_INCOMING_AND_OUTGOING_LINKS_SUM: frozenset[str] = frozenset(
     {"LevelBoundary"}
 )
 
+# Observation flow variables and the link direction they sum over.
+# ``inflow_rate`` sums incoming flow links; ``outflow_rate`` sums outgoing.
+_OBSERVATION_FLOW_DIRECTION: dict[str, str] = {
+    "inflow_rate": "to",
+    "outflow_rate": "from",
+}
+
 RIBASIM_HOME_SETTING = "ribasim/home"
 RIBASIM_LAST_MODEL_PATH_SETTING = "ribasim/last_model_path"
 
@@ -143,6 +152,9 @@ class DatasetWidget:
         self.basin_layer: QgsVectorLayer | None = None
         self.concentration_layer: QgsVectorLayer | None = None
         self.results: dict[str, NetCDFResult] = {}
+
+        # Observation input data (read from the GeoPackage, not the results).
+        self.observations: Observations | None = None
 
         # Plot widget for timeseries
         self.plot_widget = PlotWidget(
@@ -608,6 +620,7 @@ class DatasetWidget:
 
     def refresh_results(self) -> None:
         self._load_netcdf_results()
+        self._load_observations()
         self._preload_plot_variables()
         self._set_node_results()
         self._set_link_results()
@@ -672,14 +685,56 @@ class DatasetWidget:
             if result is not None:
                 self.results[name] = result
 
+    def _load_observations(self) -> None:
+        """Load Observation input data from the GeoPackage into self.observations."""
+        self.observations = read_observations(
+            get_database_path_from_model_file(self.ribasim_widget.path)
+        )
+
+    def _observation_units(self) -> dict[str, str]:
+        """Map each observation variable to a unit borrowed from the results.
+
+        Observed and simulated series share a variable name, so reusing the
+        result unit guarantees they land on the same unit-grouped subplot.
+        """
+        if self.observations is None:
+            return {}
+        units: dict[str, str] = {}
+        for variable in self.observations.variables:
+            for result in self.results.values():
+                if variable in result.units:
+                    units[variable] = result.units[variable]
+                    break
+        return units
+
     def _preload_plot_variables(self) -> None:
         """Pre-populate the plot widget dropdowns from loaded results."""
         available: dict[str, list[str]] = {}
         units: dict[str, dict[str, str]] = {}
+        defaults = dict(_DEFAULT_VARIABLES)
         for name, result in self.results.items():
             available[name] = list(result.variables.keys())
             units[name] = result.units
-        self.plot_widget.preload_variables(available, units, _DEFAULT_VARIABLES)
+        if self.observations is not None and self.observations.variables:
+            available["observation"] = sorted(self.observations.variables)
+            units["observation"] = self._observation_units()
+            # Default observation variables on, so their root group is checked
+            # even without results (when it is the group's only constituent).
+            defaults["observation"] = available["observation"]
+        self.plot_widget.preload_variables(available, units, defaults)
+        self._set_plot_simulated_period()
+
+    def _set_plot_simulated_period(self) -> None:
+        """Tell the plot widget the simulated period to use as default x-range.
+
+        Use the model's ``starttime``/``endtime`` from the TOML so plots open on
+        the simulation window even when an observed series extends beyond it.
+        """
+        toml = get_toml_dict(self.path)
+        self.plot_widget.set_simulated_period(
+            toml["starttime"].strftime(TIME_FORMAT),
+            toml["endtime"].strftime(TIME_FORMAT),
+        )
 
     def _get_concentration_for_node(self, node_id: int) -> dict[str, Trace] | None:
         """Return concentration traces for a single *node_id*."""
@@ -690,7 +745,7 @@ class DatasetWidget:
         idx = id_to_idx.get(node_id)
         if idx is None:
             return None
-        time_strings = result.time.strftime("%Y-%m-%dT%H:%M:%S").to_numpy()
+        time_strings = result.time_strings
         return {
             sub: (time_strings, arr[:, idx]) for sub, arr in result.variables.items()
         }
@@ -707,7 +762,7 @@ class DatasetWidget:
         idx = id_to_idx.get(link_id)
         if idx is None:
             return None
-        time_strings = result.time.strftime("%Y-%m-%dT%H:%M:%S").to_numpy()
+        time_strings = result.time_strings
         return (time_strings, flow_arr[:, idx])
 
     def _set_node_results(self) -> None:
@@ -986,7 +1041,7 @@ class DatasetWidget:
             entity = _ENTITY_BY_FILE.get(name, "")
             # Build id -> column-index mapping (O(1) lookup)
             id_to_idx = {int(v): i for i, v in enumerate(result.ids)}
-            time_strings = result.time.strftime("%Y-%m-%dT%H:%M:%S").to_numpy()
+            time_strings = result.time_strings
 
             vars_data: dict[str, VariableTraces] = {}
             for var_name, arr in result.variables.items():
@@ -1006,10 +1061,16 @@ class DatasetWidget:
         # non-Basin conservative nodes (e.g. TabulatedRatingCurve).
         self._inject_node_flow_rate_traces(plot_data, selected_nodes, link_layer)
 
+        # Inject observed (input) and matching simulated traces for selected
+        # Observation nodes.
+        self._inject_observation_traces(plot_data, selected_nodes, link_layer)
+
         # Collect units from results
         units: dict[str, dict[str, str]] = {
             name: result.units for name, result in self.results.items()
         }
+        if self.observations is not None and self.observations.variables:
+            units["observation"] = self._observation_units()
         if plot_data:
             self.plot_widget.set_data(plot_data, units)
         else:
@@ -1042,7 +1103,7 @@ class DatasetWidget:
             return
 
         link_id_to_idx = {int(v): i for i, v in enumerate(flow_result.ids)}
-        time_strings = flow_result.time.strftime("%Y-%m-%dT%H:%M:%S").to_numpy()
+        time_strings = flow_result.time_strings
 
         new_traces: VariableTraces = {}
         for node_id, node_type in selected_nodes:
@@ -1128,3 +1189,167 @@ class DatasetWidget:
             if idx is not None:
                 columns.append(flow_arr[:, idx])
         return columns
+
+    def _inject_observation_traces(
+        self,
+        plot_data: PlotData,
+        selected_nodes: list[tuple[int, str]],
+        link_layer: Any,
+    ) -> None:
+        """Add observed (input) and simulated traces for selected Observation nodes.
+
+        For each selected Observation node we plot, per observed variable, the
+        observed series read from the GeoPackage together with the matching
+        simulated series from the results of the observed target node. Observed
+        and simulated traces share the same ``("observation", variable)`` key so
+        a single dropdown entry toggles both. When no matching simulated series
+        is available (e.g. results not loaded), only the observed series is
+        shown.
+        """
+        if self.observations is None:
+            return
+
+        node_layer = self.ribasim_widget.node_layer
+        for node_id, node_type in selected_nodes:
+            if node_type != "Observation":
+                continue
+            node_data = self.observations.data.get(node_id)
+            if not node_data:
+                continue
+
+            target_id = self._observation_target_node_id(link_layer, node_id)
+            target_type = (
+                self._node_type_of(node_layer, target_id)
+                if target_id is not None
+                else None
+            )
+
+            for variable, (times, values) in node_data.items():
+                var_traces = plot_data.setdefault("observation", {}).setdefault(
+                    variable, {}
+                )
+                var_traces[f"Observation #{node_id} observed {variable}"] = (
+                    times,
+                    values,
+                )
+                simulated: Trace | None = None
+                if target_id is not None:
+                    simulated = self._simulated_observation_trace(
+                        target_id, target_type, variable, link_layer
+                    )
+                if simulated is not None:
+                    var_traces[f"Observation #{node_id} simulated {variable}"] = (
+                        simulated
+                    )
+
+    def _simulated_observation_trace(
+        self,
+        target_id: int,
+        target_type: str | None,
+        variable: str,
+        link_layer: Any,
+    ) -> Trace | None:
+        """Return the simulated series of *variable* for the observed target node.
+
+        Node-indexed results (e.g. Basin ``level``, ``inflow_rate``) are looked
+        up directly by node_id. Flow variables on connector nodes are derived
+        from the connected flow links of ``flow.nc``.
+        """
+        # Node-indexed results: direct lookup by node_id.
+        basin_result = self.results.get("basin")
+        if basin_result is not None and variable in basin_result.variables:
+            id_to_idx = {int(v): i for i, v in enumerate(basin_result.ids)}
+            idx = id_to_idx.get(target_id)
+            if idx is not None:
+                return (
+                    basin_result.time_strings,
+                    basin_result.variables[variable][:, idx],
+                )
+
+        # Flow variables: derive from connected flow links.
+        flow_result = self.results.get("flow")
+        if (
+            flow_result is not None
+            and link_layer is not None
+            and target_type is not None
+        ):
+            flow_arr = flow_result.variables.get("flow_rate")
+            if flow_arr is not None:
+                link_id_to_idx = {int(v): i for i, v in enumerate(flow_result.ids)}
+                column = self._observation_flow_column(
+                    link_layer,
+                    target_id,
+                    target_type,
+                    variable,
+                    link_id_to_idx,
+                    flow_arr,
+                )
+                if column is not None:
+                    return (flow_result.time_strings, column)
+
+        return None
+
+    def _observation_flow_column(
+        self,
+        link_layer: Any,
+        target_id: int,
+        target_type: str,
+        variable: str,
+        link_id_to_idx: dict[int, int],
+        flow_arr: np.ndarray,
+    ) -> np.ndarray | None:
+        """Return the summed flow_rate column for a flow observation variable.
+
+        ``inflow_rate`` and ``outflow_rate`` sum incoming resp. outgoing flow
+        links. Plain ``flow_rate`` is only meaningful for conservative nodes and
+        is taken from the relevant single link direction.
+        """
+        direction = _OBSERVATION_FLOW_DIRECTION.get(variable)
+        if direction is not None:
+            columns = self._connected_flow_columns(
+                link_layer, target_id, direction, link_id_to_idx, flow_arr
+            )
+            return np.sum(columns, axis=0) if columns else None
+
+        if variable == "flow_rate":
+            # A conservative node's flow_rate equals its single connected flow
+            # link: outgoing for source-style nodes, incoming for sink-style.
+            if target_type in _FLOW_RATE_FROM_OUTGOING_LINK:
+                columns = self._connected_flow_columns(
+                    link_layer, target_id, "from", link_id_to_idx, flow_arr
+                )
+            elif target_type in _FLOW_RATE_FROM_INCOMING_LINKS_SUM:
+                columns = self._connected_flow_columns(
+                    link_layer, target_id, "to", link_id_to_idx, flow_arr
+                )
+            else:
+                return None
+            return np.sum(columns, axis=0) if columns else None
+
+        return None
+
+    @staticmethod
+    def _observation_target_node_id(link_layer: Any, node_id: int) -> int | None:
+        """Return the node_id observed by Observation *node_id*, if any.
+
+        An Observation node connects to at most one other node via an
+        ``observation`` link (from the Observation node to the target).
+        """
+        if link_layer is None:
+            return None
+        request = QgsFeatureRequest().setFilterExpression(
+            f'"from_node_id" = {node_id} AND "link_type" = \'observation\''
+        )
+        for feat in link_layer.getFeatures(request):
+            return int(feat["to_node_id"])
+        return None
+
+    @staticmethod
+    def _node_type_of(node_layer: Any, node_id: int) -> str | None:
+        """Return the node_type of *node_id* from the node layer, if found."""
+        if node_layer is None:
+            return None
+        request = QgsFeatureRequest().setFilterExpression(f'"node_id" = {node_id}')
+        for feat in node_layer.getFeatures(request):
+            return str(feat["node_type"])
+        return None

--- a/ribasim_qgis/widgets/plot_widget.py
+++ b/ribasim_qgis/widgets/plot_widget.py
@@ -1,6 +1,7 @@
 """Plot widget using plotly to render Ribasim timeseries from NetCDF results."""
 
 import importlib.resources
+import json
 from collections import defaultdict
 from collections.abc import Callable
 from enum import Enum, auto
@@ -186,14 +187,17 @@ _BASIN_WATER_BALANCE_ERROR_TERM = "balance_error"
 # (file, variable) keys together.  Group constituents are hidden from their
 # file submenus, so the only way to toggle them is via the group checkbox.
 _ROOT_VARIABLE_GROUPS: tuple[tuple[str, tuple[tuple[str, str], ...]], ...] = (
-    ("level", (("basin", "level"),)),
-    ("storage", (("basin", "storage"),)),
+    ("level", (("basin", "level"), ("observation", "level"))),
+    ("storage", (("basin", "storage"), ("observation", "storage"))),
     (
         "flow_rate",
         (
             ("basin", "inflow_rate"),
             ("basin", "outflow_rate"),
             ("flow", "flow_rate"),
+            ("observation", "flow_rate"),
+            ("observation", "inflow_rate"),
+            ("observation", "outflow_rate"),
         ),
     ),
 )
@@ -459,6 +463,21 @@ class PlotWidget(QWidget):
         self._available: dict[str, list[str]] = {}
         # Default variables per file: {file_name: [variable, ...]}
         self._defaults: dict[str, list[str]] = {}
+        # Default x-axis range (the simulated period) as ISO time strings.
+        # When set, every plot opens on this range instead of auto-fitting all
+        # data (which may include observed series longer than the simulation).
+        self._sim_x_range: tuple[str, str] | None = None
+        # Plotly ``uirevision`` token. Kept constant while the simulated period
+        # is unchanged so Plotly preserves the user's pan/zoom across in-place
+        # updates; it changes when a new model (period) is loaded, resetting it.
+        self._uirevision: str | None = None
+        # In-place update bookkeeping: after the first full page load we update
+        # the existing plot via ``Plotly.react`` (no reload, hence no flicker).
+        self._initialized = False
+        self._page_loaded = False
+        self._pending_js: str | None = None
+        # pyrefly: ignore[missing-attribute]
+        self._web_view.loadFinished.connect(self._on_load_finished)
 
         # Keep node/link buttons in sync with the active layer and map tool.
         if self._iface is not None:
@@ -553,6 +572,35 @@ class PlotWidget(QWidget):
         )
         self._redraw()
 
+    def set_simulated_period(self, start: str | None, end: str | None) -> None:
+        """Set the default x-axis range (the simulated period).
+
+        Plots open on this range so an observed series that extends beyond the
+        simulation does not stretch the view. ``start``/``end`` are ISO time
+        strings (``"%Y-%m-%dT%H:%M:%S"``); pass ``None`` to clear and fall back
+        to auto-ranging.
+        """
+        if not self.plotting_supported:
+            return
+        if start is None or end is None:
+            new_range = None
+            new_token = None
+        else:
+            new_range = (start, end)
+            # One token per simulated period: unchanged within a model so the
+            # user's zoom persists, changed across models so the view resets.
+            new_token = f"{start}/{end}"
+
+        if new_token != self._uirevision:
+            # Plotly's "Reset axes" button restores the range saved at the first
+            # full render; in-place ``Plotly.react`` updates never re-save it.
+            # Force the next render to reload the page so the reset target
+            # becomes this simulated period instead of a previous model's span.
+            self._initialized = False
+
+        self._sim_x_range = new_range
+        self._uirevision = new_token
+
     def set_data(
         self,
         plot_data: PlotData,
@@ -579,9 +627,10 @@ class PlotWidget(QWidget):
         if not self.plotting_supported:
             return
         self._plot_data = {}
-        self._web_view.setVisible(False)
-        self._web_view.setUrl(QUrl("about:blank"))
-        self._placeholder.setVisible(True)
+        # Keep the (now hidden) plot DOM alive rather than navigating away, so a
+        # transient empty selection (e.g. a misclick) doesn't discard the user's
+        # zoom; re-selecting reacts onto the same plot and uirevision restores it.
+        self._show_placeholder(self._placeholder_for_current_preset())
 
     # --- Internal slots ---
 
@@ -686,12 +735,21 @@ class PlotWidget(QWidget):
                     legend_name = f"{trace_name} {var}"
                 else:
                     legend_name = trace_name
+                # Observation comparison traces use fixed colors: the observed
+                # (measured) series is black, the simulated series is red.
+                line = None
+                if file_name == "observation":
+                    if "observed" in trace_name:
+                        line = {"color": "black"}
+                    elif "simulated" in trace_name:
+                        line = {"color": "red"}
                 traces_by_unit[unit_key].append(
                     go.Scatter(
                         x=x_data,
                         y=y_data,
                         mode="lines",
                         name=legend_name,
+                        line=line,
                         hovertemplate=self._hover_template(legend_name),
                     )
                 )
@@ -713,6 +771,29 @@ class PlotWidget(QWidget):
         self._placeholder.setVisible(True)
 
     def _render_figure(self, fig, config: dict[str, bool | list[str]]) -> None:
+        # Open every plot on the simulated period rather than auto-fitting all
+        # data (observed series may extend past the simulation). This range is
+        # also what Plotly saves as the "Reset axes" target on a full render;
+        # "Autoscale" still fits all data. ``set_simulated_period`` forces a full
+        # render whenever the period changes so the reset target stays correct.
+        if self._sim_x_range is not None:
+            fig.update_xaxes(range=list(self._sim_x_range))
+        # ``uirevision`` makes Plotly preserve the user's pan/zoom across
+        # in-place updates: supplying the same range token each redraw keeps the
+        # user's edits, while a new model (new token) resets to its own range.
+        fig.update_layout(uirevision=self._uirevision)
+
+        self._placeholder.setVisible(False)
+        self._web_view.setVisible(True)
+
+        if self._initialized:
+            # Update the existing plot in place — no page reload, no flicker.
+            self._update_figure_in_place(fig, config)
+        else:
+            self._load_figure_page(fig, config)
+
+    def _load_figure_page(self, fig, config: dict[str, bool | list[str]]) -> None:
+        """Write the full plot HTML and load it into the web view (first draw)."""
         div = po.plot(
             fig,
             output_type="div",
@@ -731,9 +812,49 @@ class PlotWidget(QWidget):
             f'<body style="margin:0;overflow:hidden">{div}</body></html>'
         )
         _PLOT_HTML_FILE.write_text(html, encoding="utf-8")
-        self._placeholder.setVisible(False)
-        self._web_view.setVisible(True)
+        self._page_loaded = False
+        self._pending_js = None
+        self._initialized = True
         self._web_view.setUrl(QUrl.fromLocalFile(str(_PLOT_HTML_FILE)))
+
+    def _update_figure_in_place(self, fig, config: dict[str, bool | list[str]]) -> None:
+        """Update the already-loaded plot via ``Plotly.react``.
+
+        Reusing the existing page (instead of reloading) avoids flicker and lets
+        ``uirevision`` keep the user's pan/zoom across updates, as long as the
+        subplot layout is unchanged. If the page is still loading, defer the
+        update until ``loadFinished``.
+        """
+        js = (
+            "(function(){var f=" + fig.to_json() + ";"
+            "var gd=document.querySelector('.plotly-graph-div');"
+            "if(gd&&window.Plotly){Plotly.react(gd,f.data,f.layout,"
+            + json.dumps(config)
+            + ");}})();"
+        )
+        if self._page_loaded:
+            self._run_js(js)
+        else:
+            self._pending_js = js
+
+    def _run_js(self, js: str) -> None:
+        """Execute JavaScript in the web view for the active backend."""
+        page = self._web_view.page()
+        if page is None:
+            return
+        if _BACKEND is _WebViewBackend.WEBENGINE:
+            page.runJavaScript(js)
+        else:
+            frame = page.mainFrame()  # pyrefly: ignore[missing-attribute]
+            if frame is not None:
+                frame.evaluateJavaScript(js)
+
+    def _on_load_finished(self, _ok: bool = True) -> None:
+        """Flush any update that was requested while the page was loading."""
+        self._page_loaded = True
+        if self._pending_js is not None:
+            self._run_js(self._pending_js)
+            self._pending_js = None
 
     def _redraw_standard(
         self, selected_keys: list[tuple[str, str]], config: dict[str, bool | list[str]]


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/2951

Adds support for comparing observed vs. simulated timeseries in the QGIS plugin's timeseries plot. When a model has [Observation](https://ribasim.org/reference/node/observation.html) nodes, selecting one (via the `node` button) plots its observed input series alongside the matching simulated series from the results.

<img width="657" height="467" alt="timeseries-plot-observation" src="https://github.com/user-attachments/assets/d7ecafa6-c636-4175-b222-32171d619b47" />

- **Observation input reader** (observations.py): reads the `Observation / time` table from the model GeoPackage — the plugin's first read of input timeseries data.
- **Observed vs. simulated traces**: for each selected Observation node, the observed series (read from input) is drawn in **black** and the corresponding simulated series in **red**, sharing a single dropdown entry so one checkbox toggles both.
- **Unit-grouped subplots**: observation variables borrow their unit from the matching result variable, so observed and simulated land on the same unit-grouped subplot. Observation variables are merged into the existing root variable groups (`level`, `storage`, `flow_rate`).
- **Simulated-target resolution**: resolves the observed target node via the `observation` link and derives the simulated series — node-indexed lookups for Basin variables, and connected-flow-link sums for flow variables (`flow_rate`, `inflow_rate`, `outflow_rate`).
- **Works without results**: if results aren't loaded, the observed series is still plotted on its own (all observation root groups are checked by default, so flow_rate/level/etc. all show).
- **Default x-axis = simulated period**: plots open on the model's `starttime`/`endtime` (from the TOML) rather than auto-fitting, so an observed series extending beyond the simulation doesn't stretch the view.

- **Retaining the zoom**: the user's pan/zoom is preserved across redraws (e.g. changing the node/link selection) via plotly's `uirevision`, and the "Reset axes" button returns to the simulated period rather than the full data span. Zoom resets only when a different model/period is loaded.
- **Retaining the figure (no flicker)**: redraws update the existing plot in place with `Plotly.react` instead of reloading the page, eliminating flicker. A transient empty selection (e.g. a misclick) hides the plot but keeps its DOM alive, so the zoom survives.

- Added a section to the QGIS guide (qgis.qmd) describing the observation comparison.
- New unit tests for the observation reader and plot widget (72 QGIS tests passing).