### PR TITLE
Update Julia manifest

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -5,9 +5,9 @@ manifest_format = "2.0"
 project_hash = "59f3296d9439e7973b95504a1c63dce6cf57c91a"
 
 [[deps.ADTypes]]
-git-tree-sha1 = "ec6be48a85c93d995563b84bff8a86bc98df45ce"
+git-tree-sha1 = "0a81a018463de6c3f4f2c9360121c562e5add9e4"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
-version = "1.22.2"
+version = "1.22.3"
 
     [deps.ADTypes.extensions]
     ADTypesChainRulesCoreExt = "ChainRulesCore"
@@ -144,9 +144,9 @@ uuid = "59605e27-edc0-445a-b93d-c09a3a50b330"
 version = "0.1.1"
 
 [[deps.BinaryHeaps]]
-git-tree-sha1 = "4661a9d719ef993f2cb792b65d9b810019a4e36d"
+git-tree-sha1 = "25718f410ed710fda29a8122eb8f9dcdb640c5fc"
 uuid = "b2a6c25c-c996-4615-94ab-6e519ffb8690"
-version = "1.0.3"
+version = "1.0.4"
 
 [[deps.BitFlags]]
 git-tree-sha1 = "bbe1079eecf9c9fbb52765193ad2bae27ae09bc8"
@@ -161,9 +161,9 @@ version = "1.21.7+0"
 
 [[deps.BracketingNonlinearSolve]]
 deps = ["CommonSolve", "ConcreteStructs", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "SciMLLogging"]
-git-tree-sha1 = "5c73d9606dcb9cdc392ff231d07d2b3ce6c5a375"
+git-tree-sha1 = "ed4222fe2ee1a4ac58a156ec3f33f94d4713718c"
 uuid = "70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
-version = "1.12.3"
+version = "1.12.4"
 
     [deps.BracketingNonlinearSolve.extensions]
     BracketingNonlinearSolveChainRulesCoreExt = ["ChainRulesCore", "ForwardDiff"]
@@ -264,9 +264,9 @@ uuid = "1fbeeb36-5f17-413c-809b-666fb144f157"
 version = "0.4.4"
 
 [[deps.CommonSolve]]
-git-tree-sha1 = "eeaad7cef88554c2fa56b5a3f71cfd5cb708c662"
+git-tree-sha1 = "f54afab101687a7049833d07636418a83e9a250b"
 uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
-version = "0.2.11"
+version = "0.2.12"
 
 [[deps.CommonSubexpressions]]
 deps = ["MacroTools"]
@@ -275,9 +275,9 @@ uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
 version = "0.3.1"
 
 [[deps.CommonWorldInvalidations]]
-git-tree-sha1 = "cde75cb34c9ee07b4c37981b0f32378d0dc19ffe"
+git-tree-sha1 = "ef2022bff55342a8c9846cdf218f62e475f0444d"
 uuid = "f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8"
-version = "1.1.1"
+version = "1.1.2"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
@@ -309,9 +309,9 @@ weakdeps = ["InverseFunctions"]
     CompositionsBaseInverseFunctionsExt = "InverseFunctions"
 
 [[deps.ConcreteStructs]]
-git-tree-sha1 = "23a2ac1ab2a39460d4feecddf09b02e9019d6dd5"
+git-tree-sha1 = "804fc3ca1cbfdd5aa52ae3149c0cb0555f875eec"
 uuid = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
-version = "0.2.6"
+version = "0.2.7"
 
 [[deps.ConcurrentUtilities]]
 deps = ["Serialization", "Sockets"]
@@ -427,9 +427,9 @@ version = "1.9.1"
 
 [[deps.DiffEqBase]]
 deps = ["ArrayInterface", "BracketingNonlinearSolve", "ConcreteStructs", "DocStringExtensions", "FastBroadcast", "FastClosures", "FastPower", "FunctionWrappers", "FunctionWrappersWrappers", "LinearAlgebra", "Logging", "Markdown", "MuladdMacro", "PrecompileTools", "Printf", "RecursiveArrayTools", "Reexport", "RespecializeParams", "SciMLBase", "SciMLLogging", "SciMLOperators", "SciMLStructures", "Setfield", "StaticArraysCore", "SymbolicIndexingInterface", "TruncatedStacktraces"]
-git-tree-sha1 = "4111d35644f41e35155b1a5a5665d6926f19c729"
+git-tree-sha1 = "9dc0de3ae033558589433b3bc7d15e937ace7fb4"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
-version = "7.7.0"
+version = "7.8.0"
 
     [deps.DiffEqBase.extensions]
     DiffEqBaseCUDAExt = "CUDA"
@@ -470,9 +470,9 @@ version = "7.7.0"
 
 [[deps.DiffEqCallbacks]]
 deps = ["ConcreteStructs", "DataStructures", "DiffEqBase", "DifferentiationInterface", "LinearAlgebra", "Markdown", "PrecompileTools", "RecipesBase", "RecursiveArrayTools", "SciMLBase", "StaticArraysCore"]
-git-tree-sha1 = "7f3d38ff9555696c29d13da449e57745623ddd2a"
+git-tree-sha1 = "9fe2f1cd33835bf1db4e09571939975fd4598f31"
 uuid = "459566f4-90b8-5000-8ac3-15dfb0a30def"
-version = "4.18.3"
+version = "4.19.0"
 
     [deps.DiffEqCallbacks.extensions]
     DiffEqCallbacksFunctorsExt = "Functors"
@@ -641,9 +641,9 @@ version = "8.1.2+0"
 
 [[deps.FastBroadcast]]
 deps = ["ArrayInterface", "LinearAlgebra"]
-git-tree-sha1 = "52216cc6b2e5b11ac6623ff2398ac00faf1c6e42"
+git-tree-sha1 = "8dc134f37a4ad842679e14e33f7e4ebf20963792"
 uuid = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
-version = "1.3.4"
+version = "1.3.5"
 
     [deps.FastBroadcast.extensions]
     FastBroadcastPolyesterExt = "Polyester"
@@ -659,9 +659,9 @@ uuid = "9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a"
 version = "0.3.2"
 
 [[deps.FastPower]]
-git-tree-sha1 = "33a6dfb7ad41394b15e90c10c216181dba06cf15"
+git-tree-sha1 = "cd70b50f2a164b9c5ca8a410b2a427eae07dee1e"
 uuid = "a4df4552-cc26-4903-aec0-212e50a0e84b"
-version = "1.3.4"
+version = "1.4.0"
 
     [deps.FastPower.extensions]
     FastPowerEnzymeExt = "Enzyme"
@@ -716,9 +716,9 @@ version = "1.17.0"
 
 [[deps.FindFirstFunctions]]
 deps = ["PrecompileTools"]
-git-tree-sha1 = "acb3ed7a72a4f8736d6f34454306cbbe24e63cb2"
+git-tree-sha1 = "bba475ce782fc77777f539cf0b7c029207798db1"
 uuid = "64ca27bc-2ba2-4a57-88aa-44e436879224"
-version = "3.2.0"
+version = "3.2.1"
 
 [[deps.FiniteDiff]]
 deps = ["ArrayInterface", "LinearAlgebra", "Setfield"]
@@ -757,9 +757,9 @@ version = "1.3.7"
 
 [[deps.ForwardDiff]]
 deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions"]
-git-tree-sha1 = "2c5d0b0e12088cde2cf84afb2784415b1ea3dfee"
+git-tree-sha1 = "73d5084cae45f9d0857776ad78cf303fec09eb02"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "1.4.1"
+version = "1.4.3"
 weakdeps = ["StaticArrays"]
 
     [deps.ForwardDiff.extensions]
@@ -783,10 +783,10 @@ uuid = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
 version = "1.1.3"
 
 [[deps.FunctionWrappersWrappers]]
-deps = ["FunctionWrappers", "PrecompileTools", "TruncatedStacktraces"]
-git-tree-sha1 = "70a6ddcf65ee666a6873ba4bf1b02dc721474b38"
+deps = ["FunctionWrappers", "PrecompileTools", "SciMLPublic"]
+git-tree-sha1 = "755903758db86cd86ee10b079fd15d2036e090c3"
 uuid = "77dc65aa-8811-40c2-897b-53d922fa7daf"
-version = "1.10.1"
+version = "1.12.0"
 
     [deps.FunctionWrappersWrappers.extensions]
     FunctionWrappersWrappersEnzymeExt = ["Enzyme", "EnzymeCore"]
@@ -846,9 +846,9 @@ version = "9.55.1+0"
 
 [[deps.Glib_jll]]
 deps = ["Artifacts", "GettextRuntime_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE2_jll", "Zlib_jll"]
-git-tree-sha1 = "24f6def62397474a297bfcec22384101609142ed"
+git-tree-sha1 = "090526e65de8f69648ac156daae153de8b56df62"
 uuid = "7746bdde-850d-59dc-9ae8-88ece973131d"
-version = "2.86.3+0"
+version = "2.88.3+0"
 
 [[deps.Glob]]
 git-tree-sha1 = "246c628cec062230b7d183aab88841fa94fcabe9"
