### PR TITLE
Refactor to single main loop and allocation call

### DIFF
--- a/core/src/Ribasim.jl
+++ b/core/src/Ribasim.jl
@@ -32,7 +32,7 @@ using DifferentiationInterface:
 using ForwardDiff: derivative as forward_diff
 
 # Algorithms for solving ODEs.
-using OrdinaryDiffEqCore: OrdinaryDiffEqCore
+using OrdinaryDiffEqCore: OrdinaryDiffEqCore, loopheader!
 using OrdinaryDiffEqDifferentiation:
     OrdinaryDiffEqDifferentiation, dolinsolve, jacobian2W!
 using SciMLOperators: WOperator, MatrixOperator
@@ -52,6 +52,7 @@ using SciMLBase:
     ODEProblem,
     get_du,
     get_proposed_dt,
+    add_tstop!,
     DEIntegrator,
     FullSpecialize,
     NoSpecialize,

--- a/core/src/allocation_optim.jl
+++ b/core/src/allocation_optim.jl
@@ -1274,12 +1274,11 @@ Solve the allocation problem for all demands and assign allocated abstractions.
 whether `cumulative_supplied_volume` is reset. Set `record = false` for
 intermediate (sub-saveat) adaptive LP solves
 """
-function update_allocation!(model, Δt::Float64; record::Bool = true)::Nothing
-    (; integrator, config) = model
+function update_allocation!(integrator::DEIntegrator, Δt::Float64; record::Bool = true)::Nothing
     (; u, p, t) = integrator
     (; p_independent) = p
     (; allocation, pump, outlet, tabulated_rating_curve) = p_independent
-    (; allocation_models, primary_network_connections, demand_priorities_all) = allocation
+    (; allocation_models, primary_network_connections, demand_priorities_all, config) = allocation
 
     # Don't run the allocation algorithm if allocation is not active
     !is_active(allocation) && return nothing

--- a/core/src/allocation_util.jl
+++ b/core/src/allocation_util.jl
@@ -648,3 +648,28 @@ function delete_flow!(
     (; problem) = allocation_model
     return JuMP.delete(problem, problem[:flow])
 end
+
+function add_allocation_tstop!(time::AllocationTime, tstop_new::Float64)
+    return if tstop_new ∉ time.tstops
+        insert!(
+            time.tstops,
+            searchsortedfirst(time.tstops, tstop_new),
+            tstop_new
+        )
+        @assert issorted(time.tstops)
+    end
+end
+
+"""
+Whether `t` falls on a save boundary, i.e. a multiple of `saveat` or the end
+of the simulation horizon. The save grid is degenerate when `saveat` is 0 (every
+step) or `Inf` (only end), so both return `true`.
+"""
+function is_saveat_time(t::Float64, time::AllocationTime; atol::Float64 = 1.0e-9)::Bool
+    (; saveat, t_end) = time
+    iszero(saveat) && return true
+    isinf(saveat) && return true
+    isapprox(t, t_end; atol) && return true
+    rem = t % saveat
+    return isapprox(rem, 0.0; atol) || isapprox(rem, saveat; atol)
+end

--- a/core/src/allocation_util.jl
+++ b/core/src/allocation_util.jl
@@ -357,12 +357,12 @@ The timestep is bounded by two linearization error sources:
 Both give a Δh_max. The global Δh_max is the minimum across all basins
 and connector nodes. Then Δt_i = A_i·Δh_max / |dS_i/dt| per basin.
 """
