### PR TITLE
Update Julia manifest

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -5,9 +5,9 @@ manifest_format = "2.0"
 project_hash = "59f3296d9439e7973b95504a1c63dce6cf57c91a"
 
 [[deps.ADTypes]]
-git-tree-sha1 = "0a81a018463de6c3f4f2c9360121c562e5add9e4"
+git-tree-sha1 = "9b38b82a9fe131f3d331a53b7203d9d1a2a4602c"
 uuid = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
-version = "1.22.3"
+version = "1.22.4"
 
     [deps.ADTypes.extensions]
     ADTypesChainRulesCoreExt = "ChainRulesCore"
@@ -264,9 +264,9 @@ uuid = "1fbeeb36-5f17-413c-809b-666fb144f157"
 version = "0.4.4"
 
 [[deps.CommonSolve]]
-git-tree-sha1 = "f54afab101687a7049833d07636418a83e9a250b"
+git-tree-sha1 = "cf963add2340ad9960e5eb22844e61ad8f931fe1"
 uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
-version = "0.2.12"
+version = "0.2.13"
 
 [[deps.CommonSubexpressions]]
 deps = ["MacroTools"]
@@ -315,9 +315,9 @@ version = "0.2.7"
 
 [[deps.ConcurrentUtilities]]
 deps = ["Serialization", "Sockets"]
-git-tree-sha1 = "21d088c496ea22914fe80906eb5bce65755e5ec8"
+git-tree-sha1 = "3c9be947934c38475bafe822c6d61aaed17f0738"
 uuid = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
-version = "2.5.1"
+version = "2.6.0"
 
 [[deps.CondaPkg]]
 deps = ["JSON", "Markdown", "MicroMamba", "Pidfile", "Pkg", "Preferences", "Scratch", "TOML", "pixi_jll"]
@@ -357,9 +357,9 @@ uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 version = "4.2.0"
 
 [[deps.DBInterface]]
-git-tree-sha1 = "a444404b3f94deaa43ca2a58e18153a82695282b"
+git-tree-sha1 = "265d7f87f329c063cbde41920f9d00713a43cedd"
 uuid = "a10d1c49-ce27-4219-8d33-6db1a4562965"
-version = "2.6.1"
+version = "2.7.0"
 
 [[deps.DataAPI]]
 git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
@@ -470,9 +470,9 @@ version = "7.8.0"
 
 [[deps.DiffEqCallbacks]]
 deps = ["ConcreteStructs", "DataStructures", "DiffEqBase", "DifferentiationInterface", "LinearAlgebra", "Markdown", "PrecompileTools", "RecipesBase", "RecursiveArrayTools", "SciMLBase", "StaticArraysCore"]
-git-tree-sha1 = "9fe2f1cd33835bf1db4e09571939975fd4598f31"
+git-tree-sha1 = "50212426ed10a2da3494a56b35874c2148606d78"
 uuid = "459566f4-90b8-5000-8ac3-15dfb0a30def"
-version = "4.19.0"
+version = "4.19.1"
 
     [deps.DiffEqCallbacks.extensions]
     DiffEqCallbacksFunctorsExt = "Functors"
@@ -641,9 +641,9 @@ version = "8.1.2+0"
 
 [[deps.FastBroadcast]]
 deps = ["ArrayInterface", "LinearAlgebra"]
-git-tree-sha1 = "8dc134f37a4ad842679e14e33f7e4ebf20963792"
+git-tree-sha1 = "6a97f3e08655ea9df1a946e378770c4d3fb3c4e9"
 uuid = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
-version = "1.3.5"
+version = "1.3.6"
 
     [deps.FastBroadcast.extensions]
     FastBroadcastPolyesterExt = "Polyester"
@@ -659,9 +659,9 @@ uuid = "9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a"
 version = "0.3.2"
 
 [[deps.FastPower]]
-git-tree-sha1 = "cd70b50f2a164b9c5ca8a410b2a427eae07dee1e"
+git-tree-sha1 = "eb92a563909f2d4cb2911e0e2cb247ad17c6e9ae"
 uuid = "a4df4552-cc26-4903-aec0-212e50a0e84b"
-version = "1.4.0"
+version = "1.4.1"
 
     [deps.FastPower.extensions]
     FastPowerEnzymeExt = "Enzyme"
@@ -722,9 +722,9 @@ version = "3.2.1"
 
 [[deps.FiniteDiff]]
 deps = ["ArrayInterface", "LinearAlgebra", "Setfield"]
-git-tree-sha1 = "07e98e3f332ee60179813dd9cdf21412e3c0a96a"
+git-tree-sha1 = "5031f23e040bf17082e5b52422d77b5e844eefb1"
 uuid = "6a86dc24-6348-571c-b903-95158fe2bd41"
-version = "2.32.0"
+version = "2.33.0"
 
     [deps.FiniteDiff.extensions]
     FiniteDiffBandedMatricesExt = "BandedMatrices"
@@ -757,9 +757,9 @@ version = "1.3.7"
 
 [[deps.ForwardDiff]]
 deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions"]
-git-tree-sha1 = "73d5084cae45f9d0857776ad78cf303fec09eb02"
+git-tree-sha1 = "1b86cca764a61dcac4fef4c5e16e378e5ed6953c"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "1.4.3"
+version = "1.4.5"
 weakdeps = ["StaticArrays"]
 
     [deps.ForwardDiff.extensions]
@@ -784,9 +784,9 @@ version = "1.1.3"
 
 [[deps.FunctionWrappersWrappers]]
 deps = ["FunctionWrappers", "PrecompileTools", "SciMLPublic"]
-git-tree-sha1 = "755903758db86cd86ee10b079fd15d2036e090c3"
+git-tree-sha1 = "daced009d54a7cf502a9b5ed2f615c341f78af6f"
 uuid = "77dc65aa-8811-40c2-897b-53d922fa7daf"
-version = "1.12.0"
+version = "1.12.1"
 
     [deps.FunctionWrappersWrappers.extensions]
     FunctionWrappersWrappersEnzymeExt = ["Enzyme", "EnzymeCore"]
@@ -1005,9 +1005,9 @@ version = "1.8.0"
 
 [[deps.JSON]]
 deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
-git-tree-sha1 = "c89d196f5ffb64bfbf80985b699ea913b0d2c211"
+git-tree-sha1 = "c7345ab1a7ca4dc8a02c9f6510da0d9857bbe513"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "1.6.1"
+version = "1.7.1"
 
     [deps.JSON.extensions]
     JSONArrowExt = ["ArrowTypes"]
@@ -1213,9 +1213,9 @@ version = "0.2.3"
 
 [[deps.LineSearch]]
 deps = ["ADTypes", "CommonSolve", "ConcreteStructs", "FastClosures", "LinearAlgebra", "MaybeInplace", "PrecompileTools", "SciMLBase", "SciMLJacobianOperators", "StaticArraysCore"]
-git-tree-sha1 = "0ddc77c97e42b3024a1646278bdaafee0bd61583"
+git-tree-sha1 = "36d9ea45f400b185d291528dd2e7659ace2da2c7"
 uuid = "87fe0de2-c867-4266-b59a-2f0a94fc965b"
-version = "0.1.12"
+version = "0.1.13"
 
     [deps.LineSearch.extensions]
     LineSearchLineSearchesExt = "LineSearches"
@@ -1743,9 +1743,9 @@ weakdeps = ["SparseArrays"]
 
 [[deps.OrdinaryDiffEqLowOrderRK]]
 deps = ["DiffEqBase", "FastBroadcast", "LinearAlgebra", "MuladdMacro", "OrdinaryDiffEqCore", "RecursiveArrayTools", "Reexport", "SciMLBase"]
-git-tree-sha1 = "e9a7115946ec02491498d2b161fb28015a101692"
+git-tree-sha1 = "53c095374a39bdd3d46f5cfb24883839918a7497"
 uuid = "1344f307-1e59-4825-a18e-ace9aa3fa4c6"
-version = "2.2.1"
+version = "2.2.2"
 
 [[deps.OrdinaryDiffEqNonlinearSolve]]
 deps = ["ADTypes", "ArrayInterface", "ConstructionBase", "DiffEqBase", "FastBroadcast", "FastClosures", "ForwardDiff", "LinearAlgebra", "LinearSolve", "MuladdMacro", "NonlinearSolve", "NonlinearSolveBase", "OrdinaryDiffEqCore", "OrdinaryDiffEqDifferentiation", "PreallocationTools", "RecursiveArrayTools", "SciMLBase", "SciMLOperators", "SimpleNonlinearSolve", "SparseArrays", "StaticArraysCore"]
@@ -1760,9 +1760,9 @@ uuid = "43230ef6-c299-4910-a778-202eb28ce4ce"
 version = "2.4.2"
 
 [[deps.OrdinaryDiffEqRosenbrockTableaus]]
-git-tree-sha1 = "edd12a8982ed2a464770a57c43eebb301173b8a8"
+git-tree-sha1 = "0ecd1c905c82963f8748e82b6d2bf16d2b1bdf2b"
 uuid = "b4bd8bb3-f80f-41d2-9b21-73a655b304b9"
-version = "2.4.0"
+version = "2.4.1"
 
 [[deps.OrdinaryDiffEqSDIRK]]
 deps = ["ADTypes", "CommonSolve", "ConstructionBase", "DiffEqBase", "FastBroadcast", "LinearAlgebra", "MacroTools", "MuladdMacro", "OrdinaryDiffEqCore", "OrdinaryDiffEqDifferentiation", "OrdinaryDiffEqNonlinearSolve", "PrecompileTools", "Preferences", "RecursiveArrayTools", "Reexport", "SciMLBase", "TruncatedStacktraces"]
@@ -1797,15 +1797,15 @@ version = "2.4.0"
 
 [[deps.Pango_jll]]
 deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "FriBidi_jll", "Glib_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "58e5ed5e386e156bd93e86b305ebd21ac63d2d04"
+git-tree-sha1 = "7126b66b721a605a2fec966a2874c5ed53258eb3"
 uuid = "36c8627f-9965-5494-a995-c6b170f724f3"