@@ -881,9 +881,9 @@ version = "1.0.2"
 
 [[deps.HDF5_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "MPIABI_jll", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "OpenSSL_jll", "TOML", "Zlib_jll", "aws_c_s3_jll", "dlfcn_win32_jll", "libaec_jll", "mpif_jll"]
-git-tree-sha1 = "45337643a2d97262d5fe72ce1f13e8a662d13d62"
+git-tree-sha1 = "e8558f9122b392106b6de96c6bc57364a74ef2a2"
 uuid = "0234f1f7-429e-5d53-9886-15a909be8d59"
-version = "2.1.2+0"
+version = "2.2.0+0"
 
 [[deps.HTTP]]
 deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "PrecompileTools", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
@@ -1064,9 +1064,9 @@ version = "1.12.0"
 
 [[deps.Krylov]]
 deps = ["LinearAlgebra", "Printf", "SparseArrays"]
-git-tree-sha1 = "fc2e5bc665dfa1be33fac60b5762d462bccfae7b"
+git-tree-sha1 = "71e740d00d71cdb15145d7fe0d6000ec70534598"
 uuid = "ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
-version = "0.10.8"
+version = "0.10.9"
 
 [[deps.LAME_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -1136,9 +1136,9 @@ version = "1.11.0"
 
 [[deps.LeftChildRightSiblingTrees]]
 deps = ["AbstractTrees"]
-git-tree-sha1 = "95ba48564903b43b2462318aa243ee79d81135ff"
+git-tree-sha1 = "d4816abce26971e3237b46a47b99991f306e4832"
 uuid = "1d6d02ad-be62-4b6b-8a6d-2f90e265016e"
-version = "0.2.1"
+version = "0.3.0"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -1424,9 +1424,9 @@ version = "0.2.0"
 
 [[deps.MathOptInterface]]
 deps = ["CodecBzip2", "CodecZlib", "ForwardDiff", "JSON", "LinearAlgebra", "MutableArithmetics", "NaNMath", "OrderedCollections", "PrecompileTools", "Printf", "SparseArrays", "SpecialFunctions", "Test"]
-git-tree-sha1 = "7b57dbe5d2c988a0c7a0ea977045e844e3d0b263"
+git-tree-sha1 = "f1ccd9ffcb8577e207deb9aaebeb3f961de70380"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "1.51.2"
+version = "1.52.0"
 
     [deps.MathOptInterface.extensions]
     MathOptInterfaceBenchmarkToolsExt = "BenchmarkTools"
@@ -1509,9 +1509,9 @@ version = "2025.11.4"
 
 [[deps.MuladdMacro]]
 deps = ["PrecompileTools"]
-git-tree-sha1 = "e8dcbeef032ba2f9051a44ac22b4e54e3a1a0099"
+git-tree-sha1 = "283bf85d4a767481dd924dff0eee1735e95f449e"
 uuid = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
-version = "0.2.6"
+version = "0.2.7"
 
 [[deps.MutableArithmetics]]
 deps = ["LinearAlgebra", "SparseArrays", "Test"]
@@ -1630,9 +1630,9 @@ weakdeps = ["ForwardDiff"]
 
 [[deps.NonlinearSolveSpectralMethods]]
 deps = ["CommonSolve", "ConcreteStructs", "LineSearch", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "SciMLLogging"]
-git-tree-sha1 = "cb18c69f8dfd9422a9095fde6b6cd0eed9e5e164"
+git-tree-sha1 = "681973b2ade169dc41c58accfecc2a77278bf3e0"
 uuid = "26075421-4e9a-44e1-8bd1-420ed7ad02b2"
-version = "1.7.3"
+version = "1.7.4"
 weakdeps = ["ForwardDiff"]
 
     [deps.NonlinearSolveSpectralMethods.extensions]
@@ -1717,9 +1717,9 @@ version = "2.4.0"
 
 [[deps.OrdinaryDiffEqCore]]
 deps = ["ADTypes", "Accessors", "Adapt", "ArrayInterface", "BinaryHeaps", "CommonSolve", "ConstructionBase", "DiffEqBase", "DocStringExtensions", "EnumX", "EnzymeCore", "FastBroadcast", "FastClosures", "FastPower", "FindFirstFunctions", "FunctionWrappers", "FunctionWrappersWrappers", "InteractiveUtils", "LinearAlgebra", "Logging", "MacroTools", "MuladdMacro", "PrecompileTools", "Preferences", "Random", "RecursiveArrayTools", "Reexport", "SciMLBase", "SciMLLogging", "SciMLOperators", "SciMLStructures", "SymbolicIndexingInterface", "TruncatedStacktraces"]
-git-tree-sha1 = "c6b1285393fea2aed95876801110d3b4959231f1"
+git-tree-sha1 = "24ab0cd225025c3255910f47975fd5fbcfba1406"
 uuid = "bbf590c4-e513-4bbe-9b18-05decba2e5d8"
-version = "4.8.0"
+version = "4.10.0"
 
     [deps.OrdinaryDiffEqCore.extensions]
     OrdinaryDiffEqCoreMooncakeExt = "Mooncake"
@@ -1879,10 +1879,10 @@ uuid = "2dfb63ee-cc39-5dd5-95bd-886bf059d720"
 version = "1.4.3"
 
 [[deps.PreallocationTools]]
-deps = ["Adapt", "ArrayInterface", "PrecompileTools"]
-git-tree-sha1 = "920abd8738c02528d1078885e07bbd57939fc949"
+deps = ["Adapt", "ArrayInterface", "PrecompileTools", "SciMLPublic"]
+git-tree-sha1 = "241a537533777c5e07c88e9c70ad180b42525d06"
 uuid = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
-version = "1.3.0"
+version = "1.4.0"
 
     [deps.PreallocationTools.extensions]
     PreallocationToolsEnzymeCoreExt = "EnzymeCore"
@@ -1910,9 +1910,9 @@ version = "1.5.2"
 
 [[deps.PrettyTables]]
 deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "REPL", "Reexport", "StringManipulation", "Tables"]
-git-tree-sha1 = "7cf039cf79bb41afda7336edf2f3ca2115c44f76"
+git-tree-sha1 = "807a56f504aa08838a11e9a0727c3d704f90c44b"
 uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
-version = "3.4.2"
+version = "3.4.4"
 
     [deps.PrettyTables.extensions]
     PrettyTablesExcelExt = "XLSX"
@@ -1939,10 +1939,10 @@ uuid = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
 version = "1.4.0"
 
 [[deps.PureKLU]]
-deps = ["LinearAlgebra", "MuladdMacro", "PrecompileTools", "SparseArrays"]
-git-tree-sha1 = "c24613c5ca510086fb22fe891d48d8969839dae1"
+deps = ["LinearAlgebra", "PrecompileTools", "SparseArrays"]
+git-tree-sha1 = "7ef298d8ec41c57fd93239023836696f9c90e524"
 uuid = "0c0d3e7f-3a8b-4f7e-b6f1-9a4d2e7c1f01"
-version = "1.1.1"
+version = "1.2.0"
 weakdeps = ["ForwardDiff"]
 
     [deps.PureKLU.extensions]
@@ -2016,9 +2016,9 @@ version = "0.6.12"
 
 [[deps.RecursiveArrayTools]]
 deps = ["Adapt", "ArrayInterface", "DocStringExtensions", "GPUArraysCore", "LinearAlgebra", "PrecompileTools", "RecipesBase", "StaticArraysCore", "SymbolicIndexingInterface"]
-git-tree-sha1 = "7bdf89cbe4f5e1837b6e64adba6065e59b3b9f94"
+git-tree-sha1 = "4236ff8c2721e9503b83054ba6c1478856e27c0f"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
-version = "4.3.4"
+version = "4.3.5"
 
     [deps.RecursiveArrayTools.extensions]
     RecursiveArrayToolsCUDAExt = "CUDA"
@@ -2079,9 +2079,9 @@ version = "1.3.1"
 
 [[deps.RespecializeParams]]
 deps = ["FunctionWrappersWrappers"]
-git-tree-sha1 = "b0e50eb973aacb54dfb47e04be2cec6987401679"
+git-tree-sha1 = "a6b8358681ac20a448dc762770487e25c98a5085"
 uuid = "9fe22ead-9e00-4db2-8b46-706a60d40f5e"
-version = "1.1.0"
+version = "1.2.0"
 
 [[deps.Revise]]
 deps = ["CRC32c", "CodeTracking", "FileWatching", "JuliaInterpreter", "LibGit2", "LoweredCodeUtils", "OrderedCollections", "Preferences", "REPL", "UUIDs"]
@@ -2101,9 +2101,9 @@ version = "2026.1.2"
 
 [[deps.RuntimeGeneratedFunctions]]
 deps = ["ExprTools", "SHA", "Serialization"]
-git-tree-sha1 = "0e3eba2ca347b001baade9fb830623e04da64b38"
+git-tree-sha1 = "65c9e1142f0372bfc16ba14b9edd57737fe0039f"
 uuid = "7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
-version = "0.5.22"
+version = "0.5.24"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -2199,30 +2199,28 @@ version = "2.0.3"
 
 [[deps.SciMLOperators]]
 deps = ["Accessors", "Adapt", "ArrayInterface", "DocStringExtensions", "LinearAlgebra"]
-git-tree-sha1 = "10e4313d1bce847140611c12469ce532ffbdf3dd"
+git-tree-sha1 = "c92b87cd04563954537c4e832fb894b00f1b407e"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
-version = "1.25.0"
+version = "1.25.2"
 
     [deps.SciMLOperators.extensions]
     SciMLOperatorsLoopVectorizationExt = "LoopVectorization"
     SciMLOperatorsSparseArraysExt = "SparseArrays"
-    SciMLOperatorsStaticArraysCoreExt = "StaticArraysCore"
 
     [deps.SciMLOperators.weakdeps]
     LoopVectorization = "bdcacae8-1622-11e9-2a5c-532679323890"
     SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
 [[deps.SciMLPublic]]
-git-tree-sha1 = "24ff31136f3f991b74fbef71d5c638e2881d29d2"
+git-tree-sha1 = "cf9aaf8b9ed5db993259ea8b24cf2b7ba9bd3b79"
 uuid = "431bcebd-1456-4ced-9d72-93c2757fff0b"
-version = "1.2.3"
+version = "1.2.4"
 
 [[deps.SciMLStructures]]
 deps = ["ArrayInterface", "PrecompileTools"]
-git-tree-sha1 = "14d4ca3d334637233b9f730d2b9e6061e6338122"
+git-tree-sha1 = "53bf620cb2c3763d41495b2a145611c6ca400dcd"
 uuid = "53ae85a6-f571-4167-b2af-e1d143709226"
-version = "1.10.3"
+version = "1.10.4"
 
 [[deps.Scratch]]
 deps = ["Dates"]
@@ -2259,9 +2257,9 @@ version = "1.2.0"
 
 [[deps.SimpleNonlinearSolve]]
 deps = ["ADTypes", "ArrayInterface", "BracketingNonlinearSolve", "CommonSolve", "ConcreteStructs", "DifferentiationInterface", "FastClosures", "FiniteDiff", "ForwardDiff", "LineSearch", "LinearAlgebra", "MaybeInplace", "NonlinearSolveBase", "PrecompileTools", "Reexport", "SciMLBase", "SciMLLogging", "Setfield", "StaticArraysCore"]
-git-tree-sha1 = "6aa0b4a61df6796fbdba42686927cdbb30d8f743"
+git-tree-sha1 = "1fd67e1f3ce828b181ae8a53af43ef09b78df790"
 uuid = "727e6d20-b764-4bd8-a329-72de5adea6c7"
-version = "2.13.0"
+version = "2.13.1"
 
     [deps.SimpleNonlinearSolve.extensions]
     SimpleNonlinearSolveChainRulesCoreExt = "ChainRulesCore"
@@ -2296,9 +2294,9 @@ version = "1.12.0"
 
 [[deps.SparseColumnPivotedQR]]
 deps = ["LinearAlgebra", "PrecompileTools", "SparseArrays"]
-git-tree-sha1 = "cd2b583a035b559dbd7c3a9a88c43dc2a86203ca"
+git-tree-sha1 = "6c16137917345386c614ab68dd58e4bdc3f4a6e0"
 uuid = "a57abbd0-fea5-4d57-96be-5e525945e8e4"
-version = "2.1.4"
+version = "2.1.5"
 weakdeps = ["AMD"]
 
     [deps.SparseColumnPivotedQR.extensions]
@@ -2348,9 +2346,9 @@ version = "0.4.27"
 
 [[deps.SpecialFunctions]]
 deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
-git-tree-sha1 = "6547cbdd8ce32efba0d21c5a40fa96d1a3548f9f"
+git-tree-sha1 = "97c8329c5f503d2936fb36719fe25b9f94b1ae8a"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "2.8.0"
+version = "2.8.1"
 
     [deps.SpecialFunctions.extensions]
     SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
@@ -2366,9 +2364,9 @@ version = "1.0.4"
 
 [[deps.Static]]
 deps = ["CommonWorldInvalidations", "IfElse", "PrecompileTools", "SciMLPublic"]
-git-tree-sha1 = "5ef96deaf82834d64e1456c6a6665ca4188afd48"
+git-tree-sha1 = "4abff9ad312e476839c25b9398f619255af9a0e4"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-version = "1.4.4"
+version = "1.4.5"
 
 [[deps.StaticArrayInterface]]
 deps = ["ArrayInterface", "Compat", "IfElse", "LinearAlgebra", "PrecompileTools", "SciMLPublic", "Static"]
@@ -2430,9 +2428,9 @@ version = "0.5.9"
 
 [[deps.StringManipulation]]
 deps = ["PrecompileTools"]
-git-tree-sha1 = "532e983cd333609f95d618c744fc40d01ea6e17a"
+git-tree-sha1 = "8a90c1d77c3277a5d43b83927b3cbe2c70a37484"
 uuid = "892a3eda-7b42-436c-8928-eab12a02cf0e"
-version = "0.4.6"
+version = "0.4.7"
 
 [[deps.StructArrays]]
 deps = ["ConstructionBase", "DataAPI", "Tables"]
@@ -2537,9 +2535,9 @@ version = "0.1.1"
 
 [[deps.TerminalLoggers]]
 deps = ["LeftChildRightSiblingTrees", "Logging", "Markdown", "Printf", "ProgressLogging", "UUIDs"]
-git-tree-sha1 = "f133fab380933d042f6796eda4e130272ba520ca"
+git-tree-sha1 = "81c9b4137edfe56a56efcdcb35d721b2ce3e2416"
 uuid = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
-version = "0.1.7"
+version = "0.1.8"
 
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
@@ -2597,9 +2595,9 @@ uuid = "781d530d-4396-4725-bb49-402e4bee1e77"
 version = "1.4.0"
 
 [[deps.URIs]]
-git-tree-sha1 = "bef26fb046d031353ef97a82e3fdb6afe7f21b1a"
+git-tree-sha1 = "3b0738bd7c5645641845da25cbd99800b8718689"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.6.1"
+version = "1.6.2"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
@@ -2711,9 +2709,9 @@ version = "6.0.2+0"
 
 [[deps.Xorg_libXi_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXext_jll", "Xorg_libXfixes_jll"]
-git-tree-sha1 = "a376af5c7ae60d29825164db40787f15c80c7c54"
+git-tree-sha1 = "dcb316b3ce0941f195537dda56bea4517fcd3ff5"
 uuid = "a51aa0fd-4e3c-5386-b890-e753decda492"
-version = "1.8.3+0"
+version = "1.8.4+0"
 
 [[deps.Xorg_libXinerama_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXext_jll"]

--- a/Ribasim.spdx.json
+++ b/Ribasim.spdx.json
@@ -3,12 +3,12 @@
     "dataLicense": "CC0-1.0",
     "SPDXID": "SPDXRef-DOCUMENT",
     "name": "Ribasim.jl",
-    "documentNamespace": "https://github.com/Deltares/Ribasim/Ribasim.spdx.json-d93b6ada-54a3-4e51-ae04-2e822086925a",
+    "documentNamespace": "https://github.com/Deltares/Ribasim/Ribasim.spdx.json-de907855-06b0-42ec-b7cc-d6ddd3b9df33",
     "creationInfo": {
         "creators": [
             "Organization:  Deltares  (software@deltares.nl)"
         ],
-        "created": "2026-07-27T11:03:44Z",
+        "created": "2026-08-04T09:01:08Z",
         "comment": "Target Platform: Platform(\"x86_64\", \"linux\"; libgfortran_version = \"5.0.0\", julia_version = \"1.12.6\", libc = \"glibc\", libstdcxx_version = \"3.4.30\", cxxstring_abi = \"cxx11\")"
     },
     "comment": "Registries used for populating Package data:\nGeneral registry: https://github.com/JuliaRegistries/General.git\nOfficial general Julia package registry where people can\nregister any package they want without too much debate about\nnaming and without enforced standards on documentation or\ntesting. We nevertheless encourage documentation, testing and\nsome amount of consideration when choosing package names.\n",
@@ -786,13 +786,13 @@
         {
             "name": "SpecialFunctions",
             "SPDXID": "SPDXRef-SpecialFunctions-276daf66-3868-5448-9aa4-cd146d93841b",
-            "versionInfo": "2.8.0",
+            "versionInfo": "2.8.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaMath/SpecialFunctions.jl.git@6547cbdd8ce32efba0d21c5a40fa96d1a3548f9f",
+            "downloadLocation": "git+https://github.com/JuliaMath/SpecialFunctions.jl.git@97c8329c5f503d2936fb36719fe25b9f94b1ae8a",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "7553fef7b43f39f529a50219fcc6ffe648b207e8"
+                "packageVerificationCodeValue": "638b67dbde684d8315c14e5fd7e95a1203ccfc66"
             },
             "homepage": "https://github.com/JuliaMath/SpecialFunctions.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -808,7 +808,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/SpecialFunctions@2.8.0?uuid=276daf66-3868-5448-9aa4-cd146d93841b"
+                    "referenceLocator": "pkg:julia/SpecialFunctions@2.8.1?uuid=276daf66-3868-5448-9aa4-cd146d93841b"
                 }
             ]
         },
@@ -902,13 +902,13 @@
         {
             "name": "ForwardDiff",
             "SPDXID": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210",
-            "versionInfo": "1.4.1",
+            "versionInfo": "1.4.3",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaDiff/ForwardDiff.jl.git@2c5d0b0e12088cde2cf84afb2784415b1ea3dfee",
+            "downloadLocation": "git+https://github.com/JuliaDiff/ForwardDiff.jl.git@73d5084cae45f9d0857776ad78cf303fec09eb02",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "0b2536cb7a1c845eba94662e68a973f48a484e14"
+                "packageVerificationCodeValue": "67472613b72be4747519304ddb24b306797fc338"
             },
             "homepage": "https://github.com/JuliaDiff/ForwardDiff.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -924,7 +924,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/ForwardDiff@1.4.1?uuid=f6369f11-7733-5829-9624-2563aa707210"
+                    "referenceLocator": "pkg:julia/ForwardDiff@1.4.3?uuid=f6369f11-7733-5829-9624-2563aa707210"
                 }
             ]
         },
