### PR TITLE
Update HWS image

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ For most users the [latest release](https://github.com/Deltares/Ribasim/releases
 
 Ribasim model of the main water distribution network in the Netherlands.
 
-![dutch_model_on_map](https://github.com/user-attachments/assets/5095a4fe-c336-4380-aa0c-851c851d3895)
+![Dutch main water network](https://s3.deltares.nl/ribasim/doc-image/network-nl.png)

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -16,4 +16,4 @@ Ribasim will be used as the surface water module of the [Netherlands Hydrologic 
 
 Ribasim model of the main water distribution network in the Netherlands.
 
-<img alt="HWS on map" src="https://github.com/user-attachments/assets/5095a4fe-c336-4380-aa0c-851c851d3895" class="img-fluid">
+![](https://s3.deltares.nl/ribasim/doc-image/network-nl.png){fig-align="left"}


### PR DESCRIPTION
Fix https://github.com/Deltares/Ribasim/issues/3142 by updating both the model and use the current node icons.

![Dutch main water network](https://s3.deltares.nl/ribasim/doc-image/network-nl.png)
