### PR TITLE
Lock the Runic formatter version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,6 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                "aviatesk.jetls-client",
                 "charliermarsh.ruff",
                 "GitHub.copilot",
                 "julialang.language-julia",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,10 @@ repos:
         entry: pixi run typecheck
         pass_filenames: false
         language: system
-  - repo: https://github.com/fredrikekre/runic-pre-commit
-    rev: v2.2.0
-    hooks:
       - id: runic
+        name: runic
+        description: Format Julia code
+        entry: pixi run julia --project --startup-file=no --module Runic
+        args: [--docstrings, --diff, --inplace]
+        language: system
+        types: [julia]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
     "recommendations": [
-        "aviatesk.jetls-client",
         "charliermarsh.ruff",
         "julialang.language-julia",
         "astral-sh.ty",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "[julia]": {
         "editor.formatOnSave": true,
-        "editor.defaultFormatter": "aviatesk.jetls-client"
+        "editor.defaultFormatter": "julialang.language-julia"
     },
     "[python]": {
         "editor.codeActionsOnSave": {

--- a/JuliaFormat.toml
+++ b/JuliaFormat.toml
@@ -1,0 +1,1 @@
+style = "runic"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.7"
 manifest_format = "2.0"
-project_hash = "4fba35c44bb2f2dab1995806f59d3d0de2cd9c04"
+project_hash = "866e6457d07d2f88be59897a279e48fa51e1d658"
 
 [[deps.ADTypes]]
 deps = ["PrecompileTools"]
@@ -1039,6 +1039,11 @@ deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
 git-tree-sha1 = "c3d401f110454b4ea24a76be33f6ee0d7d385103"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
 version = "0.11.4"
+
+[[deps.JuliaSyntax]]
+git-tree-sha1 = "0d4b3dab95018bcf3925204475693d9f09dc45b8"
+uuid = "70703baa-626e-46a2-a12c-08ffd08c73b4"
+version = "1.0.2"
 
 [[deps.JuliaSyntaxHighlighting]]
 deps = ["StyledStrings"]
@@ -2082,6 +2087,12 @@ deps = ["ADTypes", "Accessors", "ArrayInterface", "BasicModelInterface", "Config
 path = "core"
 uuid = "aac5e3d9-0b8f-4d4f-8241-b1a7a9632635"
 version = "2026.1.2"
+
+[[deps.Runic]]
+deps = ["JuliaSyntax", "Preferences"]
+git-tree-sha1 = "4bb4f4bbff3fe1c1f9b55ed2c1d08082a63a2d6b"
+uuid = "62bfec6d-59d7-401d-8490-b29ee721c001"
+version = "1.10.0"
 
 [[deps.RuntimeGeneratedFunctions]]
 deps = ["ExprTools", "PrecompileTools", "SHA", "Serialization"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.7"
 manifest_format = "2.0"
-project_hash = "866e6457d07d2f88be59897a279e48fa51e1d658"
+project_hash = "e32c1f80294fa64fd7cf7b94fd35f82dedfeff70"
 
 [[deps.ADTypes]]
 deps = ["PrecompileTools"]

--- a/Project.toml
+++ b/Project.toml
@@ -65,6 +65,7 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Ribasim = "aac5e3d9-0b8f-4d4f-8241-b1a7a9632635"
+Runic = "62bfec6d-59d7-401d-8490-b29ee721c001"
 SQLite = "0aa819cd-b072-5ff4-a722-6bc24af294d9"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SciMLOperators = "c0aeaf25-5076-4817-a8d5-81caf7dfa961"
@@ -92,6 +93,7 @@ PkgToSoftwareBOM = "0.2"
 Plots = "1.41.4"
 PythonCall = "=0.9.35"
 Revise = "3.16.2"
+Runic = "1.10"
 
 [preferences.Revise]
 revise_structs = true

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ authors = ["Deltares and contributors <ribasim.info@deltares.nl>"]
 description = "Meta-project used to share the Manifest of Ribasim and its dependents"
 
 [workspace]
-projects = ["core"]
+projects = ["core", "utils/formatting"]
 
 [deps]
 ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
@@ -93,7 +93,6 @@ PkgToSoftwareBOM = "0.2"
 Plots = "1.41.4"
 PythonCall = "=0.9.35"
 Revise = "3.16.2"
-Runic = "1.10"
 
 [preferences.Revise]
 revise_structs = true

--- a/core/src/solve.jl
+++ b/core/src/solve.jl
@@ -606,7 +606,7 @@ We assume velocity differences are negligible (v_a = v_b):
 
 The friction losses are approximated by the Gauckler-Manning formula:
 
-    Q = A * (1 / n) * R_h^(2/3) * S_f^(1/2)
+    Q = A * (1 / n) * R_h^(2 / 3) * S_f^(1 / 2)
 
 Where:
 

--- a/docs/dev/core.qmd
+++ b/docs/dev/core.qmd
@@ -37,17 +37,6 @@ pkg> add Revise
 Revise.jl is a library that allows you to modify code and use the changes without restarting Julia.
 You can let it start automatically by following these [instructions](https://timholy.github.io/Revise.jl/stable/config/#Using-Revise-by-default-1).
 
-
-## Add `.julia/bin` to your Path
-
-We use the [Runic](https://github.com/fredrikekre/Runic.jl) formatter and [JETLS](https://github.com/aviatesk/JETLS.jl/) language server as [Pkg apps](https://pkgdocs.julialang.org/v1/apps/). which we expect to be available on the Path.
-The JETLS VSCode extension will prompt for you to install JETLS, and `pixi run install` will install Runic.
-
-Repeating the note from the Pkg docs:
-
-- You need to manually make `~/.julia/bin` available on the PATH environment.
-- The path to the julia executable used is the same as the one used to install the app. If this julia installation gets removed, you might need to reinstall the app.
-
 ## Install Visual Studio Code (optional)
 
 There is a section on editors and IDEs for Julia on <https://julialang.org/>, scroll down to see it.

--- a/pixi.toml
+++ b/pixi.toml
@@ -26,12 +26,10 @@ install = { depends-on = [
     "install-qgis-plugins",
     "install-prek",
     "instantiate-julia",
-    "install-runic",
 ] }
 # Julia
 update-manifest-julia = { cmd = "julia --project utils/update-manifest.jl" }
 instantiate-julia = { cmd = "julia --project --eval='using Pkg; Registry.update(); Pkg.instantiate()'" }
-install-runic = { cmd = "julia --eval='using Pkg; Pkg.Apps.add(\"Runic\")'" }
 initialize-julia-test = { cmd = "julia --project=core --eval 'using Pkg; Pkg.test(allow_reresolve=false, test_args=[\"skip\"])'", depends-on = [
     "instantiate-julia",
 ] }

--- a/pixi.toml
+++ b/pixi.toml
@@ -21,7 +21,12 @@ test-ribasim-api = "pytest -p no:pytest_qgis --basetemp=python/ribasim_api/tests
 # This is only for developers who want their global Julia to use the right version.
 # Use `pixi run julia` for the package used by CI.
 install-julia = "juliaup add 1.12.7 && juliaup override set 1.12.7"
-install-prek = "prek install --overwrite"
+_prek-install = "prek install --overwrite"
+instantiate-formatting = { cmd = "julia --project=utils/formatting --eval 'using Pkg; Pkg.instantiate()'" }
+install-prek = { depends-on = [
+    "_prek-install",
+    "instantiate-formatting",
+] }
 install = { depends-on = [
     "install-qgis-plugins",
     "install-prek",

--- a/utils/formatting/Project.toml
+++ b/utils/formatting/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Runic = "62bfec6d-59d7-401d-8490-b29ee721c001"
+
+[compat]
+Runic = "1.10"


### PR DESCRIPTION
Runic v1.10 was just released, and we didn't lock the version in our pre commit hook so far, leading to CI failures. We could do that, but the whole setup was unnecessarily complicated, and can be made simpler. The biggest downside was that we relied on a global, non-locked install of Runic, and that we needed the JETLS extension so we could ask that to use Runic as a formatter. Luckily the current julia-vscode pre-release now also support runic as a formatter, via [JuliaFormat.toml](https://www.julia-vscode.org/docs/dev/userguide/configuration/#Formatting:-JuliaFormat.toml).

That means we can drop both the app install and JETLS recommendation (it can still be useful).

I added some extra new options from Runic to make it display the diff using git, and format julia code in docstrings as well.

One downside is that the Runic version bundled with julia-vscode is not controlled by us and lags behind. But at least prek fixes is right.