### PR TITLE
Don't set external filepath in TOML `if df is None`

### DIFF
--- a/docs/reference/usage.qmd
+++ b/docs/reference/usage.qmd
@@ -233,6 +233,9 @@ To revert a table back to being stored in the GeoPackage database instead of an 
 model.basin.profile.filepath = None
 ```
 
+If a table is absent, its external filepath is omitted from the TOML.
+Existing external files are not deleted when overwriting a model, but Ribasim uses them only when they are referenced in the TOML.
+
 ### Using result files as initial conditions
 
 One common use case is to use the final state of a simulation as the initial condition for

--- a/python/ribasim/ribasim/input_base.py
+++ b/python/ribasim/ribasim/input_base.py
@@ -480,7 +480,7 @@ class TableModel[TableT: _BaseSchema](FileModel, ChildModel):
 
     @model_serializer
     def _set_model(self) -> "str | None":
-        if self.is_external:
+        if self.is_external and self.df is not None:
             assert self.filepath is not None
             return self.filepath.as_posix()
         else:

--- a/python/ribasim/tests/test_input_base.py
+++ b/python/ribasim/tests/test_input_base.py
@@ -96,3 +96,12 @@ def test_filepath_appears_in_toml(tmp_path):
         assert "level" in ds.variables, "level should be in the dataset"
         assert "area" in ds.variables, "area should be in the dataset"
         assert len(ds["level"]) == 3, "Should have 3 profile points"
+
+    model.basin.profile.df = None
+    model.write(toml_path)
+
+    with Path.open(toml_path, "rb") as f:
+        toml_data = tomli.load(f)
+
+    assert "basin" not in toml_data, "basin section should be removed from TOML"
+    assert nc_path.exists(), "existing NetCDF file should not be deleted"


### PR DESCRIPTION
If I have a model with this external file:

```toml
[basin]
time = "basin_time.nc"
```

And I then remove that table in Python:

```python
model.basin.time.df = None
```

It will leave the reference in the TOML, but not write the NetCDF file. That crashes the core with:

```
ERROR: NetCDF error: Opening path input/basin_time.nc: No such file or directory (NetCDF error code: 2)
```

What I want is to remove the TOML reference when I clear the table in Python.

Ran into this in Ribasim-NL.