### PR TITLE
Python: replace Pyrefly with ty

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
                 "charliermarsh.ruff",
                 "GitHub.copilot",
                 "julialang.language-julia",
-                "meta.pyrefly",
+                "astral-sh.ty",
                 "ms-python.python",
                 "ms-toolsai.jupyter",
                 "njpwerner.autodocstring",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,8 +54,8 @@ repos:
         args: [--write-changes, --force-exclude]
         types: [text]
         stages: [pre-commit, pre-merge-commit, pre-push, manual]
-      - id: pyrefly-check
-        name: Pyrefly (type checking)
+      - id: typecheck
+        name: typecheck
         entry: pixi run typecheck
         pass_filenames: false
         language: system

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,7 @@
         "aviatesk.jetls-client",
         "charliermarsh.ruff",
         "julialang.language-julia",
-        "meta.pyrefly",
+        "astral-sh.ty",
         "ms-python.python",
         "ms-toolsai.jupyter",
         "njpwerner.autodocstring",

--- a/pixi.lock
+++ b/pixi.lock
@@ -352,7 +352,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.11-py313h938ae94_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.17.0-py313h7033f15_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqtwebkit-5.15.11-py313h938ae94_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-1.1.1-hb17b654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.1-py313hcd51b16_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.14-h6add32d_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-gssapi-1.11.1-py313h71539a6_1.conda
@@ -390,6 +389,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.30.1-h8f647a8_15.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py313h07c4f96_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.63-h4e94fc0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/typos-1.48.0-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/typst-0.14.2-h4c46f8d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tzcode-2026b-h280c20c_0.conda
@@ -991,7 +991,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyproj-3.7.2-py313h93e4dea_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyqt-5.15.11-py313h7cbc9b8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyqt5-sip-12.17.0-py313he352c24_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyrefly-1.1.1-h069e38c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyside6-6.11.1-py313h83050ec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.13.14-h6185564_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-gssapi-1.11.1-py313haba7a9f_1.conda
@@ -1017,6 +1016,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlite-3.53.3-hf1c7be2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tornado-6.5.7-py313he149459_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ty-0.0.63-h47ce4e6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/typos-1.48.0-h069e38c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/uriparser-0.9.8-h0a1ffab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/uv-0.11.26-haa595b2_0.conda
@@ -1872,7 +1872,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.2-py313h9902f63_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqt-5.15.11-py313h003178d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqt5-sip-12.17.0-py313h0e822ff_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-1.1.1-h6fdd925_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.14-h448ec07_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-gssapi-1.11.1-py313h97cd5db_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytokens-0.4.1-py313h6688731_2.conda
@@ -1895,6 +1894,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.53.3-h85ec8f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.7-py313h0997733_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ty-0.0.63-hdfcc030_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/typos-1.48.0-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/typst-0.14.2-hd1458d2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.8-h00cdb27_0.conda
@@ -2482,7 +2482,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.11-py313h1048830_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.17.0-py313hfe59770_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyqtwebkit-5.15.11-py313h1048830_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyrefly-1.1.1-h18a1a76_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.11.1-py313h0c3c3c1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.14-h09917c8_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-gssapi-1.11.1-py313h8d67570_1.conda
@@ -2521,6 +2520,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.30.1-h81c97d3_15.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.5.7-py313h5ea7bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ty-0.0.63-hc21aad4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/typos-1.48.0-h18a1a76_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/typst-0.14.2-h77a83cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
@@ -2897,7 +2897,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.11-py313h938ae94_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.17.0-py313h7033f15_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqtwebkit-5.15.11-py313h938ae94_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-1.1.1-hb17b654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.1-py313hcd51b16_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.14-h6add32d_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-gssapi-1.11.1-py313h71539a6_1.conda
@@ -2935,6 +2934,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.30.1-h8f647a8_15.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py313h07c4f96_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.63-h4e94fc0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/typos-1.48.0-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/typst-0.14.2-h4c46f8d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tzcode-2026b-h280c20c_0.conda
@@ -3536,7 +3536,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyproj-3.7.2-py313h93e4dea_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyqt-5.15.11-py313h7cbc9b8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyqt5-sip-12.17.0-py313he352c24_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyrefly-1.1.1-h069e38c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyside6-6.11.1-py313h83050ec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.13.14-h6185564_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-gssapi-1.11.1-py313haba7a9f_1.conda
@@ -3562,6 +3561,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlite-3.53.3-hf1c7be2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tornado-6.5.7-py313he149459_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ty-0.0.63-h47ce4e6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/typos-1.48.0-h069e38c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/uriparser-0.9.8-h0a1ffab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/uv-0.11.26-haa595b2_0.conda
@@ -4419,7 +4419,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.2-py313h9902f63_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqt-5.15.11-py313h003178d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqt5-sip-12.17.0-py313h0e822ff_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-1.1.1-h6fdd925_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.14-h448ec07_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-gssapi-1.11.1-py313h97cd5db_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytokens-0.4.1-py313h6688731_2.conda
@@ -4442,6 +4441,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.53.3-h85ec8f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.7-py313h0997733_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ty-0.0.63-hdfcc030_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/typos-1.48.0-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/typst-0.14.2-hd1458d2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.8-h00cdb27_0.conda
@@ -5029,7 +5029,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.11-py313h1048830_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.17.0-py313hfe59770_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyqtwebkit-5.15.11-py313h1048830_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyrefly-1.1.1-h18a1a76_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.11.1-py313h0c3c3c1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.14-h09917c8_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-gssapi-1.11.1-py313h8d67570_1.conda
@@ -5068,6 +5067,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.30.1-h81c97d3_15.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.5.7-py313h5ea7bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ty-0.0.63-hc21aad4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/typos-1.48.0-h18a1a76_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/typst-0.14.2-h77a83cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
@@ -5443,7 +5443,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt-5.15.11-py312h82c0db2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqt5-sip-12.17.0-py312h1289d80_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyqtwebkit-5.15.11-py312h82c0db2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-1.1.1-hb17b654_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.1-py312h50ac2ff_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-gssapi-1.11.1-py312hf9980d4_1.conda
@@ -5481,6 +5480,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.30.1-h8f647a8_15.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py312h4c3975b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.63-h4e94fc0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/typos-1.48.0-hb17b654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/typst-0.14.2-h4c46f8d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tzcode-2026b-h280c20c_0.conda
@@ -6082,7 +6082,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyproj-3.7.2-py312hb292342_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyqt-5.15.11-py312hc13527c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyqt5-sip-12.17.0-py312h1ab2c47_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyrefly-1.1.1-h069e38c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyside6-6.11.1-py312hfc1e6cc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.13-h91f4b29_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-gssapi-1.11.1-py312h3cc9a29_1.conda
@@ -6108,6 +6107,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/sqlite-3.53.3-hf1c7be2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-noxft_h0dc03b3_103.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tornado-6.5.7-py312hefbd42c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ty-0.0.63-h47ce4e6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/typos-1.48.0-h069e38c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/unicodedata2-17.0.1-py312hcd1a082_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/uriparser-0.9.8-h0a1ffab_0.conda
@@ -6963,7 +6963,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyproj-3.7.2-py312h2a764c1_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqt-5.15.11-py312h6612b97_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyqt5-sip-12.17.0-py312h455b684_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-1.1.1-h6fdd925_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-gssapi-1.11.1-py312h858ef95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pytokens-0.4.1-py312hb3ab3e3_2.conda
@@ -6986,6 +6985,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.53.3-h85ec8f2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h010d191_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.5.7-py312h2bbb03f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ty-0.0.63-hdfcc030_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/typos-1.48.0-h6fdd925_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/typst-0.14.2-hd1458d2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-17.0.1-py312h2bbb03f_0.conda
@@ -7573,7 +7573,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt-5.15.11-py312h7eb3e20_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyqt5-sip-12.17.0-py312hbb81ca0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyqtwebkit-5.15.11-py312h7eb3e20_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyrefly-1.1.1-h18a1a76_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.11.1-py312ha7d0d2e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.13-h0159041_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-gssapi-1.11.1-py312hcf70c7a_1.conda
@@ -7612,6 +7611,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.30.1-h81c97d3_15.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h6ed50ae_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.5.7-py312he06e257_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ty-0.0.63-hc21aad4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/typos-1.48.0-h18a1a76_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/typst-0.14.2-h77a83cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
@@ -7693,7 +7693,7 @@ packages:
   license: MIT AND Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/aiohttp?source=compressed-mapping
+  - pkg:pypi/aiohttp?source=hash-mapping
   size: 1078273
   timestamp: 1780913823270
 - conda: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.14.1-py313hd6074c6_0.conda