-version = "1.57.1+0"
+version = "1.58.0+0"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
-git-tree-sha1 = "32a4e09c5f29402573d673901778a0e03b0807b9"
+git-tree-sha1 = "3de8f5e6e90ebfa8d6d1f86997d6cdcd6a912ff3"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.8.6"
+version = "2.8.7"
 
 [[deps.Patchelf_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
@@ -1880,9 +1880,9 @@ version = "1.4.3"
 
 [[deps.PreallocationTools]]
 deps = ["Adapt", "ArrayInterface", "PrecompileTools", "SciMLPublic"]
-git-tree-sha1 = "241a537533777c5e07c88e9c70ad180b42525d06"
+git-tree-sha1 = "315eb21a0da58dccdbd29e3c617e3a9fbdd768a8"
 uuid = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
-version = "1.4.0"
+version = "1.4.1"
 
     [deps.PreallocationTools.extensions]
     PreallocationToolsEnzymeCoreExt = "EnzymeCore"
@@ -1910,9 +1910,9 @@ version = "1.5.2"
 
 [[deps.PrettyTables]]
 deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "REPL", "Reexport", "StringManipulation", "Tables"]
-git-tree-sha1 = "807a56f504aa08838a11e9a0727c3d704f90c44b"
+git-tree-sha1 = "4ac881f5432bd93463a41767a814a45245be22b6"
 uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
-version = "3.4.4"
+version = "3.4.6"
 
     [deps.PrettyTables.extensions]
     PrettyTablesExcelExt = "XLSX"
@@ -1940,9 +1940,9 @@ version = "1.4.0"
 
 [[deps.PureKLU]]
 deps = ["LinearAlgebra", "PrecompileTools", "SparseArrays"]
-git-tree-sha1 = "7ef298d8ec41c57fd93239023836696f9c90e524"
+git-tree-sha1 = "762c7006b147e31fc7dd272b5e4714aae648e05b"
 uuid = "0c0d3e7f-3a8b-4f7e-b6f1-9a4d2e7c1f01"
-version = "1.2.0"
+version = "1.4.0"
 weakdeps = ["ForwardDiff"]
 
     [deps.PureKLU.extensions]
@@ -2015,10 +2015,10 @@ uuid = "01d81517-befc-4cb6-b9ec-a95719d0359c"
 version = "0.6.12"
 
 [[deps.RecursiveArrayTools]]
-deps = ["Adapt", "ArrayInterface", "DocStringExtensions", "GPUArraysCore", "LinearAlgebra", "PrecompileTools", "RecipesBase", "StaticArraysCore", "SymbolicIndexingInterface"]
-git-tree-sha1 = "4236ff8c2721e9503b83054ba6c1478856e27c0f"
+deps = ["Adapt", "ArrayInterface", "DocStringExtensions", "GPUArraysCore", "LinearAlgebra", "PrecompileTools", "RecipesBase", "SciMLPublic", "StaticArraysCore", "SymbolicIndexingInterface"]
+git-tree-sha1 = "89a235781fdda53fe6c8092e4a4ed9ce9cf04ed3"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
-version = "4.3.5"
+version = "4.3.6"
 
     [deps.RecursiveArrayTools.extensions]
     RecursiveArrayToolsCUDAExt = "CUDA"
@@ -2085,9 +2085,9 @@ version = "1.2.0"
 
 [[deps.Revise]]
 deps = ["CRC32c", "CodeTracking", "FileWatching", "JuliaInterpreter", "LibGit2", "LoweredCodeUtils", "OrderedCollections", "Preferences", "REPL", "UUIDs"]
-git-tree-sha1 = "6098400ed73008c45f5f47b35ae114475436ad37"
+git-tree-sha1 = "ec46aed6a3a8cc6b67839ca361e7b4aa32eaeee1"
 uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
-version = "3.16.2"
+version = "3.16.3"
 weakdeps = ["Distributed"]
 
     [deps.Revise.extensions]
@@ -2181,15 +2181,15 @@ version = "3.39.1"
 
 [[deps.SciMLJacobianOperators]]
 deps = ["ADTypes", "ArrayInterface", "ConcreteStructs", "ConstructionBase", "DifferentiationInterface", "FastClosures", "LinearAlgebra", "SciMLBase", "SciMLOperators"]
-git-tree-sha1 = "396fd0f85b71f87111618e1cbe6608a1bcc8a447"
+git-tree-sha1 = "ad167d716fc134c0873c76ba0469ede56a678732"
 uuid = "19f34311-ddf3-4b8b-af20-060888a46c0e"
-version = "0.1.16"
+version = "0.1.17"
 
 [[deps.SciMLLogging]]
 deps = ["Logging", "LoggingExtras", "Preferences"]
-git-tree-sha1 = "5a9e890ad708f45cb33d31ef358bc15764dfb544"
+git-tree-sha1 = "36be2198d9dc476ac27efb1fe0f789d9e1dca01c"
 uuid = "a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
-version = "2.0.3"
+version = "2.0.4"
 
     [deps.SciMLLogging.extensions]
     SciMLLoggingTracyExt = "Tracy"
@@ -2198,10 +2198,10 @@ version = "2.0.3"
     Tracy = "e689c965-62c8-4b79-b2c5-8359227902fd"
 
 [[deps.SciMLOperators]]
-deps = ["Accessors", "Adapt", "ArrayInterface", "DocStringExtensions", "LinearAlgebra"]
-git-tree-sha1 = "c92b87cd04563954537c4e832fb894b00f1b407e"
+deps = ["Accessors", "Adapt", "ArrayInterface", "DocStringExtensions", "LinearAlgebra", "SciMLPublic"]
+git-tree-sha1 = "54333a8ba01ff383643b44d5a97a4bc2c07d4d2f"
 uuid = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
-version = "1.25.2"
+version = "1.26.1"
 
     [deps.SciMLOperators.extensions]
     SciMLOperatorsLoopVectorizationExt = "LoopVectorization"
@@ -2294,9 +2294,9 @@ version = "1.12.0"
 
 [[deps.SparseColumnPivotedQR]]
 deps = ["LinearAlgebra", "PrecompileTools", "SparseArrays"]
-git-tree-sha1 = "6c16137917345386c614ab68dd58e4bdc3f4a6e0"
+git-tree-sha1 = "ee8155fd93f0efc510e4523850bd9e0bb6e03199"
 uuid = "a57abbd0-fea5-4d57-96be-5e525945e8e4"
-version = "2.1.5"
+version = "2.1.6"
 weakdeps = ["AMD"]
 
     [deps.SparseColumnPivotedQR.extensions]
@@ -2346,9 +2346,9 @@ version = "0.4.27"
 
 [[deps.SpecialFunctions]]
 deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
-git-tree-sha1 = "97c8329c5f503d2936fb36719fe25b9f94b1ae8a"
+git-tree-sha1 = "c3ac026e735264e9bdc6a9bcbd1b1e781b36e3bc"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "2.8.1"
+version = "2.8.3"
 
     [deps.SpecialFunctions.extensions]
     SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
@@ -2364,9 +2364,9 @@ version = "1.0.4"
 
 [[deps.Static]]
 deps = ["CommonWorldInvalidations", "IfElse", "PrecompileTools", "SciMLPublic"]
-git-tree-sha1 = "4abff9ad312e476839c25b9398f619255af9a0e4"
+git-tree-sha1 = "474a5283ad435618090122872eea6a8165ea6bcf"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-version = "1.4.5"
+version = "1.4.6"
 
 [[deps.StaticArrayInterface]]
 deps = ["ArrayInterface", "Compat", "IfElse", "LinearAlgebra", "PrecompileTools", "SciMLPublic", "Static"]
@@ -2466,9 +2466,9 @@ version = "1.11.0"
 
 [[deps.StructUtils]]
 deps = ["Dates", "UUIDs"]
-git-tree-sha1 = "82bee338d650aa515f31866c460cb7e3bcef90b8"
+git-tree-sha1 = "2d0fc55c61321ba245c47be599570d11bac50303"
 uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
-version = "2.8.2"
+version = "2.8.5"
 
     [deps.StructUtils.extensions]
     StructUtilsMeasurementsExt = ["Measurements"]
@@ -2491,9 +2491,9 @@ version = "7.8.3+2"
 
 [[deps.SymbolicIndexingInterface]]
 deps = ["Accessors", "ArrayInterface", "RuntimeGeneratedFunctions", "StaticArraysCore"]
-git-tree-sha1 = "73048fd086b7a169bbd7232bf60bfd43240691eb"
+git-tree-sha1 = "ae6fd46b22508c2dfcd0fabf144ce5e9d9d2e719"
 uuid = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
-version = "0.3.51"
+version = "0.3.53"
 weakdeps = ["PrettyTables"]
 
     [deps.SymbolicIndexingInterface.extensions]
@@ -2506,9 +2506,9 @@ version = "1.0.3"
 
 [[deps.TZJData]]
 deps = ["Artifacts"]
-git-tree-sha1 = "72df96b3a595b7aab1e101eb07d2a435963a97e2"
+git-tree-sha1 = "d3b30a9f29a898e21fb4bdf280101b7a12e1f39c"
 uuid = "dc5dba14-91b3-4cab-a142-028a31da12f7"
-version = "1.5.0+2025b"
+version = "1.5.1+2025b"
 
 [[deps.TableTraits]]
 deps = ["IteratorInterfaceExtensions"]
@@ -2595,9 +2595,9 @@ uuid = "781d530d-4396-4725-bb49-402e4bee1e77"
 version = "1.4.0"
 
 [[deps.URIs]]
-git-tree-sha1 = "3b0738bd7c5645641845da25cbd99800b8718689"
+git-tree-sha1 = "5253f44481f18cd938d4559d5e44fa82198408a6"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.6.2"
+version = "1.6.3"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]

--- a/Ribasim.spdx.json
+++ b/Ribasim.spdx.json
@@ -3,12 +3,12 @@
     "dataLicense": "CC0-1.0",
     "SPDXID": "SPDXRef-DOCUMENT",
     "name": "Ribasim.jl",
-    "documentNamespace": "https://github.com/Deltares/Ribasim/Ribasim.spdx.json-de907855-06b0-42ec-b7cc-d6ddd3b9df33",
+    "documentNamespace": "https://github.com/Deltares/Ribasim/Ribasim.spdx.json-48d6b13c-509d-4ea7-997d-9843f201a151",
     "creationInfo": {
         "creators": [
             "Organization:  Deltares  (software@deltares.nl)"
         ],
-        "created": "2026-08-04T09:01:08Z",
+        "created": "2026-08-10T07:49:22Z",
         "comment": "Target Platform: Platform(\"x86_64\", \"linux\"; libgfortran_version = \"5.0.0\", julia_version = \"1.12.6\", libc = \"glibc\", libstdcxx_version = \"3.4.30\", cxxstring_abi = \"cxx11\")"
     },
     "comment": "Registries used for populating Package data:\nGeneral registry: https://github.com/JuliaRegistries/General.git\nOfficial general Julia package registry where people can\nregister any package they want without too much debate about\nnaming and without enforced standards on documentation or\ntesting. We nevertheless encourage documentation, testing and\nsome amount of consideration when choosing package names.\n",
@@ -786,13 +786,13 @@
         {
             "name": "SpecialFunctions",
             "SPDXID": "SPDXRef-SpecialFunctions-276daf66-3868-5448-9aa4-cd146d93841b",
-            "versionInfo": "2.8.1",
+            "versionInfo": "2.8.3",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaMath/SpecialFunctions.jl.git@97c8329c5f503d2936fb36719fe25b9f94b1ae8a",
+            "downloadLocation": "git+https://github.com/JuliaMath/SpecialFunctions.jl.git@c3ac026e735264e9bdc6a9bcbd1b1e781b36e3bc",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "638b67dbde684d8315c14e5fd7e95a1203ccfc66"
+                "packageVerificationCodeValue": "85d8846d84f284cb33ca3f43cd67239d17b0e0a0"
             },
             "homepage": "https://github.com/JuliaMath/SpecialFunctions.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -808,7 +808,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/SpecialFunctions@2.8.1?uuid=276daf66-3868-5448-9aa4-cd146d93841b"