@@ -1667,13 +1667,13 @@
         {
             "name": "MathOptInterface",
             "SPDXID": "SPDXRef-MathOptInterface-b8f27783-ece8-5eb3-8dc8-9495eed66fee",
-            "versionInfo": "1.51.2",
+            "versionInfo": "1.52.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/jump-dev/MathOptInterface.jl.git@7b57dbe5d2c988a0c7a0ea977045e844e3d0b263",
+            "downloadLocation": "git+https://github.com/jump-dev/MathOptInterface.jl.git@f1ccd9ffcb8577e207deb9aaebeb3f961de70380",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "f5811e56ede6a9de7f074d9a41928e8963182fc3"
+                "packageVerificationCodeValue": "4478b42011310f629a4005ccff9120755787cdb6"
             },
             "homepage": "https://github.com/jump-dev/MathOptInterface.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -1689,7 +1689,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/MathOptInterface@1.51.2?uuid=b8f27783-ece8-5eb3-8dc8-9495eed66fee"
+                    "referenceLocator": "pkg:julia/MathOptInterface@1.52.0?uuid=b8f27783-ece8-5eb3-8dc8-9495eed66fee"
                 }
             ]
         },
@@ -1829,13 +1829,13 @@
         {
             "name": "SparseColumnPivotedQR",
             "SPDXID": "SPDXRef-SparseColumnPivotedQR-a57abbd0-fea5-4d57-96be-5e525945e8e4",
-            "versionInfo": "2.1.4",
+            "versionInfo": "2.1.5",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/SparseColumnPivotedQR.jl.git@cd2b583a035b559dbd7c3a9a88c43dc2a86203ca",
+            "downloadLocation": "git+https://github.com/SciML/SparseColumnPivotedQR.jl.git@6c16137917345386c614ab68dd58e4bdc3f4a6e0",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "03980534627fa8a09fb054f187744bcd83cba492"
+                "packageVerificationCodeValue": "0a0ad19d1640a3da85fb446fb18cb9cbc82a357a"
             },
             "homepage": "https://github.com/SciML/SparseColumnPivotedQR.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -1851,20 +1851,20 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/SparseColumnPivotedQR@2.1.4?uuid=a57abbd0-fea5-4d57-96be-5e525945e8e4"
+                    "referenceLocator": "pkg:julia/SparseColumnPivotedQR@2.1.5?uuid=a57abbd0-fea5-4d57-96be-5e525945e8e4"
                 }
             ]
         },
         {
             "name": "Krylov",
             "SPDXID": "SPDXRef-Krylov-ba0b0d4f-ebba-5204-a429-3ac8c609bfb7",
-            "versionInfo": "0.10.8",
+            "versionInfo": "0.10.9",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaSmoothOptimizers/Krylov.jl.git@fc2e5bc665dfa1be33fac60b5762d462bccfae7b",
+            "downloadLocation": "git+https://github.com/JuliaSmoothOptimizers/Krylov.jl.git@71e740d00d71cdb15145d7fe0d6000ec70534598",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "a0d72b5f2fb96c8057ee1b1c027fa5aea5bf13a3"
+                "packageVerificationCodeValue": "9dbb910ca7419a82f4199f5a937525ba4404d69f"
             },
             "homepage": "https://github.com/JuliaSmoothOptimizers/Krylov.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -1880,7 +1880,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/Krylov@0.10.8?uuid=ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
+                    "referenceLocator": "pkg:julia/Krylov@0.10.9?uuid=ba0b0d4f-ebba-5204-a429-3ac8c609bfb7"
                 }
             ]
         },
@@ -2061,13 +2061,13 @@
         {
             "name": "SciMLOperators",
             "SPDXID": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961",
-            "versionInfo": "1.25.0",
+            "versionInfo": "1.25.2",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/SciMLOperators.jl.git@10e4313d1bce847140611c12469ce532ffbdf3dd",
+            "downloadLocation": "git+https://github.com/SciML/SciMLOperators.jl.git@c92b87cd04563954537c4e832fb894b00f1b407e",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "d4baf8e4a124e6e68e609bf4bbc3d61b3b4cc224"
+                "packageVerificationCodeValue": "ecfd2ca64b9f3e7b827bd6b32744da25f68f6321"
             },
             "homepage": "https://github.com/SciML/SciMLOperators.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2083,20 +2083,20 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/SciMLOperators@1.25.0?uuid=c0aeaf25-5076-4817-a8d5-81caf7dfa961"
+                    "referenceLocator": "pkg:julia/SciMLOperators@1.25.2?uuid=c0aeaf25-5076-4817-a8d5-81caf7dfa961"
                 }
             ]
         },
         {
             "name": "SciMLStructures",
             "SPDXID": "SPDXRef-SciMLStructures-53ae85a6-f571-4167-b2af-e1d143709226",
-            "versionInfo": "1.10.3",
+            "versionInfo": "1.10.4",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/SciMLStructures.jl.git@14d4ca3d334637233b9f730d2b9e6061e6338122",
+            "downloadLocation": "git+https://github.com/SciML/SciMLStructures.jl.git@53bf620cb2c3763d41495b2a145611c6ca400dcd",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "8d93db5ef244e60c8268a50ee0e625f3d7c03791"
+                "packageVerificationCodeValue": "a994283c1140b24d3395e91f8908c447670d6643"
             },
             "homepage": "https://github.com/SciML/SciMLStructures.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2112,7 +2112,36 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/SciMLStructures@1.10.3?uuid=53ae85a6-f571-4167-b2af-e1d143709226"
+                    "referenceLocator": "pkg:julia/SciMLStructures@1.10.4?uuid=53ae85a6-f571-4167-b2af-e1d143709226"
+                }
+            ]
+        },
+        {
+            "name": "SciMLPublic",
+            "SPDXID": "SPDXRef-SciMLPublic-431bcebd-1456-4ced-9d72-93c2757fff0b",
+            "versionInfo": "1.2.4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/SciMLPublic.jl.git@cf9aaf8b9ed5db993259ea8b24cf2b7ba9bd3b79",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "ef7b4ed297e0e95899df620a2d92884076f3727b"
+            },
+            "homepage": "https://github.com/SciML/SciMLPublic.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it.",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceType": "purl",
+                    "referenceLocator": "pkg:julia/SciMLPublic@1.2.4?uuid=431bcebd-1456-4ced-9d72-93c2757fff0b"
                 }
             ]
         },
@@ -2146,44 +2175,15 @@
             ]
         },
         {
-            "name": "TruncatedStacktraces",
-            "SPDXID": "SPDXRef-TruncatedStacktraces-781d530d-4396-4725-bb49-402e4bee1e77",
-            "versionInfo": "1.4.0",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/TruncatedStacktraces.jl.git@ea3e54c2bdde39062abf5a9758a23735558705e1",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "74054bfbcb43c552a22c3eeeab3e9c66bccb3e7f"
-            },
-            "homepage": "https://github.com/SciML/TruncatedStacktraces.jl.git",
-            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "MIT"
-            ],
-            "licenseDeclared": "MIT",
-            "copyrightText": "NOASSERTION",
-            "summary": "This is a Julia package, written in the Julia language.",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it.",
-            "externalRefs": [
-                {
-                    "referenceCategory": "PACKAGE-MANAGER",
-                    "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/TruncatedStacktraces@1.4.0?uuid=781d530d-4396-4725-bb49-402e4bee1e77"
-                }
-            ]
-        },
-        {
             "name": "FunctionWrappersWrappers",
             "SPDXID": "SPDXRef-FunctionWrappersWrappers-77dc65aa-8811-40c2-897b-53d922fa7daf",
-            "versionInfo": "1.10.1",
+            "versionInfo": "1.12.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/FunctionWrappersWrappers.jl.git@70a6ddcf65ee666a6873ba4bf1b02dc721474b38",
+            "downloadLocation": "git+https://github.com/SciML/FunctionWrappersWrappers.jl.git@755903758db86cd86ee10b079fd15d2036e090c3",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "7ec64fa3fcf26714c201dde5eab722db102a28dc"
+                "packageVerificationCodeValue": "8c69e0c134a1f88416c04f207b4e430094f9d326"
             },
             "homepage": "https://github.com/SciML/FunctionWrappersWrappers.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2199,7 +2199,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/FunctionWrappersWrappers@1.10.1?uuid=77dc65aa-8811-40c2-897b-53d922fa7daf"
+                    "referenceLocator": "pkg:julia/FunctionWrappersWrappers@1.12.0?uuid=77dc65aa-8811-40c2-897b-53d922fa7daf"
                 }
             ]
         },
@@ -2264,13 +2264,13 @@
         {
             "name": "RuntimeGeneratedFunctions",
             "SPDXID": "SPDXRef-RuntimeGeneratedFunctions-7e49a35a-f44a-4d26-94aa-eba1b4ca6b47",
-            "versionInfo": "0.5.22",
+            "versionInfo": "0.5.24",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/RuntimeGeneratedFunctions.jl.git@0e3eba2ca347b001baade9fb830623e04da64b38",
+            "downloadLocation": "git+https://github.com/SciML/RuntimeGeneratedFunctions.jl.git@65c9e1142f0372bfc16ba14b9edd57737fe0039f",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "a1081a3ef59537cd454d6a43374ac2ae866184cf"
+                "packageVerificationCodeValue": "362a56a0c999effa564292a54c120ef4ce0393a1"
             },
             "homepage": "https://github.com/SciML/RuntimeGeneratedFunctions.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2286,7 +2286,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/RuntimeGeneratedFunctions@0.5.22?uuid=7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
+                    "referenceLocator": "pkg:julia/RuntimeGeneratedFunctions@0.5.24?uuid=7e49a35a-f44a-4d26-94aa-eba1b4ca6b47"
                 }
             ]
         },
@@ -2435,13 +2435,13 @@
         {
             "name": "ADTypes",
             "SPDXID": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
-            "versionInfo": "1.22.2",
+            "versionInfo": "1.22.3",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/ADTypes.jl.git@ec6be48a85c93d995563b84bff8a86bc98df45ce",
+            "downloadLocation": "git+https://github.com/SciML/ADTypes.jl.git@0a81a018463de6c3f4f2c9360121c562e5add9e4",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "0d6c575082da3573e7712647d8c319172d68c7bc"
+                "packageVerificationCodeValue": "e0212a6f8b0ee278d721570e69fd03d0aa234c9d"
             },
             "homepage": "https://github.com/SciML/ADTypes.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2457,7 +2457,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/ADTypes@1.22.2?uuid=47edcb42-4c32-4615-8424-f2b9edc5f35b"
+                    "referenceLocator": "pkg:julia/ADTypes@1.22.3?uuid=47edcb42-4c32-4615-8424-f2b9edc5f35b"
                 }
             ]
         },
@@ -2520,44 +2520,15 @@
             ]
         },
         {
-            "name": "SciMLPublic",
-            "SPDXID": "SPDXRef-SciMLPublic-431bcebd-1456-4ced-9d72-93c2757fff0b",
-            "versionInfo": "1.2.3",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/SciMLPublic.jl.git@24ff31136f3f991b74fbef71d5c638e2881d29d2",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "d1a948d57fdc50afff418d0e83e2b574d66b0d4e"
-            },
-            "homepage": "https://github.com/SciML/SciMLPublic.jl.git",
-            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "MIT"
-            ],
-            "licenseDeclared": "MIT",
-            "copyrightText": "NOASSERTION",
-            "summary": "This is a Julia package, written in the Julia language.",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it.",
-            "externalRefs": [
-                {
-                    "referenceCategory": "PACKAGE-MANAGER",
-                    "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/SciMLPublic@1.2.3?uuid=431bcebd-1456-4ced-9d72-93c2757fff0b"
-                }
-            ]
-        },
-        {
             "name": "RecursiveArrayTools",
             "SPDXID": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd",
-            "versionInfo": "4.3.4",
+            "versionInfo": "4.3.5",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/RecursiveArrayTools.jl.git@7bdf89cbe4f5e1837b6e64adba6065e59b3b9f94",
+            "downloadLocation": "git+https://github.com/SciML/RecursiveArrayTools.jl.git@4236ff8c2721e9503b83054ba6c1478856e27c0f",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "6330616d3dbb413f9622b106ca98e5b779357654"
+                "packageVerificationCodeValue": "7f546c03fa71286134a7107ac0d89ce814d58b51"
             },
             "homepage": "https://github.com/SciML/RecursiveArrayTools.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2573,20 +2544,20 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/RecursiveArrayTools@4.3.4?uuid=731186ca-8d62-57ce-b412-fbd966d074cd"
