### PR TITLE
Fold registry update into instantiate

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,5 +29,5 @@
         }
     },
     "postCreateCommand": "pixi run install && pixi run generate-testmodels",
-    "postStartCommand": "pixi run initialize-julia"
+    "postStartCommand": "pixi run instantiate-julia"
 }

--- a/pixi.toml
+++ b/pixi.toml
@@ -25,20 +25,15 @@ install-prek = "prek install --overwrite"
 install = { depends-on = [
     "install-qgis-plugins",
     "install-prek",
-    "initialize-julia",
+    "instantiate-julia",
     "install-runic",
 ] }
 # Julia
-update-registry-julia = { cmd = "julia --eval='using Pkg; Registry.update()'" }
 update-manifest-julia = { cmd = "julia --project utils/update-manifest.jl" }
-instantiate-julia = { cmd = "julia --project --eval='using Pkg; Pkg.instantiate()'" }
+instantiate-julia = { cmd = "julia --project --eval='using Pkg; Registry.update(); Pkg.instantiate()'" }
 install-runic = { cmd = "julia --eval='using Pkg; Pkg.Apps.add(\"Runic\")'" }
-initialize-julia = { depends-on = [
-    "update-registry-julia",
-    "instantiate-julia",
-] }
 initialize-julia-test = { cmd = "julia --project=core --eval 'using Pkg; Pkg.test(allow_reresolve=false, test_args=[\"skip\"])'", depends-on = [
-    "initialize-julia",
+    "instantiate-julia",
 ] }
 # Docs
 quartodoc-build = { cmd = "quartodoc build && rm objects.json", cwd = "docs", inputs = [
@@ -53,7 +48,7 @@ quarto-render = { cmd = "PYTHON_JULIAPKG_PROJECT=$PIXI_PROJECT_ROOT quarto rende
 ], depends-on = [
     "quartodoc-build",
     "generate-testmodels",
-    "initialize-julia",
+    "instantiate-julia",
 ], env = { "PYTHON_JULIACALL_CHECK_BOUNDS" = "yes", "PYTHON_JULIACALL_HANDLE_SIGNALS" = "yes", "PYTHON_JULIAPKG_OFFLINE" = "yes" } }
 # Publish pre-rendered docs to ribasim.org; should normally only run on CI on main
 quarto-publish = { cmd = "quarto publish gh-pages --no-render --no-prompt --no-browser", cwd = "docs", env = { "PRE_COMMIT_ALLOW_NO_CONFIG" = "1" } }
@@ -62,7 +57,7 @@ docs = { cmd = "PYTHON_JULIAPKG_PROJECT=$PIXI_PROJECT_ROOT quarto preview docs/{
 ], depends-on = [
     "quartodoc-build",
     "generate-testmodels",
-    "initialize-julia",
+    "instantiate-julia",
 ], env = { "PYTHON_JULIACALL_CHECK_BOUNDS" = "yes", "PYTHON_JULIACALL_HANDLE_SIGNALS" = "yes", "PYTHON_JULIAPKG_OFFLINE" = "yes" } }
 # Lint
 typecheck = "ty check"
@@ -71,7 +66,7 @@ lint = { depends-on = ["prek-run"] }
 # Build
 build = { "cmd" = "julia --project build/build.jl", depends-on = [
     "generate-testmodels",
-    "initialize-julia",
+    "instantiate-julia",
 ] }
 # Tests
 s3-download = { cmd = "python utils/s3_download.py {{ remote }} {{ local }}", args = [
@@ -126,7 +121,7 @@ model-integration-test = { cmd = "julia --project=core --eval 'using Pkg; Pkg.te
 ] }
 # Codegen
 codegen = { cmd = "julia --project utils/gen_python.jl && ruff format python/ribasim/ribasim/schemas.py python/ribasim/ribasim/validation.py", depends-on = [
-    "initialize-julia",
+    "instantiate-julia",
 ], inputs = [
     "core",
     "utils",
@@ -156,7 +151,7 @@ test-ribasim-qgis = { cmd = "pytest --basetemp=ribasim_qgis/tests/temp ribasim_q
 
 # Run
 ribasim-core = { cmd = "julia --project=core -e 'using Ribasim; Ribasim.main(ARGS)'", depends-on = [
-    "initialize-julia",
+    "instantiate-julia",
 ] }
 ribasim-core-testmodels = { cmd = "julia --project utils/testmodelrun.jl {{name}}", args = [
     { "arg" = "name", "default" = "" },
@@ -164,11 +159,11 @@ ribasim-core-testmodels = { cmd = "julia --project utils/testmodelrun.jl {{name}
     { task = "generate-testmodels", args = [
         "{{name}}",
     ] },
-    "initialize-julia",
+    "instantiate-julia",
 ] }
 write-allocation-problems = { cmd = "julia --project utils/write_allocation_problems.jl", depends-on = [
     "generate-testmodels",
-    "initialize-julia",
+    "instantiate-julia",
 ] }
 migrate-model = "python utils/migrate_model.py"
 filter-model = "python utils/filter_model.py"
@@ -216,7 +211,7 @@ depends-on = [
 
 [tasks.generate-sbom-ribasim-core]
 cmd = "julia --project -- utils/generate-sbom.jl"
-depends-on = ["initialize-julia"]
+depends-on = ["instantiate-julia"]
 inputs = ["core/Project.toml"]
 outputs = ["Ribasim.spdx.json"]
 

--- a/utils/update-manifest.jl
+++ b/utils/update-manifest.jl
@@ -19,6 +19,7 @@ function (@main)(_)
     redirect_stdio(; stdout = path, stderr = path) do
         println("Update the Julia Manifest.toml to get the latest dependencies.\n")
         println("__Changed packages__\n```")
+        Pkg.Registry.update()
         Pkg.update()
         println("```\n\n__Packages still outdated after update__\n```")
         Pkg.status(; outdated = true)


### PR DESCRIPTION
This combines the registry update and instantiation into `pixi run instantiate-julia`: `using Pkg; Registry.update(); Pkg.instantiate()`

It is more efficient to do both in the same Julia session, and we have less initialization tasks to think about.