+                    "referenceLocator": "pkg:julia/SpecialFunctions@2.8.3?uuid=276daf66-3868-5448-9aa4-cd146d93841b"
                 }
             ]
         },
@@ -902,13 +902,13 @@
         {
             "name": "ForwardDiff",
             "SPDXID": "SPDXRef-ForwardDiff-f6369f11-7733-5829-9624-2563aa707210",
-            "versionInfo": "1.4.3",
+            "versionInfo": "1.4.5",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaDiff/ForwardDiff.jl.git@73d5084cae45f9d0857776ad78cf303fec09eb02",
+            "downloadLocation": "git+https://github.com/JuliaDiff/ForwardDiff.jl.git@1b86cca764a61dcac4fef4c5e16e378e5ed6953c",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "67472613b72be4747519304ddb24b306797fc338"
+                "packageVerificationCodeValue": "eb6586c22d8107e585aeaa01164a69f12ba74d0b"
             },
             "homepage": "https://github.com/JuliaDiff/ForwardDiff.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -924,7 +924,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/ForwardDiff@1.4.3?uuid=f6369f11-7733-5829-9624-2563aa707210"
+                    "referenceLocator": "pkg:julia/ForwardDiff@1.4.5?uuid=f6369f11-7733-5829-9624-2563aa707210"
                 }
             ]
         },
@@ -1388,13 +1388,13 @@
         {
             "name": "Parsers",
             "SPDXID": "SPDXRef-Parsers-69de0a69-1ddd-5017-9359-2bf0b02dc9f0",
-            "versionInfo": "2.8.6",
+            "versionInfo": "2.8.7",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaData/Parsers.jl.git@32a4e09c5f29402573d673901778a0e03b0807b9",
+            "downloadLocation": "git+https://github.com/JuliaData/Parsers.jl.git@3de8f5e6e90ebfa8d6d1f86997d6cdcd6a912ff3",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "92ec43c5548de992123fa974695da48a52f9c6d8"
+                "packageVerificationCodeValue": "417c847720ef740e6abf1a17c2e6d618cc0ea419"
             },
             "homepage": "https://github.com/JuliaData/Parsers.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -1410,20 +1410,20 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/Parsers@2.8.6?uuid=69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+                    "referenceLocator": "pkg:julia/Parsers@2.8.7?uuid=69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
                 }
             ]
         },
         {
             "name": "StructUtils",
             "SPDXID": "SPDXRef-StructUtils-ec057cc2-7a8d-4b58-b3b3-92acb9f63b42",
-            "versionInfo": "2.8.2",
+            "versionInfo": "2.8.5",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaServices/StructUtils.jl.git@82bee338d650aa515f31866c460cb7e3bcef90b8",
+            "downloadLocation": "git+https://github.com/JuliaServices/StructUtils.jl.git@2d0fc55c61321ba245c47be599570d11bac50303",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "f566284a59c5d87bc7d2079c6fc101f44c53b359"
+                "packageVerificationCodeValue": "d7bfa9a3e97baf2ba02ac1ee3a29316edd122ed9"
             },
             "homepage": "https://github.com/JuliaServices/StructUtils.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -1439,20 +1439,20 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/StructUtils@2.8.2?uuid=ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
+                    "referenceLocator": "pkg:julia/StructUtils@2.8.5?uuid=ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
                 }
             ]
         },
         {
             "name": "JSON",
             "SPDXID": "SPDXRef-JSON-682c06a0-de6a-54ab-a142-c8b1cf79cde6",
-            "versionInfo": "1.6.1",
+            "versionInfo": "1.7.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaIO/JSON.jl.git@c89d196f5ffb64bfbf80985b699ea913b0d2c211",
+            "downloadLocation": "git+https://github.com/JuliaIO/JSON.jl.git@c7345ab1a7ca4dc8a02c9f6510da0d9857bbe513",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "8f88dacf5c4b55923c8e02385d3ccc49e7147d59"
+                "packageVerificationCodeValue": "f443cf0e3e90ffcdc0601209b977f0fe700b3d80"
             },
             "homepage": "https://github.com/JuliaIO/JSON.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -1468,7 +1468,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/JSON@1.6.1?uuid=682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+                    "referenceLocator": "pkg:julia/JSON@1.7.1?uuid=682c06a0-de6a-54ab-a142-c8b1cf79cde6"
                 }
             ]
         },
@@ -1829,13 +1829,13 @@
         {
             "name": "SparseColumnPivotedQR",
             "SPDXID": "SPDXRef-SparseColumnPivotedQR-a57abbd0-fea5-4d57-96be-5e525945e8e4",
-            "versionInfo": "2.1.5",
+            "versionInfo": "2.1.6",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/SparseColumnPivotedQR.jl.git@6c16137917345386c614ab68dd58e4bdc3f4a6e0",
+            "downloadLocation": "git+https://github.com/SciML/SparseColumnPivotedQR.jl.git@ee8155fd93f0efc510e4523850bd9e0bb6e03199",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "0a0ad19d1640a3da85fb446fb18cb9cbc82a357a"
+                "packageVerificationCodeValue": "d669f96c891ff928129d650d430a3195552807d5"
             },
             "homepage": "https://github.com/SciML/SparseColumnPivotedQR.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -1851,7 +1851,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/SparseColumnPivotedQR@2.1.5?uuid=a57abbd0-fea5-4d57-96be-5e525945e8e4"
+                    "referenceLocator": "pkg:julia/SparseColumnPivotedQR@2.1.6?uuid=a57abbd0-fea5-4d57-96be-5e525945e8e4"
                 }
             ]
         },
@@ -2030,6 +2030,35 @@
             ]
         },
         {
+            "name": "SciMLPublic",
+            "SPDXID": "SPDXRef-SciMLPublic-431bcebd-1456-4ced-9d72-93c2757fff0b",
+            "versionInfo": "1.2.4",
+            "supplier": "NOASSERTION",
+            "originator": "NOASSERTION",
+            "downloadLocation": "git+https://github.com/SciML/SciMLPublic.jl.git@cf9aaf8b9ed5db993259ea8b24cf2b7ba9bd3b79",
+            "filesAnalyzed": true,
+            "packageVerificationCode": {
+                "packageVerificationCodeValue": "ef7b4ed297e0e95899df620a2d92884076f3727b"
+            },
+            "homepage": "https://github.com/SciML/SciMLPublic.jl.git",
+            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
+            "licenseConcluded": "NOASSERTION",
+            "licenseInfoFromFiles": [
+                "MIT"
+            ],
+            "licenseDeclared": "MIT",
+            "copyrightText": "NOASSERTION",
+            "summary": "This is a Julia package, written in the Julia language.",
+            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it.",
+            "externalRefs": [
+                {
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceType": "purl",
+                    "referenceLocator": "pkg:julia/SciMLPublic@1.2.4?uuid=431bcebd-1456-4ced-9d72-93c2757fff0b"
+                }
+            ]
+        },
+        {
             "name": "ArrayInterface",
             "SPDXID": "SPDXRef-ArrayInterface-4fba245c-0d91-5ea0-9b3e-6abc04ee57a9",
             "versionInfo": "7.27.0",
@@ -2061,13 +2090,13 @@
         {
             "name": "SciMLOperators",
             "SPDXID": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961",
-            "versionInfo": "1.25.2",
+            "versionInfo": "1.26.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/SciMLOperators.jl.git@c92b87cd04563954537c4e832fb894b00f1b407e",
+            "downloadLocation": "git+https://github.com/SciML/SciMLOperators.jl.git@54333a8ba01ff383643b44d5a97a4bc2c07d4d2f",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "ecfd2ca64b9f3e7b827bd6b32744da25f68f6321"
+                "packageVerificationCodeValue": "df856a74c408aa037fa32aac5b079ebff1a1ebab"
             },
             "homepage": "https://github.com/SciML/SciMLOperators.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2083,7 +2112,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/SciMLOperators@1.25.2?uuid=c0aeaf25-5076-4817-a8d5-81caf7dfa961"
+                    "referenceLocator": "pkg:julia/SciMLOperators@1.26.1?uuid=c0aeaf25-5076-4817-a8d5-81caf7dfa961"
                 }
             ]
         },
@@ -2113,35 +2142,6 @@
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
                     "referenceLocator": "pkg:julia/SciMLStructures@1.10.4?uuid=53ae85a6-f571-4167-b2af-e1d143709226"
-                }
-            ]
-        },
-        {
-            "name": "SciMLPublic",
-            "SPDXID": "SPDXRef-SciMLPublic-431bcebd-1456-4ced-9d72-93c2757fff0b",
-            "versionInfo": "1.2.4",
-            "supplier": "NOASSERTION",
-            "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/SciMLPublic.jl.git@cf9aaf8b9ed5db993259ea8b24cf2b7ba9bd3b79",
-            "filesAnalyzed": true,
-            "packageVerificationCode": {
-                "packageVerificationCodeValue": "ef7b4ed297e0e95899df620a2d92884076f3727b"
-            },
-            "homepage": "https://github.com/SciML/SciMLPublic.jl.git",
-            "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
-            "licenseConcluded": "NOASSERTION",
-            "licenseInfoFromFiles": [
-                "MIT"
-            ],
-            "licenseDeclared": "MIT",
-            "copyrightText": "NOASSERTION",
-            "summary": "This is a Julia package, written in the Julia language.",
-            "comment": "The SPDX ID field is derived from the UUID that all Julia packages are assigned by their developer to uniquely identify it.",
-            "externalRefs": [
-                {
-                    "referenceCategory": "PACKAGE-MANAGER",
-                    "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/SciMLPublic@1.2.4?uuid=431bcebd-1456-4ced-9d72-93c2757fff0b"
                 }
             ]
         },
@@ -2177,13 +2177,13 @@
         {
             "name": "FunctionWrappersWrappers",
             "SPDXID": "SPDXRef-FunctionWrappersWrappers-77dc65aa-8811-40c2-897b-53d922fa7daf",
-            "versionInfo": "1.12.0",
+            "versionInfo": "1.12.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/FunctionWrappersWrappers.jl.git@755903758db86cd86ee10b079fd15d2036e090c3",
+            "downloadLocation": "git+https://github.com/SciML/FunctionWrappersWrappers.jl.git@daced009d54a7cf502a9b5ed2f615c341f78af6f",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "8c69e0c134a1f88416c04f207b4e430094f9d326"
+                "packageVerificationCodeValue": "6c0ca7cb582fcaff50b93334c3b89756fb89dc27"
             },
             "homepage": "https://github.com/SciML/FunctionWrappersWrappers.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2199,7 +2199,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/FunctionWrappersWrappers@1.12.0?uuid=77dc65aa-8811-40c2-897b-53d922fa7daf"
+                    "referenceLocator": "pkg:julia/FunctionWrappersWrappers@1.12.1?uuid=77dc65aa-8811-40c2-897b-53d922fa7daf"
                 }
             ]
         },
