### PR TITLE
Ensure the precompile workload runs during compilation

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.6"
 manifest_format = "2.0"
-project_hash = "95d864dd7be26332b49d2e10dce568dee76b88f4"
+project_hash = "2ac76a9e69096fd270e13dc839e672f88382713a"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "d9aaef7c63466eee4de23b4d9dad03629df54bea"
@@ -2116,7 +2116,7 @@ weakdeps = ["Distributed"]
     DistributedExt = "Distributed"
 
 [[deps.Ribasim]]
-deps = ["ADTypes", "Accessors", "BasicModelInterface", "Configurations", "DBInterface", "DataInterpolations", "DataStructures", "Dates", "DelimitedFiles", "DiffEqBase", "DiffEqCallbacks", "DifferentiationInterface", "EnumX", "FindFirstFunctions", "FiniteDiff", "ForwardDiff", "Graphs", "HiGHS", "IterTools", "JuMP", "LinearAlgebra", "LinearSolve", "Logging", "LoggingExtras", "MathOptAnalyzer", "MetaGraphsNext", "Moshi", "NCDatasets", "NaNMath", "OrdinaryDiffEqBDF", "OrdinaryDiffEqCore", "OrdinaryDiffEqDifferentiation", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqTsit5", "PrecompileTools", "Printf", "SQLite", "SciMLBase", "SciMLOperators", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings", "StructArrays", "Tables", "TerminalLoggers", "TranscodingStreams"]
+deps = ["ADTypes", "Accessors", "ArrayInterface", "BasicModelInterface", "Configurations", "DBInterface", "DataInterpolations", "DataStructures", "Dates", "DelimitedFiles", "DiffEqBase", "DiffEqCallbacks", "DifferentiationInterface", "EnumX", "FindFirstFunctions", "FiniteDiff", "ForwardDiff", "Graphs", "HiGHS", "IterTools", "JuMP", "LinearAlgebra", "LinearSolve", "Logging", "LoggingExtras", "MathOptAnalyzer", "MetaGraphsNext", "Moshi", "NCDatasets", "NaNMath", "OrdinaryDiffEqBDF", "OrdinaryDiffEqCore", "OrdinaryDiffEqDifferentiation", "OrdinaryDiffEqLowOrderRK", "OrdinaryDiffEqNonlinearSolve", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqTsit5", "Polyester", "PrecompileTools", "Printf", "SQLite", "SciMLBase", "SciMLOperators", "SparseArrays", "SparseConnectivityTracer", "SparseMatrixColorings", "StrideArraysCore", "StructArrays", "Tables", "TerminalLoggers", "TranscodingStreams"]
 path = "core"
 uuid = "aac5e3d9-0b8f-4d4f-8241-b1a7a9632635"
 version = "2026.1.2"

--- a/build/build.jl
+++ b/build/build.jl
@@ -28,7 +28,10 @@ function (@main)(_)::Cint
     )
     bundle_recipe = BundleRecipe(; link_recipe, output_dir)
 
-    compile_products(image_recipe)
+    precompile_workload = abspath("generated_testmodels/basic/ribasim.toml")
+    withenv("RIBASIM_PRECOMPILE_WORKLOAD" => precompile_workload) do
+        compile_products(image_recipe)
+    end
     link_products(link_recipe)
     bundle_products(bundle_recipe)
 

--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -194,7 +194,16 @@ include("concentration.jl")
 include("main.jl")
 
 @setup_workload begin
-    toml_path = normpath(@__DIR__, "../../generated_testmodels/basic/ribasim.toml")
+    # Binary builds set this to require the workload; regular package use keeps it optional.
+    precompile_workload = get(ENV, "RIBASIM_PRECOMPILE_WORKLOAD", nothing)
+    toml_path = if isnothing(precompile_workload)
+        normpath(@__DIR__, "../../generated_testmodels/basic/ribasim.toml")
+    else
+        isfile(precompile_workload) || error(
+            "Ribasim precompile workload not found at $precompile_workload",
+        )
+        precompile_workload
+    end
     isfile(toml_path) || return
     @compile_workload begin
         main(toml_path)


### PR DESCRIPTION
Fixes a regression from https://github.com/Deltares/Ribasim/pull/3151 that stopped running the workload due to JuliaC using a temp dir and not finding the TOML file.

We still allow not having the TOML file around, just not during compilation anymore, otherwise this is hard to catch.