@@ -7715,7 +7715,7 @@ packages:
   license: MIT AND Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/aiohttp?source=compressed-mapping
+  - pkg:pypi/aiohttp?source=hash-mapping
   size: 1083744
   timestamp: 1780914191006
 - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16.1-hb03c661_0.conda
@@ -8112,7 +8112,7 @@ packages:
   - zstd >=1.5.7,<1.6.0a0
   license: BSD-3-Clause AND MIT AND EPL-2.0
   purls:
-  - pkg:pypi/backports-zstd?source=compressed-mapping
+  - pkg:pypi/backports-zstd?source=hash-mapping
   size: 242845
   timestamp: 1781450812380
 - conda: https://conda.anaconda.org/conda-forge/linux-64/billiard-4.2.4-py312h4c3975b_0.conda
@@ -8477,7 +8477,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/coverage?source=hash-mapping
+  - pkg:pypi/coverage?source=compressed-mapping
   size: 394452
   timestamp: 1783019257881
 - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.15.0-py313h3dea7bd_0.conda
@@ -12561,7 +12561,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/msgpack?source=compressed-mapping
+  - pkg:pypi/msgpack?source=hash-mapping
   size: 112800
   timestamp: 1782460774570
 - conda: https://conda.anaconda.org/conda-forge/linux-64/msgpack-python-1.2.1-py313hc8edb43_1.conda
@@ -12576,7 +12576,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/msgpack?source=compressed-mapping
+  - pkg:pypi/msgpack?source=hash-mapping
   size: 112798
   timestamp: 1782460772873
 - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py312h8a5da7c_0.conda
@@ -12670,7 +12670,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/nh3?source=compressed-mapping
+  - pkg:pypi/nh3?source=hash-mapping
   size: 672346
   timestamp: 1782129862714
 - conda: https://conda.anaconda.org/conda-forge/linux-64/nitro-2.7.dev8-h59595ed_0.conda
@@ -13122,7 +13122,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pandas?source=compressed-mapping
+  - pkg:pypi/pandas?source=hash-mapping
   size: 15001668
   timestamp: 1778602610159
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.8.3-ha770c72_0.conda
@@ -13213,7 +13213,7 @@ packages:
   - libwebp-base >=1.6.0,<2.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   size: 1064129
   timestamp: 1782912080163
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.3.0-py313h80991f8_0.conda
@@ -13900,19 +13900,6 @@ packages:
   purls: []
   size: 155621
   timestamp: 1759596293883
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyrefly-1.1.1-hb17b654_1.conda
-  sha256: a2d656603d21f31d57a393a381442c2747251fe7049e8cc031973cb9e57cab68
-  md5: de7298b455eceac99bd624b97ba727ef
-  depends:
-  - libgcc >=14
-  - __glibc >=2.17,<3.0.a0
-  constrains:
-  - __glibc >=2.17
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 11408406
-  timestamp: 1782826707443
 - conda: https://conda.anaconda.org/conda-forge/linux-64/pyside6-6.11.1-py312h50ac2ff_1.conda
   sha256: 6f9e4fd9f6aa1d82a524384399c956c0c79c6c5df5ae42e241eb59f42c11ffbf
   md5: 90f891bc96f673acbff89f6f405aef10
@@ -15066,7 +15053,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/tornado?source=hash-mapping
+  - pkg:pypi/tornado?source=compressed-mapping
   size: 864705
   timestamp: 1781006801632
 - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.7-py313h07c4f96_0.conda
@@ -15083,6 +15070,23 @@ packages:
   - pkg:pypi/tornado?source=compressed-mapping
   size: 885824
   timestamp: 1781006802459
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ty-0.0.63-h4e94fc0_0.conda
+  noarch: python
+  sha256: 3340cef93f507e05f7243cb1f706a4fc273d591848073d8ab54b04a1357e0898
+  md5: 51139cd6c5ca525dec9b2f74c4e43d93
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - _python_abi3_support 1.*
+  - cpython >=3.10
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  purls:
+  - pkg:pypi/ty?source=hash-mapping
+  size: 10529624
+  timestamp: 1784852395499
 - conda: https://conda.anaconda.org/conda-forge/linux-64/typos-1.48.0-hb17b654_0.conda
   sha256: b8cd6270cf71afa1ea5abb21c5ea65d9f4f0ec2614d3af3d0d2185011a1ff3b4
   md5: a66c11d121cd29ee901edb4eb50d1075
@@ -15244,7 +15248,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   size: 115842
   timestamp: 1782133640094
 - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-2.2.2-py313h07c4f96_0.conda
@@ -19922,18 +19926,6 @@ packages:
   - pkg:pypi/pyqt5-sip?source=hash-mapping
   size: 90134
   timestamp: 1759495727553
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyrefly-1.1.1-h069e38c_1.conda
-  sha256: beff78ecd7021c513c337b47323dec2ec20ee63834408517df976bd2f7dcbf54
-  md5: dc6e51c8a74ab06ca14e959ad283fd06
-  depends:
-  - libgcc >=14
-  constrains:
-  - __glibc >=2.17
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 11147745
-  timestamp: 1782826720700
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyside6-6.11.1-py312hfc1e6cc_1.conda
   sha256: b738004d7cdecd26c838548a7ae3fc9943d4d204022329317e7f72f96ea4096f
   md5: 15646d3df9799fdafafeb3ec749f09c2
@@ -20650,6 +20642,22 @@ packages:
   - pkg:pypi/tornado?source=hash-mapping
   size: 886696
   timestamp: 1781008029685
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ty-0.0.63-h47ce4e6_0.conda
+  noarch: python
+  sha256: 91f683ebe120935d8cfbe788b94ec31038b46d3938d1e348bbace4dd14113b5d
+  md5: 22571299c0e334d070dbcc345b4876ae
+  depends:
+  - python
+  - libgcc >=14
+  - _python_abi3_support 1.*
+  - cpython >=3.10
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  purls:
+  - pkg:pypi/ty?source=hash-mapping
+  size: 10136261
+  timestamp: 1784852395008
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/typos-1.48.0-h069e38c_0.conda
   sha256: 3141ffeddc27e9a98298dade1faf6c233701bdff47209f3871d6688188adeed5
   md5: d2ff6fd5e80452e6b88ecfd5da3f4a73
@@ -20764,7 +20772,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   size: 115536
   timestamp: 1782133697736
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.1-hca56bd8_2.conda
@@ -21319,7 +21327,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/anyio?source=compressed-mapping
+  - pkg:pypi/anyio?source=hash-mapping
   size: 161308
   timestamp: 1782357087265
 - conda: https://conda.anaconda.org/conda-forge/noarch/appdirs-1.4.4-pyhd8ed1ab_1.conda
@@ -21525,7 +21533,7 @@ packages:
   - tinycss2 >=1.1.0,<1.5
   license: Apache-2.0 AND MIT
   purls:
-  - pkg:pypi/bleach?source=compressed-mapping
+  - pkg:pypi/bleach?source=hash-mapping
   size: 142246
   timestamp: 1780675823953
 - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-with-css-6.4.0-hac0b51c_0.conda
@@ -21884,7 +21892,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/dask?source=compressed-mapping
+  - pkg:pypi/dask?source=hash-mapping
   size: 1069053
   timestamp: 1781221472758
 - conda: https://conda.anaconda.org/conda-forge/noarch/datacompy-1.0.2-pyhd8ed1ab_0.conda
@@ -22406,8 +22414,7 @@ packages:
   - xyzservices
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/geopandas?source=compressed-mapping
+  purls: []
   size: 8267
   timestamp: 1782507446937
 - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.4-pyha770c72_0.conda
@@ -22568,7 +22575,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/hatchling?source=compressed-mapping
+  - pkg:pypi/hatchling?source=hash-mapping
   size: 61807
   timestamp: 1780403469805
 - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.2.0-pyhd8ed1ab_0.conda
@@ -22834,7 +22841,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/ipykernel?source=compressed-mapping
+  - pkg:pypi/ipykernel?source=hash-mapping
   size: 138046
   timestamp: 1781101760172
 - conda: https://conda.anaconda.org/conda-forge/noarch/ipykernel-7.3.0-pyha191276_0.conda
@@ -24408,7 +24415,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/python-discovery?source=compressed-mapping
+  - pkg:pypi/python-discovery?source=hash-mapping
   size: 35503
   timestamp: 1783111064496
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-dotenv-1.2.2-pyhcf101f3_0.conda
@@ -25196,7 +25203,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/traitlets?source=compressed-mapping
+  - pkg:pypi/traitlets?source=hash-mapping
   size: 115158
   timestamp: 1780507822178
 - conda: https://conda.anaconda.org/conda-forge/noarch/trove-classifiers-2026.6.1.19-pyhcf101f3_0.conda
