### PR TITLE
Upgrade to latest JuliaC, add `ribasim_set_julia_threads`

### DIFF
--- a/.teamcity/Ribasim_Windows/RibasimWindowsProject.kt
+++ b/.teamcity/Ribasim_Windows/RibasimWindowsProject.kt
@@ -141,7 +141,7 @@ object Windows_TestRibasimBinaries : BuildType({
     name = "Test Ribasim Binaries"
 
     failureConditions {
-        executionTimeoutMin = 30
+        executionTimeoutMin = 60
     }
 
     dependencies {

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.6"
 manifest_format = "2.0"
-project_hash = "4a1c54453712ec36523d0a77fe2ba0726bb1dfec"
+project_hash = "6bf23582f390808ae01021fb12e0032ac76725eb"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "d9aaef7c63466eee4de23b4d9dad03629df54bea"
@@ -1035,10 +1035,10 @@ version = "1.30.1"
     DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 
 [[deps.JuliaC]]
-deps = ["LazyArtifacts", "Libdl", "Mmap", "ObjectFile", "PackageCompiler", "Patchelf_jll", "Pkg", "RelocatableFolders", "StructIO"]
-git-tree-sha1 = "dbbecb7776be9d9d1c58f990d12084656551c4c6"
+deps = ["LazyArtifacts", "Libdl", "Mmap", "ObjectFile", "PackageCompiler", "Patchelf_jll", "Pkg", "Preferences", "RelocatableFolders", "StructIO", "TOML"]
+git-tree-sha1 = "7fe35f8ec64e3754c85673d2bfcfd35d8a322566"
 uuid = "acedd4c2-ced6-4a15-accc-2607eb759ba2"
-version = "0.3.0"
+version = "0.3.8"
 
 [[deps.JuliaInterpreter]]
 deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]

--- a/Project.toml
+++ b/Project.toml
@@ -85,7 +85,7 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 Ribasim = {path = "core"}
 
 [compat]
-JuliaC = "=0.3.0"
+JuliaC = "0.3"
 OpenSSL_jll = "3.5.4"
 OteraEngine = "1.1.3"
 PackageCompiler = "2.3"

--- a/build/README.md
+++ b/build/README.md
@@ -30,10 +30,27 @@ In [1]: from ctypes import CDLL, c_int, c_char_p, create_string_buffer, byref
 
 In [2]: c_dll = CDLL("libribasim", winmode=0x08)  # winmode for Windows
 
-In [3]: config_path = "ribasim.toml"
+In [3]: c_dll.ribasim_set_julia_threads.argtypes = [c_int]
 
-In [4]: c_dll.initialize(c_char_p(config_path.encode()))
-Out[4]: 0
+In [4]: c_dll.ribasim_set_julia_threads.restype = c_int
 
-In [5]: c_dll.update()
+In [5]: c_dll.ribasim_set_julia_threads(2)
 Out[5]: 0
+
+In [6]: config_path = "ribasim.toml"
+
+In [7]: c_dll.initialize(c_char_p(config_path.encode()))
+Out[7]: 0
+
+In [8]: c_dll.update()
+Out[8]: 0
+```
+
+`ribasim_set_julia_threads` accepts a positive integer and must be called before any function that
+initializes Julia. It returns zero on success, one if Julia was already initialized, and two if the
+thread count is invalid.
+
+A value larger than one enables Julia's process-wide signal handlers. Julia requires these handlers
+for garbage collection safepoints when using multiple Julia threads, but they can conflict with
+signal handling in the embedding application. The default is one thread with Julia signal handling
+disabled.

--- a/build/build.jl
+++ b/build/build.jl
@@ -18,6 +18,7 @@ function (@main)(_)::Cint
         project = project_dir,
         cpu_target = default_app_cpu_target(),
         add_ccallables = true,
+        c_sources = ["build/set_julia_threads.c"],
         verbose = true,
     )
     link_recipe = LinkRecipe(;

--- a/build/cli/src/main.rs
+++ b/build/cli/src/main.rs
@@ -15,8 +15,15 @@ struct Cli {
     toml_path: PathBuf,
 
     /// Number of threads to use
-    #[arg(short='t', long="threads", value_name="#THREADS", help="Number of threads to use.", default_value = "1", hide=true)]
-    threads: String,
+    #[arg(
+        short = 't',
+        long = "threads",
+        value_name = "#THREADS",
+        help = "Number of threads to use.",
+        default_value = "1",
+        hide = true
+    )]
+    threads: i32,
 }
 
 fn main() -> ExitCode {
@@ -38,9 +45,6 @@ fn main() -> ExitCode {
         _ => unimplemented!("Your OS is not supported yet."),
     };
     unsafe {
-        // Set JULIA_NUM_THREADS to the value from CLI
-        env::set_var("JULIA_NUM_THREADS", &cli.threads);
-
         // Load the library
         let lib = match Library::new(&shared_lib_path) {
             Ok(lib) => lib,
@@ -50,6 +54,31 @@ fn main() -> ExitCode {
                 return ExitCode::FAILURE;
             }
         };
+
+        // Configure Julia before the first Julia entrypoint initializes the runtime.
+        let set_threads: Symbol<unsafe extern "C" fn(i32) -> i32> =
+            match lib.get(b"ribasim_set_julia_threads") {
+                Ok(symbol) => symbol,
+                Err(error) => {
+                    eprintln!("Failed to find the Julia thread configurator: {error}");
+                    return ExitCode::FAILURE;
+                }
+            };
+        match set_threads(cli.threads) {
+            0 => {}
+            1 => {
+                eprintln!("Julia was initialized before its thread count was configured");
+                return ExitCode::FAILURE;
+            }
+            2 => {
+                eprintln!("Julia thread count must be between 1 and {}", i16::MAX);
+                return ExitCode::FAILURE;
+            }
+            code => {
+                eprintln!("Failed to configure Julia threads (error code {code})");
+                return ExitCode::FAILURE;
+            }
+        }
 
         // Execute
         let execute: Symbol<unsafe extern "C" fn(*const libc::c_char) -> i32> =

--- a/build/set_julia_threads.c
+++ b/build/set_julia_threads.c
@@ -1,0 +1,49 @@
+#include <getopt.h>
+#include <julia.h>
+#include <stdint.h>
+#include <stdio.h>
+
+JL_DLLEXPORT int ribasim_set_julia_threads(int32_t threads)
+{
+    // Julia reads jl_options once, while initializing the runtime.
+    if (jl_is_initialized())
+    {
+        return 1;
+    }
+    if (threads < 1 || threads > INT16_MAX)
+    {
+        return 2;
+    }
+
+    char threads_option[32];
+    snprintf(threads_option, sizeof(threads_option), "--threads=%d", threads);
+
+    // jl_parse_opts mutates process-global getopt state and the selected sysimage.
+    int saved_optind = optind;
+    int saved_opterr = opterr;
+    int saved_optopt = optopt;
+    char *saved_optarg = optarg;
+    const char *saved_image_file = jl_options.image_file;
+
+    // Julia's GC requires signal-based safepoints when multiple threads are active.
+    int enable_signals = threads > 1;
+    char *argv[] = {
+        "ribasim",
+        threads_option,
+        enable_signals ? "--handle-signals=yes" : NULL,
+        NULL,
+    };
+    int argc = enable_signals ? 3 : 2;
+    char **argvp = argv;
+    optind = 0;
+
+    jl_parse_opts(&argc, &argvp);
+
+    // Preserve JuliaC's sysimage and avoid disturbing argument parsing in the host.
+    jl_options.image_file = saved_image_file;
+    optind = saved_optind;
+    opterr = saved_opterr;
+    optopt = saved_optopt;
+    optarg = saved_optarg;
+    return 0;
+}

--- a/build/set_julia_threads.c
+++ b/build/set_julia_threads.c
@@ -3,7 +3,13 @@
 #include <stdint.h>
 #include <stdio.h>
 
-JL_DLLEXPORT int ribasim_set_julia_threads(int32_t threads)
+#ifdef _WIN32
+#define RIBASIM_DLLEXPORT __declspec(dllexport)
+#else
+#define RIBASIM_DLLEXPORT __attribute__((visibility("default")))
+#endif
+
+RIBASIM_DLLEXPORT int ribasim_set_julia_threads(int32_t threads)
 {
     // Julia reads jl_options once, while initializing the runtime.
     if (jl_is_initialized())

--- a/build/set_julia_threads.c
+++ b/build/set_julia_threads.c
@@ -1,13 +1,13 @@
-#include <getopt.h>
 #include <julia.h>
 #include <stdint.h>
-#include <stdio.h>
 
 #ifdef _WIN32
 #define RIBASIM_DLLEXPORT __declspec(dllexport)
 #else
 #define RIBASIM_DLLEXPORT __attribute__((visibility("default")))
 #endif
+
+static int16_t threads_per_pool[1];
 
 RIBASIM_DLLEXPORT int ribasim_set_julia_threads(int32_t threads)
 {
@@ -21,35 +21,14 @@ RIBASIM_DLLEXPORT int ribasim_set_julia_threads(int32_t threads)
         return 2;
     }
 
-    char threads_option[32];
-    snprintf(threads_option, sizeof(threads_option), "--threads=%d", threads);
-
-    // jl_parse_opts mutates process-global getopt state and the selected sysimage.
-    int saved_optind = optind;
-    int saved_opterr = opterr;
-    int saved_optopt = optopt;
-    char *saved_optarg = optarg;
-    const char *saved_image_file = jl_options.image_file;
+    // JuliaC already parsed --threads=1, so update all fields read by jl_init_threading.
+    threads_per_pool[0] = (int16_t)threads;
+    jl_options.nthreadpools = 1;
+    jl_options.nthreads = (int16_t)threads;
+    jl_options.nthreads_per_pool = threads_per_pool;
 
     // Julia's GC requires signal-based safepoints when multiple threads are active.
-    int enable_signals = threads > 1;
-    char *argv[] = {
-        "ribasim",
-        threads_option,
-        enable_signals ? "--handle-signals=yes" : NULL,
-        NULL,
-    };
-    int argc = enable_signals ? 3 : 2;
-    char **argvp = argv;
-    optind = 0;
-
-    jl_parse_opts(&argc, &argvp);
-
-    // Preserve JuliaC's sysimage and avoid disturbing argument parsing in the host.
-    jl_options.image_file = saved_image_file;
-    optind = saved_optind;
-    opterr = saved_opterr;
-    optopt = saved_optopt;
-    optarg = saved_optarg;
+    jl_options.handle_signals =
+        threads > 1 ? JL_OPTIONS_HANDLE_SIGNALS_ON : JL_OPTIONS_HANDLE_SIGNALS_OFF;
     return 0;
 }

--- a/build/tests/test_cli.py
+++ b/build/tests/test_cli.py
@@ -93,6 +93,21 @@ def test_threads_cli_argument(tmp_path):
     assert "threads = 2" in result.stderr
 
 
+def test_threads_cli_argument_must_be_positive(tmp_path):
+    model = ribasim_testmodels.basic_model()
+    model.write(tmp_path / "ribasim.toml")
+
+    result = subprocess.run(
+        [executable, "--threads", "0", tmp_path / "ribasim.toml"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert result.returncode != 0
+    assert "Julia thread count must be between 1 and 32767" in result.stderr
+
+
 def test_threads_env_var(tmp_path):
     """Test that JULIA_NUM_THREADS environment variable is not used."""
     model = ribasim_testmodels.basic_model()


### PR DESCRIPTION
JuliaC now fixes the library thread count at build time, so JULIA_NUM_THREADS can no longer configure libribasim when it is loaded. Add ribasim_set_julia_threads to the libribasim C API, allowing embedders and the Ribasim CLI to set the number of Julia threads before runtime initialization.

Fixes https://github.com/Deltares/Ribasim/issues/3092
