### PR TITLE
Delwaq: avoid OOM in parse by not sorting the full results frame

### DIFF
--- a/python/ribasim/ribasim/delwaq/parse.py
+++ b/python/ribasim/ribasim/delwaq/parse.py
@@ -93,9 +93,12 @@ def parse(
 
             dfs.append(df)
 
-    df = _concat(dfs).reset_index(drop=True)
-    df.sort_values(["time", "node_id"], inplace=True)
+    df = _concat(dfs, ignore_index=True)
 
+    # set_index(...).to_xarray() reindexes to sorted coords, so the NetCDF output is
+    # independent of row order. We don't sort df here: it would copy the large
+    # PyArrow-backed `substance` column (and can blow up memory), while write() already
+    # sorts concentration_external by its sort_keys before writing it to disk.
     ds = df.set_index(["time", "substance", "node_id"]).to_xarray()
     ds.to_netcdf(model.results_path / "concentration.nc")
 


### PR DESCRIPTION
### Problem

`parse` could fail with `pyarrow.lib.ArrowMemoryError: malloc of size ...` on large, multi-substance runs (e.g. 3-year LHM runs). The crash happened at `df.sort_values(["time", "node_id"])`: with pandas >= 3.0 the `substance` column is a PyArrow-backed string, and the sort's `take` allocates a fresh contiguous copy of the whole column (multiple GB).

### Fix

Drop the explicit sort in `parse`. It was unnecessary on both output paths:

- `concentration.nc` is written via `set_index(...).to_xarray()`, which reindexes to sorted coordinate values and is therefore independent of the DataFrame row order.
- `concentration_external` is sorted automatically by `TableModel.write()` (using its `sort_keys = ["node_id", "substance", "time"]`) before being written to disk. The removed sort used different keys (`["time", "node_id"]`) and didn't match the on-disk order anyway.

Also switched `_concat(dfs).reset_index(drop=True)` to `_concat(dfs, ignore_index=True)`.

### Notes

No output or schema changes. The existing `test_delwaq.py` tests (run with `to_input=True`) continue to cover the parse path.