-function compute_adaptive_Δt(
+function compute_adaptive_allocation_Δt(
         allocation_model::AllocationModel,
         p::Parameters,
         du::CVector,
         t::Float64,
-        allocation_config,
+        config::Config,
     )::Float64
     (; node_ids_in_subnetwork) = allocation_model
     (;
@@ -374,8 +374,8 @@ function compute_adaptive_Δt(
     (; basin, tabulated_rating_curve, linear_resistance, manning_resistance) = p.p_independent
     (; current_storage) = p.state_and_time_dependent_cache
 
-    Δt_min = allocation_config.dtmin
-    ε_rel = allocation_config.reltol_linearization
+    Δt_min = config.allocation.dtmin
+    ε_rel = config.allocation.reltol_linearization
     overshoot_reduction = 0.8
 
     # Phase 1: compute global Δh_max from all linearization curvatures

--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -46,7 +46,7 @@ function BMI.update_until(model::Model, time::Float64)::Nothing
     elseif dt == 0
         return nothing
     else
-        step!(model, dt)
+        SciMLBase.step!(model.integrator, dt, true)
     end
     return nothing
 end

--- a/core/src/bmi.jl
+++ b/core/src/bmi.jl
@@ -46,6 +46,7 @@ function BMI.update_until(model::Model, time::Float64)::Nothing
     elseif dt == 0
         return nothing
     else
+        add_allocation_tstop!(model.integrator.p.p_independent.allocation.time, time)
         SciMLBase.step!(model.integrator, dt, true)
     end
     return nothing

--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -278,71 +278,44 @@ function is_finished(model::Model)::Bool
 end
 
 """
-    step!(model::Model, dt::Float64)::Model
-
-Take Model timesteps until `t + dt` is reached exactly.
+Wrap the loopheader! call from the OrdinaryDiffEq.jl internals to inject the allocation call
+before a timestep when needed.
 """
-function step!(model::Model, dt::Float64)::Model
-    (; config, integrator) = model
-    (; t) = integrator
-    if config.experimental.allocation
-        dt_allocation = config.allocation.dt
-        if isnothing(dt_allocation)
-            error(
-                """
-                Ribasim was called with allocation active and adaptive timestepping from the BMI, which is currently not supported.
-                Supply a fixed allocation timestep in the Ribasim config.
-                """
-            )
-        end
-        ntimes = t / dt_allocation
-        if round(ntimes) ≈ ntimes
-            update_allocation!(model, dt_allocation)
-        end
+function OrdinaryDiffEqCore.loopheader!(integrator::DEIntegrator{<:Any, <:Any, RibasimCVectorType{Float64}})
+    (; p, t) = integrator
+    (; allocation) = p.p_independent
+    t_end::Float64 = integrator.sol.prob.tspan[end]
+    if is_active(allocation) && (t == allocation.time.t_allocation_next)
+        allocation_Δt = compute_adaptive_allocation_Δt(integrator, t_end)
+        update_allocation!(integrator, allocation_Δt, record = is_saveat_time(t, allocation.time.saveat, t_end))
+        allocation.time.t_allocation_next += allocation_Δt
+        add_tstop!(integrator, t + allocation_Δt)
     end
-    SciMLBase.step!(integrator, dt, true)
-    return model
+    return invoke(loopheader!, Tuple{DEIntegrator}, integrator)
 end
 
 """
 Compute and return  the adaptive allocation Δt if the timestepping is adaptive, otherwise return
 the fixed timestep.
 """
-function compute_allocation_Δt(model, saveat, tspan_end)::Float64
-    (; config, integrator) = model
+function compute_adaptive_allocation_Δt(integrator, tspan_end)::Float64
     (; u, p, t) = integrator
     (; allocation) = p.p_independent
 
-    if isnothing(allocation.dt_allocation)
+    if allocation.time.adaptive
         du = get_du(integrator)
 
         water_balance!(du, u, p, t)
 
-        Δt = time_to_next_saveat(t, saveat, tspan_end)
+        Δt = time_to_next_saveat(t, allocation.time.saveat, tspan_end)
         for am in allocation.allocation_models
-            Δt_sub = compute_adaptive_Δt(am, p, du, t, config.allocation)
+            Δt_sub = compute_adaptive_allocation_Δt(am, p, du, t, allocation.config)
             Δt = min(Δt, Δt_sub)
         end
         return Δt
     else
-        return allocation.dt_allocation
+        return allocation.time.dt_fixed
     end
-end
-
-"""
-Step through the simulation with allocation, using either adaptive or fixed timesteps.
-"""
-function solve_with_allocation!(model::Model)::Nothing
-    (; config, integrator) = model
-    (; tspan::Tuple{Float64, Float64}) = integrator.sol.prob
-    (; saveat) = config.solver
-    t_end::Float64 = integrator.sol.prob.tspan[end]
-    while integrator.t < t_end - eps(t_end)
-        Δt = compute_allocation_Δt(model, saveat, t_end)
-        update_allocation!(model, Δt; record = is_saveat_time(integrator.t, saveat, t_end))
-        SciMLBase.step!(integrator, Δt, true)
-    end
-    return nothing
 end
 
 """
@@ -351,13 +324,9 @@ end
 Solve a Model until the configured `endtime`.
 """
 function solve!(model::Model)::Model
-    (; config, integrator) = model
+    (; integrator) = model
 
-    comptime_s = @elapsed if config.experimental.allocation
-        solve_with_allocation!(model)
-    else
-        SciMLBase.solve!(integrator)
-    end
+    comptime_s = @elapsed SciMLBase.solve!(integrator)
     check_error!(integrator)
     comptime = canonicalize(Millisecond(round(Int, comptime_s * 1000)))
     @info "Computation time: $comptime"

--- a/core/src/model.jl
+++ b/core/src/model.jl
@@ -280,16 +280,24 @@ end
 """
 Wrap the loopheader! call from the OrdinaryDiffEq.jl internals to inject the allocation call
 before a timestep when needed.
+
+Workaround for pre-step callbacks: https://github.com/SciML/OrdinaryDiffEq.jl/issues/3977
 """
 function OrdinaryDiffEqCore.loopheader!(integrator::DEIntegrator{<:Any, <:Any, RibasimCVectorType{Float64}})
     (; p, t) = integrator
     (; allocation) = p.p_independent
-    t_end::Float64 = integrator.sol.prob.tspan[end]
-    if is_active(allocation) && (t == allocation.time.t_allocation_next)
-        allocation_Δt = compute_adaptive_allocation_Δt(integrator, t_end)
-        update_allocation!(integrator, allocation_Δt, record = is_saveat_time(t, allocation.time.saveat, t_end))
-        allocation.time.t_allocation_next += allocation_Δt
-        add_tstop!(integrator, t + allocation_Δt)
+    if is_active(allocation) && !isempty(allocation.time.tstops)
+        if (t == first(allocation.time.tstops))
+            popfirst!(allocation.time.tstops)
+            tstop_new = compute_next_allocation_tstop(integrator)
+            allocation_Δt = tstop_new - t
+            update_allocation!(integrator, allocation_Δt, record = is_saveat_time(t, allocation.time))
+            tstop_new = t + allocation_Δt
+            add_allocation_tstop!(allocation.time, tstop_new)
+            add_tstop!(integrator, tstop_new)
+        elseif (t > first(allocation.time.tstops))
+            error("Allocation has skipped a tstop, please make an issue.")
+        end
     end
     return invoke(loopheader!, Tuple{DEIntegrator}, integrator)
 end
@@ -298,23 +306,31 @@ end
 Compute and return  the adaptive allocation Δt if the timestepping is adaptive, otherwise return
 the fixed timestep.
 """
-function compute_adaptive_allocation_Δt(integrator, tspan_end)::Float64
+function compute_next_allocation_tstop(integrator)::Float64
     (; u, p, t) = integrator
     (; allocation) = p.p_independent
 
-    if allocation.time.adaptive
+    Δt = if allocation.time.adaptive
         du = get_du(integrator)
 
         water_balance!(du, u, p, t)
+        Δt = Inf
 
-        Δt = time_to_next_saveat(t, allocation.time.saveat, tspan_end)
         for am in allocation.allocation_models
             Δt_sub = compute_adaptive_allocation_Δt(am, p, du, t, allocation.config)
             Δt = min(Δt, Δt_sub)
         end
-        return Δt
+        Δt
     else
-        return allocation.time.dt_fixed
+        allocation.time.dt_fixed
+    end
+    (Δt ≤ 0) && error("A non-positive allocation timestep was computed, please make an issue.")
+
+    tstop_next = t + Δt
+    return if tstop_next ≈ first(allocation.time.tstops)
+        first(allocation.time.tstops)
+    else
+        min(first(allocation.time.tstops), tstop_next)
     end
 end
 

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -336,7 +336,8 @@ allocation_models: The allocation models for the primary network and subnetworks
 primary_network_connections: (from_id: pump or outlet in the primary network, to_id: node in the subnetwork, generally a basin)
     per subnetwork
 demand_priorities_all: All used demand priority values from all subnetworks
-adaptive: True for adaptive timestepping, false for fixed timestep of dt_allocation
+config: The Ribasim Model config
+time: The data needed to handle allocation timestepping
 record_demand: A record of demands and allocated flows for nodes that have these
 record_flow: A record of all flows computed by allocation optimization, eventually saved to
     output file

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -326,6 +326,17 @@ Data for the allocation timestepping
     tstops::Vector{Float64} = [0.0]
     # The output writing interval
     const saveat::Float64 = 0.0
+
+    function AllocationTime(
+            adaptive::Bool,
+            dt_fixed::Float64,
+            t_end::Float64,
+            tstops::Vector{Float64},
+            saveat::Float64,
+        )
+        adaptive && !iszero(dt_fixed) && throw(ArgumentError("dt_fixed must be 0.0 when adaptive."))
+        return new(adaptive, dt_fixed, t_end, tstops, saveat)
+    end
 end
 
 """

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -320,8 +320,10 @@ Data for the allocation timestepping
     const adaptive::Bool = true
     # The fixed timestep if applicable
     const dt_fixed::Float64 = 0.0
-    # The time (s) when allocation is called next
-    t_allocation_next::Float64 = 0.0
+    # The endtime of the simulation in se
+    const t_end::Float64 = 0.0
+    # The times (s) when allocation is called next
+    tstops::Vector{Float64} = [0.0]
     # The output writing interval
     const saveat::Float64 = 0.0
 end
@@ -346,8 +348,8 @@ record_control: A record of all flow rates assigned to pumps and outlets by allo
     primary_network_connections::OrderedDict{Int32, Vector{Tuple{NodeID, NodeID}}} =
         OrderedDict()
     demand_priorities_all::Vector{Int32} = []
-    time::AllocationTime = AllocationTime(; adaptive = true)
     config::Config
+    time::AllocationTime = AllocationTime(config)
     record_demand::Vector{DemandRecordDatum} = []
     record_flow::Vector{FlowRecordDatum} = []
     record_control::Vector{AllocationControlRecordDatum} = []

--- a/core/src/parameter.jl
+++ b/core/src/parameter.jl
@@ -314,6 +314,19 @@ struct AllocationControlRecordDatum
 end
 
 """
+Data for the allocation timestepping
+"""
+@kwdef mutable struct AllocationTime
+    const adaptive::Bool = true
+    # The fixed timestep if applicable
+    const dt_fixed::Float64 = 0.0
+    # The time (s) when allocation is called next
+    t_allocation_next::Float64 = 0.0
+    # The output writing interval
+    const saveat::Float64 = 0.0
+end
+
+"""
 Object for all information about allocation
 subnetwork_ids: The unique sorted allocation network IDs
 allocation_models: The allocation models for the primary network and subnetworks corresponding to
@@ -321,7 +334,6 @@ allocation_models: The allocation models for the primary network and subnetworks
 primary_network_connections: (from_id: pump or outlet in the primary network, to_id: node in the subnetwork, generally a basin)
     per subnetwork
 demand_priorities_all: All used demand priority values from all subnetworks
-dt_allocation: Used as the timestep if the timestepping is not adaptive
 adaptive: True for adaptive timestepping, false for fixed timestep of dt_allocation
 record_demand: A record of demands and allocated flows for nodes that have these
 record_flow: A record of all flows computed by allocation optimization, eventually saved to
@@ -334,7 +346,8 @@ record_control: A record of all flow rates assigned to pumps and outlets by allo
     primary_network_connections::OrderedDict{Int32, Vector{Tuple{NodeID, NodeID}}} =
         OrderedDict()
     demand_priorities_all::Vector{Int32} = []
-    dt_allocation::Union{Float64, Nothing} = nothing
+    time::AllocationTime = AllocationTime(; adaptive = true)
+    config::Config
     record_demand::Vector{DemandRecordDatum} = []
     record_flow::Vector{FlowRecordDatum} = []
     record_control::Vector{AllocationControlRecordDatum} = []

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -1683,10 +1683,17 @@ function Subgrid(db::DB, config::Config, basin::Basin)
 end
 
 function Allocation(db::DB, config::Config, graph::MetaGraph)::Allocation
+    dt_fixed = config.allocation.dt
+    time = if isnothing(dt_fixed)
+        AllocationTime(; adaptive = true, config.solver.saveat)
+    else
+        AllocationTime(; adaptive = false, dt_fixed, config.solver.saveat)
+    end
     return Allocation(;
         demand_priorities_all = get_all_demand_priorities(db, config),
         subnetwork_ids = sort(collect(keys(graph[].node_ids))),
-        dt_allocation = config.allocation.dt,
+        config,
+        time,
     )
 end
 

--- a/core/src/read.jl
+++ b/core/src/read.jl
@@ -1682,18 +1682,26 @@ function Subgrid(db::DB, config::Config, basin::Basin)
     return subgrid
 end
 
-function Allocation(db::DB, config::Config, graph::MetaGraph)::Allocation
+function AllocationTime(config::Config)
+    (; saveat) = config.solver
     dt_fixed = config.allocation.dt
-    time = if isnothing(dt_fixed)
-        AllocationTime(; adaptive = true, config.solver.saveat)
-    else
-        AllocationTime(; adaptive = false, dt_fixed, config.solver.saveat)
-    end
+    t_end = seconds_since(config.endtime, config.starttime)
+    tstops = iszero(saveat) ? [0.0] : collect(range(0, t_end; step = saveat))
+
+    return AllocationTime(;
+        adaptive = isnothing(dt_fixed),
+        dt_fixed = something(dt_fixed, 0.0),
+        t_end,
+        tstops,
+        saveat,
+    )
+end
+
+function Allocation(db::DB, config::Config, graph::MetaGraph)::Allocation
     return Allocation(;
         demand_priorities_all = get_all_demand_priorities(db, config),
         subnetwork_ids = sort(collect(keys(graph[].node_ids))),
-        config,
-        time,
+        config
     )
 end
 

--- a/core/src/util.jl
+++ b/core/src/util.jl
@@ -440,33 +440,6 @@ function get_Δt(integrator)::Float64
     end
 end
 
-"""
-Time from `t` to the next save boundary, capped at `t_end`.
-
-For `saveat == 0` (every step saved) or `saveat == Inf` (only end saved),
-the full remaining horizon is returned so the caller imposes no extra clamp.
-"""
-function time_to_next_saveat(t::Float64, saveat::Float64, t_end::Float64)::Float64
-    iszero(saveat) && return t_end - t
-    isinf(saveat) && return t_end - t
-    rem = t % saveat
-    Δ = iszero(rem) ? saveat : saveat - rem
-    return min(Δ, t_end - t)
-end
-
-"""
-Whether `t` falls on a save boundary, i.e. a multiple of `saveat` or the end
-of the simulation horizon. The save grid is degenerate when `saveat` is 0 (every
-step) or `Inf` (only end), so both return `true`.
-"""
-function is_saveat_time(t::Float64, saveat::Float64, t_end::Float64; atol::Float64 = 1.0e-9)::Bool
-    iszero(saveat) && return true
-    isinf(saveat) && return true
-    isapprox(t, t_end; atol) && return true
-    rem = t % saveat
-    return isapprox(rem, 0.0; atol) || isapprox(rem, saveat; atol)
-end
-
 inflow_link(graph, node_id)::LinkMetadata = graph[inflow_id(graph, node_id), node_id]
 outflow_link(graph, node_id)::LinkMetadata = graph[node_id, outflow_id(graph, node_id)]
 

--- a/core/test/allocation_test.jl
+++ b/core/test/allocation_test.jl
@@ -534,9 +534,9 @@ end
     @test all(>(0), nonlinear_curvatures)
 end
 
-@testitem "compute_adaptive_Δt" begin
+@testitem "compute_adaptive_allocation_Δt" begin
     import Ribasim
-    using Ribasim: compute_adaptive_Δt, water_balance!, get_du
+    using Ribasim: compute_adaptive_allocation_Δt, water_balance!, get_du
 
     toml_path = normpath(
         @__DIR__,
@@ -553,7 +553,7 @@ end
     water_balance!(du, u, p, t)
 
     for am in allocation.allocation_models
-        Δt = compute_adaptive_Δt(am, p, du, t, config.allocation)
+        Δt = compute_adaptive_allocation_Δt(am, p, du, t, config)
 
         # Result must be at least dtmin and positive
         @test Δt >= config.allocation.dtmin


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/3213
Fixes https://github.com/Deltares/Ribasim/issues/3158

The approach of overloading `OrdinaryDiffEqCore.loopheader!` in combination with `invoke` is not the prettiest, but I think unifying the way allocation is called in different scenarios is worth it.

Now that we support the adaptive timestep for allocation when calling Ribasim from the BMI, we have to be careful about synchronization. It would make sense from the side of a coupler that Ribasim calls allocation each time the demands are updated from the outside, but that is not necessarily the case. The only thing a coupler can rely on is that allocation is called at each multiple of `saveat`, but that seems brittle / not what it was meant for. I think it would be the most clear if allocation updates on multiples of the supplied allocation timestep even if it is adaptive, but that is not compatible with the current config (and also enforces coupling on a fixed timestep). We could also design it such that the `update_until` `t` also becomes an update time for allocation, meaning that allocation has to keep track of its own `tstops`.