### PR TITLE
Use PackageCompiler fork to fix Linux builds

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1789,7 +1789,9 @@ version = "10.44.0+1"
 
 [[deps.PackageCompiler]]
 deps = ["Artifacts", "Glob", "LazyArtifacts", "Libdl", "Pkg", "Printf", "RelocatableFolders", "TOML", "UUIDs", "p7zip_jll"]
-git-tree-sha1 = "513193b976208b1b646ad4303323153e8bff0997"
+git-tree-sha1 = "8579d35f16cd50da52477f9f80355c587f3f93bb"
+repo-rev = "ribasim_libdir"
+repo-url = "https://github.com/visr/PackageCompiler.jl"
 uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
 version = "2.4.0"
 

--- a/Project.toml
+++ b/Project.toml
@@ -81,8 +81,8 @@ TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [sources]
-DataInterpolations = {url = "https://github.com/SciML/DataInterpolations.jl", rev = "fix_SCT_for_intinv_itps"}
-PackageCompiler = {url = "https://github.com/JuliaLang/PackageCompiler.jl", rev = "ribasim_libdir"}
+DataInterpolations = {rev = "fix_SCT_for_intinv_itps", url = "https://github.com/SciML/DataInterpolations.jl"}
+PackageCompiler = {rev = "ribasim_libdir", url = "https://github.com/visr/PackageCompiler.jl"}
 Ribasim = {path = "core"}
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -82,6 +82,7 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [sources]
 DataInterpolations = {url = "https://github.com/SciML/DataInterpolations.jl", rev = "fix_SCT_for_intinv_itps"}
+PackageCompiler = {url = "https://github.com/JuliaLang/PackageCompiler.jl", rev = "ribasim_libdir"}
 Ribasim = {path = "core"}
 
 [compat]


### PR DESCRIPTION
Upstream PR incoming.
Replaces https://github.com/Deltares/Ribasim/pull/3181

This works, merging after binary tests pass and builds checked manually on Linux and Windows.