+                    "referenceLocator": "pkg:julia/RecursiveArrayTools@4.3.5?uuid=731186ca-8d62-57ce-b412-fbd966d074cd"
                 }
             ]
         },
         {
             "name": "FindFirstFunctions",
             "SPDXID": "SPDXRef-FindFirstFunctions-64ca27bc-2ba2-4a57-88aa-44e436879224",
-            "versionInfo": "3.2.0",
+            "versionInfo": "3.2.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/FindFirstFunctions.jl.git@acb3ed7a72a4f8736d6f34454306cbbe24e63cb2",
+            "downloadLocation": "git+https://github.com/SciML/FindFirstFunctions.jl.git@bba475ce782fc77777f539cf0b7c029207798db1",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "5e7a46143e8a8906fae882bcac9c3547f8440e5f"
+                "packageVerificationCodeValue": "389785f2bdbbae522b46321bc67ef640b8066c5a"
             },
             "homepage": "https://github.com/SciML/FindFirstFunctions.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2602,20 +2573,20 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/FindFirstFunctions@3.2.0?uuid=64ca27bc-2ba2-4a57-88aa-44e436879224"
+                    "referenceLocator": "pkg:julia/FindFirstFunctions@3.2.1?uuid=64ca27bc-2ba2-4a57-88aa-44e436879224"
                 }
             ]
         },
         {
             "name": "CommonSolve",
             "SPDXID": "SPDXRef-CommonSolve-38540f10-b2f7-11e9-35d8-d573e4eb0ff2",
-            "versionInfo": "0.2.11",
+            "versionInfo": "0.2.12",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/CommonSolve.jl.git@eeaad7cef88554c2fa56b5a3f71cfd5cb708c662",
+            "downloadLocation": "git+https://github.com/SciML/CommonSolve.jl.git@f54afab101687a7049833d07636418a83e9a250b",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "81aa0e8921454f21a9f65e01ed18f55e15b8676c"
+                "packageVerificationCodeValue": "fb1d85c83bf7d66c150894eaed44199061999f6f"
             },
             "homepage": "https://github.com/SciML/CommonSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2631,20 +2602,20 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/CommonSolve@0.2.11?uuid=38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
+                    "referenceLocator": "pkg:julia/CommonSolve@0.2.12?uuid=38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
                 }
             ]
         },
         {
             "name": "PreallocationTools",
             "SPDXID": "SPDXRef-PreallocationTools-d236fae5-4411-538c-8e31-a6e3d9e00b46",
-            "versionInfo": "1.3.0",
+            "versionInfo": "1.4.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/PreallocationTools.jl.git@920abd8738c02528d1078885e07bbd57939fc949",
+            "downloadLocation": "git+https://github.com/SciML/PreallocationTools.jl.git@241a537533777c5e07c88e9c70ad180b42525d06",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "f96698cc46fe7698eea19934b12f527eafb05173"
+                "packageVerificationCodeValue": "0adbf47f6d8cd0b2bc82d5b91a0622d608824f02"
             },
             "homepage": "https://github.com/SciML/PreallocationTools.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2660,7 +2631,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/PreallocationTools@1.3.0?uuid=d236fae5-4411-538c-8e31-a6e3d9e00b46"
+                    "referenceLocator": "pkg:julia/PreallocationTools@1.4.0?uuid=d236fae5-4411-538c-8e31-a6e3d9e00b46"
                 }
             ]
         },
@@ -2696,13 +2667,13 @@
         {
             "name": "ConcreteStructs",
             "SPDXID": "SPDXRef-ConcreteStructs-2569d6c7-a4a2-43d3-a901-331e8e4be471",
-            "versionInfo": "0.2.6",
+            "versionInfo": "0.2.7",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/ConcreteStructs.jl.git@23a2ac1ab2a39460d4feecddf09b02e9019d6dd5",
+            "downloadLocation": "git+https://github.com/SciML/ConcreteStructs.jl.git@804fc3ca1cbfdd5aa52ae3149c0cb0555f875eec",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "5a0e848e8d754c2499f2f76c934f2325d2367d38"
+                "packageVerificationCodeValue": "f9a9eaa5df6890ada32aa471462ef193dcdd85c5"
             },
             "homepage": "https://github.com/SciML/ConcreteStructs.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2718,49 +2689,20 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/ConcreteStructs@0.2.6?uuid=2569d6c7-a4a2-43d3-a901-331e8e4be471"
-                }
-            ]
-        },
-        {
-            "name": "MuladdMacro",
-            "SPDXID": "SPDXRef-MuladdMacro-46d2c3a1-f734-5fdb-9937-b9b9aeba4221",
-            "versionInfo": "0.2.6",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/MuladdMacro.jl.git@e8dcbeef032ba2f9051a44ac22b4e54e3a1a0099",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "29dd70b76ac1637d3fa15cfcbe722d004e365718"
-            },
-            "homepage": "https://github.com/SciML/MuladdMacro.jl.git",
-            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "MIT"
-            ],
-            "licenseDeclared": "MIT",
-            "copyrightText": "NOASSERTION",
-            "summary": "This is a Julia package, written in the Julia language.",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it.",
-            "externalRefs": [
-                {
-                    "referenceCategory": "PACKAGE-MANAGER",
-                    "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/MuladdMacro@0.2.6?uuid=46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
+                    "referenceLocator": "pkg:julia/ConcreteStructs@0.2.7?uuid=2569d6c7-a4a2-43d3-a901-331e8e4be471"
                 }
             ]
         },
         {
             "name": "PureKLU",
             "SPDXID": "SPDXRef-PureKLU-0c0d3e7f-3a8b-4f7e-b6f1-9a4d2e7c1f01",
-            "versionInfo": "1.1.1",
+            "versionInfo": "1.2.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/PureKLU.jl.git@c24613c5ca510086fb22fe891d48d8969839dae1",
+            "downloadLocation": "git+https://github.com/SciML/PureKLU.jl.git@7ef298d8ec41c57fd93239023836696f9c90e524",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "77fdbd8ca27ade68bb3bf29451209d0a061009a3"
+                "packageVerificationCodeValue": "c3d8dbc0dab146750a3271acb2db7482f41968ea"
             },
             "homepage": "https://github.com/SciML/PureKLU.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2777,7 +2719,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/PureKLU@1.1.1?uuid=0c0d3e7f-3a8b-4f7e-b6f1-9a4d2e7c1f01"
+                    "referenceLocator": "pkg:julia/PureKLU@1.2.0?uuid=0c0d3e7f-3a8b-4f7e-b6f1-9a4d2e7c1f01"
                 }
             ]
         },
@@ -3789,13 +3731,13 @@
         {
             "name": "CommonWorldInvalidations",
             "SPDXID": "SPDXRef-CommonWorldInvalidations-f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8",
-            "versionInfo": "1.1.1",
+            "versionInfo": "1.1.2",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/CommonWorldInvalidations.jl.git@cde75cb34c9ee07b4c37981b0f32378d0dc19ffe",
+            "downloadLocation": "git+https://github.com/SciML/CommonWorldInvalidations.jl.git@ef2022bff55342a8c9846cdf218f62e475f0444d",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "7de8da5b057f72b89250070039dc3558f4dc5341"
+                "packageVerificationCodeValue": "17b182ffbf6c7d0ab87ccd4b26536f6c4d34b644"
             },
             "homepage": "https://github.com/SciML/CommonWorldInvalidations.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3811,20 +3753,20 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/CommonWorldInvalidations@1.1.1?uuid=f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8"
+                    "referenceLocator": "pkg:julia/CommonWorldInvalidations@1.1.2?uuid=f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8"
                 }
             ]
         },
         {
             "name": "Static",
             "SPDXID": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3",
-            "versionInfo": "1.4.4",
+            "versionInfo": "1.4.5",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/Static.jl.git@5ef96deaf82834d64e1456c6a6665ca4188afd48",
+            "downloadLocation": "git+https://github.com/SciML/Static.jl.git@4abff9ad312e476839c25b9398f619255af9a0e4",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "1abeddf1d477f6ab6e9a5d403935aac3e5e72a11"
+                "packageVerificationCodeValue": "246feb3df7b672a4581113cef4e2dcf54d0535d6"
             },
             "homepage": "https://github.com/SciML/Static.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3840,7 +3782,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/Static@1.4.4?uuid=aedffcd0-7271-4cad-89d0-dc628f76c6d3"
+                    "referenceLocator": "pkg:julia/Static@1.4.5?uuid=aedffcd0-7271-4cad-89d0-dc628f76c6d3"
                 }
             ]
         },
@@ -3992,13 +3934,13 @@
         {
             "name": "FastBroadcast",
             "SPDXID": "SPDXRef-FastBroadcast-7034ab61-46d4-4ed7-9d0f-46aef9175898",
-            "versionInfo": "1.3.4",
+            "versionInfo": "1.3.5",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/FastBroadcast.jl.git@52216cc6b2e5b11ac6623ff2398ac00faf1c6e42",
+            "downloadLocation": "git+https://github.com/SciML/FastBroadcast.jl.git@8dc134f37a4ad842679e14e33f7e4ebf20963792",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "e0a603535dbdaeafac0bcd8226c75cba324127a7"
+                "packageVerificationCodeValue": "81e9345eeac9e4c77ae1b0fd719ca4f27fc64d22"
             },
             "homepage": "https://github.com/SciML/FastBroadcast.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4014,7 +3956,36 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/FastBroadcast@1.3.4?uuid=7034ab61-46d4-4ed7-9d0f-46aef9175898"
+                    "referenceLocator": "pkg:julia/FastBroadcast@1.3.5?uuid=7034ab61-46d4-4ed7-9d0f-46aef9175898"
+                }
+            ]
+        },
+        {
+            "name": "MuladdMacro",
+            "SPDXID": "SPDXRef-MuladdMacro-46d2c3a1-f734-5fdb-9937-b9b9aeba4221",
+            "versionInfo": "0.2.7",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/MuladdMacro.jl.git@283bf85d4a767481dd924dff0eee1735e95f449e",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "1c66ab362f234b4b88f5786b8858ba2c0dc2125d"
+            },
+            "homepage": "https://github.com/SciML/MuladdMacro.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it.",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceType": "purl",
+                    "referenceLocator": "pkg:julia/MuladdMacro@0.2.7?uuid=46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
                 }
             ]
         },
@@ -4227,13 +4198,13 @@
         {
             "name": "BracketingNonlinearSolve",
             "SPDXID": "SPDXRef-BracketingNonlinearSolve-70df07ce-3d50-431d-a3e7-ca6ddb60ac1e",
-            "versionInfo": "1.12.3",
+            "versionInfo": "1.12.4",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@5c73d9606dcb9cdc392ff231d07d2b3ce6c5a375#lib/BracketingNonlinearSolve",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@ed4222fe2ee1a4ac58a156ec3f33f94d4713718c#lib/BracketingNonlinearSolve",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "955d5777b72ca6ea02af289405b59c5e94e5b6f8"
+                "packageVerificationCodeValue": "df7e521423eab7111af8f0f07bd6acb89d1124fc"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4249,20 +4220,20 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/BracketingNonlinearSolve@1.12.3?uuid=70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
+                    "referenceLocator": "pkg:julia/BracketingNonlinearSolve@1.12.4?uuid=70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
                 }
             ]
         },
         {
             "name": "RespecializeParams",
             "SPDXID": "SPDXRef-RespecializeParams-9fe22ead-9e00-4db2-8b46-706a60d40f5e",
-            "versionInfo": "1.1.0",
+            "versionInfo": "1.2.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/RespecializeParams.jl.git@b0e50eb973aacb54dfb47e04be2cec6987401679",
+            "downloadLocation": "git+https://github.com/SciML/RespecializeParams.jl.git@a6b8358681ac20a448dc762770487e25c98a5085",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "65cca016d63005a298c5ded363ddbf7124c1478e"
+                "packageVerificationCodeValue": "f2eb0227c1787c2acf0f34d52a5d57c274c56b00"
             },
             "homepage": "https://github.com/SciML/RespecializeParams.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4278,20 +4249,49 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/RespecializeParams@1.1.0?uuid=9fe22ead-9e00-4db2-8b46-706a60d40f5e"
+                    "referenceLocator": "pkg:julia/RespecializeParams@1.2.0?uuid=9fe22ead-9e00-4db2-8b46-706a60d40f5e"
+                }
+            ]
+        },
+        {
+            "name": "TruncatedStacktraces",
+            "SPDXID": "SPDXRef-TruncatedStacktraces-781d530d-4396-4725-bb49-402e4bee1e77",
+            "versionInfo": "1.4.0",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/TruncatedStacktraces.jl.git@ea3e54c2bdde39062abf5a9758a23735558705e1",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "74054bfbcb43c552a22c3eeeab3e9c66bccb3e7f"
+            },
+            "homepage": "https://github.com/SciML/TruncatedStacktraces.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it.",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceType": "purl",
+                    "referenceLocator": "pkg:julia/TruncatedStacktraces@1.4.0?uuid=781d530d-4396-4725-bb49-402e4bee1e77"
                 }
             ]
         },
         {
             "name": "FastPower",
             "SPDXID": "SPDXRef-FastPower-a4df4552-cc26-4903-aec0-212e50a0e84b",
-            "versionInfo": "1.3.4",
+            "versionInfo": "1.4.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/FastPower.jl.git@33a6dfb7ad41394b15e90c10c216181dba06cf15",
+            "downloadLocation": "git+https://github.com/SciML/FastPower.jl.git@cd70b50f2a164b9c5ca8a410b2a427eae07dee1e",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "c113e96bf1727a0ade6ec15e4ee3bae63fd04c10"
+                "packageVerificationCodeValue": "162f54c60badc7ff2e0b03c215ad9de322488edd"
             },
             "homepage": "https://github.com/SciML/FastPower.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4307,20 +4307,20 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/FastPower@1.3.4?uuid=a4df4552-cc26-4903-aec0-212e50a0e84b"