@@ -25208,7 +25215,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/trove-classifiers?source=compressed-mapping
+  - pkg:pypi/trove-classifiers?source=hash-mapping
   size: 24210
   timestamp: 1780385194431
 - conda: https://conda.anaconda.org/conda-forge/noarch/truststore-0.10.4-pyhcf101f3_0.conda
@@ -25273,7 +25280,7 @@ packages:
   - python
   license: MIT AND BSD-3-Clause
   purls:
-  - pkg:pypi/typer?source=compressed-mapping
+  - pkg:pypi/typer?source=hash-mapping
   size: 186572
   timestamp: 1782477870892
 - conda: https://conda.anaconda.org/conda-forge/noarch/types-geopandas-1.1.4.20260628-pyhd8ed1ab_0.conda
@@ -25359,7 +25366,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/typing-extensions?source=compressed-mapping
+  - pkg:pypi/typing-extensions?source=hash-mapping
   size: 52631
   timestamp: 1783002732887
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing_inspect-0.9.0-pyhd8ed1ab_1.conda
@@ -25684,7 +25691,7 @@ packages:
   license: MIT AND Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/aiohttp?source=compressed-mapping
+  - pkg:pypi/aiohttp?source=hash-mapping
   size: 1049144
   timestamp: 1780913992605
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.14.1-py313h53c0e3e_0.conda
@@ -28411,7 +28418,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/matplotlib?source=hash-mapping
+  - pkg:pypi/matplotlib?source=compressed-mapping
   size: 8650165
   timestamp: 1782829632549
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.11.0-py313ha8b9ad1_1.conda
@@ -28561,7 +28568,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/netcdf4?source=compressed-mapping
+  - pkg:pypi/netcdf4?source=hash-mapping
   size: 996742
   timestamp: 1782151700070
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nh3-0.3.6-py310h3b8a9b8_0.conda
@@ -29049,7 +29056,7 @@ packages:
   - python_abi 3.12.* *_cp312
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   size: 977597
   timestamp: 1782912213683
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.3.0-py313h45e5a15_0.conda
@@ -29426,7 +29433,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyobjc-framework-cocoa?source=compressed-mapping
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
   size: 383474
   timestamp: 1782265775966
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-12.2.1-py313hc8aa7a0_0.conda
@@ -29584,18 +29591,6 @@ packages:
   - pkg:pypi/pyqt5-sip?source=hash-mapping
   size: 75880
   timestamp: 1759495995105
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyrefly-1.1.1-h6fdd925_1.conda
-  sha256: 9ae74ec65270548f6ad2b5584ddea38754001f274013aecf633a8331761be637
-  md5: 4187ee60069a0baf6c98fbfff392ea7f
-  depends:
-  - __osx >=11.0
-  constrains:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 10708112
-  timestamp: 1782826805517
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
   sha256: e658e647a4a15981573d6018928dec2c448b10c77c557c29872043ff23c0eb6a
   md5: 8e7608172fa4d1b90de9a745c2fd2b81
@@ -29895,7 +29890,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/ruff?source=compressed-mapping
+  - pkg:pypi/ruff?source=hash-mapping
   size: 8539333
   timestamp: 1782428897543
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.96.1-h4ff7c5d_1.conda
@@ -29971,7 +29966,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/scipy?source=compressed-mapping
+  - pkg:pypi/scipy?source=hash-mapping
   size: 14165071
   timestamp: 1781912652942
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.18.0-py313h52f5312_0.conda
@@ -30129,6 +30124,22 @@ packages:
   - pkg:pypi/tornado?source=hash-mapping
   size: 889689
   timestamp: 1781007967544
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/ty-0.0.63-hdfcc030_0.conda
+  noarch: python
+  sha256: 9972b216f4607d35130b2d88457f18c643cfb143e44face2bf0ce420f9ae803c
+  md5: 81c6e3e15e98b2aefdd6f27903445ea7
+  depends:
+  - python
+  - __osx >=11.0
+  - _python_abi3_support 1.*
+  - cpython >=3.10
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  purls:
+  - pkg:pypi/ty?source=hash-mapping
+  size: 9534315
+  timestamp: 1784852405770
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/typos-1.48.0-h6fdd925_0.conda
   sha256: 1d9e347d6ce66bbb0486d97f1799ffde92c068b9b7bbd0f249941c736f5db12b
   md5: c679568be20dfa9f4bd979d010636be2
@@ -30230,7 +30241,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   size: 112459
   timestamp: 1782134073014
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-2.2.2-py313h0997733_0.conda
@@ -30244,7 +30255,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   size: 113551
   timestamp: 1782133966372
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.3.0-h25f632f_1.conda
@@ -34385,8 +34396,7 @@ packages:
   - tornado >=5
   license: PSF-2.0
   license_family: PSF
-  purls:
-  - pkg:pypi/matplotlib?source=compressed-mapping
+  purls: []
   size: 15163
   timestamp: 1782829753413
 - conda: https://conda.anaconda.org/conda-forge/win-64/matplotlib-3.11.0-py313hfa70ccb_1.conda
@@ -34725,7 +34735,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/numpy?source=compressed-mapping
+  - pkg:pypi/numpy?source=hash-mapping
   size: 7169449
   timestamp: 1779169226122
 - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.4.6-py313ha8dc839_0.conda
@@ -35715,18 +35725,6 @@ packages:
   purls: []
   size: 126327
   timestamp: 1759598462673
-- conda: https://conda.anaconda.org/conda-forge/win-64/pyrefly-1.1.1-h18a1a76_1.conda
-  sha256: 7864ace0d6cd8633e984bd5a47bceb80d9114a36f7669ed33efda1d5ca076f16
-  md5: 0ef4447a0161d78facfa6681bd9f7b37
-  depends:
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 11736626
-  timestamp: 1782826757042
 - conda: https://conda.anaconda.org/conda-forge/win-64/pyside6-6.11.1-py312ha7d0d2e_1.conda
   sha256: 3b74e218df8f1e44599fcec686b50daa13214949087a109beca54db5a2db344e
   md5: 08cd4cab6c22ee97776628d6c8292092
@@ -36014,7 +36012,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pyzmq?source=compressed-mapping
+  - pkg:pypi/pyzmq?source=hash-mapping
   size: 182831
   timestamp: 1779483925948
 - conda: https://conda.anaconda.org/conda-forge/win-64/qca-2.3.10-hcfd1de8_0.conda
@@ -36395,7 +36393,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   size: 217956
   timestamp: 1782831653430
 - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-2026.6.3-py313ha9ea572_0.conda
@@ -36527,8 +36525,7 @@ packages:
   - vc14_runtime >=14.44.35208
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/scipy?source=compressed-mapping
+  purls: []
   size: 15077907
   timestamp: 1781914327034
 - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.18.0-py313he51e9a2_0.conda
@@ -36777,6 +36774,22 @@ packages:
   - pkg:pypi/tornado?source=compressed-mapping
   size: 888693
   timestamp: 1781006912014
+- conda: https://conda.anaconda.org/conda-forge/win-64/ty-0.0.63-hc21aad4_0.conda
+  noarch: python
+  sha256: de0c79b8304d872e4e63af65f4d96dd9119373460fe070182ac409b76b3c8271
+  md5: 66261f3fc686d321af4dc1914fe5ab11
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - _python_abi3_support 1.*
+  - cpython >=3.10
+  license: MIT
+  purls:
+  - pkg:pypi/ty?source=hash-mapping
+  size: 10619599
+  timestamp: 1784852441590
 - conda: https://conda.anaconda.org/conda-forge/win-64/typos-1.48.0-h18a1a76_0.conda
   sha256: 10f973b1a21082f06ef9c8388bb3b95ff9fc37054b18879c16fa443339e44633
   md5: 36422364f71f8110de1829127d0e99fc
@@ -36955,7 +36968,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   size: 114396
   timestamp: 1782133745518
 - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.3.0-hac47afa_1.conda

--- a/pixi.toml
+++ b/pixi.toml
@@ -66,7 +66,7 @@ docs = { cmd = "PYTHON_JULIAPKG_PROJECT=$PIXI_PROJECT_ROOT quarto preview docs/{
     "initialize-julia",
 ], env = { "PYTHON_JULIACALL_CHECK_BOUNDS" = "yes", "PYTHON_JULIACALL_HANDLE_SIGNALS" = "yes", "PYTHON_JULIAPKG_OFFLINE" = "yes" } }
 # Lint