@@ -2377,13 +2377,13 @@
         {
             "name": "SymbolicIndexingInterface",
             "SPDXID": "SPDXRef-SymbolicIndexingInterface-2efcf032-c050-4f8e-a9bb-153293bab1f5",
-            "versionInfo": "0.3.51",
+            "versionInfo": "0.3.53",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/SymbolicIndexingInterface.jl.git@73048fd086b7a169bbd7232bf60bfd43240691eb",
+            "downloadLocation": "git+https://github.com/SciML/SymbolicIndexingInterface.jl.git@ae6fd46b22508c2dfcd0fabf144ce5e9d9d2e719",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "18f3ccdb2a8ce7888ba9586e07ede95ef0a91e4f"
+                "packageVerificationCodeValue": "4e36dfa3e4786f010bd343465a5abb30453c258b"
             },
             "homepage": "https://github.com/SciML/SymbolicIndexingInterface.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2399,7 +2399,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/SymbolicIndexingInterface@0.3.51?uuid=2efcf032-c050-4f8e-a9bb-153293bab1f5"
+                    "referenceLocator": "pkg:julia/SymbolicIndexingInterface@0.3.53?uuid=2efcf032-c050-4f8e-a9bb-153293bab1f5"
                 }
             ]
         },
@@ -2435,13 +2435,13 @@
         {
             "name": "ADTypes",
             "SPDXID": "SPDXRef-ADTypes-47edcb42-4c32-4615-8424-f2b9edc5f35b",
-            "versionInfo": "1.22.3",
+            "versionInfo": "1.22.4",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/ADTypes.jl.git@0a81a018463de6c3f4f2c9360121c562e5add9e4",
+            "downloadLocation": "git+https://github.com/SciML/ADTypes.jl.git@9b38b82a9fe131f3d331a53b7203d9d1a2a4602c",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "e0212a6f8b0ee278d721570e69fd03d0aa234c9d"
+                "packageVerificationCodeValue": "e4d6756de029205866cf5dcc8c74ce3d020e4630"
             },
             "homepage": "https://github.com/SciML/ADTypes.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2457,7 +2457,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/ADTypes@1.22.3?uuid=47edcb42-4c32-4615-8424-f2b9edc5f35b"
+                    "referenceLocator": "pkg:julia/ADTypes@1.22.4?uuid=47edcb42-4c32-4615-8424-f2b9edc5f35b"
                 }
             ]
         },
@@ -2493,13 +2493,13 @@
         {
             "name": "SciMLLogging",
             "SPDXID": "SPDXRef-SciMLLogging-a6db7da4-7206-11f0-1eab-35f2a5dbe1d1",
-            "versionInfo": "2.0.3",
+            "versionInfo": "2.0.4",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/SciMLLogging.jl.git@5a9e890ad708f45cb33d31ef358bc15764dfb544",
+            "downloadLocation": "git+https://github.com/SciML/SciMLLogging.jl.git@36be2198d9dc476ac27efb1fe0f789d9e1dca01c",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "7bc29df16aacc974b4101f355b947b3bc42656ab"
+                "packageVerificationCodeValue": "39c1151b4807f90ba7fd8a461cc2daf8afc10d52"
             },
             "homepage": "https://github.com/SciML/SciMLLogging.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2515,20 +2515,20 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/SciMLLogging@2.0.3?uuid=a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
+                    "referenceLocator": "pkg:julia/SciMLLogging@2.0.4?uuid=a6db7da4-7206-11f0-1eab-35f2a5dbe1d1"
                 }
             ]
         },
         {
             "name": "RecursiveArrayTools",
             "SPDXID": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd",
-            "versionInfo": "4.3.5",
+            "versionInfo": "4.3.6",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/RecursiveArrayTools.jl.git@4236ff8c2721e9503b83054ba6c1478856e27c0f",
+            "downloadLocation": "git+https://github.com/SciML/RecursiveArrayTools.jl.git@89a235781fdda53fe6c8092e4a4ed9ce9cf04ed3",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "7f546c03fa71286134a7107ac0d89ce814d58b51"
+                "packageVerificationCodeValue": "674bcbd9a7f52ce145af0a4feff3926f62219899"
             },
             "homepage": "https://github.com/SciML/RecursiveArrayTools.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2544,7 +2544,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/RecursiveArrayTools@4.3.5?uuid=731186ca-8d62-57ce-b412-fbd966d074cd"
+                    "referenceLocator": "pkg:julia/RecursiveArrayTools@4.3.6?uuid=731186ca-8d62-57ce-b412-fbd966d074cd"
                 }
             ]
         },
@@ -2580,13 +2580,13 @@
         {
             "name": "CommonSolve",
             "SPDXID": "SPDXRef-CommonSolve-38540f10-b2f7-11e9-35d8-d573e4eb0ff2",
-            "versionInfo": "0.2.12",
+            "versionInfo": "0.2.13",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/CommonSolve.jl.git@f54afab101687a7049833d07636418a83e9a250b",
+            "downloadLocation": "git+https://github.com/SciML/CommonSolve.jl.git@cf963add2340ad9960e5eb22844e61ad8f931fe1",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "fb1d85c83bf7d66c150894eaed44199061999f6f"
+                "packageVerificationCodeValue": "7cc71cc1856a3339b4f71f232dd0b0c59f22092f"
             },
             "homepage": "https://github.com/SciML/CommonSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2602,20 +2602,20 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/CommonSolve@0.2.12?uuid=38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
+                    "referenceLocator": "pkg:julia/CommonSolve@0.2.13?uuid=38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
                 }
             ]
         },
         {
             "name": "PreallocationTools",
             "SPDXID": "SPDXRef-PreallocationTools-d236fae5-4411-538c-8e31-a6e3d9e00b46",
-            "versionInfo": "1.4.0",
+            "versionInfo": "1.4.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/PreallocationTools.jl.git@241a537533777c5e07c88e9c70ad180b42525d06",
+            "downloadLocation": "git+https://github.com/SciML/PreallocationTools.jl.git@315eb21a0da58dccdbd29e3c617e3a9fbdd768a8",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "0adbf47f6d8cd0b2bc82d5b91a0622d608824f02"
+                "packageVerificationCodeValue": "340c386ac5b46a97fc8dc0fd2af1e67ab595b3a8"
             },
             "homepage": "https://github.com/SciML/PreallocationTools.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2631,7 +2631,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/PreallocationTools@1.4.0?uuid=d236fae5-4411-538c-8e31-a6e3d9e00b46"
+                    "referenceLocator": "pkg:julia/PreallocationTools@1.4.1?uuid=d236fae5-4411-538c-8e31-a6e3d9e00b46"
                 }
             ]
         },
@@ -2696,13 +2696,13 @@
         {
             "name": "PureKLU",
             "SPDXID": "SPDXRef-PureKLU-0c0d3e7f-3a8b-4f7e-b6f1-9a4d2e7c1f01",
-            "versionInfo": "1.2.0",
+            "versionInfo": "1.4.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/PureKLU.jl.git@7ef298d8ec41c57fd93239023836696f9c90e524",
+            "downloadLocation": "git+https://github.com/SciML/PureKLU.jl.git@762c7006b147e31fc7dd272b5e4714aae648e05b",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "c3d8dbc0dab146750a3271acb2db7482f41968ea"
+                "packageVerificationCodeValue": "2cbe4d2ad9b23946e58dc03d62874978f29eb901"
             },
             "homepage": "https://github.com/SciML/PureKLU.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -2719,7 +2719,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/PureKLU@1.2.0?uuid=0c0d3e7f-3a8b-4f7e-b6f1-9a4d2e7c1f01"
+                    "referenceLocator": "pkg:julia/PureKLU@1.4.0?uuid=0c0d3e7f-3a8b-4f7e-b6f1-9a4d2e7c1f01"
                 }
             ]
         },
@@ -3760,13 +3760,13 @@
         {
             "name": "Static",
             "SPDXID": "SPDXRef-Static-aedffcd0-7271-4cad-89d0-dc628f76c6d3",
-            "versionInfo": "1.4.5",
+            "versionInfo": "1.4.6",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/Static.jl.git@4abff9ad312e476839c25b9398f619255af9a0e4",
+            "downloadLocation": "git+https://github.com/SciML/Static.jl.git@474a5283ad435618090122872eea6a8165ea6bcf",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "246feb3df7b672a4581113cef4e2dcf54d0535d6"
+                "packageVerificationCodeValue": "908f57ac42e91e8e43cca8fa8b2faf9b9f4c4670"
             },
             "homepage": "https://github.com/SciML/Static.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3782,7 +3782,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/Static@1.4.5?uuid=aedffcd0-7271-4cad-89d0-dc628f76c6d3"
+                    "referenceLocator": "pkg:julia/Static@1.4.6?uuid=aedffcd0-7271-4cad-89d0-dc628f76c6d3"
                 }
             ]
         },
@@ -3934,13 +3934,13 @@
         {
             "name": "FastBroadcast",
             "SPDXID": "SPDXRef-FastBroadcast-7034ab61-46d4-4ed7-9d0f-46aef9175898",
-            "versionInfo": "1.3.5",
+            "versionInfo": "1.3.6",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/FastBroadcast.jl.git@8dc134f37a4ad842679e14e33f7e4ebf20963792",
+            "downloadLocation": "git+https://github.com/SciML/FastBroadcast.jl.git@6a97f3e08655ea9df1a946e378770c4d3fb3c4e9",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "81e9345eeac9e4c77ae1b0fd719ca4f27fc64d22"
+                "packageVerificationCodeValue": "32af971939033d45e905053273011ea2756d2a9c"
             },
             "homepage": "https://github.com/SciML/FastBroadcast.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -3956,7 +3956,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/FastBroadcast@1.3.5?uuid=7034ab61-46d4-4ed7-9d0f-46aef9175898"
+                    "referenceLocator": "pkg:julia/FastBroadcast@1.3.6?uuid=7034ab61-46d4-4ed7-9d0f-46aef9175898"
                 }
             ]
         },
@@ -4111,13 +4111,13 @@
         {
             "name": "SciMLJacobianOperators",
             "SPDXID": "SPDXRef-SciMLJacobianOperators-19f34311-ddf3-4b8b-af20-060888a46c0e",
-            "versionInfo": "0.1.16",
+            "versionInfo": "0.1.17",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@396fd0f85b71f87111618e1cbe6608a1bcc8a447#lib/SciMLJacobianOperators",
+            "downloadLocation": "git+https://github.com/SciML/NonlinearSolve.jl.git@ad167d716fc134c0873c76ba0469ede56a678732#lib/SciMLJacobianOperators",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "33f8c88fb839ef65218f57b8af962aac5d4bbbc0"
+                "packageVerificationCodeValue": "42a2267ebdcfe59d58e8a0f339eb9b5b8e90ce56"
             },
             "homepage": "https://github.com/SciML/NonlinearSolve.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4133,7 +4133,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/SciMLJacobianOperators@0.1.16?uuid=19f34311-ddf3-4b8b-af20-060888a46c0e"