+                    "referenceLocator": "pkg:julia/FastPower@1.4.0?uuid=a4df4552-cc26-4903-aec0-212e50a0e84b"
                 }
             ]
         },
         {
             "name": "DiffEqBase",
             "SPDXID": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e",
-            "versionInfo": "7.7.0",
+            "versionInfo": "7.8.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@4111d35644f41e35155b1a5a5665d6926f19c729#lib/DiffEqBase",
+            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@9dc0de3ae033558589433b3bc7d15e937ace7fb4#lib/DiffEqBase",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "d7541ac8a4c6c2079bbe75f87ce643a2ef349604"
+                "packageVerificationCodeValue": "5e4a2e562dbf74c783b33374b0b8d10da000dfbd"
             },
             "homepage": "https://github.com/SciML/OrdinaryDiffEq.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4336,20 +4336,20 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/DiffEqBase@7.7.0?uuid=2b5f629d-d688-5b77-993f-72d75c75574e"
+                    "referenceLocator": "pkg:julia/DiffEqBase@7.8.0?uuid=2b5f629d-d688-5b77-993f-72d75c75574e"
                 }
             ]
         },
         {
             "name": "BinaryHeaps",
             "SPDXID": "SPDXRef-BinaryHeaps-b2a6c25c-c996-4615-94ab-6e519ffb8690",
-            "versionInfo": "1.0.3",
+            "versionInfo": "1.0.4",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/BinaryHeaps.jl.git@4661a9d719ef993f2cb792b65d9b810019a4e36d",
+            "downloadLocation": "git+https://github.com/SciML/BinaryHeaps.jl.git@25718f410ed710fda29a8122eb8f9dcdb640c5fc",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "c3d4909d96ace324657295108c8887749cf51860"
+                "packageVerificationCodeValue": "952f74125af1b58d9bca9e7d41b94bce917fd282"
             },
             "homepage": "https://github.com/SciML/BinaryHeaps.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4365,20 +4365,20 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/BinaryHeaps@1.0.3?uuid=b2a6c25c-c996-4615-94ab-6e519ffb8690"
+                    "referenceLocator": "pkg:julia/BinaryHeaps@1.0.4?uuid=b2a6c25c-c996-4615-94ab-6e519ffb8690"
                 }
             ]
         },
         {
             "name": "OrdinaryDiffEqCore",
             "SPDXID": "SPDXRef-OrdinaryDiffEqCore-bbf590c4-e513-4bbe-9b18-05decba2e5d8",
-            "versionInfo": "4.8.0",
+            "versionInfo": "4.10.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@c6b1285393fea2aed95876801110d3b4959231f1#lib/OrdinaryDiffEqCore",
+            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@24ab0cd225025c3255910f47975fd5fbcfba1406#lib/OrdinaryDiffEqCore",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "aebb42a1bb3ba1ae00002e79b3d5a3969df5dd3b"
+                "packageVerificationCodeValue": "b8fb84f4a76df3bb3c74fde6f60c300c751be20f"
             },
             "homepage": "https://github.com/SciML/OrdinaryDiffEq.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4394,7 +4394,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/OrdinaryDiffEqCore@4.8.0?uuid=bbf590c4-e513-4bbe-9b18-05decba2e5d8"
+                    "referenceLocator": "pkg:julia/OrdinaryDiffEqCore@4.10.0?uuid=bbf590c4-e513-4bbe-9b18-05decba2e5d8"
                 }
             ]
         },
@@ -4968,13 +4968,13 @@
         {
             "name": "LeftChildRightSiblingTrees",
             "SPDXID": "SPDXRef-LeftChildRightSiblingTrees-1d6d02ad-be62-4b6b-8a6d-2f90e265016e",
-            "versionInfo": "0.2.1",
+            "versionInfo": "0.3.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaCollections/LeftChildRightSiblingTrees.jl.git@95ba48564903b43b2462318aa243ee79d81135ff",
+            "downloadLocation": "git+https://github.com/JuliaCollections/LeftChildRightSiblingTrees.jl.git@d4816abce26971e3237b46a47b99991f306e4832",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "efa5ce0a56986018b9084bcc5d398571eb74ae13"
+                "packageVerificationCodeValue": "796069f8cf55a2bfdbcd15c0b6623e85b5628241"
             },
             "homepage": "https://github.com/JuliaCollections/LeftChildRightSiblingTrees.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4990,20 +4990,20 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/LeftChildRightSiblingTrees@0.2.1?uuid=1d6d02ad-be62-4b6b-8a6d-2f90e265016e"
+                    "referenceLocator": "pkg:julia/LeftChildRightSiblingTrees@0.3.0?uuid=1d6d02ad-be62-4b6b-8a6d-2f90e265016e"
                 }
             ]
         },
         {
             "name": "TerminalLoggers",
             "SPDXID": "SPDXRef-TerminalLoggers-5d786b92-1e48-4d6f-9151-6b4477ca9bed",
-            "versionInfo": "0.1.7",
+            "versionInfo": "0.1.8",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaLogging/TerminalLoggers.jl.git@f133fab380933d042f6796eda4e130272ba520ca",
+            "downloadLocation": "git+https://github.com/JuliaLogging/TerminalLoggers.jl.git@81c9b4137edfe56a56efcdcb35d721b2ce3e2416",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "bb05ec07eeb5cab560956757b792bfbf9678bab6"
+                "packageVerificationCodeValue": "a41c6a648babb9b8ba3bb133f8969c4f376132f8"
             },
             "homepage": "https://github.com/JuliaLogging/TerminalLoggers.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -5019,7 +5019,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/TerminalLoggers@0.1.7?uuid=5d786b92-1e48-4d6f-9151-6b4477ca9bed"
+                    "referenceLocator": "pkg:julia/TerminalLoggers@0.1.8?uuid=5d786b92-1e48-4d6f-9151-6b4477ca9bed"
                 }
             ]
         },
@@ -5316,13 +5316,13 @@
         {
             "name": "SimpleNonlinearSolve",
             "SPDXID": "SPDXRef-SimpleNonlinearSolve-727e6d20-b764-4bd8-a329-72de5adea6c7",
-            "versionInfo": "2.13.0",
+            "versionInfo": "2.13.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@6aa0b4a61df6796fbdba42686927cdbb30d8f743#lib/SimpleNonlinearSolve",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@1fd67e1f3ce828b181ae8a53af43ef09b78df790#lib/SimpleNonlinearSolve",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "367b183800b0d9d52c0fce33127b04d45524a6aa"
+                "packageVerificationCodeValue": "b28c0f2c4defe8d6ef05b4a590858b8582fb990f"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -5338,20 +5338,20 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/SimpleNonlinearSolve@2.13.0?uuid=727e6d20-b764-4bd8-a329-72de5adea6c7"
+                    "referenceLocator": "pkg:julia/SimpleNonlinearSolve@2.13.1?uuid=727e6d20-b764-4bd8-a329-72de5adea6c7"
                 }
             ]
         },
         {
             "name": "NonlinearSolveSpectralMethods",
             "SPDXID": "SPDXRef-NonlinearSolveSpectralMethods-26075421-4e9a-44e1-8bd1-420ed7ad02b2",
-            "versionInfo": "1.7.3",
+            "versionInfo": "1.7.4",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@cb18c69f8dfd9422a9095fde6b6cd0eed9e5e164#lib/NonlinearSolveSpectralMethods",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@681973b2ade169dc41c58accfecc2a77278bf3e0#lib/NonlinearSolveSpectralMethods",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "3d1767a92a914f45240141109bc10a78f0623e68"
+                "packageVerificationCodeValue": "1353c287041982dd81b2626a314bd6ad4b4d09b2"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -5367,7 +5367,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/NonlinearSolveSpectralMethods@1.7.3?uuid=26075421-4e9a-44e1-8bd1-420ed7ad02b2"
+                    "referenceLocator": "pkg:julia/NonlinearSolveSpectralMethods@1.7.4?uuid=26075421-4e9a-44e1-8bd1-420ed7ad02b2"
                 }
             ]
         },
@@ -5519,13 +5519,13 @@
         {
             "name": "DiffEqCallbacks",
             "SPDXID": "SPDXRef-DiffEqCallbacks-459566f4-90b8-5000-8ac3-15dfb0a30def",
-            "versionInfo": "4.18.3",
+            "versionInfo": "4.19.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/DiffEqCallbacks.jl.git@7f3d38ff9555696c29d13da449e57745623ddd2a",
+            "downloadLocation": "git+https://github.com/SciML/DiffEqCallbacks.jl.git@9fe2f1cd33835bf1db4e09571939975fd4598f31",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "eb35865c20d4b68e95e561bdb5f39cc2bc900a45"
+                "packageVerificationCodeValue": "d71e8fcb7e8f8eb858a8b1764e864e8da0ff9340"
             },
             "homepage": "https://github.com/SciML/DiffEqCallbacks.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -5541,7 +5541,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/DiffEqCallbacks@4.18.3?uuid=459566f4-90b8-5000-8ac3-15dfb0a30def"
+                    "referenceLocator": "pkg:julia/DiffEqCallbacks@4.19.0?uuid=459566f4-90b8-5000-8ac3-15dfb0a30def"
                 }
             ]
         },
@@ -5720,13 +5720,13 @@
         {
             "name": "StringManipulation",
             "SPDXID": "SPDXRef-StringManipulation-892a3eda-7b42-436c-8928-eab12a02cf0e",
-            "versionInfo": "0.4.6",
+            "versionInfo": "0.4.7",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/ronisbr/StringManipulation.jl.git@532e983cd333609f95d618c744fc40d01ea6e17a",
+            "downloadLocation": "git+https://github.com/ronisbr/StringManipulation.jl.git@8a90c1d77c3277a5d43b83927b3cbe2c70a37484",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "eb8ac346d79b381900f3732700a5c38254c12982"
+                "packageVerificationCodeValue": "9a1d7dadaec528766a22c6cd059e290a26b7fdda"
             },
             "homepage": "https://github.com/ronisbr/StringManipulation.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -5742,7 +5742,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/StringManipulation@0.4.6?uuid=892a3eda-7b42-436c-8928-eab12a02cf0e"
+                    "referenceLocator": "pkg:julia/StringManipulation@0.4.7?uuid=892a3eda-7b42-436c-8928-eab12a02cf0e"
                 }
             ]
         },
@@ -5836,13 +5836,13 @@
         {
             "name": "PrettyTables",
             "SPDXID": "SPDXRef-PrettyTables-08abe8d2-0d0c-5749-adfa-8a2ac140af0d",
-            "versionInfo": "3.4.2",
+            "versionInfo": "3.4.4",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/ronisbr/PrettyTables.jl.git@7cf039cf79bb41afda7336edf2f3ca2115c44f76",
+            "downloadLocation": "git+https://github.com/ronisbr/PrettyTables.jl.git@807a56f504aa08838a11e9a0727c3d704f90c44b",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "24904d1a7f4c6f4e218d6ee9620054e84ddcd403"
+                "packageVerificationCodeValue": "dab34bb7b9a5a3b6fd9c936b000c59c49b17f112"
             },
             "homepage": "https://github.com/ronisbr/PrettyTables.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -5858,23 +5858,23 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/PrettyTables@3.4.2?uuid=08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+                    "referenceLocator": "pkg:julia/PrettyTables@3.4.4?uuid=08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
                 }
             ]
         },
         {
             "name": "DataInterpolations",
             "SPDXID": "SPDXRef-DataInterpolations-82cc6244-b520-54b8-b5a6-8a565e85f1d0",
-            "versionInfo": "9.0.2",
+            "versionInfo": "9.0.3",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/DataInterpolations.jl.git@75758ff6282fd4a69bc143d8df8a32e4694f4098",
+            "downloadLocation": "git+https://github.com/SciML/DataInterpolations.jl@fix_SCT_for_intinv_itps",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "1ae967d372037200216acce31caced99b53df0e4"
+                "packageVerificationCodeValue": "342a92988df6ab5ec1eb3cbf2ecd95649447e2e5"
             },
-            "homepage": "https://github.com/SciML/DataInterpolations.jl.git",
-            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "homepage": "https://github.com/SciML/DataInterpolations.jl",
+            "sourceInfo": "DataInterpolations is directly tracking a git repository.",
             "licenseConcluded": "NOASSERTION",
             "licenseInfoFromFiles": [
                 "MIT"
@@ -5887,7 +5887,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/DataInterpolations@9.0.2?uuid=82cc6244-b520-54b8-b5a6-8a565e85f1d0"
+                    "referenceLocator": "pkg:julia/DataInterpolations@9.0.3?uuid=82cc6244-b520-54b8-b5a6-8a565e85f1d0"
                 }
             ]
         },
