### PR TITLE
Dependabot re-enable Julia, monthly intervals

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,19 @@
 # https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
 version: 2
-enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       all-actions:
         patterns:
           - "*"
-# - package-ecosystem: "julia"
-#   directory: "/"
-#   schedule:
-#     interval: "weekly"
-#   groups: # group all julia package updates into a single PR
-#     all-julia-packages:
-#       patterns:
-#         - "*"
+  - package-ecosystem: "julia"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups: # group all julia package updates into a single PR
+      all-julia-packages:
+        patterns:
+          - "*"


### PR DESCRIPTION
Weekly is a bit noisy, and we do the other updates monthly as well.

Dependabot was previously disabled because it wanted to add compat bounds everywhere.
Let's see if it works the way we want after https://github.com/dependabot/dependabot-core/pull/15643