+                    "referenceLocator": "pkg:julia/SciMLJacobianOperators@0.1.17?uuid=19f34311-ddf3-4b8b-af20-060888a46c0e"
                 }
             ]
         },
@@ -4285,13 +4285,13 @@
         {
             "name": "FastPower",
             "SPDXID": "SPDXRef-FastPower-a4df4552-cc26-4903-aec0-212e50a0e84b",
-            "versionInfo": "1.4.0",
+            "versionInfo": "1.4.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/FastPower.jl.git@cd70b50f2a164b9c5ca8a410b2a427eae07dee1e",
+            "downloadLocation": "git+https://github.com/SciML/FastPower.jl.git@eb92a563909f2d4cb2911e0e2cb247ad17c6e9ae",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "162f54c60badc7ff2e0b03c215ad9de322488edd"
+                "packageVerificationCodeValue": "fddc8547ed65fc8aa824f252943634338f93db84"
             },
             "homepage": "https://github.com/SciML/FastPower.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4307,7 +4307,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/FastPower@1.4.0?uuid=a4df4552-cc26-4903-aec0-212e50a0e84b"
+                    "referenceLocator": "pkg:julia/FastPower@1.4.1?uuid=a4df4552-cc26-4903-aec0-212e50a0e84b"
                 }
             ]
         },
@@ -4401,13 +4401,13 @@
         {
             "name": "OrdinaryDiffEqLowOrderRK",
             "SPDXID": "SPDXRef-OrdinaryDiffEqLowOrderRK-1344f307-1e59-4825-a18e-ace9aa3fa4c6",
-            "versionInfo": "2.2.1",
+            "versionInfo": "2.2.2",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@e9a7115946ec02491498d2b161fb28015a101692#lib/OrdinaryDiffEqLowOrderRK",
+            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@53c095374a39bdd3d46f5cfb24883839918a7497#lib/OrdinaryDiffEqLowOrderRK",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "5d12842990cd026d854a3b54c07717ee43d3d450"
+                "packageVerificationCodeValue": "6fc768c88c68685cd4a0270d063a82f84f6b5f1b"
             },
             "homepage": "https://github.com/SciML/OrdinaryDiffEq.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4423,7 +4423,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/OrdinaryDiffEqLowOrderRK@2.2.1?uuid=1344f307-1e59-4825-a18e-ace9aa3fa4c6"
+                    "referenceLocator": "pkg:julia/OrdinaryDiffEqLowOrderRK@2.2.2?uuid=1344f307-1e59-4825-a18e-ace9aa3fa4c6"
                 }
             ]
         },
@@ -4633,13 +4633,13 @@
         {
             "name": "DBInterface",
             "SPDXID": "SPDXRef-DBInterface-a10d1c49-ce27-4219-8d33-6db1a4562965",
-            "versionInfo": "2.6.1",
+            "versionInfo": "2.7.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaDatabases/DBInterface.jl.git@a444404b3f94deaa43ca2a58e18153a82695282b",
+            "downloadLocation": "git+https://github.com/JuliaDatabases/DBInterface.jl.git@265d7f87f329c063cbde41920f9d00713a43cedd",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "103a2d624d4388110b5b7173c8e5019b70f4b0b5"
+                "packageVerificationCodeValue": "b270c7955d37b9e66ba711759a3947e895fb16d2"
             },
             "homepage": "https://github.com/JuliaDatabases/DBInterface.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -4655,7 +4655,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/DBInterface@2.6.1?uuid=a10d1c49-ce27-4219-8d33-6db1a4562965"
+                    "referenceLocator": "pkg:julia/DBInterface@2.7.0?uuid=a10d1c49-ce27-4219-8d33-6db1a4562965"
                 }
             ]
         },
@@ -5026,13 +5026,13 @@
         {
             "name": "FiniteDiff",
             "SPDXID": "SPDXRef-FiniteDiff-6a86dc24-6348-571c-b903-95158fe2bd41",
-            "versionInfo": "2.32.0",
+            "versionInfo": "2.33.0",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/JuliaDiff/FiniteDiff.jl.git@07e98e3f332ee60179813dd9cdf21412e3c0a96a",
+            "downloadLocation": "git+https://github.com/JuliaDiff/FiniteDiff.jl.git@5031f23e040bf17082e5b52422d77b5e844eefb1",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "899f0153c62240085838596332a6b745c5ef3775"
+                "packageVerificationCodeValue": "ac8d3676582b0df24cc1297b9c5dac25ccd243dd"
             },
             "homepage": "https://github.com/JuliaDiff/FiniteDiff.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -5048,7 +5048,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/FiniteDiff@2.32.0?uuid=6a86dc24-6348-571c-b903-95158fe2bd41"
+                    "referenceLocator": "pkg:julia/FiniteDiff@2.33.0?uuid=6a86dc24-6348-571c-b903-95158fe2bd41"
                 }
             ]
         },
@@ -5084,13 +5084,13 @@
         {
             "name": "OrdinaryDiffEqRosenbrockTableaus",
             "SPDXID": "SPDXRef-OrdinaryDiffEqRosenbrockTableaus-b4bd8bb3-f80f-41d2-9b21-73a655b304b9",
-            "versionInfo": "2.4.0",
+            "versionInfo": "2.4.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@edd12a8982ed2a464770a57c43eebb301173b8a8#lib/OrdinaryDiffEqRosenbrockTableaus",
+            "downloadLocation": "git+https://github.com/SciML/OrdinaryDiffEq.jl.git@0ecd1c905c82963f8748e82b6d2bf16d2b1bdf2b#lib/OrdinaryDiffEqRosenbrockTableaus",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "5b6c24def609807413f971b352e8dbe8c63802c3"
+                "packageVerificationCodeValue": "32f7cd9614b4b494f9eb95c265028e65c2d77323"
             },
             "homepage": "https://github.com/SciML/OrdinaryDiffEq.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -5106,7 +5106,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/OrdinaryDiffEqRosenbrockTableaus@2.4.0?uuid=b4bd8bb3-f80f-41d2-9b21-73a655b304b9"
+                    "referenceLocator": "pkg:julia/OrdinaryDiffEqRosenbrockTableaus@2.4.1?uuid=b4bd8bb3-f80f-41d2-9b21-73a655b304b9"
                 }
             ]
         },
@@ -5287,13 +5287,13 @@
         {
             "name": "LineSearch",
             "SPDXID": "SPDXRef-LineSearch-87fe0de2-c867-4266-b59a-2f0a94fc965b",
-            "versionInfo": "0.1.12",
+            "versionInfo": "0.1.13",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/LineSearch.jl.git@0ddc77c97e42b3024a1646278bdaafee0bd61583",
+            "downloadLocation": "git+https://github.com/SciML/LineSearch.jl.git@36d9ea45f400b185d291528dd2e7659ace2da2c7",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "775fd64cb7c65238c549ec9a998f5396855db134"
+                "packageVerificationCodeValue": "b8e455a6077d0a14199c04f447ff78d042a87ed6"
             },
             "homepage": "https://github.com/SciML/LineSearch.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -5309,7 +5309,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/LineSearch@0.1.12?uuid=87fe0de2-c867-4266-b59a-2f0a94fc965b"
+                    "referenceLocator": "pkg:julia/LineSearch@0.1.13?uuid=87fe0de2-c867-4266-b59a-2f0a94fc965b"
                 }
             ]
         },
@@ -5519,13 +5519,13 @@
         {
             "name": "DiffEqCallbacks",
             "SPDXID": "SPDXRef-DiffEqCallbacks-459566f4-90b8-5000-8ac3-15dfb0a30def",
-            "versionInfo": "4.19.0",
+            "versionInfo": "4.19.1",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/SciML/DiffEqCallbacks.jl.git@9fe2f1cd33835bf1db4e09571939975fd4598f31",
+            "downloadLocation": "git+https://github.com/SciML/DiffEqCallbacks.jl.git@50212426ed10a2da3494a56b35874c2148606d78",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "d71e8fcb7e8f8eb858a8b1764e864e8da0ff9340"
+                "packageVerificationCodeValue": "38ed4f0eeb40d95ffe76e85ece5a328e13aaed98"
             },
             "homepage": "https://github.com/SciML/DiffEqCallbacks.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -5541,7 +5541,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/DiffEqCallbacks@4.19.0?uuid=459566f4-90b8-5000-8ac3-15dfb0a30def"
+                    "referenceLocator": "pkg:julia/DiffEqCallbacks@4.19.1?uuid=459566f4-90b8-5000-8ac3-15dfb0a30def"
                 }
             ]
         },
@@ -5836,13 +5836,13 @@
         {
             "name": "PrettyTables",
             "SPDXID": "SPDXRef-PrettyTables-08abe8d2-0d0c-5749-adfa-8a2ac140af0d",
-            "versionInfo": "3.4.4",
+            "versionInfo": "3.4.6",
             "supplier": "NOASSERTION",
             "originator": "NOASSERTION",
-            "downloadLocation": "git+https://github.com/ronisbr/PrettyTables.jl.git@807a56f504aa08838a11e9a0727c3d704f90c44b",
+            "downloadLocation": "git+https://github.com/ronisbr/PrettyTables.jl.git@4ac881f5432bd93463a41767a814a45245be22b6",
             "filesAnalyzed": true,
             "packageVerificationCode": {
-                "packageVerificationCodeValue": "dab34bb7b9a5a3b6fd9c936b000c59c49b17f112"
+                "packageVerificationCodeValue": "fc7eff5176daeb3abf7008ae1e4921fece72ea5f"
             },
             "homepage": "https://github.com/ronisbr/PrettyTables.jl.git",
             "sourceInfo": "Download Location is supplied by the General registry:\nhttps://github.com/JuliaRegistries/General.git\nThe hash supplied in Download Location is not the typical git commit hash. Instead it is a git tree hash. The easiest way to retrieve this version from the cloned repository is to use the command:\ngit archive --output=path/to/archive.tar <tree hash>",
@@ -5858,7 +5858,7 @@
                 {
                     "referenceCategory": "PACKAGE-MANAGER",
                     "referenceType": "purl",
-                    "referenceLocator": "pkg:julia/PrettyTables@3.4.4?uuid=08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
+                    "referenceLocator": "pkg:julia/PrettyTables@3.4.6?uuid=08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
                 }
             ]
         },
@@ -9065,6 +9065,11 @@
             "relatedSpdxElement": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961"
         },
         {
+            "spdxElementId": "SPDXRef-SciMLPublic-431bcebd-1456-4ced-9d72-93c2757fff0b",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961"
+        },
+        {
             "spdxElementId": "SPDXRef-LinearAlgebra-37e2e46d-f89d-539d-b4ee-838fcccc9c8e",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-SciMLOperators-c0aeaf25-5076-4817-a8d5-81caf7dfa961"
@@ -9325,12 +9330,17 @@
             "relatedSpdxElement": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd"
         },
         {
-            "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
+            "spdxElementId": "SPDXRef-SciMLPublic-431bcebd-1456-4ced-9d72-93c2757fff0b",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd"
         },
         {
             "spdxElementId": "SPDXRef-LinearAlgebra-37e2e46d-f89d-539d-b4ee-838fcccc9c8e",
+            "relationshipType": "DEPENDENCY_OF",
+            "relatedSpdxElement": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd"
+        },
+        {
+            "spdxElementId": "SPDXRef-StaticArraysCore-1e83bf80-4336-4d27-bf5d-d5a4f845583c",
             "relationshipType": "DEPENDENCY_OF",
             "relatedSpdxElement": "SPDXRef-RecursiveArrayTools-731186ca-8d62-57ce-b412-fbd966d074cd"
         },