@@ -8112,29 +8112,29 @@
         },
         {
             "name": "HDF5_source",
-            "SPDXID": "SPDXRef-5503e8486ee98ef3d63fd731c96c4cc043d8920f",
+            "SPDXID": "SPDXRef-c5c4d89798879479df8c7d3c0cc6cacef96f7e17",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaPackaging/Yggdrasil.git@5503e8486ee98ef3d63fd731c96c4cc043d8920f#/H/HDF5/",
+            "downloadLocation": "git+https://github.com/JuliaPackaging/Yggdrasil.git@c5c4d89798879479df8c7d3c0cc6cacef96f7e17#/H/HDF5/",
             "filesAnalyzed": false,
-            "sourceInfo": "The location of this repository was extracted from the README.md file of SPDXRef-999d3f4ac06c5d8d61b88fe458ab23179cd6334f",
+            "sourceInfo": "The location of this repository was extracted from the README.md file of SPDXRef-72e077f9e95c54a84ba95a3feb9a5f610870f6bf",
             "licenseConcluded": "NOASSERTION",
             "licenseDeclared": "NOASSERTION",
             "copyrightText": "NOASSERTION",
-            "summary": "The binary artifact SPDXRef-999d3f4ac06c5d8d61b88fe458ab23179cd6334f is built using the scripts and source files in this package.\nThe build system is called Yggdrasil, the Julia community build tree.",
+            "summary": "The binary artifact SPDXRef-72e077f9e95c54a84ba95a3feb9a5f610870f6bf is built using the scripts and source files in this package.\nThe build system is called Yggdrasil, the Julia community build tree.",
             "comment": "The SPDX ID field is derived from the Git hash in the DownloadLocation"
         },
         {
             "name": "HDF5",
-            "SPDXID": "SPDXRef-999d3f4ac06c5d8d61b88fe458ab23179cd6334f",
+            "SPDXID": "SPDXRef-72e077f9e95c54a84ba95a3feb9a5f610870f6bf",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "https://github.com/JuliaBinaryWrappers/HDF5_jll.jl/releases/download/HDF5-v2.1.2+0/HDF5.v2.1.2.x86_64-linux-gnu-libgfortran5-cxx11-mpi+openmpi.tar.gz",
+            "downloadLocation": "https://github.com/JuliaBinaryWrappers/HDF5_jll.jl/releases/download/HDF5-v2.2.0+0/HDF5.v2.2.0.x86_64-linux-gnu-libgfortran5-cxx11-mpi+openmpi.tar.gz",
             "filesAnalyzed": true,
             "checksums": [
                 {
                     "algorithm": "SHA256",
-                    "checksumValue": "5fe2a7b80b90f9ee4ba15bb1f5f5358b1c8ef9d107175a674f10d46fb46bf8d6"
+                    "checksumValue": "a6fe2a8c694685e6ba6231f3bd36d43fd8a2b76e6c05c73f05d307c5dd0c1f61"
                 }
             ],
             "homepage": "NOASSERTION",
@@ -8148,13 +8148,13 @@
         {
             "name": "HDF5_jll",
             "SPDXID": "SPDXRef-HDF5-jll-0234f1f7-429e-5d53-9886-15a909be8d59",
-            "versionInfo": "2.1.2+0",
+            "versionInfo": "2.2.0+0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/HDF5_jll.jl.git@45337643a2d97262d5fe72ce1f13e8a662d13d62",
+            "downloadLocation": "git+https://github.com/JuliaBinaryWrappers/HDF5_jll.jl.git@e8558f9122b392106b6de96c6bc57364a74ef2a2",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "5357263c0b94a0da01b756fa7430dfdb00255e0c"
+                "packageVerificationCodeValue": "c5ee80281d04ad638ad3729a13940e4e72cce107"
             },
             "homepage": "https://github.com/JuliaBinaryWrappers/HDF5_jll.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -8170,7 +8170,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/HDF5_jll@2.1.2+0?uuid=0234f1f7-429e-5d53-9886-15a909be8d59"
+                    "referenceLocator": "pkg:julia/HDF5_jll@2.2.0+0?uuid=0234f1f7-429e-5d53-9886-15a909be8d59"
                 }
             ]
         },
@@ -9130,27 +9130,12 @@
             "relatedSpdxElement": "SPDXRef-FunctionWrappersWrappers-77dc65aa-8811-40c2-897b-53d922fa7daf"
         },
         {
-            "spdxElementId": "SPDXRef-FunctionWrappers-069b7b12-0de2-55c6-9aab-29f3d0a68a2e",
+            "spdxElementId": "SPDXRef-SciMLPublic-431bcebd-1456-4ced-9d72-93c2757fff0b",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-FunctionWrappersWrappers-77dc65aa-8811-40c2-897b-53d922fa7daf"
         },
         {
-            "spdxElementId": "SPDXRef-InteractiveUtils-b77e0a4c-d291-57a0-90e8-8db25a27a240",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-TruncatedStacktraces-781d530d-4396-4725-bb49-402e4bee1e77"
-        },
-        {
-            "spdxElementId": "SPDXRef-Preferences-21216c6a-2e73-6563-6e65-726566657250",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-TruncatedStacktraces-781d530d-4396-4725-bb49-402e4bee1e77"
-        },
-        {
-            "spdxElementId": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-TruncatedStacktraces-781d530d-4396-4725-bb49-402e4bee1e77"
-        },
-        {
-            "spdxElementId": "SPDXRef-TruncatedStacktraces-781d530d-4396-4725-bb49-402e4bee1e77",
+            "spdxElementId": "SPDXRef-FunctionWrappers-069b7b12-0de2-55c6-9aab-29f3d0a68a2e",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-FunctionWrappersWrappers-77dc65aa-8811-40c2-897b-53d922fa7daf"
         },
@@ -9410,6 +9395,11 @@
             "relatedSpdxElement": "SPDXRef-PreallocationTools-d236fae5-4411-538c-8e31-a6e3d9e00b46"
         },
         {
+            "spdxElementId": "SPDXRef-SciMLPublic-431bcebd-1456-4ced-9d72-93c2757fff0b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-PreallocationTools-d236fae5-4411-538c-8e31-a6e3d9e00b46"
+        },
+        {
             "spdxElementId": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-PreallocationTools-d236fae5-4411-538c-8e31-a6e3d9e00b46"
@@ -9476,16 +9466,6 @@
         },
         {
             "spdxElementId": "SPDXRef-SparseArrays-2f01184e-e22b-5df5-ae63-d93ebab69eaf",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-PureKLU-0c0d3e7f-3a8b-4f7e-b6f1-9a4d2e7c1f01"
-        },
-        {
-            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
-            "relationshipType": "DEPENDENCY_OF",
-            "relatedSpdxElement": "SPDXRef-MuladdMacro-46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
-        },
-        {
-            "spdxElementId": "SPDXRef-MuladdMacro-46d2c3a1-f734-5fdb-9937-b9b9aeba4221",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-PureKLU-0c0d3e7f-3a8b-4f7e-b6f1-9a4d2e7c1f01"
         },
@@ -10205,6 +10185,11 @@
             "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
         },
         {
+            "spdxElementId": "SPDXRef-PrecompileTools-aea7be01-6a6a-4083-8856-8a6e6704d82a",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-MuladdMacro-46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
+        },
+        {
             "spdxElementId": "SPDXRef-MuladdMacro-46d2c3a1-f734-5fdb-9937-b9b9aeba4221",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -10493,6 +10478,21 @@
             "spdxElementId": "SPDXRef-LinearAlgebra-37e2e46d-f89d-539d-b4ee-838fcccc9c8e",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-DiffEqBase-2b5f629d-d688-5b77-993f-72d75c75574e"
+        },
+        {
+            "spdxElementId": "SPDXRef-InteractiveUtils-b77e0a4c-d291-57a0-90e8-8db25a27a240",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-TruncatedStacktraces-781d530d-4396-4725-bb49-402e4bee1e77"
+        },
+        {
+            "spdxElementId": "SPDXRef-Preferences-21216c6a-2e73-6563-6e65-726566657250",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-TruncatedStacktraces-781d530d-4396-4725-bb49-402e4bee1e77"
+        },
+        {
+            "spdxElementId": "SPDXRef-MacroTools-1914dd2f-81c6-5fcd-8719-6d5c9610ff09",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-TruncatedStacktraces-781d530d-4396-4725-bb49-402e4bee1e77"
         },
         {
             "spdxElementId": "SPDXRef-TruncatedStacktraces-781d530d-4396-4725-bb49-402e4bee1e77",
@@ -12195,6 +12195,16 @@
             "relatedSpdxElement": "SPDXRef-DataInterpolations-82cc6244-b520-54b8-b5a6-8a565e85f1d0"
         },
         {
+            "spdxElementId": "SPDXRef-Test-8dfed614-e22c-5e08-85e1-65c5234f0b40",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DataInterpolations-82cc6244-b520-54b8-b5a6-8a565e85f1d0"
+        },
+        {
+            "spdxElementId": "SPDXRef-SparseConnectivityTracer-9f842d2f-2579-4b1d-911e-f412cf18a3f5",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-DataInterpolations-82cc6244-b520-54b8-b5a6-8a565e85f1d0"
+        },
+        {
             "spdxElementId": "SPDXRef-FindFirstFunctions-64ca27bc-2ba2-4a57-88aa-44e436879224",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-DataInterpolations-82cc6244-b520-54b8-b5a6-8a565e85f1d0"
@@ -13455,12 +13465,12 @@
             "relatedSpdxElement": "SPDXRef-HDF5-jll-0234f1f7-429e-5d53-9886-15a909be8d59"
         },
         {
-            "spdxElementId": "SPDXRef-999d3f4ac06c5d8d61b88fe458ab23179cd6334f",
+            "spdxElementId": "SPDXRef-72e077f9e95c54a84ba95a3feb9a5f610870f6bf",
             "relationshipType": "GENERATED_FROM",
-            "relatedSpdxElement": "SPDXRef-5503e8486ee98ef3d63fd731c96c4cc043d8920f"
+            "relatedSpdxElement": "SPDXRef-c5c4d89798879479df8c7d3c0cc6cacef96f7e17"
         },
         {
-            "spdxElementId": "SPDXRef-999d3f4ac06c5d8d61b88fe458ab23179cd6334f",
+            "spdxElementId": "SPDXRef-72e077f9e95c54a84ba95a3feb9a5f610870f6bf",
             "relationshipType": "RUNTIME_DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-HDF5-jll-0234f1f7-429e-5d53-9886-15a909be8d59"
         },


### PR DESCRIPTION
Update the Julia Manifest.toml to get the latest dependencies.

__Changed packages__
```
  Installing known registries into `~/.julia`
       Added `General` registry to ~/.julia/registries
    Updating registry at `~/.julia/registries/General.toml`
     Cloning git-repo `https://github.com/visr/PackageCompiler.jl`
    Updating git-repo `https://github.com/visr/PackageCompiler.jl`
     Cloning git-repo `https://github.com/SciML/DataInterpolations.jl`
    Updating git-repo `https://github.com/SciML/DataInterpolations.jl`
  Installing 106 artifacts
    Updating `~/work/Ribasim/Ribasim/Project.toml`
  [47edcb42] ↑ ADTypes v1.22.2 ⇒ v1.22.3
⌃ [2b5f629d] ↑ DiffEqBase v7.7.0 ⇒ v7.8.0
  [459566f4] ↑ DiffEqCallbacks v4.18.3 ⇒ v4.19.0
  [64ca27bc] ↑ FindFirstFunctions v3.2.0 ⇒ v3.2.1
  [f6369f11] ↑ ForwardDiff v1.4.1 ⇒ v1.4.3
⌃ [bbf590c4] ↑ OrdinaryDiffEqCore v4.8.0 ⇒ v4.10.0
  [c0aeaf25] ↑ SciMLOperators v1.25.0 ⇒ v1.25.2
  [5d786b92] ↑ TerminalLoggers v0.1.7 ⇒ v0.1.8
    Updating `~/work/Ribasim/Ribasim/Manifest.toml`
  [47edcb42] ↑ ADTypes v1.22.2 ⇒ v1.22.3
  [b2a6c25c] ↑ BinaryHeaps v1.0.3 ⇒ v1.0.4
  [70df07ce] ↑ BracketingNonlinearSolve v1.12.3 ⇒ v1.12.4
  [38540f10] ↑ CommonSolve v0.2.11 ⇒ v0.2.12
  [f70d9fcc] ↑ CommonWorldInvalidations v1.1.1 ⇒ v1.1.2
  [2569d6c7] ↑ ConcreteStructs v0.2.6 ⇒ v0.2.7
⌃ [2b5f629d] ↑ DiffEqBase v7.7.0 ⇒ v7.8.0
  [459566f4] ↑ DiffEqCallbacks v4.18.3 ⇒ v4.19.0
  [7034ab61] ↑ FastBroadcast v1.3.4 ⇒ v1.3.5
  [a4df4552] ↑ FastPower v1.3.4 ⇒ v1.4.0
  [64ca27bc] ↑ FindFirstFunctions v3.2.0 ⇒ v3.2.1
  [f6369f11] ↑ ForwardDiff v1.4.1 ⇒ v1.4.3
  [77dc65aa] ↑ FunctionWrappersWrappers v1.10.1 ⇒ v1.12.0
  [ba0b0d4f] ↑ Krylov v0.10.8 ⇒ v0.10.9
  [1d6d02ad] ↑ LeftChildRightSiblingTrees v0.2.1 ⇒ v0.3.0
  [b8f27783] ↑ MathOptInterface v1.51.2 ⇒ v1.52.0
  [46d2c3a1] ↑ MuladdMacro v0.2.6 ⇒ v0.2.7
  [26075421] ↑ NonlinearSolveSpectralMethods v1.7.3 ⇒ v1.7.4