-typecheck = "pyrefly check"
+typecheck = "ty check"
 prek-run = "prek run --all-files"
 lint = { depends-on = ["prek-run"] }
 # Build
@@ -280,7 +280,6 @@ pydantic = ">=2.0"
 pydantic-settings = "*"
 pyogrio = ">=0.8"
 pyqt-stubs = "*"
-pyrefly = "*"
 pytest = "*"
 pytest-cov = "*"
 pytest-xdist = "*"
@@ -293,6 +292,7 @@ teamcity-messages = "*"
 tomli = ">=2.0"
 tomli-w = ">=1.0"
 twine = "*"
+ty = "*"
 types-geopandas = "*"
 types-networkx = "*"
 typos = "*"

--- a/python/ribasim/ribasim/cli.py
+++ b/python/ribasim/ribasim/cli.py
@@ -113,7 +113,7 @@ def _subprocess_handling() -> SubprocessHandling:
     """
     # Check for Marimo first
     try:
-        import marimo  # pyrefly: ignore[missing-import]
+        import marimo  # ty: ignore[unresolved-import]
 
         if marimo.running_in_notebook():
             return SubprocessHandling.DISPLAY

--- a/python/ribasim/ribasim/delwaq/generate.py
+++ b/python/ribasim/ribasim/delwaq/generate.py
@@ -35,7 +35,7 @@ from ribasim.utils import (
 try:
     import networkx as _nx
 except ImportError:
-    _nx = MissingOptionalModule("networkx", "delwaq")
+    _nx = MissingOptionalModule("networkx", "delwaq")  # ty: ignore[invalid-assignment]
 
 import numpy as np
 import pandas as pd
@@ -46,7 +46,7 @@ from ribasim.geometry.link import SPATIALCONTROLNODETYPES
 try:
     import jinja2 as _jinja2
 except ImportError:
-    _jinja2 = MissingOptionalModule("jinja2", "delwaq")
+    _jinja2 = MissingOptionalModule("jinja2", "delwaq")  # ty: ignore[invalid-assignment]
 
 import ribasim
 from ribasim.delwaq.util import (

--- a/python/ribasim/ribasim/delwaq/plot.py
+++ b/python/ribasim/ribasim/delwaq/plot.py
@@ -74,7 +74,7 @@ def plot_fraction(
     color_iters = cycle(prop_cycle.by_key()["color"])
     ax.stackplot(
         time,
-        stack.values(),  # pyrefly: ignore[bad-argument-type]
+        stack.values(),  # ty: ignore[invalid-argument-type]
         labels=stack.keys(),
         colors=[colors.get(k, next(color_iters)) for k in stack],
     )
@@ -116,7 +116,6 @@ def plot_spatial(model, tracer="Initial", versus=None, limit=0.001, ax=None):
         alpha = c > limit
     else:
         total_concentration = (
-            # pyrefly: ignore[unbound-name]
             table["concentration"][nodes.index] + vtable["concentration"][nodes.index]
         )
         c = table["concentration"][nodes.index] / total_concentration

--- a/python/ribasim/ribasim/delwaq/util.py
+++ b/python/ribasim/ribasim/delwaq/util.py
@@ -18,7 +18,7 @@ from ribasim.utils import MissingOptionalModule
 try:
     import xugrid as _xugrid
 except ImportError:
-    _xugrid = MissingOptionalModule("xugrid")
+    _xugrid = MissingOptionalModule("xugrid")  # ty: ignore[invalid-assignment]
 
 if TYPE_CHECKING:
     import xugrid as xugrid_types

--- a/python/ribasim/ribasim/geometry/area.py
+++ b/python/ribasim/ribasim/geometry/area.py
@@ -1,5 +1,5 @@
+import numpy as np
 import pandera as pa
-from pandera.dtypes import Int32
 from pandera.typing import Index, Series
 from pandera.typing.geopandas import GeoSeries
 from shapely.geometry import MultiPolygon, Polygon
@@ -9,8 +9,8 @@ from .base import _GeoBaseSchema
 
 class BasinAreaSchema(_GeoBaseSchema):
     _node_id_relation: str = "subset"
-    fid: Index[Int32] = pa.Field(default=0, check_name=True)
-    node_id: Series[Int32] = pa.Field(nullable=False, default=0)
+    fid: Index[np.int32] = pa.Field(default=0, check_name=True)
+    node_id: Series[np.int32] = pa.Field(nullable=False, default=0)
     geometry: GeoSeries[MultiPolygon] = pa.Field(default=None, nullable=True)
 
     @pa.parser("geometry")
@@ -22,8 +22,8 @@ class BasinAreaSchema(_GeoBaseSchema):
 
 class FlowBoundaryAreaSchema(_GeoBaseSchema):
     _node_id_relation: str = "subset"
-    fid: Index[Int32] = pa.Field(default=0, check_name=True)
-    node_id: Series[Int32] = pa.Field(nullable=False, default=0)
+    fid: Index[np.int32] = pa.Field(default=0, check_name=True)
+    node_id: Series[np.int32] = pa.Field(nullable=False, default=0)
     geometry: GeoSeries[MultiPolygon] = pa.Field(default=None, nullable=True)
 
     @pa.parser("geometry")

--- a/python/ribasim/ribasim/geometry/link.py
+++ b/python/ribasim/ribasim/geometry/link.py
@@ -10,7 +10,6 @@ import pandera as pa
 import shapely
 from matplotlib.axes import Axes
 from numpy.typing import NDArray
-from pandera.dtypes import Int32
 from pandera.typing import Index, Series
 from pandera.typing.geopandas import GeoDataFrame, GeoSeries
 from pydantic import NonNegativeInt, PrivateAttr, model_validator
@@ -69,10 +68,10 @@ def _infer_link_type(from_node_type: str, to_node_type: str) -> str:
 
 
 class LinkSchema(_GeoBaseSchema):
-    link_id: Index[Int32] = pa.Field(default=0, ge=0, check_name=True)
+    link_id: Index[np.int32] = pa.Field(default=0, ge=0, check_name=True)
     name: Series[str] = pa.Field(default="")
-    from_node_id: Series[Int32] = pa.Field(default=0)
-    to_node_id: Series[Int32] = pa.Field(default=0)
+    from_node_id: Series[np.int32] = pa.Field(default=0)
+    to_node_id: Series[np.int32] = pa.Field(default=0)
     link_type: Series[str] = pa.Field(default="flow")
     geometry: GeoSeries[LineString] = pa.Field(default=None, nullable=True)
 

--- a/python/ribasim/ribasim/geometry/node.py
+++ b/python/ribasim/ribasim/geometry/node.py
@@ -12,7 +12,6 @@ from geopandas import GeoDataFrame as GeoDataFrameType
 from matplotlib.axes import Axes
 from matplotlib.offsetbox import AnnotationBbox
 from matplotlib.patches import Patch
-from pandera.dtypes import Int32
 from pandera.typing import Index, Series
 from pandera.typing.geopandas import GeoSeries
 from pydantic import (
@@ -50,7 +49,7 @@ __all__ = ("NodeTable",)
 
 
 class NodeSchema(_GeoBaseSchema):
-    node_id: Index[Int32] = pa.Field(default=0, ge=0, check_name=True)
+    node_id: Index[np.int32] = pa.Field(default=0, ge=0, check_name=True)
     name: Series[str] = pa.Field(default="")
     node_type: Series[str] = pa.Field(default="")
     subnetwork_id: Series[pd.Int32Dtype] = pa.Field(
@@ -116,7 +115,7 @@ class NodeTable(SpatialTableModel[NodeSchema], ChildModel):
             hull = gpd.GeoDataFrame(
                 geometry=[df_subnetwork.geometry.unary_union.convex_hull]
             )
-            hull.plot(ax=ax, color=color, alpha=ALPHA, zorder=zorder)
+            hull.plot(ax=ax, color=color, alpha=ALPHA, zorder=zorder)  # ty: ignore[invalid-argument-type]
 
         handles = []
         labels = []
@@ -511,10 +510,10 @@ class NodeModel(ParentModel, ChildModel):
         )
         if has_extra_cols:
             # User-provided extra columns go through validation
-            model.node.df = df  # type: ignore[assignment]
+            model.node.df = df  # ty: ignore[invalid-assignment]
         else:
             with model.node._no_validate():
-                model.node.df = df  # type: ignore[assignment]
+                model.node.df = df  # ty: ignore[invalid-assignment]
 
         model.node._used_node_ids.add(node_id)
         return self[node_id]

--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -47,11 +47,11 @@ try:
 except ImportError:
     try:
         # pre-v1 API
-        from datacompy.core import (  # pyrefly: ignore[missing-import]
+        from datacompy.core import (  # ty: ignore[unresolved-import]
             Compare as _Compare,
         )
     except ImportError:
-        _Compare = MissingOptionalModule("datacompy", "diff")
+        _Compare = MissingOptionalModule("datacompy", "diff")  # ty: ignore[conflicting-declarations]
 
 
 __all__ = ("TableModel",)
@@ -85,12 +85,14 @@ context_file_writing: ContextVar[dict[str, Path]] = ContextVar(
 )
 
 
-_init_context_var = ContextVar("_init_context_var", default=None)
+_init_context_var: ContextVar[dict[str, Any] | None] = ContextVar(
+    "_init_context_var", default=None
+)
 
 
 @contextmanager
 def init_context(value: dict[str, Any]) -> Generator[None]:
-    token = _init_context_var.set(value)  # pyrefly: ignore[bad-argument-type]
+    token = _init_context_var.set(value)
     try:
         yield
     finally:
@@ -130,7 +132,7 @@ class BaseModel(PydanticBaseModel):
         input data has already been validated at construction time.
         """
         original = cls.__setattr__
