### PR TITLE
Switch default solver to NordsieckBDF

### DIFF
--- a/core/src/config.jl
+++ b/core/src/config.jl
@@ -19,7 +19,7 @@ using OrdinaryDiffEqNonlinearSolve: NLNewton
 using OrdinaryDiffEqLowOrderRK: Euler, RK4
 using OrdinaryDiffEqTsit5: Tsit5
 using OrdinaryDiffEqSDIRK: ImplicitEuler, KenCarp4, TRBDF2
-using OrdinaryDiffEqBDF: FBDF, QNDF
+using OrdinaryDiffEqBDF: FBDF, QNDF, NordsieckBDF
 using OrdinaryDiffEqRosenbrock: Rosenbrock23, Rodas4P, Rodas5P
 import OrdinaryDiffEqDifferentiation
 using LinearSolve:
@@ -178,7 +178,7 @@ for (node_type, kinds) in pairs(node_kinds)
 end
 
 @option struct Solver <: TableOption
-    algorithm::String = "QNDF"
+    algorithm::String = "NordsieckBDF"
     saveat::Float64 = 86400.0
     dt::Union{Float64, Nothing} = nothing
     dtmin::Float64 = 0.0
@@ -353,6 +353,7 @@ Map from config string to a supported algorithm type from [OrdinaryDiffEq](https
 
 Supported algorithms:
 
+- `NordsieckBDF`
 - `QNDF`
 - `FBDF`
 - `Rosenbrock23`
@@ -366,6 +367,7 @@ Supported algorithms:
 - `Euler`
 """
 const algorithms = Dict{String, Type}(
+    "NordsieckBDF" => NordsieckBDF,
     "QNDF" => QNDF,
     "FBDF" => FBDF,
     "Rosenbrock23" => Rosenbrock23,

--- a/core/test/config_test.jl
+++ b/core/test/config_test.jl
@@ -31,7 +31,7 @@ end
     using Ribasim: convert_saveat, is_adaptive, Solver, algorithm
 
     solver = Solver()
-    @test solver.algorithm == "QNDF"
+    @test solver.algorithm == "NordsieckBDF"
     Solver(;
         algorithm = "Rosenbrock23",
         autodiff = true,

--- a/core/test/docs.toml
+++ b/core/test/docs.toml
@@ -39,7 +39,7 @@ outlet = 40                 # optional, default 40
 pump = 50                   # optional, default 50
 
 [solver]
-algorithm = "QNDF"  # optional, default "QNDF"
+algorithm = "NordsieckBDF"  # optional, default "NordsieckBDF"
 saveat = 86400      # optional, default 86400, 0 saves every timestep, inf saves only at start- and endtime
 dt = 60.0           # optional, remove for adaptive time stepping
 dtmin = 0.0         # optional, default 0.0

--- a/core/test/utils_test.jl
+++ b/core/test/utils_test.jl
@@ -299,13 +299,13 @@ end
 @testitem "Solver algorithm" begin
     using LinearSolve: KLUFactorization, LUFactorization
     using OrdinaryDiffEqNonlinearSolve: NLNewton
-    using OrdinaryDiffEqBDF: QNDF
+    using OrdinaryDiffEqBDF: NordsieckBDF
 
     model =
         Ribasim.Model(normpath(@__DIR__, "../../generated_testmodels/bucket/ribasim.toml"))
     (; alg) = model.integrator
 
-    @test alg isa QNDF
+    @test alg isa NordsieckBDF
     @test alg.step_limiter! == Ribasim.limit_flow!
     @test alg.nlsolve == NLNewton()
     @test alg.linsolve ==

--- a/docs/concept/equations.qmd
+++ b/docs/concept/equations.qmd
@@ -159,8 +159,8 @@ There are many things that can influence the calculations times, for instance:
 
 - [Solver tolerance](https://docs.sciml.ai/DiffEqDocs/stable/basics/faq/#What-does-tolerance-mean-and-how-much-error-should-I-expect):
   By default both the absolute and relative tolerance is `1e-5`.
-- [ODE solvers](https://diffeq.sciml.ai/stable/solvers/ode_solve/):
-  The `QNDF` method we use is robust to oscillations and massive stiffness, however other solvers should be tried as well.
+- [ODE solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve/):
+  The `NordsieckBDF` method we use is robust to oscillations and massive stiffness, however other solvers should be tried as well.
 - Forcing: Every time new forcing data is injected into the model, it needs to pause.
   Moreover, the larger the forcing fluxes are, the bigger the shock to the system, leading to smaller timesteps and thus longer simulation times.
 

--- a/docs/concept/modelconcept.qmd
+++ b/docs/concept/modelconcept.qmd
@@ -34,7 +34,7 @@ For more details on this see [Equations](/concept/equations.qmd).
 
 The water balance equation can be applied on many timescales; years, weeks, days or hours.
 Depending on the application and available data any of these can be the best choice.
-In Ribasim, we make use of DifferentialEquations.jl and its [ODE solvers](https://diffeq.sciml.ai/stable/solvers/ode_solve/).
+In Ribasim, we make use of DifferentialEquations.jl and its [ODE solvers](https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve/).
 Many of these solvers are based on adaptive time stepping, which means the solver will decide how large the time steps can be depending on the state of the system.
 
 The forcing, like precipitation, is generally provided as a time series.

--- a/docs/dev/numerics.qmd
+++ b/docs/dev/numerics.qmd
@@ -10,7 +10,7 @@ Ribasim builds on several packages from the [SciML](https://sciml.ai/) ecosystem
 
 | Package | Role |
 |---------|------|
-| [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl) subpackages | Time integration (default solver: QNDF) |
+| [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl) subpackages | Time integration (default solver: NordsieckBDF) |
 | [DifferentiationInterface.jl](https://github.com/JuliaDiff/DifferentiationInterface.jl) | Unified API for Jacobian computation |
 | [ForwardDiff.jl](https://github.com/JuliaDiff/ForwardDiff.jl) | Forward-mode automatic differentiation via dual numbers |
 | [SparseConnectivityTracer.jl](https://github.com/adrhill/SparseConnectivityTracer.jl) | Sparsity pattern detection |

--- a/docs/reference/usage.qmd
+++ b/docs/reference/usage.qmd
@@ -20,9 +20,9 @@ The solver section in the configuration file is entirely optional, since we aim 
 Common reasons to modify the solver settings are to adjust the calculation or result stepsizes: `dt`, and `saveat`.
 If your model does not converge, or your performance is lower than expected, it can help to adjust other solver settings as well.
 
-The default solver `algorithm = "QNDF"`, which is a multistep method similar to Matlab's `ode15s` [@shampine1997matlab].
+The default solver `algorithm = "NordsieckBDF"`, which is an adaptive-order, adaptive-time BDF method on a propagated Nordsieck history array`, following SUNDIALS CVODE [@byrne1975polyalgorithm, @hindmarsh2005sundials].
 It is an implicit method that supports the default adaptive timestepping.
-The full list of available solvers is: `QNDF`, `FBDF`, `Rosenbrock23`, `Rodas4P`, `Rodas5P`, `TRBDF2`, `KenCarp4`, `Tsit5`, `RK4`, `ImplicitEuler`, `Euler`.
+The full list of available solvers is: `NordsieckBDF`, `FBDF`, `QNDF`, `Rosenbrock23`, `Rodas4P`, `Rodas5P`, `TRBDF2`, `KenCarp4`, `Tsit5`, `RK4`, `ImplicitEuler`, `Euler`.
 Information on the solver algorithms can be found on the [ODE solvers page](https://docs.sciml.ai/DiffEqDocs/stable/solvers/ode_solve/).
 
 By default Ribasim uses adaptive timestepping, though not all algorithms support adaptive timestepping.

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -88,13 +88,23 @@
   note = "[Online; accessed 31-August-2022]"
 }
 
-@article{shampine1997matlab,
-  title={The matlab ode suite},
-  author={Shampine, Lawrence F and Reichelt, Mark W},
-  journal={SIAM journal on scientific computing},
-  volume={18},
+@article{byrne1975polyalgorithm,
+  title={A polyalgorithm for the numerical solution of ordinary differential equations},
+  author={Byrne, George D and Hindmarsh, Alan C},
+  journal={ACM Transactions on Mathematical Software},
+  volume={1},
   number={1},
-  pages={1--22},
-  year={1997},
-  publisher={SIAM}
+  pages={71--96},
+  year={1975}
+}
+
+@article{hindmarsh2005sundials,
+  title={{SUNDIALS}: Suite of nonlinear and differential/algebraic equation solvers},
+  author={Hindmarsh, Alan C and Brown, Peter N and Grant, Keith E and Lee, Steven L
+          and Serban, Radu and Shumaker, Dan E and Woodward, Carol S},
+  journal={ACM Transactions on Mathematical Software},
+  volume={31},
+  number={3},
+  pages={363--396},
+  year={2005}
 }

--- a/python/ribasim/ribasim/config.py
+++ b/python/ribasim/ribasim/config.py
@@ -121,7 +121,7 @@ class Solver(ChildModel):
     Attributes
     ----------
     algorithm : str
-        The used numerical time integration algorithm (Optional, defaults to QNDF)
+        The used numerical time integration algorithm (Optional, defaults to NordsieckBDF)
     saveat : float
         Time interval in seconds between saves of output data.
         0 saves every timestep, inf only saves at start- and endtime. (Optional, defaults to 86400)
@@ -154,7 +154,7 @@ class Solver(ChildModel):
         Trades initialization speed for simulation speed, useful for long-running simulations. (Optional, defaults to false)
     """
 
-    algorithm: str = "QNDF"
+    algorithm: str = "NordsieckBDF"
     saveat: float = 86400.0
     dt: float | None = None
     dtmin: float | None = None

--- a/python/ribasim/tests/test_model.py
+++ b/python/ribasim/tests/test_model.py
@@ -39,7 +39,7 @@ def test_repr(basic):
 
 def test_solver():
     solver = Solver()
-    assert solver.algorithm == "QNDF"  # default
+    assert solver.algorithm == "NordsieckBDF"
     assert solver.saveat == 86400.0
 
     solver = Solver(saveat=3600.0)


### PR DESCRIPTION
Fixes https://github.com/Deltares/Ribasim/issues/3212

Docstring here: https://github.com/SciML/OrdinaryDiffEq.jl/blob/b7a983f325087c34d92c77e795bab337662894f3/lib/OrdinaryDiffEqBDF/src/algorithms.jl#L770-L817

I ran this over several larger models, and saw a decent ~10% computation time decrease. Here is a summary of [solver stats](https://ribasim.org/reference/usage.html#solver-statistics---solver_stats.nc) differences for a Zuiderzeeland model run:

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/PROGRA~3/DevDrive/cache/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/PROGRA~3/DevDrive/cache/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:"Aptos Narrow", sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl64
	{color:white;
	font-weight:700;
	text-align:center;
	background:#4472C4;
	mso-pattern:black none;}
.xl65
	{border-top:none;
	border-right:none;
	border-bottom:.5pt solid windowtext;
	border-left:none;}
.xl66
	{mso-number-format:Fixed;
	border-top:none;
	border-right:none;
	border-bottom:.5pt solid windowtext;
	border-left:none;}
.xl67
	{border-top:.5pt solid windowtext;
	border-right:none;
	border-bottom:.5pt solid windowtext;
	border-left:none;}
.xl68
	{mso-number-format:Fixed;
	border-top:.5pt solid windowtext;
	border-right:none;
	border-bottom:.5pt solid windowtext;
	border-left:none;}
.xl69
	{border-top:.5pt solid windowtext;
	border-right:none;
	border-bottom:none;
	border-left:none;}
.xl70
	{mso-number-format:Standard;
	border-top:.5pt solid windowtext;
	border-right:none;
	border-bottom:none;
	border-left:none;}
.xl71
	{font-weight:700;
	mso-number-format:"0\.0%";
	border-top:.5pt solid windowtext;
	border-right:none;
	border-bottom:none;
	border-left:none;}
.xl72
	{color:#C00000;
	font-weight:700;
	mso-number-format:"0\.0%";
	border-top:.5pt solid windowtext;
	border-right:none;
	border-bottom:.5pt solid windowtext;
	border-left:none;}
.xl73
	{color:green;
	font-weight:700;
	mso-number-format:"0\.0%";
	border-top:none;
	border-right:none;
	border-bottom:.5pt solid windowtext;
	border-left:none;}
.xl74
	{color:green;
	font-weight:700;
	mso-number-format:"0\.0%";
	border-top:.5pt solid windowtext;
	border-right:none;
	border-bottom:.5pt solid windowtext;
	border-left:none;}
-->
</style>
</head>

<body link="#467886" vlink="#96607D">


Metric | QNDF Average | NordsieckBDF Average | Nordsieck vs QNDF
-- | -- | -- | --
Computation time | 256.99 | 229.98 | -10.5%
RHS calls | 117.88 | 98.85 | -16.1%
Linear solves | 116.85 | 97.81 | -16.3%
Accepted   timesteps | 48.73 | 53.63 | 10.1%
Rejected   timesteps | 4.76 | 1.54 | -67.6%
dt | 4,544.01 | 4,334.34 | -4.6%



</body>

</html>

The `dt` does go down a bit. Though note that this is not the average dt, but the last one before the end of the saveat.