⌃ [bbf590c4] ↑ OrdinaryDiffEqCore v4.8.0 ⇒ v4.10.0
  [d236fae5] ↑ PreallocationTools v1.3.0 ⇒ v1.4.0
  [08abe8d2] ↑ PrettyTables v3.4.2 ⇒ v3.4.4
  [0c0d3e7f] ↑ PureKLU v1.1.1 ⇒ v1.2.0
  [731186ca] ↑ RecursiveArrayTools v4.3.4 ⇒ v4.3.5
  [9fe22ead] ↑ RespecializeParams v1.1.0 ⇒ v1.2.0
  [7e49a35a] ↑ RuntimeGeneratedFunctions v0.5.22 ⇒ v0.5.24
  [c0aeaf25] ↑ SciMLOperators v1.25.0 ⇒ v1.25.2
  [431bcebd] ↑ SciMLPublic v1.2.3 ⇒ v1.2.4
  [53ae85a6] ↑ SciMLStructures v1.10.3 ⇒ v1.10.4
  [727e6d20] ↑ SimpleNonlinearSolve v2.13.0 ⇒ v2.13.1
  [a57abbd0] ↑ SparseColumnPivotedQR v2.1.4 ⇒ v2.1.5
  [276daf66] ↑ SpecialFunctions v2.8.0 ⇒ v2.8.1
  [aedffcd0] ↑ Static v1.4.4 ⇒ v1.4.5
  [892a3eda] ↑ StringManipulation v0.4.6 ⇒ v0.4.7
  [5d786b92] ↑ TerminalLoggers v0.1.7 ⇒ v0.1.8
  [5c2747f8] ↑ URIs v1.6.1 ⇒ v1.6.2
  [7746bdde] ↑ Glib_jll v2.86.3+0 ⇒ v2.88.3+0
  [0234f1f7] ↑ HDF5_jll v2.1.2+0 ⇒ v2.2.0+0
  [a51aa0fd] ↑ Xorg_libXi_jll v1.8.3+0 ⇒ v1.8.4+0
        Info Packages marked with ⌃ have new versions available and may be upgradable.
        Info We haven't cleaned this depot up for a bit, running Pkg.gc()...
      Active manifest files: 1 found
      Active artifact files: 120 found
      Active scratchspaces: 0 found
     Deleted no artifacts, repos, packages or scratchspaces
```

__Packages still outdated after update__
```
Status `~/work/Ribasim/Ribasim/Project.toml`
  [82cc6244] DataInterpolations v9.0.3 `https://github.com/SciML/DataInterpolations.jl#fix_SCT_for_intinv_itps` (<v9.1.0)
⌃ [2b5f629d] DiffEqBase v7.8.0 (<v7.10.0)
⌅ [7ed4a6bd] LinearSolve v4.3.0 (<v5.4.0): OrdinaryDiffEqDifferentiation, OrdinaryDiffEqNonlinearSolve, OrdinaryDiffEqRosenbrock
⌃ [6ad6398a] OrdinaryDiffEqBDF v2.4.0 (<v2.4.1)
⌃ [bbf590c4] OrdinaryDiffEqCore v4.10.0 (<v4.12.0)
⌃ [4302a76b] OrdinaryDiffEqDifferentiation v3.4.1 (<v3.6.0)
⌃ [127b3ac7] OrdinaryDiffEqNonlinearSolve v2.4.0 (<v2.6.0)
⌃ [43230ef6] OrdinaryDiffEqRosenbrock v2.4.2 (<v2.6.3)
⌃ [2d112036] OrdinaryDiffEqSDIRK v2.8.1 (<v2.8.2)
⌃ [b1df2697] OrdinaryDiffEqTsit5 v2.1.0 (<v2.1.2)
⌅ [0bca4576] SciMLBase v3.39.1 (<v3.41.0): DiffEqBase, NonlinearSolveBase, OrdinaryDiffEqCore, OrdinaryDiffEqDifferentiation, OrdinaryDiffEqNonlinearSolve, OrdinaryDiffEqRosenbrock
```
<details>
<summary>
All package versions
</summary>

```