-        cls.__setattr__ = _bypass_setattr  # pyrefly: ignore[bad-assignment]
+        cls.__setattr__ = _bypass_setattr
         try:
             yield
         finally:
@@ -233,13 +235,13 @@ class BaseModel(PydanticBaseModel):
             getter = (
                 operator.itemgetter(*model_fields)
                 if model_fields
-                else lambda _: pydantic._utils._SENTINEL  # pyrefly: ignore[missing-attribute]
+                else lambda _: pydantic._utils._SENTINEL  # ty: ignore[unresolved-attribute]
             )
             try:
                 return getter(self.__dict__) == getter(other.__dict__)
             except KeyError:
-                self_fields_proxy = pydantic._utils.SafeGetItemProxy(self.__dict__)  # pyrefly: ignore[missing-attribute]
-                other_fields_proxy = pydantic._utils.SafeGetItemProxy(other.__dict__)  # pyrefly: ignore[missing-attribute]
+                self_fields_proxy = pydantic._utils.SafeGetItemProxy(self.__dict__)  # ty: ignore[unresolved-attribute]
+                other_fields_proxy = pydantic._utils.SafeGetItemProxy(other.__dict__)  # ty: ignore[unresolved-attribute]
                 return getter(self_fields_proxy) == getter(other_fields_proxy)
 
         else:
@@ -300,10 +302,11 @@ class FileModel(BaseModel, ABC):
 
         # Pydantic Model init requires a dict
         if isinstance(value, dict):
+            value_dict = cast(dict[str, Any], value)
             # We only load when the context is correct
 
             if info.context is None:
-                return value
+                return value_dict
             dir = info.context.get("directory")
             internal = info.context.get("internal", False)
             external = info.context.get("external", False)
@@ -311,18 +314,18 @@ class FileModel(BaseModel, ABC):
             # Skip loading when lazy (internal/external is False)
             # Otherwise load data and update our values
             # If no filepath is given, assume it is expected to be loaded from the database
-            filepath = value.get("filepath")
+            filepath = value_dict.get("filepath")
             if filepath is None and internal:
                 filepath = cls.default_filepath()
             elif filepath is not None and external:
                 filepath = Path(filepath)
             elif cls.allows_lazy():
-                value["lazy"] = True
-                return value
+                value_dict["lazy"] = True
+                return value_dict
 
             data = cls._load(dir / filepath)
-            value.update(data)
-            return value
+            value_dict.update(data)
+            return value_dict
         else:
             raise ValueError(f"Invalid type of value for FileModel: {type(value)}")
 
@@ -509,7 +512,7 @@ class TableModel[TableT: _BaseSchema](FileModel, ChildModel):
     def _check_dataframe(cls, value: object) -> object:
         # Enable initialization with a Dict.
         if isinstance(value, dict) and len(value) > 0 and "df" not in value:
-            value = DataFrame(dict(**value))
+            value = DataFrame(value)
 
         # Enable initialization with a DataFrame.
         if isinstance(value, pd.DataFrame | gpd.GeoDataFrame):
@@ -574,7 +577,7 @@ class TableModel[TableT: _BaseSchema](FileModel, ChildModel):
         filepath = self.filepath or self.default_filepath()
 
         data = self._load(directory / filepath)
-        self.df = data.get("df", self.df)  # pyrefly: ignore[bad-assignment]
+        self.df = data.get("df", self.df)  # ty: ignore[invalid-assignment]
         self.lazy = False
         context_file_loading.set({})
 
@@ -590,9 +593,13 @@ class TableModel[TableT: _BaseSchema](FileModel, ChildModel):
         if not self.root:
             raise ValueError("Table is not connected to a model.")
         assert hasattr(self.root, "filepath") and hasattr(self.root, "input_dir")
-        if not self.root.filepath:
+        filepath = self.root.filepath
+        if not isinstance(filepath, Path):
             raise ValueError("Model has no filepath set.")
-        return self.root.filepath.parent / self.root.input_dir
+        input_dir = self.root.input_dir
+        if not isinstance(input_dir, Path):
+            raise ValueError("Model has no input directory set.")
+        return filepath.parent / input_dir
 
     def write(
         self,
@@ -721,7 +728,7 @@ class TableModel[TableT: _BaseSchema](FileModel, ChildModel):
         The type of the field `df` is known to always be an DataFrame[TableT]]] | None
         """
         optionalfieldtype = cls.model_fields["df"].annotation
-        fieldtype = optionalfieldtype.__args__[0]  # pyrefly: ignore[missing-attribute]
+        fieldtype = optionalfieldtype.__args__[0]
         T: TableT = fieldtype.__args__[0]
         return T
 
@@ -740,7 +747,7 @@ class TableModel[TableT: _BaseSchema](FileModel, ChildModel):
         if self.df is None:
             return self.__repr__()
         else:
-            table_html = self.df._repr_html_()  # pyrefly: ignore[not-callable]
+            table_html = self.df._repr_html_()  # ty: ignore[call-non-callable]
             return f"<div>{self.tablename()}</div>" + table_html
 
     def __getitem__(self, index) -> pd.DataFrame | gpd.GeoDataFrame:
@@ -764,15 +771,13 @@ class SpatialTableModel[TableT: _BaseSchema](TableModel[TableT]):
     Overrides the reading and writing methods of a TableModel.
     """
 
-    df: GeoDataFrame[TableT] | None = Field(  # pyrefly: ignore[bad-override]
-        default=None, exclude=True, repr=False
-    )
+    df: GeoDataFrame[TableT] | None = Field(default=None, exclude=True, repr=False)
 
     def sort(self):
         # Only sort the index (node_id / link_id) since this needs to be sorted in a GeoPackage.
         # Under most circumstances, this retains the input order,
         # making the link_id as stable as possible; useful for post-processing.
-        self.df.sort_index(inplace=True)  # pyrefly: ignore[missing-attribute]
+        self.df.sort_index(inplace=True)  # ty: ignore[unresolved-attribute]
 
     @classmethod
     def _from_db(cls, path: Path, table: str):

--- a/python/ribasim/ribasim/model.py
+++ b/python/ribasim/ribasim/model.py
@@ -76,7 +76,7 @@ from ribasim.validation import link_neighbor_amount
 try:
     import xugrid as _xugrid
 except ImportError:
-    _xugrid = MissingOptionalModule("xugrid")
+    _xugrid = MissingOptionalModule("xugrid")  # ty: ignore[invalid-assignment]
 
 
 logger = logging.getLogger(__name__)
@@ -433,7 +433,7 @@ class Model(FileModel, ParentModel):
                 "directory": Path(filepath).parent,
             }
         ):