--- a/core/src/differentiation.jl
+++ b/core/src/differentiation.jl
@@ -104,6 +104,24 @@ function LinearAlgebra.mul!(
     return nothing
 end
 
+# Fallback so SciMLOperators/OrdinaryDiffEq internals that concretize a Jacobian
+# regardless of `isconvertible` (e.g. https://github.com/SciML/SciMLOperators.jl/pull/408)
+# get a correct, if expensive, dense matrix instead of a MethodError.
+function Base.convert(::Type{AbstractMatrix}, J::HalfLazyJacobian)
+    (; state_ranges) = J.p_independent
+    n = length(J.du)
+    mat = zeros(n, n)
+    v = CVector(zeros(n), state_ranges)
+    u = CVector(zeros(n), state_ranges)
+    for i in 1:n
+        v[i] = 1.0
+        mul!(u, J, v)
+        mat[:, i] .= getdata(u)
+        v[i] = 0.0
+    end
+    return mat
+end
+
 # SciMLOperators interface
 SciMLOperators.isconstant(::HalfLazyJacobian) = false
 SciMLOperators.issquare(::HalfLazyJacobian) = true

--- a/core/test/differentiation_test.jl
+++ b/core/test/differentiation_test.jl
@@ -25,3 +25,31 @@
 
     @test all(isfinite, nonzeros(J.J_intermediate))
 end
+
+@testitem "HalfLazyJacobian converts to a dense matrix" begin
+    using Ribasim: reduce_state!
+
+    toml_path = normpath(@__DIR__, "../../generated_testmodels/basic/ribasim.toml")
+    model = Ribasim.Model(toml_path)
+    (; integrator) = model
+    (; p, u, t) = integrator
+    J = integrator.f.jac_prototype
+
+    du = J.du
+    Ribasim.water_balance!(du, u, p, t)
+    Ribasim.get_jacobian!(J, du, u, p, t, J.prep, J.backend)
+
+    (; u_reduced) = p.p_independent
+    n = length(u)
+    A = zeros(length(u_reduced), n)
+    unit_vector = copy(u)
+    for i in 1:n
+        unit_vector .= 0
+        unit_vector[i] = 1
+        reduce_state!(u_reduced, unit_vector, p.p_independent)
+        A[:, i] .= u_reduced
+    end
+    J_expected = J.J_intermediate * A
+
+    @test convert(AbstractMatrix, J) ≈ J_expected
+end


### PR DESCRIPTION
Update the Julia Manifest.toml to get the latest dependencies.

__Changed packages__
```
  Installing known registries into `~/.julia`
       Added `General` registry to ~/.julia/registries
    Updating registry at `~/.julia/registries/General.toml`
     Cloning git-repo `https://github.com/visr/PackageCompiler.jl`
    Updating git-repo `https://github.com/visr/PackageCompiler.jl`
     Cloning git-repo `https://github.com/SciML/DataInterpolations.jl`
    Updating git-repo `https://github.com/SciML/DataInterpolations.jl`
  Installing 106 artifacts
    Updating `~/work/Ribasim/Ribasim/Project.toml`
  [47edcb42] ↑ ADTypes v1.22.3 ⇒ v1.22.4
  [a10d1c49] ↑ DBInterface v2.6.1 ⇒ v2.7.0
  [459566f4] ↑ DiffEqCallbacks v4.19.0 ⇒ v4.19.1
  [6a86dc24] ↑ FiniteDiff v2.32.0 ⇒ v2.33.0
  [f6369f11] ↑ ForwardDiff v1.4.3 ⇒ v1.4.5
  [1344f307] ↑ OrdinaryDiffEqLowOrderRK v2.2.1 ⇒ v2.2.2
  [295af30f] ↑ Revise v3.16.2 ⇒ v3.16.3
  [c0aeaf25] ↑ SciMLOperators v1.25.2 ⇒ v1.26.1
    Updating `~/work/Ribasim/Ribasim/Manifest.toml`
  [47edcb42] ↑ ADTypes v1.22.3 ⇒ v1.22.4
  [38540f10] ↑ CommonSolve v0.2.12 ⇒ v0.2.13
  [f0e56b4a] ↑ ConcurrentUtilities v2.5.1 ⇒ v2.6.0
  [a10d1c49] ↑ DBInterface v2.6.1 ⇒ v2.7.0
  [459566f4] ↑ DiffEqCallbacks v4.19.0 ⇒ v4.19.1
  [7034ab61] ↑ FastBroadcast v1.3.5 ⇒ v1.3.6
  [a4df4552] ↑ FastPower v1.4.0 ⇒ v1.4.1
  [6a86dc24] ↑ FiniteDiff v2.32.0 ⇒ v2.33.0
  [f6369f11] ↑ ForwardDiff v1.4.3 ⇒ v1.4.5
  [77dc65aa] ↑ FunctionWrappersWrappers v1.12.0 ⇒ v1.12.1
  [682c06a0] ↑ JSON v1.6.1 ⇒ v1.7.1
  [87fe0de2] ↑ LineSearch v0.1.12 ⇒ v0.1.13
  [1344f307] ↑ OrdinaryDiffEqLowOrderRK v2.2.1 ⇒ v2.2.2
  [b4bd8bb3] ↑ OrdinaryDiffEqRosenbrockTableaus v2.4.0 ⇒ v2.4.1
  [69de0a69] ↑ Parsers v2.8.6 ⇒ v2.8.7
  [d236fae5] ↑ PreallocationTools v1.4.0 ⇒ v1.4.1
  [08abe8d2] ↑ PrettyTables v3.4.4 ⇒ v3.4.6
  [0c0d3e7f] ↑ PureKLU v1.2.0 ⇒ v1.4.0
  [731186ca] ↑ RecursiveArrayTools v4.3.5 ⇒ v4.3.6
  [295af30f] ↑ Revise v3.16.2 ⇒ v3.16.3
  [19f34311] ↑ SciMLJacobianOperators v0.1.16 ⇒ v0.1.17
  [a6db7da4] ↑ SciMLLogging v2.0.3 ⇒ v2.0.4
  [c0aeaf25] ↑ SciMLOperators v1.25.2 ⇒ v1.26.1
  [a57abbd0] ↑ SparseColumnPivotedQR v2.1.5 ⇒ v2.1.6
  [276daf66] ↑ SpecialFunctions v2.8.1 ⇒ v2.8.3
  [aedffcd0] ↑ Static v1.4.5 ⇒ v1.4.6
  [ec057cc2] ↑ StructUtils v2.8.2 ⇒ v2.8.5
  [2efcf032] ↑ SymbolicIndexingInterface v0.3.51 ⇒ v0.3.53
  [dc5dba14] ↑ TZJData v1.5.0+2025b ⇒ v1.5.1+2025b
  [5c2747f8] ↑ URIs v1.6.2 ⇒ v1.6.3
  [36c8627f] ↑ Pango_jll v1.57.1+0 ⇒ v1.58.0+0
        Info We haven't cleaned this depot up for a bit, running Pkg.gc()...
      Active manifest files: 1 found
      Active artifact files: 120 found
      Active scratchspaces: 0 found
     Deleted no artifacts, repos, packages or scratchspaces
```

__Packages still outdated after update__
```
Status `~/work/Ribasim/Ribasim/Project.toml`
  [82cc6244] DataInterpolations v9.0.3 `https://github.com/SciML/DataInterpolations.jl#fix_SCT_for_intinv_itps` (<v9.2.0)
⌃ [2b5f629d] DiffEqBase v7.8.0 (<v7.13.0)
⌅ [7ed4a6bd] LinearSolve v4.3.0 (<v5.8.0): OrdinaryDiffEqDifferentiation, OrdinaryDiffEqNonlinearSolve, OrdinaryDiffEqRosenbrock
⌃ [6ad6398a] OrdinaryDiffEqBDF v2.4.0 (<v2.4.1)
⌃ [bbf590c4] OrdinaryDiffEqCore v4.10.0 (<v4.13.0)
⌃ [4302a76b] OrdinaryDiffEqDifferentiation v3.4.1 (<v3.7.0)
⌃ [127b3ac7] OrdinaryDiffEqNonlinearSolve v2.4.0 (<v2.7.0)
⌃ [43230ef6] OrdinaryDiffEqRosenbrock v2.4.2 (<v2.6.3)
⌃ [2d112036] OrdinaryDiffEqSDIRK v2.8.1 (<v2.8.2)
⌃ [b1df2697] OrdinaryDiffEqTsit5 v2.1.0 (<v2.1.2)
⌅ [0bca4576] SciMLBase v3.39.1 (<v3.44.0): DiffEqBase, NonlinearSolveBase, OrdinaryDiffEqCore, OrdinaryDiffEqDifferentiation, OrdinaryDiffEqNonlinearSolve, OrdinaryDiffEqRosenbrock
```
<details>
<summary>
All package versions
</summary>

```

ADTypes ────────────────────────── v1.22.4
AMD ────────────────────────────── v0.5.3
AbstractTrees ──────────────────── v0.4.5
Accessors ──────────────────────── v0.1.45
Adapt ──────────────────────────── v4.7.0
AliasTables ────────────────────── v1.1.3
Aqua ───────────────────────────── v0.8.16
ArgCheck ───────────────────────── v2.5.0
ArnoldiMethod ──────────────────── v0.4.0
ArrayInterface ─────────────────── v7.27.0
BasicModelInterface ────────────── v0.1.1
BinaryHeaps ────────────────────── v1.0.4
BitFlags ───────────────────────── v0.1.10
Blosc_jll ──────────────────────── v1.21.7+0
BracketingNonlinearSolve ───────── v1.12.4
Bzip2_jll ──────────────────────── v1.0.9+0
CFTime ─────────────────────────── v0.2.10
CSV ────────────────────────────── v0.10.16
Cairo_jll ──────────────────────── v1.18.7+0
CloseOpenIntervals ─────────────── v0.1.13
CodeTracking ───────────────────── v3.0.2
CodecBzip2 ─────────────────────── v0.8.5
CodecZlib ──────────────────────── v0.7.8
ColorSchemes ───────────────────── v3.31.0
ColorTypes ─────────────────────── v0.12.1
ColorVectorSpace ───────────────── v0.11.0
Colors ─────────────────────────── v0.13.1
CommonDataModel ────────────────── v0.4.4
CommonSolve ────────────────────── v0.2.13
CommonSubexpressions ───────────── v0.3.1
CommonWorldInvalidations ───────── v1.1.2
Compat ─────────────────────────── v4.18.1
Compiler ───────────────────────── v0.1.1
CompositionsBase ───────────────── v0.1.2
ConcreteStructs ────────────────── v0.2.7
ConcurrentUtilities ────────────── v2.6.0
CondaPkg ───────────────────────── v0.2.36
Configurations ─────────────────── v0.17.6
ConstructionBase ───────────────── v1.6.0
Contour ────────────────────────── v0.6.3
Crayons ────────────────────────── v4.2.0
DBInterface ────────────────────── v2.7.0
DataAPI ────────────────────────── v1.16.0
DataFrames ─────────────────────── v1.8.2
DataStructures ─────────────────── v0.19.6
DataValueInterfaces ────────────── v1.0.0
Dbus_jll ───────────────────────── v1.16.2+0
DelimitedFiles ─────────────────── v1.9.1
DiffEqBase ─────────────────────── v7.8.0
DiffEqCallbacks ────────────────── v4.19.1
DiffResults ────────────────────── v1.1.0
DiffRules ──────────────────────── v1.16.0
DifferentiationInterface ───────── v0.7.20
DiskArrays ─────────────────────── v0.4.22
DisplayAs ──────────────────────── v0.1.6
DocStringExtensions ────────────── v0.9.5
Dualization ────────────────────── v0.7.7
EnumX ──────────────────────────── v1.0.7
EnzymeCore ─────────────────────── v0.8.21
EpollShim_jll ──────────────────── v0.0.20230411+1
ExceptionUnwrapping ────────────── v0.1.11
Expat_jll ──────────────────────── v2.8.2+0
ExprTools ──────────────────────── v0.1.11
ExproniconLite ─────────────────── v0.10.14
FFMPEG ─────────────────────────── v0.4.5
FFMPEG_jll ─────────────────────── v8.1.2+0
FastBroadcast ──────────────────── v1.3.6
FastClosures ───────────────────── v0.3.2
FastPower ──────────────────────── v1.4.1
FilePathsBase ──────────────────── v0.9.24
FillArrays ─────────────────────── v1.17.0
FindFirstFunctions ─────────────── v3.2.1
FiniteDiff ─────────────────────── v2.33.0
FixedPointNumbers ──────────────── v0.8.6
Fontconfig_jll ─────────────────── v2.17.1+0
Format ─────────────────────────── v1.3.7
ForwardDiff ────────────────────── v1.4.5
FreeType2_jll ──────────────────── v2.14.3+1
FriBidi_jll ────────────────────── v1.0.17+0
FunctionWrappers ───────────────── v1.1.3
FunctionWrappersWrappers ───────── v1.12.1
GLFW_jll ───────────────────────── v3.4.1+1
GPUArraysCore ──────────────────── v0.2.0
GR ─────────────────────────────── v0.73.26
GR_jll ─────────────────────────── v0.73.26+0
GettextRuntime_jll ─────────────── v0.22.4+0
Ghostscript_jll ────────────────── v9.55.1+0
Glib_jll ───────────────────────── v2.88.3+0
Glob ───────────────────────────── v1.5.0
Graphite2_jll ──────────────────── v1.3.16+0
Graphs ─────────────────────────── v1.14.0
Grisu ──────────────────────────── v1.0.2
HDF5_jll ───────────────────────── v2.2.0+0
HTTP ───────────────────────────── v1.11.0
HarfBuzz_jll ───────────────────── v8.5.1+0
HiGHS ──────────────────────────── v1.24.1
HiGHS_jll ──────────────────────── v1.15.1+1
Hwloc_jll ──────────────────────── v2.14.0+0
IOCapture ──────────────────────── v1.0.0
IfElse ─────────────────────────── v0.1.1
Infiltrator ────────────────────── v1.9.11
Inflate ────────────────────────── v0.1.5
InlineStrings ──────────────────── v1.4.5
IntelOpenMP_jll ────────────────── v2025.2.0+0
InverseFunctions ───────────────── v0.1.17
InvertedIndices ────────────────── v1.3.1
IrrationalConstants ────────────── v0.2.6
IterTools ──────────────────────── v1.10.0
IteratorInterfaceExtensions ────── v1.0.0
JLFzf ──────────────────────────── v0.1.11
JLLWrappers ────────────────────── v1.8.0
JSON ───────────────────────────── v1.7.1
JSON3 ──────────────────────────── v1.14.3
JpegTurbo_jll ──────────────────── v3.2.0+0
JuMP ───────────────────────────── v1.31.1
JuliaC ─────────────────────────── v0.3.8
JuliaInterpreter ───────────────── v0.11.4
Krylov ─────────────────────────── v0.10.9
LAME_jll ───────────────────────── v3.100.3+0
LERC_jll ───────────────────────── v4.1.0+0
LLVMOpenMP_jll ─────────────────── v22.1.7+0
LRUCache ───────────────────────── v1.6.2
LaTeXStrings ───────────────────── v1.4.0
Latexify ───────────────────────── v0.16.11
LayoutPointers ─────────────────── v0.1.17
LazilyInitializedFields ────────── v1.3.0
LeftChildRightSiblingTrees ─────── v0.3.0
Libffi_jll ─────────────────────── v3.4.7+0
Libglvnd_jll ───────────────────── v1.7.1+1
Libiconv_jll ───────────────────── v1.18.0+0
Libmount_jll ───────────────────── v2.42.0+0
Libtiff_jll ────────────────────── v4.7.3+0
Libuuid_jll ────────────────────── v2.42.0+0
LicenseCheck ───────────────────── v0.2.3
LineSearch ─────────────────────── v0.1.13
LinearSolve ────────────────────── v4.3.0
LogExpFunctions ────────────────── v0.3.29
LoggingExtras ──────────────────── v1.2.0
LoweredCodeUtils ───────────────── v3.8.0
Lz4_jll ────────────────────────── v1.10.1+0
MKL_jll ────────────────────────── v2025.2.0+0
MPIABI_jll ─────────────────────── v0.1.5+0
MPICH_jll ──────────────────────── v5.0.1+0
MPIPreferences ─────────────────── v0.1.12
MPItrampoline_jll ──────────────── v5.5.6+0
MacroTools ─────────────────────── v0.5.16
ManualMemory ───────────────────── v0.1.8
MarkdownTables ─────────────────── v1.1.0
MathOptAnalyzer ────────────────── v0.1.2
MathOptIIS ─────────────────────── v0.2.0
MathOptInterface ───────────────── v1.52.0
MaybeInplace ───────────────────── v0.1.7
MbedTLS ────────────────────────── v1.1.10
MbedTLS_jll ────────────────────── v2.28.1010+0
Measures ───────────────────────── v0.3.3
MetaGraphsNext ─────────────────── v0.8.0
MicroMamba ─────────────────────── v0.1.15
MicrosoftMPI_jll ───────────────── v10.1.4+3
Missings ───────────────────────── v1.2.0
Mocking ────────────────────────── v0.8.1
MuladdMacro ────────────────────── v0.2.7
MutableArithmetics ─────────────── v1.8.0
NCDatasets ─────────────────────── v0.14.15
NaNMath ────────────────────────── v1.1.4
NetCDF_jll ─────────────────────── v401.1000.100+0
NonlinearSolve ─────────────────── v4.21.1
NonlinearSolveBase ─────────────── v2.35.0
NonlinearSolveFirstOrder ───────── v2.2.0
NonlinearSolveQuasiNewton ──────── v1.14.0
NonlinearSolveSpectralMethods ──── v1.7.4
ObjectFile ─────────────────────── v0.5.1
OffsetArrays ───────────────────── v1.17.0
Ogg_jll ────────────────────────── v1.3.6+0
OpenBLAS32_jll ─────────────────── v0.3.34+0
OpenMPI_jll ────────────────────── v5.0.11+0
OpenSSL ────────────────────────── v1.6.1
OpenSpecFun_jll ────────────────── v0.5.6+0
Opus_jll ───────────────────────── v1.6.1+0
OrderedCollections ─────────────── v1.8.2
OrdinaryDiffEqBDF ──────────────── v2.4.0
OrdinaryDiffEqCore ─────────────── v4.10.0
OrdinaryDiffEqDifferentiation ──── v3.4.1
OrdinaryDiffEqLowOrderRK ───────── v2.2.2
OrdinaryDiffEqNonlinearSolve ───── v2.4.0
OrdinaryDiffEqRosenbrock ───────── v2.4.2
OrdinaryDiffEqRosenbrockTableaus ─ v2.4.1
OrdinaryDiffEqSDIRK ────────────── v2.8.1
OrdinaryDiffEqTsit5 ────────────── v2.1.0
OteraEngine ────────────────────── v1.1.3
Pango_jll ──────────────────────── v1.58.0+0
Parsers ────────────────────────── v2.8.7
Patchelf_jll ───────────────────── v0.18.1+0
Pidfile ────────────────────────── v1.3.0
Pixman_jll ─────────────────────── v0.46.4+0
PkgToSoftwareBOM ───────────────── v0.1.19
PlotThemes ─────────────────────── v3.3.0
PlotUtils ──────────────────────── v1.4.4
Plots ──────────────────────────── v1.41.6
PooledArrays ───────────────────── v1.4.3
PreallocationTools ─────────────── v1.4.1
PrecompileTools ────────────────── v1.3.4
Preferences ────────────────────── v1.5.2
PrettyTables ───────────────────── v3.4.6
ProgressLogging ────────────────── v0.1.6
PtrArrays ──────────────────────── v1.4.0
PureKLU ────────────────────────── v1.4.0
PythonCall ─────────────────────── v0.9.35
Qt6Base_jll ────────────────────── v6.10.2+2
Qt6Declarative_jll ─────────────── v6.10.2+2
Qt6ShaderTools_jll ─────────────── v6.10.2+1
Qt6Svg_jll ─────────────────────── v6.10.2+0
Qt6Wayland_jll ─────────────────── v6.10.2+1
RecipesBase ────────────────────── v1.3.4
RecipesPipeline ────────────────── v0.6.12
RecursiveArrayTools ────────────── v4.3.6
Reexport ───────────────────────── v1.2.2
RegistryInstances ──────────────── v0.1.0
RelocatableFolders ─────────────── v1.0.1
Requires ───────────────────────── v1.3.1
RespecializeParams ─────────────── v1.2.0
Revise ─────────────────────────── v3.16.3
RuntimeGeneratedFunctions ──────── v0.5.24
SIMDTypes ──────────────────────── v0.1.0
SPDX ───────────────────────────── v0.5.0
SQLite ─────────────────────────── v1.8.1
SQLite_jll ─────────────────────── v3.53.2+0
SciMLBase ──────────────────────── v3.39.1
SciMLJacobianOperators ─────────── v0.1.17
SciMLLogging ───────────────────── v2.0.4
SciMLOperators ─────────────────── v1.26.1
SciMLPublic ────────────────────── v1.2.4
SciMLStructures ────────────────── v1.10.4
Scratch ────────────────────────── v1.3.0
SentinelArrays ─────────────────── v1.4.10
Setfield ───────────────────────── v1.1.2
Showoff ────────────────────────── v1.0.3
SimpleBufferStream ─────────────── v1.2.0
SimpleNonlinearSolve ───────────── v2.13.1
SimpleTraits ───────────────────── v0.9.6
SortingAlgorithms ──────────────── v1.2.3
SparseColumnPivotedQR ──────────── v2.1.6
SparseConnectivityTracer ───────── v1.2.2
SparseMatrixColorings ──────────── v0.4.27
SpecialFunctions ───────────────── v2.8.3
StableRNGs ─────────────────────── v1.0.4
Static ─────────────────────────── v1.4.6
StaticArrayInterface ───────────── v1.10.0
StaticArrays ───────────────────── v1.9.18
StaticArraysCore ───────────────── v1.4.4
Statistics ─────────────────────── v1.11.1
StatsAPI ───────────────────────── v1.8.0
StatsBase ──────────────────────── v0.34.12
StrideArraysCore ───────────────── v0.5.9
StringManipulation ─────────────── v0.4.7
StructArrays ───────────────────── v0.7.3
StructIO ───────────────────────── v0.3.1
StructTypes ────────────────────── v1.11.0
StructUtils ────────────────────── v2.8.5
SymbolicIndexingInterface ──────── v0.3.53
TZJData ────────────────────────── v1.5.1+2025b
TableTraits ────────────────────── v1.0.1
Tables ─────────────────────────── v1.13.0
TensorCore ─────────────────────── v0.1.1
TerminalLoggers ────────────────── v0.1.8
TestItemRunner ─────────────────── v1.1.5
TestItems ──────────────────────── v1.0.0
ThreadingUtilities ─────────────── v0.5.6
TimeZones ──────────────────────── v1.22.2
TimerOutputs ───────────────────── v0.5.29
TranscodingStreams ─────────────── v0.11.3
TruncatedStacktraces ───────────── v1.4.0
URIs ───────────────────────────── v1.6.3
UnicodeFun ─────────────────────── v0.4.1
UnsafePointers ─────────────────── v1.0.0
Unzip ──────────────────────────── v0.2.0
Vulkan_Loader_jll ──────────────── v1.3.243+0
Wayland_jll ────────────────────── v1.24.0+0
WeakRefStrings ─────────────────── v1.4.3
WorkerUtilities ────────────────── v1.6.1
XML2_jll ───────────────────────── v2.13.9+0
XZ_jll ─────────────────────────── v5.8.3+0
Xorg_libICE_jll ────────────────── v1.1.2+0
Xorg_libSM_jll ─────────────────── v1.2.6+0
Xorg_libX11_jll ────────────────── v1.8.13+0
Xorg_libXau_jll ────────────────── v1.0.13+0
Xorg_libXcursor_jll ────────────── v1.2.4+0
Xorg_libXdmcp_jll ──────────────── v1.1.6+0
Xorg_libXext_jll ───────────────── v1.3.8+0
Xorg_libXfixes_jll ─────────────── v6.0.2+0
Xorg_libXi_jll ─────────────────── v1.8.4+0
Xorg_libXinerama_jll ───────────── v1.1.7+0
Xorg_libXrandr_jll ─────────────── v1.5.6+0
Xorg_libXrender_jll ────────────── v0.9.12+0
Xorg_libpciaccess_jll ──────────── v0.19.0+0
Xorg_libxcb_jll ────────────────── v1.17.1+0
Xorg_libxkbfile_jll ────────────── v1.2.0+0
Xorg_xcb_util_cursor_jll ───────── v0.1.6+0
Xorg_xcb_util_image_jll ────────── v0.4.1+0
Xorg_xcb_util_jll ──────────────── v0.4.1+0
Xorg_xcb_util_keysyms_jll ──────── v0.4.1+0
Xorg_xcb_util_renderutil_jll ───── v0.3.10+0
Xorg_xcb_util_wm_jll ───────────── v0.4.2+0
Xorg_xkbcomp_jll ───────────────── v1.4.7+0
Xorg_xkeyboard_config_jll ──────── v2.47.0+2
Xorg_xtrans_jll ────────────────── v1.6.0+0
Zstd_jll ───────────────────────── v1.5.7+1
artifact Blosc                    44.2 KiB
artifact Bzip2                    503.5 KiB
artifact Cairo                    2.2 MiB
artifact Dbus                     489.8 KiB
artifact Expat                    297.5 KiB
artifact FFMPEG                   11.9 MiB
artifact Fontconfig               984.8 KiB
artifact FreeType2                1.5 MiB
artifact FriBidi                  78.9 KiB
artifact GLFW                     187.9 KiB
artifact GR                       19.3 MiB
artifact GettextRuntime           543.0 KiB
artifact Ghostscript              31.4 MiB
artifact Glib                     7.8 MiB
artifact Graphite2                120.3 KiB
artifact HDF5                     6.1 MiB
artifact HarfBuzz                 1.7 MiB
artifact HiGHS                    3.1 MiB
artifact Hwloc                    3.5 MiB
artifact JpegTurbo                1.9 MiB
artifact LAME                     292.5 KiB
artifact LERC                     267.4 KiB
artifact LLVMOpenMP               680.4 KiB
artifact Libffi                   44.2 KiB
artifact Libglvnd                 833.5 KiB
artifact Libiconv                 1.9 MiB
artifact Libmount                 6.9 MiB
artifact Libtiff                  2.4 MiB
artifact Libuuid                  3.9 MiB
artifact Lz4                      239.7 KiB
artifact MPICH                    8.8 MiB
artifact MbedTLS                  2.2 MiB
artifact NetCDF                   970.6 KiB
artifact Ogg                      250.3 KiB
artifact OpenBLAS32               10.3 MiB
artifact OpenSpecFun              194.9 KiB
artifact Opus                     960.9 KiB
artifact Pango                    2.1 MiB
artifact Patchelf                 1.1 MiB
artifact Pixman                   390.8 KiB
artifact Qt6Base                  23.1 MiB
artifact Qt6Declarative           23.8 MiB
artifact Qt6ShaderTools           2.1 MiB
artifact Qt6Svg                   386.4 KiB
artifact Qt6Wayland               1.4 MiB
artifact SQLite                   1.8 MiB
artifact Vulkan_Loader            177.3 KiB
artifact Wayland                  390.6 KiB
artifact XML2                     2.5 MiB
artifact XZ                       1.6 MiB
artifact Xorg_libICE              384.9 KiB
artifact Xorg_libSM               164.1 KiB
artifact Xorg_libX11              4.8 MiB
artifact Xorg_libXau              36.6 KiB
artifact Xorg_libXcursor          227.1 KiB
artifact Xorg_libXdmcp            67.7 KiB
artifact Xorg_libXext             286.6 KiB
artifact Xorg_libXfixes           59.0 KiB
artifact Xorg_libXi               1.6 MiB
artifact Xorg_libXinerama         25.5 KiB
artifact Xorg_libXrandr           97.3 KiB
artifact Xorg_libXrender          435.9 KiB
artifact Xorg_libpciaccess        26.2 KiB
artifact Xorg_libxcb              2.1 MiB
artifact Xorg_libxkbfile          91.1 KiB
artifact Xorg_xcb_util            39.5 KiB
artifact Xorg_xcb_util_cursor     27.6 KiB
artifact Xorg_xcb_util_image      54.3 KiB
artifact Xorg_xcb_util_keysyms    17.8 KiB
artifact Xorg_xcb_util_renderutil 32.1 KiB
artifact Xorg_xcb_util_wm         147.9 KiB
artifact Xorg_xkbcomp             274.8 KiB
artifact Xorg_xkeyboard_config    1.1 MiB
artifact Xorg_xtrans              48.2 KiB
artifact Zstd                     646.0 KiB
artifact aws_c_auth               130.3 KiB
artifact aws_c_cal                1.2 MiB
artifact aws_c_common             285.2 KiB
artifact aws_c_compression        13.4 KiB
artifact aws_c_http               387.4 KiB
artifact aws_c_io                 181.7 KiB
artifact aws_c_s3                 143.0 KiB
artifact aws_c_sdkutils           54.9 KiB
artifact aws_checksums            87.0 KiB
artifact eudev                    3.9 MiB
artifact fzf                      3.3 MiB
artifact libaec                   50.4 KiB
artifact libaom                   6.4 MiB
artifact libass                   427.8 KiB
artifact libdecor                 44.1 KiB
artifact libdrm                   372.6 KiB
artifact libevdev                 117.1 KiB
artifact libfdk_aac               2.8 MiB
artifact libinput                 1.0 MiB
artifact libpng                   329.4 KiB
artifact libva                    235.7 KiB
artifact libvorbis                271.0 KiB
artifact libzip                   177.6 KiB
artifact licensecheck             2.4 MiB
artifact mtdev                    79.6 KiB
artifact s2n_tls                  1.8 MiB
artifact testfiles                6.2 MiB
artifact tzjdata                  112.5 KiB
artifact x264                     2.1 MiB
artifact x265                     1.4 MiB
artifact xkbcommon                298.7 KiB
aws_c_auth_jll ─────────────────── v0.9.6+0
aws_c_cal_jll ──────────────────── v0.9.13+0
aws_c_common_jll ───────────────── v0.12.6+0
aws_c_compression_jll ──────────── v0.3.2+0
aws_c_http_jll ─────────────────── v0.10.13+0
aws_c_io_jll ───────────────────── v0.26.3+0
aws_c_s3_jll ───────────────────── v0.11.5+0
aws_c_sdkutils_jll ─────────────── v0.2.4+1
aws_checksums_jll ──────────────── v0.2.10+0
dlfcn_win32_jll ────────────────── v1.4.2+0
eudev_jll ──────────────────────── v3.2.14+0
fzf_jll ────────────────────────── v0.61.1+0
libaec_jll ─────────────────────── v1.1.7+0
libaom_jll ─────────────────────── v3.13.3+0
libass_jll ─────────────────────── v0.17.4+0
libdecor_jll ───────────────────── v0.2.2+0
libdrm_jll ─────────────────────── v2.4.134+0
libevdev_jll ───────────────────── v1.13.4+0
libfdk_aac_jll ─────────────────── v2.0.4+0
libinput_jll ───────────────────── v1.28.1+0
libpng_jll ─────────────────────── v1.6.58+0
libva_jll ──────────────────────── v2.23.0+0
libvorbis_jll ──────────────────── v1.3.8+0
libzip_jll ─────────────────────── v1.11.3+0
licensecheck_jll ───────────────── v0.4.0+0
micromamba_jll ─────────────────── v2.3.1+0
mpif_jll ───────────────────────── v0.1.7+0
mtdev_jll ──────────────────────── v1.1.7+0
oneTBB_jll ─────────────────────── v2022.3.0+0
pixi_jll ───────────────────────── v0.63.2+0
s2n_tls_jll ────────────────────── v1.7.3+0
x264_jll ───────────────────────── v10164.0.1+0
x265_jll ───────────────────────── v4.1.0+0
xkbcommon_jll ──────────────────── v1.13.0+0