ADTypes ────────────────────────── v1.22.3
AMD ────────────────────────────── v0.5.3
AbstractTrees ──────────────────── v0.4.5
Accessors ──────────────────────── v0.1.45
Adapt ──────────────────────────── v4.7.0
AliasTables ────────────────────── v1.1.3
Aqua ───────────────────────────── v0.8.16
ArgCheck ───────────────────────── v2.5.0
ArnoldiMethod ──────────────────── v0.4.0
ArrayInterface ─────────────────── v7.27.0
BasicModelInterface ────────────── v0.1.1
BinaryHeaps ────────────────────── v1.0.4
BitFlags ───────────────────────── v0.1.10
Blosc_jll ──────────────────────── v1.21.7+0
BracketingNonlinearSolve ───────── v1.12.4
Bzip2_jll ──────────────────────── v1.0.9+0
CFTime ─────────────────────────── v0.2.10
CSV ────────────────────────────── v0.10.16
Cairo_jll ──────────────────────── v1.18.7+0
CloseOpenIntervals ─────────────── v0.1.13
CodeTracking ───────────────────── v3.0.2
CodecBzip2 ─────────────────────── v0.8.5
CodecZlib ──────────────────────── v0.7.8
ColorSchemes ───────────────────── v3.31.0
ColorTypes ─────────────────────── v0.12.1
ColorVectorSpace ───────────────── v0.11.0
Colors ─────────────────────────── v0.13.1
CommonDataModel ────────────────── v0.4.4
CommonSolve ────────────────────── v0.2.12
CommonSubexpressions ───────────── v0.3.1
CommonWorldInvalidations ───────── v1.1.2
Compat ─────────────────────────── v4.18.1
Compiler ───────────────────────── v0.1.1
CompositionsBase ───────────────── v0.1.2
ConcreteStructs ────────────────── v0.2.7
ConcurrentUtilities ────────────── v2.5.1
CondaPkg ───────────────────────── v0.2.36
Configurations ─────────────────── v0.17.6
ConstructionBase ───────────────── v1.6.0
Contour ────────────────────────── v0.6.3
Crayons ────────────────────────── v4.2.0
DBInterface ────────────────────── v2.6.1
DataAPI ────────────────────────── v1.16.0
DataFrames ─────────────────────── v1.8.2
DataStructures ─────────────────── v0.19.6
DataValueInterfaces ────────────── v1.0.0
Dbus_jll ───────────────────────── v1.16.2+0
DelimitedFiles ─────────────────── v1.9.1
DiffEqBase ─────────────────────── v7.8.0
DiffEqCallbacks ────────────────── v4.19.0
DiffResults ────────────────────── v1.1.0
DiffRules ──────────────────────── v1.16.0
DifferentiationInterface ───────── v0.7.20
DiskArrays ─────────────────────── v0.4.22
DisplayAs ──────────────────────── v0.1.6
DocStringExtensions ────────────── v0.9.5
Dualization ────────────────────── v0.7.7
EnumX ──────────────────────────── v1.0.7
EnzymeCore ─────────────────────── v0.8.21
EpollShim_jll ──────────────────── v0.0.20230411+1
ExceptionUnwrapping ────────────── v0.1.11
Expat_jll ──────────────────────── v2.8.2+0
ExprTools ──────────────────────── v0.1.11
ExproniconLite ─────────────────── v0.10.14
FFMPEG ─────────────────────────── v0.4.5
FFMPEG_jll ─────────────────────── v8.1.2+0
FastBroadcast ──────────────────── v1.3.5
FastClosures ───────────────────── v0.3.2
FastPower ──────────────────────── v1.4.0
FilePathsBase ──────────────────── v0.9.24
FillArrays ─────────────────────── v1.17.0
FindFirstFunctions ─────────────── v3.2.1
FiniteDiff ─────────────────────── v2.32.0
FixedPointNumbers ──────────────── v0.8.6
Fontconfig_jll ─────────────────── v2.17.1+0
Format ─────────────────────────── v1.3.7
ForwardDiff ────────────────────── v1.4.3
FreeType2_jll ──────────────────── v2.14.3+1
FriBidi_jll ────────────────────── v1.0.17+0
FunctionWrappers ───────────────── v1.1.3
FunctionWrappersWrappers ───────── v1.12.0
GLFW_jll ───────────────────────── v3.4.1+1
GPUArraysCore ──────────────────── v0.2.0
GR ─────────────────────────────── v0.73.26
GR_jll ─────────────────────────── v0.73.26+0
GettextRuntime_jll ─────────────── v0.22.4+0
Ghostscript_jll ────────────────── v9.55.1+0
Glib_jll ───────────────────────── v2.88.3+0
Glob ───────────────────────────── v1.5.0
Graphite2_jll ──────────────────── v1.3.16+0
Graphs ─────────────────────────── v1.14.0
Grisu ──────────────────────────── v1.0.2
HDF5_jll ───────────────────────── v2.2.0+0
HTTP ───────────────────────────── v1.11.0
HarfBuzz_jll ───────────────────── v8.5.1+0
HiGHS ──────────────────────────── v1.24.1
HiGHS_jll ──────────────────────── v1.15.1+1
Hwloc_jll ──────────────────────── v2.14.0+0
IOCapture ──────────────────────── v1.0.0
IfElse ─────────────────────────── v0.1.1
Infiltrator ────────────────────── v1.9.11
Inflate ────────────────────────── v0.1.5
InlineStrings ──────────────────── v1.4.5
IntelOpenMP_jll ────────────────── v2025.2.0+0
InverseFunctions ───────────────── v0.1.17
InvertedIndices ────────────────── v1.3.1
IrrationalConstants ────────────── v0.2.6
IterTools ──────────────────────── v1.10.0
IteratorInterfaceExtensions ────── v1.0.0
JLFzf ──────────────────────────── v0.1.11
JLLWrappers ────────────────────── v1.8.0
JSON ───────────────────────────── v1.6.1
JSON3 ──────────────────────────── v1.14.3
JpegTurbo_jll ──────────────────── v3.2.0+0
JuMP ───────────────────────────── v1.31.1
JuliaC ─────────────────────────── v0.3.8
JuliaInterpreter ───────────────── v0.11.4
Krylov ─────────────────────────── v0.10.9
LAME_jll ───────────────────────── v3.100.3+0
LERC_jll ───────────────────────── v4.1.0+0
LLVMOpenMP_jll ─────────────────── v22.1.7+0
LRUCache ───────────────────────── v1.6.2
LaTeXStrings ───────────────────── v1.4.0
Latexify ───────────────────────── v0.16.11
LayoutPointers ─────────────────── v0.1.17
LazilyInitializedFields ────────── v1.3.0
LeftChildRightSiblingTrees ─────── v0.3.0
Libffi_jll ─────────────────────── v3.4.7+0
Libglvnd_jll ───────────────────── v1.7.1+1
Libiconv_jll ───────────────────── v1.18.0+0
Libmount_jll ───────────────────── v2.42.0+0
Libtiff_jll ────────────────────── v4.7.3+0
Libuuid_jll ────────────────────── v2.42.0+0
LicenseCheck ───────────────────── v0.2.3
LineSearch ─────────────────────── v0.1.12
LinearSolve ────────────────────── v4.3.0
LogExpFunctions ────────────────── v0.3.29
LoggingExtras ──────────────────── v1.2.0
LoweredCodeUtils ───────────────── v3.8.0
Lz4_jll ────────────────────────── v1.10.1+0
MKL_jll ────────────────────────── v2025.2.0+0
MPIABI_jll ─────────────────────── v0.1.5+0
MPICH_jll ──────────────────────── v5.0.1+0
MPIPreferences ─────────────────── v0.1.12
MPItrampoline_jll ──────────────── v5.5.6+0
MacroTools ─────────────────────── v0.5.16
ManualMemory ───────────────────── v0.1.8
MarkdownTables ─────────────────── v1.1.0
MathOptAnalyzer ────────────────── v0.1.2
MathOptIIS ─────────────────────── v0.2.0
MathOptInterface ───────────────── v1.52.0
MaybeInplace ───────────────────── v0.1.7
MbedTLS ────────────────────────── v1.1.10
MbedTLS_jll ────────────────────── v2.28.1010+0
Measures ───────────────────────── v0.3.3
MetaGraphsNext ─────────────────── v0.8.0
MicroMamba ─────────────────────── v0.1.15
MicrosoftMPI_jll ───────────────── v10.1.4+3
Missings ───────────────────────── v1.2.0
Mocking ────────────────────────── v0.8.1
MuladdMacro ────────────────────── v0.2.7
MutableArithmetics ─────────────── v1.8.0
NCDatasets ─────────────────────── v0.14.15
NaNMath ────────────────────────── v1.1.4
NetCDF_jll ─────────────────────── v401.1000.100+0
NonlinearSolve ─────────────────── v4.21.1
NonlinearSolveBase ─────────────── v2.35.0
NonlinearSolveFirstOrder ───────── v2.2.0
NonlinearSolveQuasiNewton ──────── v1.14.0
NonlinearSolveSpectralMethods ──── v1.7.4
ObjectFile ─────────────────────── v0.5.1
OffsetArrays ───────────────────── v1.17.0
Ogg_jll ────────────────────────── v1.3.6+0
OpenBLAS32_jll ─────────────────── v0.3.34+0
OpenMPI_jll ────────────────────── v5.0.11+0
OpenSSL ────────────────────────── v1.6.1
OpenSpecFun_jll ────────────────── v0.5.6+0
Opus_jll ───────────────────────── v1.6.1+0
OrderedCollections ─────────────── v1.8.2
OrdinaryDiffEqBDF ──────────────── v2.4.0
OrdinaryDiffEqCore ─────────────── v4.10.0
OrdinaryDiffEqDifferentiation ──── v3.4.1
OrdinaryDiffEqLowOrderRK ───────── v2.2.1
OrdinaryDiffEqNonlinearSolve ───── v2.4.0
OrdinaryDiffEqRosenbrock ───────── v2.4.2
OrdinaryDiffEqRosenbrockTableaus ─ v2.4.0
OrdinaryDiffEqSDIRK ────────────── v2.8.1
OrdinaryDiffEqTsit5 ────────────── v2.1.0
OteraEngine ────────────────────── v1.1.3
Pango_jll ──────────────────────── v1.57.1+0
Parsers ────────────────────────── v2.8.6
Patchelf_jll ───────────────────── v0.18.1+0
Pidfile ────────────────────────── v1.3.0
Pixman_jll ─────────────────────── v0.46.4+0
PkgToSoftwareBOM ───────────────── v0.1.19
PlotThemes ─────────────────────── v3.3.0
PlotUtils ──────────────────────── v1.4.4
Plots ──────────────────────────── v1.41.6
PooledArrays ───────────────────── v1.4.3
PreallocationTools ─────────────── v1.4.0
PrecompileTools ────────────────── v1.3.4
Preferences ────────────────────── v1.5.2
PrettyTables ───────────────────── v3.4.4
ProgressLogging ────────────────── v0.1.6
PtrArrays ──────────────────────── v1.4.0
PureKLU ────────────────────────── v1.2.0
PythonCall ─────────────────────── v0.9.35
Qt6Base_jll ────────────────────── v6.10.2+2
Qt6Declarative_jll ─────────────── v6.10.2+2
Qt6ShaderTools_jll ─────────────── v6.10.2+1
Qt6Svg_jll ─────────────────────── v6.10.2+0
Qt6Wayland_jll ─────────────────── v6.10.2+1
RecipesBase ────────────────────── v1.3.4
RecipesPipeline ────────────────── v0.6.12
RecursiveArrayTools ────────────── v4.3.5
Reexport ───────────────────────── v1.2.2
RegistryInstances ──────────────── v0.1.0
RelocatableFolders ─────────────── v1.0.1
Requires ───────────────────────── v1.3.1
RespecializeParams ─────────────── v1.2.0
Revise ─────────────────────────── v3.16.2
RuntimeGeneratedFunctions ──────── v0.5.24
SIMDTypes ──────────────────────── v0.1.0
SPDX ───────────────────────────── v0.5.0
SQLite ─────────────────────────── v1.8.1
SQLite_jll ─────────────────────── v3.53.2+0
SciMLBase ──────────────────────── v3.39.1
SciMLJacobianOperators ─────────── v0.1.16
SciMLLogging ───────────────────── v2.0.3
SciMLOperators ─────────────────── v1.25.2
SciMLPublic ────────────────────── v1.2.4
SciMLStructures ────────────────── v1.10.4
Scratch ────────────────────────── v1.3.0
SentinelArrays ─────────────────── v1.4.10
Setfield ───────────────────────── v1.1.2
Showoff ────────────────────────── v1.0.3
SimpleBufferStream ─────────────── v1.2.0
SimpleNonlinearSolve ───────────── v2.13.1
SimpleTraits ───────────────────── v0.9.6
SortingAlgorithms ──────────────── v1.2.3
SparseColumnPivotedQR ──────────── v2.1.5
SparseConnectivityTracer ───────── v1.2.2
SparseMatrixColorings ──────────── v0.4.27
SpecialFunctions ───────────────── v2.8.1
StableRNGs ─────────────────────── v1.0.4
Static ─────────────────────────── v1.4.5
StaticArrayInterface ───────────── v1.10.0
StaticArrays ───────────────────── v1.9.18
StaticArraysCore ───────────────── v1.4.4
Statistics ─────────────────────── v1.11.1
StatsAPI ───────────────────────── v1.8.0
StatsBase ──────────────────────── v0.34.12
StrideArraysCore ───────────────── v0.5.9
StringManipulation ─────────────── v0.4.7
StructArrays ───────────────────── v0.7.3
StructIO ───────────────────────── v0.3.1
StructTypes ────────────────────── v1.11.0
StructUtils ────────────────────── v2.8.2
SymbolicIndexingInterface ──────── v0.3.51
TZJData ────────────────────────── v1.5.0+2025b
TableTraits ────────────────────── v1.0.1
Tables ─────────────────────────── v1.13.0
TensorCore ─────────────────────── v0.1.1
TerminalLoggers ────────────────── v0.1.8
TestItemRunner ─────────────────── v1.1.5
TestItems ──────────────────────── v1.0.0
ThreadingUtilities ─────────────── v0.5.6
TimeZones ──────────────────────── v1.22.2
TimerOutputs ───────────────────── v0.5.29
TranscodingStreams ─────────────── v0.11.3
TruncatedStacktraces ───────────── v1.4.0
URIs ───────────────────────────── v1.6.2
UnicodeFun ─────────────────────── v0.4.1
UnsafePointers ─────────────────── v1.0.0
Unzip ──────────────────────────── v0.2.0
Vulkan_Loader_jll ──────────────── v1.3.243+0
Wayland_jll ────────────────────── v1.24.0+0
WeakRefStrings ─────────────────── v1.4.3
WorkerUtilities ────────────────── v1.6.1
XML2_jll ───────────────────────── v2.13.9+0
XZ_jll ─────────────────────────── v5.8.3+0
Xorg_libICE_jll ────────────────── v1.1.2+0
Xorg_libSM_jll ─────────────────── v1.2.6+0
Xorg_libX11_jll ────────────────── v1.8.13+0
Xorg_libXau_jll ────────────────── v1.0.13+0
Xorg_libXcursor_jll ────────────── v1.2.4+0
Xorg_libXdmcp_jll ──────────────── v1.1.6+0
Xorg_libXext_jll ───────────────── v1.3.8+0
Xorg_libXfixes_jll ─────────────── v6.0.2+0
Xorg_libXi_jll ─────────────────── v1.8.4+0
Xorg_libXinerama_jll ───────────── v1.1.7+0
Xorg_libXrandr_jll ─────────────── v1.5.6+0
Xorg_libXrender_jll ────────────── v0.9.12+0
Xorg_libpciaccess_jll ──────────── v0.19.0+0
Xorg_libxcb_jll ────────────────── v1.17.1+0
Xorg_libxkbfile_jll ────────────── v1.2.0+0
Xorg_xcb_util_cursor_jll ───────── v0.1.6+0
Xorg_xcb_util_image_jll ────────── v0.4.1+0
Xorg_xcb_util_jll ──────────────── v0.4.1+0
Xorg_xcb_util_keysyms_jll ──────── v0.4.1+0
Xorg_xcb_util_renderutil_jll ───── v0.3.10+0
Xorg_xcb_util_wm_jll ───────────── v0.4.2+0
Xorg_xkbcomp_jll ───────────────── v1.4.7+0
Xorg_xkeyboard_config_jll ──────── v2.47.0+2
Xorg_xtrans_jll ────────────────── v1.6.0+0
Zstd_jll ───────────────────────── v1.5.7+1
artifact Blosc                    44.2 KiB
artifact Bzip2                    503.5 KiB
artifact Cairo                    2.2 MiB
artifact Dbus                     489.8 KiB
artifact Expat                    297.5 KiB
artifact FFMPEG                   11.9 MiB
artifact Fontconfig               984.8 KiB
artifact FreeType2                1.5 MiB
artifact FriBidi                  78.9 KiB
artifact GLFW                     187.9 KiB
artifact GR                       19.3 MiB
artifact GettextRuntime           543.0 KiB
artifact Ghostscript              31.4 MiB
artifact Glib                     7.8 MiB
artifact Graphite2                120.3 KiB
artifact HDF5                     6.1 MiB
artifact HarfBuzz                 1.7 MiB
artifact HiGHS                    3.1 MiB
artifact Hwloc                    3.5 MiB
artifact JpegTurbo                1.9 MiB
artifact LAME                     292.5 KiB
artifact LERC                     267.4 KiB
artifact LLVMOpenMP               680.4 KiB
artifact Libffi                   44.2 KiB
artifact Libglvnd                 833.5 KiB
artifact Libiconv                 1.9 MiB
artifact Libmount                 6.9 MiB
artifact Libtiff                  2.4 MiB
artifact Libuuid                  3.9 MiB
artifact Lz4                      239.7 KiB
artifact MPICH                    8.8 MiB
artifact MbedTLS                  2.2 MiB
artifact NetCDF                   970.6 KiB
artifact Ogg                      250.3 KiB
artifact OpenBLAS32               10.3 MiB
artifact OpenSpecFun              194.9 KiB
artifact Opus                     960.9 KiB
artifact Pango                    2.1 MiB
artifact Patchelf                 1.1 MiB
artifact Pixman                   390.8 KiB
artifact Qt6Base                  23.1 MiB
artifact Qt6Declarative           23.8 MiB
artifact Qt6ShaderTools           2.1 MiB
artifact Qt6Svg                   386.4 KiB
artifact Qt6Wayland               1.4 MiB
artifact SQLite                   1.8 MiB
artifact Vulkan_Loader            177.3 KiB
artifact Wayland                  390.6 KiB
artifact XML2                     2.5 MiB
artifact XZ                       1.6 MiB
artifact Xorg_libICE              384.9 KiB
artifact Xorg_libSM               164.1 KiB
artifact Xorg_libX11              4.8 MiB
artifact Xorg_libXau              36.6 KiB
artifact Xorg_libXcursor          227.1 KiB
artifact Xorg_libXdmcp            67.7 KiB
artifact Xorg_libXext             286.6 KiB
artifact Xorg_libXfixes           59.0 KiB
artifact Xorg_libXi               1.6 MiB
artifact Xorg_libXinerama         25.5 KiB
artifact Xorg_libXrandr           97.3 KiB
artifact Xorg_libXrender          435.9 KiB
artifact Xorg_libpciaccess        26.2 KiB
artifact Xorg_libxcb              2.1 MiB
artifact Xorg_libxkbfile          91.1 KiB
artifact Xorg_xcb_util            39.5 KiB
artifact Xorg_xcb_util_cursor     27.6 KiB
artifact Xorg_xcb_util_image      54.3 KiB
artifact Xorg_xcb_util_keysyms    17.8 KiB
artifact Xorg_xcb_util_renderutil 32.1 KiB
artifact Xorg_xcb_util_wm         147.9 KiB
artifact Xorg_xkbcomp             274.8 KiB
artifact Xorg_xkeyboard_config    1.1 MiB
artifact Xorg_xtrans              48.2 KiB
artifact Zstd                     646.0 KiB
artifact aws_c_auth               130.3 KiB
artifact aws_c_cal                1.2 MiB
artifact aws_c_common             285.2 KiB
artifact aws_c_compression        13.4 KiB
artifact aws_c_http               387.4 KiB
artifact aws_c_io                 181.7 KiB
artifact aws_c_s3                 143.0 KiB
artifact aws_c_sdkutils           54.9 KiB
artifact aws_checksums            87.0 KiB
artifact eudev                    3.9 MiB
artifact fzf                      3.3 MiB
artifact libaec                   50.4 KiB
artifact libaom                   6.4 MiB
artifact libass                   427.8 KiB
artifact libdecor                 44.1 KiB
artifact libdrm                   372.6 KiB
artifact libevdev                 117.1 KiB
artifact libfdk_aac               2.8 MiB
artifact libinput                 1.0 MiB
artifact libpng                   329.4 KiB
artifact libva                    235.7 KiB
artifact libvorbis                271.0 KiB
artifact libzip                   177.6 KiB
artifact licensecheck             2.4 MiB
artifact mtdev                    79.6 KiB
artifact s2n_tls                  1.8 MiB
artifact testfiles                6.2 MiB
artifact tzjdata                  112.5 KiB
artifact x264                     2.1 MiB
artifact x265                     1.4 MiB
artifact xkbcommon                298.7 KiB
aws_c_auth_jll ─────────────────── v0.9.6+0
aws_c_cal_jll ──────────────────── v0.9.13+0
aws_c_common_jll ───────────────── v0.12.6+0
aws_c_compression_jll ──────────── v0.3.2+0
aws_c_http_jll ─────────────────── v0.10.13+0
aws_c_io_jll ───────────────────── v0.26.3+0
aws_c_s3_jll ───────────────────── v0.11.5+0
aws_c_sdkutils_jll ─────────────── v0.2.4+1
aws_checksums_jll ──────────────── v0.2.10+0
dlfcn_win32_jll ────────────────── v1.4.2+0
eudev_jll ──────────────────────── v3.2.14+0
fzf_jll ────────────────────────── v0.61.1+0
libaec_jll ─────────────────────── v1.1.7+0
libaom_jll ─────────────────────── v3.13.3+0
libass_jll ─────────────────────── v0.17.4+0
libdecor_jll ───────────────────── v0.2.2+0
libdrm_jll ─────────────────────── v2.4.134+0
libevdev_jll ───────────────────── v1.13.4+0
libfdk_aac_jll ─────────────────── v2.0.4+0
libinput_jll ───────────────────── v1.28.1+0
libpng_jll ─────────────────────── v1.6.58+0
libva_jll ──────────────────────── v2.23.0+0
libvorbis_jll ──────────────────── v1.3.8+0
libzip_jll ─────────────────────── v1.11.3+0
licensecheck_jll ───────────────── v0.4.0+0
micromamba_jll ─────────────────── v2.3.1+0
mpif_jll ───────────────────────── v0.1.7+0
mtdev_jll ──────────────────────── v1.1.7+0
oneTBB_jll ─────────────────────── v2022.3.0+0
pixi_jll ───────────────────────── v0.63.2+0
s2n_tls_jll ────────────────────── v1.7.3+0
x264_jll ───────────────────────── v10164.0.1+0
x265_jll ───────────────────────── v4.1.0+0
xkbcommon_jll ──────────────────── v1.13.0+0