-            # pyrefly: ignore[missing-argument]
+            # ty: ignore[missing-argument]
             return cls(filepath=Path(filepath).name)
 
     def write(
@@ -657,7 +657,9 @@ class Model(FileModel, ParentModel):
 
         # vectorized check for outneighbor minimum
         if not from_node_info.empty:
-            min_out = from_node_info["from_node_type"].map(lambda t: link_amount[t][2])
+            min_out = from_node_info["from_node_type"].map(
+                lambda t: link_amount[cast(str, t)][2]
+            )
             violations = from_node_info[from_node_info["from_node_count"] < min_out]
             for _, row in violations.iterrows():
                 is_valid = False
@@ -683,7 +685,9 @@ class Model(FileModel, ParentModel):
 
         # vectorized check for inneighbor minimum
         if not to_node_info.empty:
-            min_in = to_node_info["to_node_type"].map(lambda t: link_amount[t][0])
+            min_in = to_node_info["to_node_type"].map(
+                lambda t: link_amount[cast(str, t)][0]
+            )
             violations = to_node_info[to_node_info["to_node_count"] < min_in]
             for _, row in violations.iterrows():
                 is_valid = False
@@ -723,8 +727,9 @@ class Model(FileModel, ParentModel):
             config["filepath"] = filepath  # make sure we store the whole filepath
             directory = filepath.parent / config["input_dir"]
             context_file_loading.get()["directory"] = directory
-            # pyrefly: ignore[unsupported-operation]
-            _init_context_var.get()["directory"] = directory
+            context = _init_context_var.get()
+            assert context is not None
+            context["directory"] = directory
 
             db_path = directory / "database.gpkg"
             if not db_path.is_file():

--- a/python/ribasim/ribasim/schemas.py
+++ b/python/ribasim/ribasim/schemas.py
@@ -6,14 +6,13 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import pandera.pandas as pa
-from pandera.dtypes import Int32
 from pandera.typing import Index
 
 from ribasim import migrations
 
 
 class _BaseSchema(pa.DataFrameModel):
-    class Config:  # pyrefly: ignore[bad-override]
+    class Config:
         add_missing_columns = True
         coerce = True
 
@@ -37,7 +36,7 @@ class _BaseSchema(pa.DataFrameModel):
 
 class BasinConcentrationSchema(_BaseSchema):
     _node_id_relation: str = "subset"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     time: pd.Timestamp = pa.Field(nullable=False)
     substance: pd.StringDtype = pa.Field(nullable=False)
@@ -48,7 +47,7 @@ class BasinConcentrationSchema(_BaseSchema):
 
 class BasinConcentrationExternalSchema(_BaseSchema):
     _node_id_relation: str = "subset"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     time: pd.Timestamp = pa.Field(nullable=False)
     substance: pd.StringDtype = pa.Field(nullable=False)
@@ -57,7 +56,7 @@ class BasinConcentrationExternalSchema(_BaseSchema):
 
 class BasinConcentrationStateSchema(_BaseSchema):
     _node_id_relation: str = "subset"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     substance: pd.StringDtype = pa.Field(nullable=False)
     concentration: float = pa.Field(nullable=False)
@@ -65,7 +64,7 @@ class BasinConcentrationStateSchema(_BaseSchema):
 
 class BasinMassLoadSchema(_BaseSchema):
     _node_id_relation: str = "subset"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     time: pd.Timestamp = pa.Field(nullable=False)
     substance: pd.StringDtype = pa.Field(nullable=False)
@@ -74,7 +73,7 @@ class BasinMassLoadSchema(_BaseSchema):
 
 class BasinProfileSchema(_BaseSchema):
     _node_id_relation: str = "equal"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     area: float = pa.Field(nullable=True)
     level: float = pa.Field(nullable=False)
@@ -83,14 +82,14 @@ class BasinProfileSchema(_BaseSchema):
 
 class BasinStateSchema(_BaseSchema):
     _node_id_relation: str = "equal"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     level: float = pa.Field(nullable=False)
 
 
 class BasinStaticSchema(_BaseSchema):
     _node_id_relation: str = "subset"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     drainage: float = pa.Field(nullable=True)
     potential_evaporation: float = pa.Field(nullable=True)
@@ -101,7 +100,7 @@ class BasinStaticSchema(_BaseSchema):
 
 class BasinSubgridSchema(_BaseSchema):
     _node_id_relation: str = "subset"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     subgrid_id: np.int32 = pa.Field(nullable=False)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     basin_level: float = pa.Field(nullable=False)
@@ -110,7 +109,7 @@ class BasinSubgridSchema(_BaseSchema):
 
 class BasinSubgridTimeSchema(_BaseSchema):
     _node_id_relation: str = "subset"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     subgrid_id: np.int32 = pa.Field(nullable=False)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     time: pd.Timestamp = pa.Field(nullable=False)
@@ -120,7 +119,7 @@ class BasinSubgridTimeSchema(_BaseSchema):
 
 class BasinTimeSchema(_BaseSchema):
     _node_id_relation: str = "subset"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     time: pd.Timestamp = pa.Field(nullable=False)
     drainage: float = pa.Field(nullable=True)
@@ -132,7 +131,7 @@ class BasinTimeSchema(_BaseSchema):
 
 class ContinuousControlFunctionSchema(_BaseSchema):
     _node_id_relation: str = "equal"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     input: float = pa.Field(nullable=False)
     output: float = pa.Field(nullable=False)
@@ -141,7 +140,7 @@ class ContinuousControlFunctionSchema(_BaseSchema):
 
 class ContinuousControlVariableSchema(_BaseSchema):
     _node_id_relation: str = "equal"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     listen_node_id: np.int32 = pa.Field(nullable=False)
     variable: pd.StringDtype = pa.Field(nullable=False)
@@ -151,7 +150,7 @@ class ContinuousControlVariableSchema(_BaseSchema):
 
 class DiscreteControlConditionSchema(_BaseSchema):
     _node_id_relation: str = "equal"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     compound_variable_id: np.int32 = pa.Field(nullable=False)
     condition_id: np.int32 = pa.Field(nullable=False)
@@ -162,7 +161,7 @@ class DiscreteControlConditionSchema(_BaseSchema):
 
 class DiscreteControlLogicSchema(_BaseSchema):
     _node_id_relation: str = "equal"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     truth_state: pd.StringDtype = pa.Field(nullable=False)
     control_state: pd.StringDtype = pa.Field(nullable=False)
@@ -170,7 +169,7 @@ class DiscreteControlLogicSchema(_BaseSchema):
 
 class DiscreteControlVariableSchema(_BaseSchema):
     _node_id_relation: str = "equal"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     compound_variable_id: np.int32 = pa.Field(nullable=False)
     listen_node_id: np.int32 = pa.Field(nullable=False)
@@ -181,7 +180,7 @@ class DiscreteControlVariableSchema(_BaseSchema):
 
 class FlowBoundaryConcentrationSchema(_BaseSchema):
     _node_id_relation: str = "subset"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     time: pd.Timestamp = pa.Field(nullable=False)
     substance: pd.StringDtype = pa.Field(nullable=False)
@@ -190,14 +189,14 @@ class FlowBoundaryConcentrationSchema(_BaseSchema):
 
 class FlowBoundaryStaticSchema(_BaseSchema):
     _node_id_relation: str = "partition"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     flow_rate: float = pa.Field(nullable=False)
 
 
 class FlowBoundaryTimeSchema(_BaseSchema):
     _node_id_relation: str = "partition"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     time: pd.Timestamp = pa.Field(nullable=False)
     flow_rate: float = pa.Field(nullable=False)
@@ -205,7 +204,7 @@ class FlowBoundaryTimeSchema(_BaseSchema):
 
 class FlowDemandStaticSchema(_BaseSchema):
     _node_id_relation: str = "partition"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     demand: float = pa.Field(nullable=False)
     demand_priority: pd.Int32Dtype = pa.Field(nullable=True)
@@ -213,7 +212,7 @@ class FlowDemandStaticSchema(_BaseSchema):
 
 class FlowDemandTimeSchema(_BaseSchema):
     _node_id_relation: str = "partition"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     time: pd.Timestamp = pa.Field(nullable=False)
     demand: float = pa.Field(nullable=False)
@@ -222,7 +221,7 @@ class FlowDemandTimeSchema(_BaseSchema):
 
 class LevelBoundaryConcentrationSchema(_BaseSchema):
     _node_id_relation: str = "subset"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     time: pd.Timestamp = pa.Field(nullable=False)
     substance: pd.StringDtype = pa.Field(nullable=False)
@@ -231,14 +230,14 @@ class LevelBoundaryConcentrationSchema(_BaseSchema):
 
 class LevelBoundaryStaticSchema(_BaseSchema):
     _node_id_relation: str = "partition"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     level: float = pa.Field(nullable=False)
 
 
 class LevelBoundaryTimeSchema(_BaseSchema):
     _node_id_relation: str = "partition"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     time: pd.Timestamp = pa.Field(nullable=False)
     level: float = pa.Field(nullable=False)
@@ -246,7 +245,7 @@ class LevelBoundaryTimeSchema(_BaseSchema):
 
 class LevelDemandStaticSchema(_BaseSchema):
     _node_id_relation: str = "partition"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     min_level: float = pa.Field(nullable=True)
     max_level: float = pa.Field(nullable=True)
@@ -255,7 +254,7 @@ class LevelDemandStaticSchema(_BaseSchema):
 
 class LevelDemandTimeSchema(_BaseSchema):
     _node_id_relation: str = "partition"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     time: pd.Timestamp = pa.Field(nullable=False)
     min_level: float = pa.Field(nullable=True)
@@ -265,7 +264,7 @@ class LevelDemandTimeSchema(_BaseSchema):
 
 class LinearResistanceStaticSchema(_BaseSchema):
     _node_id_relation: str = "equal"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     resistance: float = pa.Field(nullable=False)
     max_flow_rate: float = pa.Field(nullable=True)
@@ -274,7 +273,7 @@ class LinearResistanceStaticSchema(_BaseSchema):
 
 class ManningResistanceStaticSchema(_BaseSchema):
     _node_id_relation: str = "equal"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     length: float = pa.Field(nullable=False)
     manning_n: float = pa.Field(nullable=False)
@@ -285,7 +284,7 @@ class ManningResistanceStaticSchema(_BaseSchema):
 
 class ObservationTimeSchema(_BaseSchema):
     _node_id_relation: str = "subset"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     variable: pd.StringDtype = pa.Field(nullable=False)
     time: pd.Timestamp = pa.Field(nullable=False)
@@ -294,7 +293,7 @@ class ObservationTimeSchema(_BaseSchema):
 
 class OutletStaticSchema(_BaseSchema):
     _node_id_relation: str = "partition"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     flow_rate: float = pa.Field(nullable=False)
     min_flow_rate: float = pa.Field(nullable=True)
@@ -307,7 +306,7 @@ class OutletStaticSchema(_BaseSchema):
 
 class OutletTimeSchema(_BaseSchema):
     _node_id_relation: str = "partition"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     time: pd.Timestamp = pa.Field(nullable=False)
     flow_rate: float = pa.Field(nullable=False)
@@ -319,7 +318,7 @@ class OutletTimeSchema(_BaseSchema):
 
 class PidControlStaticSchema(_BaseSchema):
     _node_id_relation: str = "partition"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     listen_node_id: np.int32 = pa.Field(nullable=False)
     target: float = pa.Field(nullable=False)
@@ -331,7 +330,7 @@ class PidControlStaticSchema(_BaseSchema):
 
 class PidControlTimeSchema(_BaseSchema):
     _node_id_relation: str = "partition"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     listen_node_id: np.int32 = pa.Field(nullable=False)
     time: pd.Timestamp = pa.Field(nullable=False)
@@ -343,7 +342,7 @@ class PidControlTimeSchema(_BaseSchema):
 
 class PumpStaticSchema(_BaseSchema):
     _node_id_relation: str = "partition"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     flow_rate: float = pa.Field(nullable=False)
     min_flow_rate: float = pa.Field(nullable=True)
@@ -356,7 +355,7 @@ class PumpStaticSchema(_BaseSchema):
 
 class PumpTimeSchema(_BaseSchema):
     _node_id_relation: str = "partition"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     time: pd.Timestamp = pa.Field(nullable=False)
     flow_rate: float = pa.Field(nullable=False)
@@ -368,7 +367,7 @@ class PumpTimeSchema(_BaseSchema):
 
 class TabulatedRatingCurveStaticSchema(_BaseSchema):
     _node_id_relation: str = "partition"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     level: float = pa.Field(nullable=False)
     flow_rate: float = pa.Field(nullable=False)
@@ -379,7 +378,7 @@ class TabulatedRatingCurveStaticSchema(_BaseSchema):
 
 class TabulatedRatingCurveTimeSchema(_BaseSchema):
     _node_id_relation: str = "partition"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     time: pd.Timestamp = pa.Field(nullable=False)
     level: float = pa.Field(nullable=False)
@@ -389,7 +388,7 @@ class TabulatedRatingCurveTimeSchema(_BaseSchema):
 
 class UserDemandConcentrationSchema(_BaseSchema):
     _node_id_relation: str = "subset"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     time: pd.Timestamp = pa.Field(nullable=False)
     substance: pd.StringDtype = pa.Field(nullable=False)
@@ -398,7 +397,7 @@ class UserDemandConcentrationSchema(_BaseSchema):
 
 class UserDemandStaticSchema(_BaseSchema):
     _node_id_relation: str = "partition"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     demand: float = pa.Field(nullable=True)
     return_factor: float = pa.Field(nullable=False)
@@ -408,7 +407,7 @@ class UserDemandStaticSchema(_BaseSchema):
 
 class UserDemandTimeSchema(_BaseSchema):
     _node_id_relation: str = "partition"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
     node_id: np.int32 = pa.Field(nullable=False, default=0)
     time: pd.Timestamp = pa.Field(nullable=False)
     demand: float = pa.Field(nullable=False)

--- a/python/ribasim/ribasim/utils.py
+++ b/python/ribasim/ribasim/utils.py
@@ -4,7 +4,6 @@ from warnings import catch_warnings, filterwarnings
 
 import numpy as np
 import pandas as pd
-from pandera.dtypes import Int32
 from pandera.typing import Series
 from pydantic import BaseModel, NonNegativeInt
 
@@ -28,13 +27,13 @@ class MissingOptionalModule:
         )
 
 
