### PR TITLE
Pin ObjectFile to v0.5.0

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.6"
 manifest_format = "2.0"
-project_hash = "f2d8a128324f25ab7cc3107e99869dc78c242abe"
+project_hash = "69a46fc4886c1d05bb15b15a88a3aaba331769da"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "ec6be48a85c93d995563b84bff8a86bc98df45ce"
@@ -1045,10 +1045,10 @@ version = "1.31.1"
     DimensionalData = "0703355e-b756-11e9-17c0-8b28908087d0"
 
 [[deps.JuliaC]]
-deps = ["LazyArtifacts", "Libdl", "Mmap", "ObjectFile", "PackageCompiler", "Patchelf_jll", "Pkg", "Preferences", "RelocatableFolders", "StructIO", "TOML"]
-git-tree-sha1 = "7fe35f8ec64e3754c85673d2bfcfd35d8a322566"
+deps = ["LazyArtifacts", "Libdl", "Mmap", "ObjectFile", "PackageCompiler", "Patchelf_jll", "Pkg", "RelocatableFolders", "StructIO"]
+git-tree-sha1 = "dbbecb7776be9d9d1c58f990d12084656551c4c6"
 uuid = "acedd4c2-ced6-4a15-accc-2607eb759ba2"
-version = "0.3.8"
+version = "0.3.0"
 
 [[deps.JuliaInterpreter]]
 deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
@@ -1639,9 +1639,9 @@ weakdeps = ["ForwardDiff"]
 
 [[deps.ObjectFile]]
 deps = ["Reexport", "StructIO"]
-git-tree-sha1 = "22faba70c22d2f03e60fbc61da99c4ebfc3eb9ba"
+git-tree-sha1 = "23c4d109603f7a7bfe888c1f63c5ab7be6183d0b"
 uuid = "d8793406-e978-5875-9003-1fc021f44a92"
-version = "0.5.0"
+version = "0.5.1"
 
 [[deps.OffsetArrays]]
 git-tree-sha1 = "117432e406b5c023f665fa73dc26e79ec3630151"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.6"
 manifest_format = "2.0"
-project_hash = "59f3296d9439e7973b95504a1c63dce6cf57c91a"
+project_hash = "f2d8a128324f25ab7cc3107e99869dc78c242abe"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "ec6be48a85c93d995563b84bff8a86bc98df45ce"
@@ -1639,9 +1639,9 @@ weakdeps = ["ForwardDiff"]
 
 [[deps.ObjectFile]]
 deps = ["Reexport", "StructIO"]
-git-tree-sha1 = "23c4d109603f7a7bfe888c1f63c5ab7be6183d0b"
+git-tree-sha1 = "22faba70c22d2f03e60fbc61da99c4ebfc3eb9ba"
 uuid = "d8793406-e978-5875-9003-1fc021f44a92"
-version = "0.5.1"
+version = "0.5.0"
 
 [[deps.OffsetArrays]]
 git-tree-sha1 = "117432e406b5c023f665fa73dc26e79ec3630151"

--- a/Project.toml
+++ b/Project.toml
@@ -47,7 +47,6 @@ MathOptAnalyzer = "d1179b25-476b-425c-b826-c7787f0fff83"
 MetaGraphsNext = "fa8bd995-216d-47f1-8a91-f3b68fbeb377"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
-ObjectFile = "d8793406-e978-5875-9003-1fc021f44a92"
 OpenSSL_jll = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
 OrdinaryDiffEqBDF = "6ad6398a-0878-4a85-9266-38940aa047c8"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
@@ -85,8 +84,7 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 Ribasim = {path = "core"}
 
 [compat]
-JuliaC = "0.3"
-ObjectFile = "=0.5.0"
+JuliaC = "=0.3.0"
 OpenSSL_jll = "3.5.4"
 OteraEngine = "1.1.3"
 PackageCompiler = "2.3"

--- a/Project.toml
+++ b/Project.toml
@@ -47,6 +47,7 @@ MathOptAnalyzer = "d1179b25-476b-425c-b826-c7787f0fff83"
 MetaGraphsNext = "fa8bd995-216d-47f1-8a91-f3b68fbeb377"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+ObjectFile = "d8793406-e978-5875-9003-1fc021f44a92"
 OpenSSL_jll = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
 OrdinaryDiffEqBDF = "6ad6398a-0878-4a85-9266-38940aa047c8"
 OrdinaryDiffEqCore = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
@@ -85,6 +86,7 @@ Ribasim = {path = "core"}
 
 [compat]
 JuliaC = "0.3"
+ObjectFile = "=0.5.0"
 OpenSSL_jll = "3.5.4"
 OteraEngine = "1.1.3"
 PackageCompiler = "2.3"

--- a/build/build.jl
+++ b/build/build.jl
@@ -35,6 +35,12 @@ function (@main)(_)::Cint
     link_products(link_recipe)
     bundle_products(bundle_recipe)
 
+    julia_lib_dir =
+        Sys.iswindows() ? joinpath(output_dir, "bin") : joinpath(output_dir, "lib", "julia")
+    bundled_libraries = isdir(julia_lib_dir) ? readdir(julia_lib_dir) : String[]
+    any(startswith("libjulia-internal"), bundled_libraries) ||
+        error("JuliaC did not bundle libjulia-internal in $julia_lib_dir")
+
     # On Windows, remove the import library from the bundle root
     if Sys.iswindows()
         import_lib_path = joinpath(output_dir, "libribasim.dll.a")

--- a/build/tests/test_cli.py
+++ b/build/tests/test_cli.py
@@ -12,6 +12,11 @@ ribasim_home = Path(__file__).parents[1] / "ribasim"
 executable = ribasim_home / "bin/ribasim"
 
 
+def test_julia_runtime_is_bundled():
+    julia_lib_dir = ribasim_home / ("bin" if os.name == "nt" else "lib/julia")
+    assert any(julia_lib_dir.glob("libjulia-internal*"))
+
+
 @pytest.mark.parametrize(
     "model_constructor",
     ribasim_testmodels.constructors.values(),


### PR DESCRIPTION
To see if this fixes the Linux binaries.

libribasim.so depends on libjulia-internal.so.1.12. The packaged bin/ribasim/lib/julia/ directory is empty.