-def _node_lookup_numpy(node_id) -> Series[Int32]:
+def _node_lookup_numpy(node_id) -> Series[np.int32]:
     """Create a lookup table from from node_id to the node dimension index.
 
     Used when adding data onto the nodes of an xugrid dataset.
     """
     return cast(
-        Series[Int32],
+        Series[np.int32],
         pd.Series(
             index=node_id,
             data=node_id.argsort().astype(np.int32),
@@ -43,13 +42,13 @@ def _node_lookup_numpy(node_id) -> Series[Int32]:
     )
 
 
-def _node_lookup(uds) -> Series[Int32]:
+def _node_lookup(uds) -> Series[np.int32]:
     """Create a lookup table from from node_id to the node dimension index.
 
     Used when adding data onto the nodes of an xugrid dataset.
     """
     return cast(
-        Series[Int32],
+        Series[np.int32],
         pd.Series(
             index=uds["node_id"],
             data=uds[uds.grid.node_dimension],
@@ -58,13 +57,13 @@ def _node_lookup(uds) -> Series[Int32]:
     )
 
 
-def _link_lookup(uds) -> Series[Int32]:
+def _link_lookup(uds) -> Series[np.int32]:
     """Create a lookup table from link_id to the link dimension index.
 
     Used when adding data onto the links of an xugrid dataset.
     """
     return cast(
-        Series[Int32],
+        Series[np.int32],
         pd.Series(
             index=uds["link_id"],
             data=uds[uds.grid.edge_dimension],

--- a/python/ribasim_testmodels/ribasim_testmodels/basic.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/basic.py
@@ -267,8 +267,8 @@ def basic_transient_model() -> Model:
         }
     )
     model.basin.static.df = None  # A node cannot have both static and dynamic forcing
-    model.basin.time = forcing  # pyrefly: ignore[bad-assignment]
-    model.basin.state = state  # pyrefly: ignore[bad-assignment]
+    model.basin.time = forcing  # ty: ignore[invalid-assignment]
+    model.basin.state = state  # ty: ignore[invalid-assignment]
 
     return model
 

--- a/python/ribasim_testmodels/ribasim_testmodels/doc_example.py
+++ b/python/ribasim_testmodels/ribasim_testmodels/doc_example.py
@@ -111,26 +111,53 @@ def local_pidcontrolled_cascade_model():
     )
 
     # Set up pid control
-    pid_control_data = {
-        "proportional": [0.1],
-        "integral": [0.00],
-        "derivative": [0.0],
-    }
     model.pid_control.add(
         Node(3, Point(-1.0, -1.0)),
-        [pid_control.Static(listen_node_id=[4], target=[2.0], **pid_control_data)],
+        [
+            pid_control.Static(
+                listen_node_id=[4],
+                target=[2.0],
+                proportional=[0.1],
+                integral=[0.0],
+                derivative=[0.0],
+            )
+        ],
     )
     model.pid_control.add(
         Node(14, Point(-1.0, -3.0)),
-        [pid_control.Static(listen_node_id=[6], target=[1.5], **pid_control_data)],
+        [
+            pid_control.Static(
+                listen_node_id=[6],
+                target=[1.5],
+                proportional=[0.1],
+                integral=[0.0],
+                derivative=[0.0],
+            )
+        ],
     )
     model.pid_control.add(
         Node(15, Point(1.0, -3.0)),
-        [pid_control.Static(listen_node_id=[8], target=[1.0], **pid_control_data)],
+        [
+            pid_control.Static(
+                listen_node_id=[8],
+                target=[1.0],
+                proportional=[0.1],
+                integral=[0.0],
+                derivative=[0.0],
+            )
+        ],
     )
     model.pid_control.add(
         Node(16, Point(3.0, -3.0)),
-        [pid_control.Static(listen_node_id=[10], target=[0.5], **pid_control_data)],
+        [
+            pid_control.Static(
+                listen_node_id=[10],
+                target=[0.5],
+                proportional=[0.1],
+                integral=[0.0],
+                derivative=[0.0],
+            )
+        ],
     )
 
     # Set up pump

--- a/ribasim_qgis/scripts/qgis_testrunner.py
+++ b/ribasim_qgis/scripts/qgis_testrunner.py
@@ -133,4 +133,4 @@ def __run_test():
         __exit_qgis(1)
 
 
-iface.initializationCompleted.connect(__run_test)
+iface.initializationCompleted.connect(__run_test)  # ty: ignore[unresolved-attribute]

--- a/ribasim_qgis/tests/test_load_plugin.py
+++ b/ribasim_qgis/tests/test_load_plugin.py
@@ -8,7 +8,7 @@ def test_plugin(ribasim_plugin: Any):
     from qgis.utils import iface
 
     assert iface is not None, "QGIS interface not available"
-    main_window = iface.mainWindow()
+    main_window = iface.mainWindow()  # ty: ignore[unresolved-attribute]
 
     toolbars = [
         c

--- a/ribasim_qgis/widgets/dataset_widget.py
+++ b/ribasim_qgis/widgets/dataset_widget.py
@@ -216,7 +216,7 @@ class DatasetWidget:
         rel.setReferencedLayer(to_layer_id)
         rel.setName(name)
         rel.setStrength(
-            # pyrefly: ignore[missing-attribute]
+            # ty: ignore[unresolved-attribute]
             rel.RelationStrength.Composition
         )
         # Both layers use the same field name for their primary key.
@@ -842,7 +842,7 @@ class DatasetWidget:
             expr = f'"{fk}" IN ({",".join(str(v) for v in fk_values)})'
             request = QgsFeatureRequest().setFilterExpression(expr)
             try:
-                target_fids = [feat.id() for feat in result_layer.getFeatures(request)]  # pyrefly: ignore[not-iterable]
+                target_fids = [feat.id() for feat in result_layer.getFeatures(request)]  # ty: ignore[not-iterable]
                 result_layer.selectByIds(target_fids)
             except RuntimeError:
                 return
@@ -904,7 +904,7 @@ class DatasetWidget:
         )
         tprop = cast(QgsVectorLayerTemporalProperties, maplayer.temporalProperties())
         tprop.setMode(
-            QgsVectorLayerTemporalProperties.TemporalMode.ModeFixedTemporalRange  # pyrefly: ignore[missing-attribute]
+            QgsVectorLayerTemporalProperties.TemporalMode.ModeFixedTemporalRange  # ty: ignore[unresolved-attribute]
         )
         tprop.setFixedTemporalRange(trange)
         tprop.setIsActive(True)
@@ -922,7 +922,9 @@ class DatasetWidget:
             dataprovider = layer.dataProvider()
             if dataprovider is not None and dataprovider.fieldNameIndex(column) == -1:
                 dataprovider.addAttributes(
-                    [QgsField(column, cast(QMetaType.Type, QMetaType.Type.Double))]
+                    [
+                        QgsField(column, cast(QMetaType.Type, QMetaType.Type.Double))  # ty: ignore[invalid-argument-type, too-many-positional-arguments]
+                    ]
                 )
             layer.updateFields()
         layer.commitChanges()

--- a/ribasim_qgis/widgets/plot_widget.py
+++ b/ribasim_qgis/widgets/plot_widget.py
@@ -439,12 +439,10 @@ class PlotWidget(QWidget):
             self._web_view = QWebView()
             ws = self._web_view.settings()
             ws.setAttribute(
-                # pyrefly: ignore[bad-argument-type]
                 QWebSettings.WebGLEnabled,
                 True,
             )
             ws.setAttribute(
-                # pyrefly: ignore[bad-argument-type]
                 QWebSettings.Accelerated2dCanvasEnabled,
                 True,
             )
@@ -476,7 +474,7 @@ class PlotWidget(QWidget):
         self._initialized = False
         self._page_loaded = False
         self._pending_js: str | None = None
-        # pyrefly: ignore[missing-attribute]
+        # ty: ignore[unresolved-attribute]
         self._web_view.loadFinished.connect(self._on_load_finished)
 
         # Keep node/link buttons in sync with the active layer and map tool.
@@ -843,9 +841,9 @@ class PlotWidget(QWidget):
         if page is None:
             return
         if _BACKEND is _WebViewBackend.WEBENGINE:
-            page.runJavaScript(js)
+            page.runJavaScript(js)  # ty: ignore[unresolved-attribute]
         else:
-            frame = page.mainFrame()  # pyrefly: ignore[missing-attribute]
+            frame = page.mainFrame()  # ty: ignore[unresolved-attribute]
             if frame is not None:
                 frame.evaluateJavaScript(js)
 

--- a/ribasim_qgis/widgets/ribasim_widget.py
+++ b/ribasim_qgis/widgets/ribasim_widget.py
@@ -108,7 +108,7 @@ class RibasimWidget(QWidget):
         group_alive = self.group is not None
         if group_alive:
             try:
-                _ = cast(QgsLayerTreeGroup, self.group).parent()
+                _ = self.group.parent()
             except RuntimeError as e:
                 if e.args and e.args[0] == PYQT_DELETED_ERROR:
                     self.group = None

--- a/ty.toml
+++ b/ty.toml
@@ -1,18 +1,16 @@
-project-includes = [
+[src]
+include = [
     "python/ribasim/ribasim",
     "python/ribasim_api/ribasim_api",
     "python/ribasim_testmodels/ribasim_testmodels",
     "ribasim_qgis",
 ]
-search-path = [
+
+[environment]
+python-version = "3.12"
+root = [
     "python/ribasim",
     "python/ribasim_api",
     "python/ribasim_testmodels",
     "ribasim_qgis/scripts",
 ]
-python-version = "3.12"
-
-[errors]
-missing-source = "error"
-untyped-import = "error"
-unused-ignore = "error"

--- a/utils/templates/schemas.py.jinja
+++ b/utils/templates/schemas.py.jinja
@@ -6,13 +6,12 @@ from typing import Any
 import numpy as np
 import pandas as pd
 import pandera.pandas as pa
-from pandera.dtypes import Int32
 from pandera.typing import Index
 
 from ribasim import migrations
 
 class _BaseSchema(pa.DataFrameModel):
-    class Config:  # pyrefly: ignore[bad-override]
+    class Config:
         add_missing_columns = True
         coerce = True
 
@@ -36,7 +35,7 @@ class _BaseSchema(pa.DataFrameModel):
 {% for m in models %}
 class {{m[:name]}}Schema(_BaseSchema):
     _node_id_relation: str = "{{m[:node_id_relation]}}"
-    fid: Index[Int32] = pa.Field(default=1, check_name=True, coerce=True)
+    fid: Index[np.int32] = pa.Field(default=1, check_name=True, coerce=True)
   {% for f in m[:fields] %}
     {% if (f[1] == :node_id) %}
     {{ f[1] }}: {{ f[2] }} = pa.Field(nullable={{ f[3] }}, default=0)


### PR DESCRIPTION
https://docs.astral.sh/ty/

It is faster and seems to be on average a bit better as well for our use case. We can remove a bunch of type ignores. I also tried it on Ribasim-NL, will switch there as well. It also comes with a language server and integrates with ruff as well.

Ty recently got built in support for Pydantic, just like Pyrefly, hence I tried it out now.

## Summary
- replace Pyrefly with ty 0.0.63 for Python type checking
- add equivalent ty project scope and module-resolution configuration
- migrate suppressions and fix typing issues exposed by ty
- use NumPy scalar annotations for Pandera schemas
- recommend the official `astral-sh.ty` VS Code extension

## Validation
- `pixi run typecheck`
- `pixi run prek run --all-files`
- Python tests: 105 passed, 2 skipped
- QGIS tests: 72 passed
- focused model/input tests: 38 passed

All existing Pyrefly references have been removed.